### PR TITLE
Add create howtos script

### DIFF
--- a/.github/workflows/apply-howto-branches.yml
+++ b/.github/workflows/apply-howto-branches.yml
@@ -1,0 +1,17 @@
+name: Apply HOWTO diffs to branches
+on: 
+  push:
+    branches:
+      - prerelease
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+      with:
+        ref: prerelease
+    - name: Apply diffs to branches
+      run: ./howtos/scripts/apply_howto_diffs.sh
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/howtos/README.md
+++ b/howtos/README.md
@@ -1,0 +1,78 @@
+# FLAX HOWTOs
+
+## Introduction
+
+FLAX HOWTOs explain how to implement standard techiques in FLAX. For instance,
+the HOWTO for ensembling learning demonstrates what changes should be made to
+the standard MNIST example in order to train an ensemble of models. As such, 
+HOWTOs are simply "diffs".
+
+## List of HOWTOs
+
+In essence, a HOWTO is a set of changes that are applied to the FLAX master 
+branch on Github. HOWTOs are currently simply diff views between HOWTO branches 
+and the master branch. Soon, they will be merged with the rest of our 
+documentation through readthedocs.
+
+Currently the following HOWTOs are available:
+
+* [Ensembling](https://github.com/marcvanzee/flax/compare/prerelease..howto-ensembling?diff=split)
+
+> :warning: We should add the HOWTOs here automatically, or refer to 
+            readthedocs.
+
+## How HOWTOs work
+
+While HOWTOs are shown as changes on a branch, these branches are read-only for
+the users. HOWTOs are represented as diff files in the repository as well. For 
+instance, the "ensembling howto" is represented in two ways:
+
+* In the branch `howto-ensembling` (only on Github).
+* In the file `howtos/diffs/howto-ensembling.diff` (in the repository).
+
+The branch `howto-ensembling` is simply the result of applying 
+`howto/howto-ensembling.diff` to the master branch.
+
+This setup allows us to ensure all local modifications to HOWTOs can be packed
+in diff files locally, pushed to origin and applied to the master branch 
+automatically.
+
+This process is automatic, which means that users usually won't notice this, 
+except if they want to add a new HOWTO, or their changes require making changes
+to HOWTOs. We explain these two cases below.
+
+## Adding a new HOWTO
+
+In order to create a new HOWTO, you can simply make the desired changes local
+changes and run:
+
+```
+./howtos/script/pack_howto_diff.sh
+```
+
+This will pack the changes made on `howto-<name>` into a diff file and stage it
+for committing. It will also revert all changes you made, but you can directly
+recover these changes simply by applying the diff:
+
+```
+git apply <diff_file>
+```
+
+After pushing your commit, the newly submitted diff file will be unpacked on
+Github with a Github action and a new howto branch will be created for it.
+
+The workflow script for the Github action can be found at 
+`.github/workflows/apply-howto-branches.yml`
+
+## Resolving a conflict with an existing HOWTO
+
+> :warning: TODO: This is still in progress. Currently conflicts are resolved by
+            checking whether the Github action fails, and if so, manually making
+            the required fixes.
+
+## Modifying an exiting HOWTO
+
+> :warning: TODO: Write this out. The summary is: apply a diff locally, make the
+            changes, pack the diff again and commit. It would be good to show 
+            this with an example. Note editing this diff is not a good idea 
+            since it is extremely error-prone.

--- a/howtos/diffs/howto-ensembling.diff
+++ b/howtos/diffs/howto-ensembling.diff
@@ -1,0 +1,143 @@
+diff --git a/examples/mnist/train.py b/examples/mnist/train.py
+index e93321f..55259db 100644
+--- a/examples/mnist/train.py
++++ b/examples/mnist/train.py
+@@ -18,11 +18,11 @@ This script trains a simple Convolutional Neural Net on the MNIST dataset.
+ The data is loaded using tensorflow_datasets.
+ 
+ """
+-
+ from absl import app
+ from absl import flags
+ from absl import logging
+ 
++from flax import jax_utils
+ from flax import nn
+ from flax import optim
+ 
+@@ -85,9 +85,11 @@ def create_model(key):
+   return model
+ 
+ 
+-def create_optimizer(model, learning_rate, beta):
+-  optimizer_def = optim.Momentum(learning_rate=learning_rate, beta=beta)
+-  optimizer = optimizer_def.create(model)
++@jax.pmap
++def create_optimizers(rng):
++  optimizer_def = optim.Momentum(
++      learning_rate=FLAGS.learning_rate, beta=FLAGS.momentum)
++  optimizer = optimizer_def.create(create_model(rng))
+   return optimizer
+ 
+ 
+@@ -110,7 +112,7 @@ def compute_metrics(logits, labels):
+   return metrics
+ 
+ 
+-@jax.jit
++@jax.pmap
+ def train_step(optimizer, batch):
+   """Train for a single step."""
+   def loss_fn(model):
+@@ -122,13 +124,13 @@ def train_step(optimizer, batch):
+   return optimizer, metrics
+ 
+ 
+-@jax.jit
++@jax.pmap
+ def eval_step(model, batch):
+   logits = model(batch['image'])
+   return compute_metrics(logits, batch['label'])
+ 
+ 
+-def train_epoch(optimizer, train_ds, batch_size, epoch, rng):
++def train_epoch(optimizers, train_ds, batch_size, epoch, rng):
+   """Train for a single epoch."""
+   train_ds_size = len(train_ds['image'])
+   steps_per_epoch = train_ds_size // batch_size
+@@ -139,25 +141,27 @@ def train_epoch(optimizer, train_ds, batch_size, epoch, rng):
+   batch_metrics = []
+   for perm in perms:
+     batch = {k: v[perm] for k, v in train_ds.items()}
+-    optimizer, metrics = train_step(optimizer, batch)
++    batch = jax_utils.replicate(batch)
++    optimizers, metrics = train_step(optimizers, batch)
+     batch_metrics.append(metrics)
+ 
+   # compute mean of metrics across each batch in epoch.
+   batch_metrics_np = jax.device_get(batch_metrics)
++  batch_metrics_np = jax.tree_multimap(lambda *xs: onp.array(xs),
++                                       *batch_metrics_np)
+   epoch_metrics_np = {
+-      k: onp.mean([metrics[k] for metrics in batch_metrics_np])
+-      for k in batch_metrics_np[0]}
+-
+-  logging.info('train epoch: %d, loss: %.4f, accuracy: %.2f', epoch,
++      k: onp.mean(batch_metrics_np[k], axis=0) for k in batch_metrics_np
++  }
++  logging.info('train epoch: %d, loss: %s, accuracy: %s', epoch,
+                epoch_metrics_np['loss'], epoch_metrics_np['accuracy'] * 100)
+ 
+-  return optimizer, epoch_metrics_np
++  return optimizers, epoch_metrics_np
+ 
+ 
+-def eval_model(model, test_ds):
+-  metrics = eval_step(model, test_ds)
++def eval_model(models, test_ds):
++  metrics = eval_step(models, test_ds)
+   metrics = jax.device_get(metrics)
+-  summary = jax.tree_map(lambda x: x.item(), metrics)
++  summary = metrics
+   return summary['loss'], summary['accuracy']
+ 
+ 
+@@ -175,18 +179,18 @@ def train(train_ds, test_ds):
+   batch_size = FLAGS.batch_size
+   num_epochs = FLAGS.num_epochs
+ 
+-  model = create_model(rng)
+-  optimizer = create_optimizer(model, FLAGS.learning_rate, FLAGS.momentum)
++  optimizers = create_optimizers(random.split(rng, jax.device_count()))
+ 
+   input_rng = onp.random.RandomState(0)
++  test_ds = jax_utils.replicate(test_ds)
+ 
+   for epoch in range(1, num_epochs + 1):
+-    optimizer, _ = train_epoch(
+-        optimizer, train_ds, batch_size, epoch, input_rng)
+-    loss, accuracy = eval_model(optimizer.target, test_ds)
+-    logging.info('eval epoch: %d, loss: %.4f, accuracy: %.2f',
+-                 epoch, loss, accuracy * 100)
+-  return optimizer
++    optimizers, _ = train_epoch(optimizers, train_ds, batch_size, epoch,
++                                input_rng)
++    loss, accuracy = eval_model(optimizers.target, test_ds)
++    logging.info('eval epoch: %d, loss: %s, accuracy: %s', epoch, loss,
++                 accuracy * 100)
++  return optimizers
+ 
+ 
+ def main(_):
+diff --git a/examples/mnist/train_test.py b/examples/mnist/train_test.py
+index eee3c3d..88fa4be 100644
+--- a/examples/mnist/train_test.py
++++ b/examples/mnist/train_test.py
+@@ -33,13 +33,12 @@ class TrainTest(absltest.TestCase):
+   def test_train_one_epoch(self):
+     train_ds, test_ds = train.get_datasets()
+     input_rng = onp.random.RandomState(0)
+-    model = train.create_model(random.PRNGKey(0))
+-    optimizer = train.create_optimizer(model, 0.1, 0.9)
+-    optimizer, train_metrics = train.train_epoch(optimizer, train_ds, 128, 0,
+-                                                 input_rng)
++    optimizers = train.create_optimizers(random.split(random.PRNGKey(0), 1))
++    optimizers, train_metrics = train.train_epoch(optimizers, train_ds, 128, 0,
++                                                  input_rng, 1)
+     self.assertLessEqual(train_metrics['loss'], 0.27)
+     self.assertGreaterEqual(train_metrics['accuracy'], 0.92)
+-    loss, accuracy = train.eval_model(optimizer.target, test_ds)
++    loss, accuracy = train.eval_model(optimizers.target, test_ds, 1)
+     self.assertLessEqual(loss, 0.06)
+     self.assertGreaterEqual(accuracy, 0.98)
+ 

--- a/howtos/scripts/apply_howto_diffs.sh
+++ b/howtos/scripts/apply_howto_diffs.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+#
+# Creates a HOWTO branch for each HOWTO diff file by apply the changes to the
+# master branch. Removes all howto branches for which no diff file exists.
+
+# https://vaneyckt.io/posts/safer_bash_scripts_with_set_euxo_pipefail/
+set -euxo
+
+old_pwd=$(pwd)
+top_dir=$(git rev-parse --show-toplevel)
+howto_diff_path="${top_dir}/howtos/diffs"
+master_branch="prerelease"
+
+# Initialize git.
+remote_repo="https://${GITHUB_ACTOR}:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+git config http.sslVerify false
+git config user.name "Automated Publisher"
+git config user.email "actions@users.noreply.github.com"
+
+# Fetch all branches.
+git fetch --all
+
+# Delete all remote branches starting with "howto-". This ensures we clean up
+# HOWTO branches for which the diff files have been deleted.
+for b in $(git branch -r | grep origin/howto); do
+  branch=${b##*/}  # Strip "origin/" prefix.
+  git push origin --delete $branch
+done
+
+# Get names of howto's from diff files.
+cd $howto_diff_path
+howtos=$(ls *.diff | sed -e 's/.diff//')
+cd $top_dir
+
+printf "Applying HOWTO diffs to branches..\n"
+
+for howto in $howtos; do
+  git checkout -b $howto
+  diff_file="${howto_diff_path}/${howto}.diff"
+  if [[ -n $(git apply --check "${diff_file}") ]]; then
+    printf "\nERROR: Cannot apply ${howto}! ==> PLEASE FIX HOWTO\n"
+    exit 1
+  fi
+  git apply $diff_file
+  git commit -am "Added howto branch ${howto}"
+  git push -u origin $howto
+  # Make sure to checkout the master branch, otherwise the next diff branch
+  # will be branched off of the current diff branch.
+  git checkout $master_branch
+done
+
+cd $old_pwd

--- a/howtos/scripts/pack_howto_diffs.sh
+++ b/howtos/scripts/pack_howto_diffs.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+#
+# Creates a new howto diff from all files that are currently edited and not
+# committed (untracked, tracked, staged). Also reverts all changes. Note the
+# changes can be recovered by simply applying the diff with 
+# `git apply <howto_diff>`.
+
+# https://vaneyckt.io/posts/safer_bash_scripts_with_set_euxo_pipefail/
+# We avoid -x since it is not very useful to be verbose in this case.
+set -euo
+
+old_pwd=$(pwd)
+top_dir=$(git rev-parse --show-toplevel)
+howto_diff_path="${top_dir}/howtos/diffs"
+
+cat << EOF
+Awesome, you are going to create a new FLAX HOWTO!
+
+More details about HOWTOs can be found here:
+https://github.com/marcvanzee/flax/blob/prerelease/howtos/README.md
+
+The following files are edited/added:
+
+EOF
+
+# Get respectively all untracked, unstaged, and stages files.
+# The awk command prepends all files with "-".
+(git ls-files --others --exclude-standard && \
+  git diff --name-only && \
+  git diff --staged --name-only) | awk '{print "- " $0}'
+
+cat << EOF
+
+WARNING: This operation will pack all changes in the files above into a diff 
+file, and undo the changes in those files.
+EOF
+read -p "Would you like to continue? " -r
+if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+  printf "Bailing out."
+  exit 1
+fi
+
+printf "\nPlease provide a name for the howto:\n"
+
+read -p "howto-" howto_name
+howto_name="howto-${howto_name}"
+howto_path="${howto_diff_path}/${howto_name}.diff"
+
+# Overwrite the existing diff 
+if test -f "${howto_path}";  then
+  printf "Diff ${howto_path} exists already.\n"
+  read -p "Overwrite? " -r
+  if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+    printf "Bailing out."
+    exit 1
+  fi
+fi
+
+# Add all untracked files. After this there are no untracked changes anymore.
+git add *
+# Create diff for both unstaged and staged changes. Add the diff to a temporal
+# location to ensure it won't be remove when we clean the changes.
+tmp_path=$(mktemp)
+(git diff && git diff --staged) > $tmp_path
+
+# Revert all tracked changes (which are all edited files).
+git reset --hard > /dev/null
+
+# Add the diff file to the correct location and track it.
+mv $tmp_path $howto_path && git add $howto_path
+
+cat << EOF
+
+Done! Diff created in ${howto_path}.
+The file has been staged, you should commit and push it yourself.
+
+NOTE: If you want to restore you changes, simply run:
+
+$ git apply ${howto_path}
+EOF
+
+cd $old_pwd


### PR DESCRIPTION
In order to show HOWTOs to users, we want to use "howto branches", which are changes applied to the master branch (currently 'prerelease'). These branches should always be on top of the master branch, and we should be able to detect when a HOWTO breaks. That is, when a user makes a change that makes the HOWTO no longer applicable.

In order to make sure the user can test this all locally, we use "diff files" locally. Each diff file is a representation of a HOWTO, and can be applied to a branch to generate the actual HOWTO.

This pull requests adds the first scripts for this workflow. The currently functioning workflow is described in the README.md, but here are some details on the specific files:

- **apply-howto-branches.yml**: Every file in `.github/workflows/` is automatically recognized as a Github action. This action is run after a push and generates HOWTO branches from the diff files.
- **howtos/scripts/apply_howto_diffs.sh**: This is ran by the workflow to generate the branches.
- **howtos/scripts/pack_howto_diff.sh**: This script can be ran locally to pack changes into a HOWTO diff.
- **howto-ensembling.diff**: This is a first HOWTO I generated using `pack_howto_diff.sh`