### PR TITLE
Rename SelfAttention to MultiHeadDotProductAttention.

### DIFF
--- a/flax/nn/__init__.py
+++ b/flax/nn/__init__.py
@@ -19,7 +19,8 @@
 from .activation import (celu, elu, gelu, glu, leaky_relu, log_sigmoid,
                          log_softmax, relu, sigmoid, soft_sign, softmax,
                          softplus, swish, tanh)
-from .attention import dot_product_attention, SelfAttention
+from .attention import (dot_product_attention, MultiHeadDotProductAttention,
+                        SelfAttention)
 from .base import (Module, Model, Collection, capture_module_outputs,
                    module, stateful, get_state, module_method)
 from .linear import Dense, DenseGeneral, Conv, Embed

--- a/tests/nn_attention_test.py
+++ b/tests/nn_attention_test.py
@@ -57,8 +57,8 @@ class AttentionTest(parameterized.TestCase):
         kernel_init=initializers.ones,
         bias_init=initializers.zeros,
     )
-    y, _ = sa_module.create(rng, x, kv)
-    self.assertEqual(y.shape, x.shape)
+    y, _ = sa_module.create(rng, q, kv)
+    self.assertEqual(y.shape, q.shape)
 
   def test_multihead_self_attention_w_dropout(self):
     rng = random.PRNGKey(0)

--- a/tests/nn_attention_test.py
+++ b/tests/nn_attention_test.py
@@ -46,6 +46,20 @@ class AttentionTest(parameterized.TestCase):
     y, _ = sa_module.create(rng, x)
     self.assertEqual(y.shape, x.shape)
 
+  def test_multihead_encoder_decoder_attention(self):
+    rng = random.PRNGKey(0)
+    q = jnp.ones((4, 2, 3, 5))
+    kv = jnp.ones((4, 2, 3, 5))
+    sa_module = nn.MultiHeadDotProductAttention.partial(
+        num_heads=8,
+        attention_axis=(1, 2),
+        qkv_features=16,
+        kernel_init=initializers.ones,
+        bias_init=initializers.zeros,
+    )
+    y, _ = sa_module.create(rng, x, kv)
+    self.assertEqual(y.shape, x.shape)
+
   def test_multihead_self_attention_w_dropout(self):
     rng = random.PRNGKey(0)
     x = jnp.ones((4, 2, 3, 5))


### PR DESCRIPTION
This clarifies that the module can also be used for encoder-decoder
attention by specifying both inputs_q and inputs_kv.

Includes SelfAttention as a shim which hardcodes inputs_kv to None.
But in the future it probably makes sense to refactor these modules
so that the details that are only relevant for SelfAttention (e.g.
causal_mask and cache) are only exposed in that class.