### PR TITLE
Fix missing imports in example

### DIFF
--- a/docs/annotated_mnist.md
+++ b/docs/annotated_mnist.md
@@ -3,6 +3,7 @@
 ```py
 import jax
 import flax
+import tensorflow as tf
 ```
 
 Load vanilla NumPy for use on host.
@@ -116,10 +117,10 @@ Create a new model, running all necessary initializers.
 The parameters are stored as nested dicts on `model.params`.
 
 ```py
-   _, initial_params = CNN.init_by_shape(
-   jax.random.PRNGKey(0),
-    [((1, 28, 28, 1), jnp.float32)])
-   model = nn.Model(CNN, initial_params)
+  _, initial_params = CNN.init_by_shape(
+  jax.random.PRNGKey(0),
+   [((1, 28, 28, 1), jnp.float32)])
+  model = flax.nn.Model(CNN, initial_params)
 ```
 
 Define an optimizer. At any particular optimzation step,


### PR DESCRIPTION
Got an issue because flax. in  model = nn.Model(... was missing
and import of tensorflow for casting was also missing