### PR TITLE
Subsume '_' into the prefix kwarg of {save,restore}_checkpoint.

### DIFF
--- a/flax/training/checkpoints.py
+++ b/flax/training/checkpoints.py
@@ -67,7 +67,7 @@ def natural_sort(file_list, signed=True):
 def save_checkpoint(ckpt_dir,
                     target,
                     step,
-                    prefix='checkpoint',
+                    prefix='checkpoint_',
                     keep=1):
   """Save a checkpoint of the model.
 
@@ -87,7 +87,7 @@ def save_checkpoint(ckpt_dir,
   # Write temporary checkpoint file.
   logging.info('Saving checkpoint at step: %s', step)
   ckpt_tmp_path = os.path.join(ckpt_dir, 'checkpoint_tmp')
-  ckpt_path = os.path.join(ckpt_dir, f'{prefix}_{step}')
+  ckpt_path = os.path.join(ckpt_dir, f'{prefix}{step}')
   gfile.makedirs(os.path.dirname(ckpt_path))
   with gfile.GFile(ckpt_tmp_path, 'wb') as fp:
     fp.write(serialization.to_bytes(target))
@@ -97,7 +97,7 @@ def save_checkpoint(ckpt_dir,
   logging.info('Saved checkpoint at %s', ckpt_path)
 
   # Remove old checkpoint files.
-  base_path = os.path.join(ckpt_dir, f'{prefix}_')
+  base_path = os.path.join(ckpt_dir, f'{prefix}')
   checkpoint_files = natural_sort(gfile.glob(base_path + '*'))
   if len(checkpoint_files) > keep:
     old_ckpts = checkpoint_files[:-keep]
@@ -108,7 +108,7 @@ def save_checkpoint(ckpt_dir,
   return ckpt_path
 
 
-def restore_checkpoint(ckpt_dir, target, prefix='checkpoint'):
+def restore_checkpoint(ckpt_dir, target, prefix='checkpoint_'):
   """Restore last/best checkpoint from checkpoints in path.
 
   Sorts the checkpoint files naturally, returning the highest-valued
@@ -126,7 +126,7 @@ def restore_checkpoint(ckpt_dir, target, prefix='checkpoint'):
     Restored `target` updated from checkpoint file or if no checkpoint
     files present returns the passed-in `target` unchanged.
   """
-  glob_path = os.path.join(ckpt_dir, f'{prefix}_*')
+  glob_path = os.path.join(ckpt_dir, f'{prefix}*')
   checkpoint_files = natural_sort(gfile.glob(glob_path))
   if not checkpoint_files:
     return target

--- a/tests/checkpoints_test.py
+++ b/tests/checkpoints_test.py
@@ -58,27 +58,27 @@ class CheckpointsTest(absltest.TestCase):
     test_object2 = {'a': np.array([4, 5, 6], np.int32),
                     'b': np.array([2, 2, 2], np.int32)}
     new_object = checkpoints.restore_checkpoint(
-        tmp_dir, test_object0, prefix='test')
+        tmp_dir, test_object0, prefix='test_')
     jtu.check_eq(new_object, test_object0)
     checkpoints.save_checkpoint(
-        tmp_dir, test_object1, 0, prefix='test', keep=1)
+        tmp_dir, test_object1, 0, prefix='test_', keep=1)
     self.assertIn('test_0', os.listdir(tmp_dir))
     new_object = checkpoints.restore_checkpoint(
-        tmp_dir, test_object0, prefix='test')
+        tmp_dir, test_object0, prefix='test_')
     jtu.check_eq(new_object, test_object1)
     checkpoints.save_checkpoint(
-        tmp_dir, test_object1, 1, prefix='test', keep=1)
+        tmp_dir, test_object1, 1, prefix='test_', keep=1)
     checkpoints.save_checkpoint(
-        tmp_dir, test_object2, 2, prefix='test', keep=1)
+        tmp_dir, test_object2, 2, prefix='test_', keep=1)
     new_object = checkpoints.restore_checkpoint(
-        tmp_dir, test_object0, prefix='test')
+        tmp_dir, test_object0, prefix='test_')
     jtu.check_eq(new_object, test_object2)
     checkpoints.save_checkpoint(
-        tmp_dir, test_object2, 3, prefix='test', keep=2)
+        tmp_dir, test_object2, 3, prefix='test_', keep=2)
     checkpoints.save_checkpoint(
-        tmp_dir, test_object1, 4, prefix='test', keep=2)
+        tmp_dir, test_object1, 4, prefix='test_', keep=2)
     new_object = checkpoints.restore_checkpoint(
-        tmp_dir, test_object0, prefix='test')
+        tmp_dir, test_object0, prefix='test_')
     jtu.check_eq(new_object, test_object1)
 
   def test_save_restore_checkpoints_w_float_steps(self):
@@ -90,24 +90,24 @@ class CheckpointsTest(absltest.TestCase):
     test_object2 = {'a': np.array([4, 5, 6], np.int32),
                     'b': np.array([2, 2, 2], np.int32)}
     checkpoints.save_checkpoint(
-        tmp_dir, test_object1, 0.0, prefix='test', keep=1)
+        tmp_dir, test_object1, 0.0, prefix='test_', keep=1)
     self.assertIn('test_0.0', os.listdir(tmp_dir))
     new_object = checkpoints.restore_checkpoint(
-        tmp_dir, test_object0, prefix='test')
+        tmp_dir, test_object0, prefix='test_')
     jtu.check_eq(new_object, test_object1)
     checkpoints.save_checkpoint(
-        tmp_dir, test_object1, 2.0, prefix='test', keep=1)
+        tmp_dir, test_object1, 2.0, prefix='test_', keep=1)
     checkpoints.save_checkpoint(
-        tmp_dir, test_object2, 1.0, prefix='test', keep=1)
+        tmp_dir, test_object2, 1.0, prefix='test_', keep=1)
     new_object = checkpoints.restore_checkpoint(
-        tmp_dir, test_object0, prefix='test')
+        tmp_dir, test_object0, prefix='test_')
     jtu.check_eq(new_object, test_object1)
     checkpoints.save_checkpoint(
-        tmp_dir, test_object2, 3.0, prefix='test', keep=2)
+        tmp_dir, test_object2, 3.0, prefix='test_', keep=2)
     checkpoints.save_checkpoint(
-        tmp_dir, test_object1, -1.0, prefix='test', keep=2)
+        tmp_dir, test_object1, -1.0, prefix='test_', keep=2)
     new_object = checkpoints.restore_checkpoint(
-        tmp_dir, test_object0, prefix='test')
+        tmp_dir, test_object0, prefix='test_')
     self.assertIn('test_3.0', os.listdir(tmp_dir))
     self.assertIn('test_2.0', os.listdir(tmp_dir))
     jtu.check_eq(new_object, test_object2)


### PR DESCRIPTION
Making restore_checkpoint more permissive makes it possible to load a checkpoint at a step earlier than the latest by specifying a different prefix.

Updates save_checkpoint to be consistent.