### PR TITLE
Improve HOWTOs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ install:
   - conda install -c conda-forge pandoc
 script:
   # build the docs
+  - (cd docs && python format_howtos.py)
   - sphinx-build -M html docs docs/_build
   # run the main flax unit tests
   - pytest -n 1 tests -W ignore

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,0 +1,1 @@
+_formatted_howtos

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -17,4 +17,5 @@ help:
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile
+	python3 format_howtos.py
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/format_howtos.py
+++ b/docs/format_howtos.py
@@ -10,6 +10,7 @@ import pygments
 import pygments.formatters
 from pygments.lexers import PythonLexer
 
+import re
 import os
 
 def main():
@@ -29,11 +30,17 @@ def format_howto(input_file, output_file):
   # index 51d2fde..a9d7dcb 100644
   diff = diff[2:]
 
-  # Remove more than one empty line in a row
+  # Remove double newlines of diff context from `diff` (which is a
+  # list of lines).
+
+  # Diff lines start with a charater in {'+', '-', ' '} designating
+  # insert, remove or context.  Create a regexp that matches empty
+  # lines that are either of these three types.
+  empty_line_regexp = re.compile('[+\\- ]\n')
   diff = [diff[lineno] for lineno in range(len(diff))
       if lineno == 0 or not (
-        diff[lineno].rstrip(' \n') == '' and
-        diff[lineno-1].rstrip(' \n') == ''
+        empty_line_regexp.match(diff[lineno]) and
+        empty_line_regexp.match(diff[lineno-1])
        )]
 
   # Don't do any special formatting.

--- a/docs/format_howtos.py
+++ b/docs/format_howtos.py
@@ -42,7 +42,7 @@ def format_howto(input_file, output_file):
       return source
 
   # Run `diff` through the normal pygments Python syntax
-  # highlighter.  Get back an array of HTML lines
+  # highlighter. Get back an array of HTML lines.
   colored_diff = (
     pygments.highlight('\n'.join(diff), PythonLexer(), RawHtmlFormatter())
   ).splitlines()

--- a/docs/format_howtos.py
+++ b/docs/format_howtos.py
@@ -36,7 +36,7 @@ def format_howto(input_file, output_file):
         diff[lineno-1].rstrip(' \n') == ''
        )]
 
-  # Don't do any special formatting
+  # Don't do any special formatting.
   class RawHtmlFormatter(pygments.formatters.HtmlFormatter):
     def wrap(self, source, outfile):
       return source

--- a/docs/format_howtos.py
+++ b/docs/format_howtos.py
@@ -1,0 +1,78 @@
+"""
+Read all of the HOWTO .diff files and convert them into .html files
+that are both Python syntax highlighted /and/ diff syntax highlighted.
+
+Then these can be included directly in readthedocs as inline HTML
+files.
+"""
+
+import pygments
+import pygments.formatters
+from pygments.lexers import PythonLexer
+
+import os
+
+def main():
+    for diff_filename in os.listdir(os.path.join('..', 'howtos', 'diffs')):
+        format_howto(os.path.join('..', 'howtos', 'diffs', diff_filename),
+                     os.path.join('_formatted_howtos', diff_filename + '.html'))
+
+def format_howto(input_file, output_file):
+    # Load one of our HOWTO diff files.
+    with open(input_file) as f:
+        diff = f.readlines()
+
+    # Ignore the first two line, which look like:
+    #
+    # diff --git a/examples/mnist/train.py b/examples/mnist/train.py
+    # index 51d2fde..a9d7dcb 100644
+    diff = diff[2:]
+
+    # Remove more than one empty line in a row
+    diff = [diff[lineno] for lineno in range(len(diff))
+            if lineno == 0 or not (
+                diff[lineno].rstrip(' \n') == '' and
+                diff[lineno-1].rstrip(' \n') == ''
+           )]
+
+    # Don't do any special formatting
+    class RawHtmlFormatter(pygments.formatters.HtmlFormatter):
+        def wrap(self, source, outfile):
+            return source
+
+    # Run `diff` through the normal pygments Python syntax
+    # highlighter.  Get back an array of HTML lines
+    colored_diff = (
+        pygments.highlight('\n'.join(diff), PythonLexer(), RawHtmlFormatter())
+    ).splitlines()
+
+    # Write a newly formatted diff-and-Python syntax highlighted
+    # output HTML file, that can be inline included into any .rst
+    # file.
+    with open(output_file, "w") as out_file:
+        # Add the relevant DIVs that Sphinx adds around code blocks
+        print('<div class="highlight-default notranslate"><div class="highlight">',
+              file=out_file)
+        print('<pre class="code">', file=out_file)
+
+        for line in colored_diff:
+            line = line.rstrip('\n')
+            if line == '':
+                continue
+
+            if line.startswith('<span class="o">@@'):
+                print('<span style="background-color: rgba(128, 128, 128, 0.3)">[...]</span>',
+                      file=out_file)
+            elif line.startswith('<span class="o">+'):
+                print('<span style="background-color: rgba(0, 255, 0, 0.3)">' + line + '</span>',
+                      file=out_file)
+            elif line.startswith('<span class="o">-'):
+                print('<span style="background-color: rgba(255, 0, 0, 0.3)">' + line + '</span>',
+                      file=out_file)
+            else:
+                print(line, file=out_file)
+
+        print('</pre></div></div>', file=out_file)
+
+
+main() 

--- a/docs/format_howtos.py
+++ b/docs/format_howtos.py
@@ -13,6 +13,7 @@ from pygments.lexers import PythonLexer
 import os
 
 def main():
+  os.makedirs('_formatted_howtos', exist_ok=True)
   for diff_filename in os.listdir(os.path.join('..', 'howtos', 'diffs')):
     format_howto(os.path.join('..', 'howtos', 'diffs', diff_filename),
            os.path.join('_formatted_howtos', diff_filename + '.html'))

--- a/docs/format_howtos.py
+++ b/docs/format_howtos.py
@@ -13,66 +13,66 @@ from pygments.lexers import PythonLexer
 import os
 
 def main():
-    for diff_filename in os.listdir(os.path.join('..', 'howtos', 'diffs')):
-        format_howto(os.path.join('..', 'howtos', 'diffs', diff_filename),
-                     os.path.join('_formatted_howtos', diff_filename + '.html'))
+  for diff_filename in os.listdir(os.path.join('..', 'howtos', 'diffs')):
+    format_howto(os.path.join('..', 'howtos', 'diffs', diff_filename),
+           os.path.join('_formatted_howtos', diff_filename + '.html'))
 
 def format_howto(input_file, output_file):
-    # Load one of our HOWTO diff files.
-    with open(input_file) as f:
-        diff = f.readlines()
+  # Load one of our HOWTO diff files.
+  with open(input_file) as f:
+    diff = f.readlines()
 
-    # Ignore the first two line, which look like:
-    #
-    # diff --git a/examples/mnist/train.py b/examples/mnist/train.py
-    # index 51d2fde..a9d7dcb 100644
-    diff = diff[2:]
+  # Ignore the first two line, which look like:
+  #
+  # diff --git a/examples/mnist/train.py b/examples/mnist/train.py
+  # index 51d2fde..a9d7dcb 100644
+  diff = diff[2:]
 
-    # Remove more than one empty line in a row
-    diff = [diff[lineno] for lineno in range(len(diff))
-            if lineno == 0 or not (
-                diff[lineno].rstrip(' \n') == '' and
-                diff[lineno-1].rstrip(' \n') == ''
-           )]
+  # Remove more than one empty line in a row
+  diff = [diff[lineno] for lineno in range(len(diff))
+      if lineno == 0 or not (
+        diff[lineno].rstrip(' \n') == '' and
+        diff[lineno-1].rstrip(' \n') == ''
+       )]
 
-    # Don't do any special formatting
-    class RawHtmlFormatter(pygments.formatters.HtmlFormatter):
-        def wrap(self, source, outfile):
-            return source
+  # Don't do any special formatting
+  class RawHtmlFormatter(pygments.formatters.HtmlFormatter):
+    def wrap(self, source, outfile):
+      return source
 
-    # Run `diff` through the normal pygments Python syntax
-    # highlighter.  Get back an array of HTML lines
-    colored_diff = (
-        pygments.highlight('\n'.join(diff), PythonLexer(), RawHtmlFormatter())
-    ).splitlines()
+  # Run `diff` through the normal pygments Python syntax
+  # highlighter.  Get back an array of HTML lines
+  colored_diff = (
+    pygments.highlight('\n'.join(diff), PythonLexer(), RawHtmlFormatter())
+  ).splitlines()
 
-    # Write a newly formatted diff-and-Python syntax highlighted
-    # output HTML file, that can be inline included into any .rst
-    # file.
-    with open(output_file, "w") as out_file:
-        # Add the relevant DIVs that Sphinx adds around code blocks
-        print('<div class="highlight-default notranslate"><div class="highlight">',
-              file=out_file)
-        print('<pre class="code">', file=out_file)
+  # Write a newly formatted diff-and-Python syntax highlighted
+  # output HTML file, that can be inline included into any .rst
+  # file.
+  with open(output_file, 'w') as out_file:
+    # Add the relevant DIVs that Sphinx adds around code blocks
+    print('<div class="highlight-default notranslate"><div class="highlight">',
+        file=out_file)
+    print('<pre class="code">', file=out_file)
 
-        for line in colored_diff:
-            line = line.rstrip('\n')
-            if line == '':
-                continue
+    for line in colored_diff:
+      line = line.rstrip('\n')
+      if line == '':
+        continue
 
-            if line.startswith('<span class="o">@@'):
-                print('<span style="background-color: rgba(128, 128, 128, 0.3)">[...]</span>',
-                      file=out_file)
-            elif line.startswith('<span class="o">+'):
-                print('<span style="background-color: rgba(0, 255, 0, 0.3)">' + line + '</span>',
-                      file=out_file)
-            elif line.startswith('<span class="o">-'):
-                print('<span style="background-color: rgba(255, 0, 0, 0.3)">' + line + '</span>',
-                      file=out_file)
-            else:
-                print(line, file=out_file)
+      if line.startswith('<span class="o">@@'):
+        print('<span style="background-color: rgba(128, 128, 128, 0.3)">[...]</span>',
+            file=out_file)
+      elif line.startswith('<span class="o">+'):
+        print('<span style="background-color: rgba(0, 255, 0, 0.3)">' + line + '</span>',
+            file=out_file)
+      elif line.startswith('<span class="o">-'):
+        print('<span style="background-color: rgba(255, 0, 0, 0.3)">' + line + '</span>',
+            file=out_file)
+      else:
+        print(line, file=out_file)
 
-        print('</pre></div></div>', file=out_file)
+    print('</pre></div></div>', file=out_file)
 
 
 main() 

--- a/docs/format_howtos.py
+++ b/docs/format_howtos.py
@@ -51,7 +51,7 @@ def format_howto(input_file, output_file):
   # output HTML file, that can be inline included into any .rst
   # file.
   with open(output_file, 'w') as out_file:
-    # Add the relevant DIVs that Sphinx adds around code blocks
+    # Add the relevant DIVs that Sphinx adds around code blocks.
     print('<div class="highlight-default notranslate"><div class="highlight">',
         file=out_file)
     print('<pre class="code">', file=out_file)

--- a/docs/howtos-howto.md
+++ b/docs/howtos-howto.md
@@ -53,7 +53,6 @@ The workflow script for the Github action can be found at
 TODO: This is still in progress. Currently conflicts are resolved by
 checking whether the Github action fails, and if so, manually making
 the required fixes.
-</div>
 
 ## Modifying an existing HOWTO
 

--- a/docs/howtos-howto.md
+++ b/docs/howtos-howto.md
@@ -1,22 +1,8 @@
-# FLAX HOWTOs
+# HOWTOs HOWTO
 
-FLAX HOWTOs explain how to implement standard techiques in FLAX. For instance,
-the HOWTO for ensembling learning demonstrates what changes should be made to
-the standard MNIST example in order to train an ensemble of models. As such, 
-HOWTOs are simply "diffs".
-
-## List of HOWTOs
-
-In essence, a HOWTO is a set of changes that are applied to the FLAX master 
-branch on Github. HOWTOs are currently simply diff views between HOWTO branches 
-and the master branch. Soon, they will be merged with the rest of our 
-documentation through readthedocs.
-
-Currently the following HOWTOs are available:
-
-* [Distributed (multi-device) training](https://github.com/google-research/flax/compare/prerelease..howto-distributed-training?diff=split)
-* [Ensembling](https://github.com/google-research/flax/compare/prerelease..howto-ensembling?diff=split)
-* [Polyak averaging](https://github.com/google-research/flax/compare/prerelease..howto-polyak-averaging?diff=split)
+This document explains how the Flax HOWTO system works: How to submit
+new HOWTOs, modify existing ones, and fix HOWTOs when base examples
+change.
 
 ## How HOWTOs work
 
@@ -64,14 +50,16 @@ The workflow script for the Github action can be found at
 
 ## Resolving a conflict with an existing HOWTO
 
-> :warning: TODO: This is still in progress. Currently conflicts are resolved by
-            checking whether the Github action fails, and if so, manually making
-            the required fixes.
+TODO: This is still in progress. Currently conflicts are resolved by
+checking whether the Github action fails, and if so, manually making
+the required fixes.
+</div>
 
-## Modifying an exiting HOWTO
+## Modifying an existing HOWTO
 
-> :warning: TODO: Write this out. The summary is: apply a diff locally, make the
-            changes, pack the diff again and commit. It would be good to show 
-            this with an example. Note editing this diff is not a good idea 
-            since it is extremely error-prone.
+TODO: Write this out. The summary is: apply a diff locally, make the
+changes, pack the diff again and commit. It would be good to show 
+this with an example. Note editing this diff is not a good idea 
+since it is extremely error-prone.
+
 

--- a/docs/howtos.rst
+++ b/docs/howtos.rst
@@ -15,7 +15,7 @@ multiple devices.
 
 Note that these HOWTOs do not require special library support, they just
 demonstate how assembling the JAX and Flax primitives in different ways
-allow you to achieve various training loop modifications.
+allow you to make various training loop modifications.
 
 Currently the following HOWTOs are available:
 

--- a/docs/howtos.rst
+++ b/docs/howtos.rst
@@ -1,0 +1,53 @@
+Flax HOWTOs
+===========
+
+Flax aims to be a thin library of composable primitives. You compose
+these primites yourself into a training loop that you write and is fully under
+your control. You have full freedom to modify the behavior of your training loop,
+and you should generally not need special library support to implement
+the modifications you want.
+
+To help you get started, we show some sample diffs, which
+we call "HOWTOs". These HOWTOs show common modifications to training loops. For instance,
+the HOWTO for ensembling learning demonstrates what changes should be made to
+the standard MNIST example in order to train an ensemble of models on
+multiple devices.
+
+Note that these HOWTOs do not require special library support, they just
+demonstate how assembling the JAX and Flax primitives in different ways
+allow you to achieve various training loop modifications.
+
+Currently the following HOWTOs are available:
+
+Multi-device data-parallel training
+-----------------------------------
+
+⟶ `View as a side-by-side diff <https://github.com/google-research/flax/compare/prerelease..howto-distributed-training?diff=split>`_
+
+.. raw:: html
+   :file: _formatted_howtos/howto-distributed-training.diff.html
+
+
+Ensembling on multiple devices
+------------------------------
+
+`View as a side-by-side diff <https://github.com/google-research/flax/compare/prerelease..howto-ensembling?diff=split>`_
+
+.. raw:: html
+   :file: _formatted_howtos/howto-ensembling.diff.html
+
+
+Polyak averaging
+----------------
+
+`View as a side-by-side diff <https://github.com/google-research/flax/compare/prerelease..howto-polyak-averaging?diff=split>`_
+
+.. raw:: html
+   :file: _formatted_howtos/howto-polyak-averaging.diff.html
+
+
+How do HOWTOs work?
+-------------------
+
+Read the `HOWTOs HOWTO <howtos-howto.md>`_ to learn how we maintain HOWTOs.
+

--- a/howtos/diffs/howto-distributed-training.diff
+++ b/howtos/diffs/howto-distributed-training.diff
@@ -1,8 +1,8 @@
 diff --git a/examples/mnist/train.py b/examples/mnist/train.py
-index 51d2fde..08951b7 100644
+index 51d2fde..a9d7dcb 100644
 --- a/examples/mnist/train.py
 +++ b/examples/mnist/train.py
-@@ -23,10 +23,14 @@ from absl import app
+@@ -23,6 +23,9 @@ from absl import app
  from absl import flags
  from absl import logging
  
@@ -12,12 +12,7 @@ index 51d2fde..08951b7 100644
  from flax import nn
  from flax import optim
  
- import jax
-+from jax import lax
- from jax import random
- 
- import jax.numpy as jnp
-@@ -89,6 +93,7 @@ def create_model(key):
+@@ -89,6 +92,7 @@ def create_model(key):
  def create_optimizer(model, learning_rate, beta):
    optimizer_def = optim.Momentum(learning_rate=learning_rate, beta=beta)
    optimizer = optimizer_def.create(model)
@@ -25,29 +20,19 @@ index 51d2fde..08951b7 100644
    return optimizer
  
  
-@@ -101,17 +106,28 @@ def cross_entropy_loss(logits, labels):
+@@ -101,6 +105,11 @@ def cross_entropy_loss(logits, labels):
    return -jnp.mean(jnp.sum(onehot(labels) * logits, axis=-1))
  
  
--def compute_metrics(logits, labels):
 +def shard(xs):
 +  return jax.tree_map(
 +      lambda x: x.reshape((jax.device_count(), -1) + x.shape[1:]), xs)
 +
 +
-+def device_get_first(xs):
-+  return jax.device_get(jax.tree_map(lambda x: x[0], xs))
-+
-+
-+def compute_metrics(logits, labels, sharded):
+ def compute_metrics(logits, labels):
    loss = cross_entropy_loss(logits, labels)
    accuracy = jnp.mean(jnp.argmax(logits, -1) == labels)
-   metrics = {
-       'loss': loss,
-       'accuracy': accuracy,
-   }
-+  if sharded:
-+    metrics = lax.pmean(metrics, 'batch')
+@@ -111,7 +120,7 @@ def compute_metrics(logits, labels):
    return metrics
  
  
@@ -56,50 +41,41 @@ index 51d2fde..08951b7 100644
  def train_step(optimizer, batch):
    """Train for a single step."""
    def loss_fn(model):
-@@ -120,19 +136,25 @@ def train_step(optimizer, batch):
+@@ -120,8 +129,10 @@ def train_step(optimizer, batch):
      return loss, logits
    grad_fn = jax.value_and_grad(loss_fn, has_aux=True)
    (_, logits), grad = grad_fn(optimizer.target)
-+  grad = lax.pmean(grad, 'batch')
++  grad = jax.lax.pmean(grad, axis_name='batch')
    optimizer = optimizer.apply_gradient(grad)
--  metrics = compute_metrics(logits, batch['label'])
-+  metrics = compute_metrics(logits, batch['label'], sharded=True)
+   metrics = compute_metrics(logits, batch['label'])
++  metrics = jax.lax.pmean(metrics, axis_name='batch')
    return optimizer, metrics
  
  
- @jax.jit
- def eval_step(model, batch):
-   logits = model(batch['image'])
--  return compute_metrics(logits, batch['label'])
-+  return compute_metrics(logits, batch['label'], sharded=False)
- 
+@@ -133,6 +144,9 @@ def eval_step(model, batch):
  
  def train_epoch(optimizer, train_ds, batch_size, epoch, rng):
    """Train for a single epoch."""
-+  device_count = jax.device_count()
-+
-+  if batch_size % device_count > 0:
++  if batch_size % jax.device_count() > 0:
 +    raise ValueError('Batch size must be divisible by the number of devices')
 +
    train_ds_size = len(train_ds['image'])
    steps_per_epoch = train_ds_size // batch_size
  
-@@ -141,7 +163,7 @@ def train_epoch(optimizer, train_ds, batch_size, epoch, rng):
-   perms = perms.reshape((steps_per_epoch, batch_size))
+@@ -142,6 +156,7 @@ def train_epoch(optimizer, train_ds, batch_size, epoch, rng):
    batch_metrics = []
    for perm in perms:
--    batch = {k: v[perm] for k, v in train_ds.items()}
-+    batch = shard({k: v[perm] for k, v in train_ds.items()})
+     batch = {k: v[perm] for k, v in train_ds.items()}
++    batch = shard(batch)
      optimizer, metrics = train_step(optimizer, batch)
      batch_metrics.append(metrics)
  
-@@ -186,7 +208,9 @@ def train(train_ds, test_ds):
+@@ -186,7 +201,8 @@ def train(train_ds, test_ds):
    for epoch in range(1, num_epochs + 1):
      optimizer, _ = train_epoch(
          optimizer, train_ds, batch_size, epoch, input_rng)
 -    loss, accuracy = eval_model(optimizer.target, test_ds)
-+    # Fetch optimizers from devices, and pick the first (they are all the same)
-+    model = device_get_first(optimizer.target)
++    model = jax_utils.unreplicate(optimizer.target)  # Fetch from 1st device
 +    loss, accuracy = eval_model(model, test_ds)
      logging.info('eval epoch: %d, loss: %.4f, accuracy: %.2f',
                   epoch, loss, accuracy * 100)

--- a/howtos/diffs/howto-ensembling.diff
+++ b/howtos/diffs/howto-ensembling.diff
@@ -1,143 +1,82 @@
 diff --git a/examples/mnist/train.py b/examples/mnist/train.py
-index e93321f..55259db 100644
+index 51d2fde..a9d7dcb 100644
 --- a/examples/mnist/train.py
 +++ b/examples/mnist/train.py
-@@ -18,11 +18,11 @@ This script trains a simple Convolutional Neural Net on the MNIST dataset.
- The data is loaded using tensorflow_datasets.
- 
- """
--
- from absl import app
+@@ -23,6 +23,9 @@ from absl import app
  from absl import flags
  from absl import logging
  
++import functools
++
 +from flax import jax_utils
  from flax import nn
  from flax import optim
  
-@@ -85,9 +85,11 @@ def create_model(key):
-   return model
- 
- 
--def create_optimizer(model, learning_rate, beta):
--  optimizer_def = optim.Momentum(learning_rate=learning_rate, beta=beta)
--  optimizer = optimizer_def.create(model)
-+@jax.pmap
-+def create_optimizers(rng):
-+  optimizer_def = optim.Momentum(
-+      learning_rate=FLAGS.learning_rate, beta=FLAGS.momentum)
-+  optimizer = optimizer_def.create(create_model(rng))
+@@ -89,6 +92,7 @@ def create_model(key):
+ def create_optimizer(model, learning_rate, beta):
+   optimizer_def = optim.Momentum(learning_rate=learning_rate, beta=beta)
+   optimizer = optimizer_def.create(model)
++  optimizer = jax_utils.replicate(optimizer)
    return optimizer
  
  
-@@ -110,7 +112,7 @@ def compute_metrics(logits, labels):
+@@ -101,6 +105,11 @@ def cross_entropy_loss(logits, labels):
+   return -jnp.mean(jnp.sum(onehot(labels) * logits, axis=-1))
+ 
+ 
++def shard(xs):
++  return jax.tree_map(
++      lambda x: x.reshape((jax.device_count(), -1) + x.shape[1:]), xs)
++
++
+ def compute_metrics(logits, labels):
+   loss = cross_entropy_loss(logits, labels)
+   accuracy = jnp.mean(jnp.argmax(logits, -1) == labels)
+@@ -111,7 +120,7 @@ def compute_metrics(logits, labels):
    return metrics
  
  
 -@jax.jit
-+@jax.pmap
++@functools.partial(jax.pmap, axis_name='batch')
  def train_step(optimizer, batch):
    """Train for a single step."""
    def loss_fn(model):
-@@ -122,13 +124,13 @@ def train_step(optimizer, batch):
+@@ -120,8 +129,10 @@ def train_step(optimizer, batch):
+     return loss, logits
+   grad_fn = jax.value_and_grad(loss_fn, has_aux=True)
+   (_, logits), grad = grad_fn(optimizer.target)
++  grad = jax.lax.pmean(grad, axis_name='batch')
+   optimizer = optimizer.apply_gradient(grad)
+   metrics = compute_metrics(logits, batch['label'])
++  metrics = jax.lax.pmean(metrics, axis_name='batch')
    return optimizer, metrics
  
  
--@jax.jit
-+@jax.pmap
- def eval_step(model, batch):
-   logits = model(batch['image'])
-   return compute_metrics(logits, batch['label'])
+@@ -133,6 +144,9 @@ def eval_step(model, batch):
  
- 
--def train_epoch(optimizer, train_ds, batch_size, epoch, rng):
-+def train_epoch(optimizers, train_ds, batch_size, epoch, rng):
+ def train_epoch(optimizer, train_ds, batch_size, epoch, rng):
    """Train for a single epoch."""
++  if batch_size % jax.device_count() > 0:
++    raise ValueError('Batch size must be divisible by the number of devices')
++
    train_ds_size = len(train_ds['image'])
    steps_per_epoch = train_ds_size // batch_size
-@@ -139,25 +141,27 @@ def train_epoch(optimizer, train_ds, batch_size, epoch, rng):
+ 
+@@ -142,6 +156,7 @@ def train_epoch(optimizer, train_ds, batch_size, epoch, rng):
    batch_metrics = []
    for perm in perms:
      batch = {k: v[perm] for k, v in train_ds.items()}
--    optimizer, metrics = train_step(optimizer, batch)
-+    batch = jax_utils.replicate(batch)
-+    optimizers, metrics = train_step(optimizers, batch)
++    batch = shard(batch)
+     optimizer, metrics = train_step(optimizer, batch)
      batch_metrics.append(metrics)
  
-   # compute mean of metrics across each batch in epoch.
-   batch_metrics_np = jax.device_get(batch_metrics)
-+  batch_metrics_np = jax.tree_multimap(lambda *xs: onp.array(xs),
-+                                       *batch_metrics_np)
-   epoch_metrics_np = {
--      k: onp.mean([metrics[k] for metrics in batch_metrics_np])
--      for k in batch_metrics_np[0]}
--
--  logging.info('train epoch: %d, loss: %.4f, accuracy: %.2f', epoch,
-+      k: onp.mean(batch_metrics_np[k], axis=0) for k in batch_metrics_np
-+  }
-+  logging.info('train epoch: %d, loss: %s, accuracy: %s', epoch,
-                epoch_metrics_np['loss'], epoch_metrics_np['accuracy'] * 100)
- 
--  return optimizer, epoch_metrics_np
-+  return optimizers, epoch_metrics_np
- 
- 
--def eval_model(model, test_ds):
--  metrics = eval_step(model, test_ds)
-+def eval_model(models, test_ds):
-+  metrics = eval_step(models, test_ds)
-   metrics = jax.device_get(metrics)
--  summary = jax.tree_map(lambda x: x.item(), metrics)
-+  summary = metrics
-   return summary['loss'], summary['accuracy']
- 
- 
-@@ -175,18 +179,18 @@ def train(train_ds, test_ds):
-   batch_size = FLAGS.batch_size
-   num_epochs = FLAGS.num_epochs
- 
--  model = create_model(rng)
--  optimizer = create_optimizer(model, FLAGS.learning_rate, FLAGS.momentum)
-+  optimizers = create_optimizers(random.split(rng, jax.device_count()))
- 
-   input_rng = onp.random.RandomState(0)
-+  test_ds = jax_utils.replicate(test_ds)
- 
+@@ -186,7 +201,8 @@ def train(train_ds, test_ds):
    for epoch in range(1, num_epochs + 1):
--    optimizer, _ = train_epoch(
--        optimizer, train_ds, batch_size, epoch, input_rng)
+     optimizer, _ = train_epoch(
+         optimizer, train_ds, batch_size, epoch, input_rng)
 -    loss, accuracy = eval_model(optimizer.target, test_ds)
--    logging.info('eval epoch: %d, loss: %.4f, accuracy: %.2f',
--                 epoch, loss, accuracy * 100)
--  return optimizer
-+    optimizers, _ = train_epoch(optimizers, train_ds, batch_size, epoch,
-+                                input_rng)
-+    loss, accuracy = eval_model(optimizers.target, test_ds)
-+    logging.info('eval epoch: %d, loss: %s, accuracy: %s', epoch, loss,
-+                 accuracy * 100)
-+  return optimizers
- 
- 
- def main(_):
-diff --git a/examples/mnist/train_test.py b/examples/mnist/train_test.py
-index eee3c3d..88fa4be 100644
---- a/examples/mnist/train_test.py
-+++ b/examples/mnist/train_test.py
-@@ -33,13 +33,12 @@ class TrainTest(absltest.TestCase):
-   def test_train_one_epoch(self):
-     train_ds, test_ds = train.get_datasets()
-     input_rng = onp.random.RandomState(0)
--    model = train.create_model(random.PRNGKey(0))
--    optimizer = train.create_optimizer(model, 0.1, 0.9)
--    optimizer, train_metrics = train.train_epoch(optimizer, train_ds, 128, 0,
--                                                 input_rng)
-+    optimizers = train.create_optimizers(random.split(random.PRNGKey(0), 1))
-+    optimizers, train_metrics = train.train_epoch(optimizers, train_ds, 128, 0,
-+                                                  input_rng, 1)
-     self.assertLessEqual(train_metrics['loss'], 0.27)
-     self.assertGreaterEqual(train_metrics['accuracy'], 0.92)
--    loss, accuracy = train.eval_model(optimizer.target, test_ds)
-+    loss, accuracy = train.eval_model(optimizers.target, test_ds, 1)
-     self.assertLessEqual(loss, 0.06)
-     self.assertGreaterEqual(accuracy, 0.98)
- 
++    model = jax_utils.unreplicate(optimizer.target)  # Fetch from 1st device
++    loss, accuracy = eval_model(model, test_ds)
+     logging.info('eval epoch: %d, loss: %.4f, accuracy: %.2f',
+                  epoch, loss, accuracy * 100)
+   return optimizer


### PR DESCRIPTION
1. Render HOWTOs as nicely formatted inline diffs in docs.
   These diffs are syntax highlighted for both Python and diffs

2. Simplify the multi-device parallel training HOWTO

3. Re-pack the ensembling diff. (Once I applied it and re-packed it
   it got a lot shorter… I wonder if this is something we need to do
   for every commit?)

4. Make the HOWTO docs page directly show HOWTOs, and separate the
   mechanics of the HOWTO system into a separate “HOWTOs HOWTO” page.

5. Modify the pack_howto_diffs.sh script to only pack changes in
   examples/. This significantly simplified the process of iterating
   on HOWTO diffs.