### PR TITLE
Fix collection anchor

### DIFF
--- a/flax/nn/base.py
+++ b/flax/nn/base.py
@@ -967,9 +967,9 @@ class Collection:
     elif self._root != root:
       if self._root.name is None or root.name is None:
         # Example:
-        # with nn.Collection() as coll:
-        #   StatefulModule.call(params, coll)
-        #   StatefulModule.call(params2, coll)
+        # with nn.statefull(state) as new_state:
+        #   StatefulModule.call(params)
+        #   StatefulModule.call(params2)
         raise ValueError('When multiple top-level module calls use a Collection'
                          ' each top-level module should have a name.')
     path = self._current_path()

--- a/flax/nn/base.py
+++ b/flax/nn/base.py
@@ -126,9 +126,6 @@ class _ModuleFrame:
     self._name_counter += 1
     return name
 
-  def __eq__(self, other):
-    return self is other
-
 
 def module_method(fn):
   """Decorates a function as a module method.

--- a/flax/nn/base.py
+++ b/flax/nn/base.py
@@ -968,8 +968,8 @@ class Collection:
       if self._root.name is None or root.name is None:
         # In the following examples, should the two calls to `StatefulModule` share state or not?
         # because it's ambiguous, we throw an error and require the user to explicitly separate state
-        # by giving each instance a separate name, or to explicitly (XXXXX??) in order to explicitly share
-        # state
+        # by giving each instance a separate name, or to explicitly pass the same name
+        # in order to share state.
         # with nn.statefull(state) as new_state:
         #   StatefulModule.call(params)
         #   StatefulModule.call(params2)

--- a/tests/nn_test.py
+++ b/tests/nn_test.py
@@ -383,6 +383,36 @@ class CollectionTest(absltest.TestCase):
     }
     self.assertEqual(activations.as_dict(), expected_state)
 
+  def test_collection_store_fails_if_not_in_module(self):
+    @nn.module
+    def test():
+      with nn.Collection().mutate() as coll:
+        pattern = 'State should be stored from within a module'
+        with self.assertRaisesRegex(ValueError, pattern):
+          coll.store(1)
+    test.init(random.PRNGKey(0))
+
+  def test_collection_store_fails_if_out_of_scope(self):
+    @nn.module
+    def stateful_module(coll):
+      coll.store(1)
+
+    @nn.module
+    def test_inner(f):
+      with nn.Collection().mutate() as coll:
+        pattern = 'Trying to capture state outside the scope'
+        with self.assertRaisesRegex(ValueError, pattern):
+          # this will fail because f is a shared module defined
+          # in the parent. Therefore we cannot capture in the scope
+          # of this Module.
+          f(coll)
+
+    @nn.module
+    def test():
+      f = stateful_module.shared()
+      test_inner(f)
+    test.init(random.PRNGKey(0))
+
 
 class UtilsTest(absltest.TestCase):
 

--- a/tests/nn_test.py
+++ b/tests/nn_test.py
@@ -387,10 +387,10 @@ class CollectionTest(absltest.TestCase):
     @nn.module
     def test():
       with nn.Collection().mutate() as coll:
-        pattern = 'State should be stored from within a module'
-        with self.assertRaisesRegex(ValueError, pattern):
-          coll.store(1)
-    test.init(random.PRNGKey(0))
+        coll.store(1)
+    pattern = 'State should be stored from within a module'
+    with self.assertRaisesRegex(ValueError, pattern):
+      test.init(random.PRNGKey(0))
 
   def test_collection_store_fails_if_out_of_scope(self):
     @nn.module
@@ -400,18 +400,18 @@ class CollectionTest(absltest.TestCase):
     @nn.module
     def test_inner(f):
       with nn.Collection().mutate() as coll:
-        pattern = 'Trying to capture state outside the scope'
-        with self.assertRaisesRegex(ValueError, pattern):
-          # this will fail because f is a shared module defined
-          # in the parent. Therefore we cannot capture in the scope
-          # of this Module.
-          f(coll)
+        # this should fail because f is a shared module defined
+        # in the parent. Therefore we cannot capture in the scope
+        # of this Module.
+        f(coll)
 
     @nn.module
     def test():
       f = stateful_module.shared()
       test_inner(f)
-    test.init(random.PRNGKey(0))
+    pattern = 'Trying to capture state outside the scope'
+    with self.assertRaisesRegex(ValueError, pattern):
+      test.init(random.PRNGKey(0))
 
 
 class UtilsTest(absltest.TestCase):


### PR DESCRIPTION
This PR aims to fix some edge cases that fail because Collection relies on inspecting the module stack at arbitrary points (not the top of the stack). This used to be okay because the stack corresponded to the child parent structure of the frames. But with the recent changes to shared modules this duality no longer holds.
