### PR TITLE
Add dataclasses to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ jax
 # tensorflow is needed for tensorflow-datasets
 tensorflow
 tensorflow-datasets
+dataclasses


### PR DESCRIPTION
Dataclasses added to distribution in Python 3.7 but README.md suggests
the aim is to support Python 3.5 or later. With this change flax
appears to run correctly on 3.6.9