### PR TITLE
[draft] improve module method api

### DIFF
--- a/flax/nn/base.py
+++ b/flax/nn/base.py
@@ -149,12 +149,10 @@ def module_method(fn):
 
       @nn.module_method
       def encode(self, x):
-        encoder, _ = self._create_modules(**hparams)
         return self.encoder(x)
 
       @nn.module_method
       def decode(self, x):
-        _, decoder = self._create_modules(**hparams)
         return self.decoder(x)
 
   A module method can be called on A Model instance directly::

--- a/flax/nn/utils.py
+++ b/flax/nn/utils.py
@@ -54,14 +54,20 @@ class CallStack(object):
 
 
 def classproperty(f):
-  """decorator that registers a function as a read-only property of the class."""
+  """decorator that registers a function as a read-only property of the class.
+  Args:
+    f: a function taking the class and an optional class instance
+      and returns the value of the property.
+  Returns:
+    The property.
+  """
 
   class _ClassProperty:
 
-    def __get__(self, _, cls):
+    def __get__(self, instance, cls):
       # python will call the __get__ magic function whenever the property is
       # read from the class.
-      return f(cls)
+      return f(cls, instance)
 
   return _ClassProperty()
 

--- a/tests/nn_test.py
+++ b/tests/nn_test.py
@@ -252,7 +252,8 @@ class ModuleTest(absltest.TestCase):
     class MultiMethod(nn.Module):
 
       def apply(self, x):
-        return x + self.param('bias', x.shape, initializers.ones)
+        y = x + self.param('bias', x.shape, initializers.ones)
+        return y, self.l2()
 
       @nn.module_method
       def l2(self):
@@ -262,12 +263,13 @@ class ModuleTest(absltest.TestCase):
 
       def apply(self, x):
         layer = MultiMethod.shared()
-        layer(x)  # init
-        return layer.l2()
+        _, l2 = layer(x)  # init
+        return layer.l2(), l2
 
     x = jnp.array([1., 2.])
-    y, _ = MultiMethodModel.init(random.PRNGKey(0), x)
-    self.assertEqual(y, 2.)
+    (l2, l2_2), _ = MultiMethodModel.init(random.PRNGKey(0), x)
+    self.assertEqual(l2, 2.)
+    self.assertEqual(l2_2, 2.)
 
   def test_module_state(self):
     class StatefulModule(nn.Module):

--- a/tests/nn_test.py
+++ b/tests/nn_test.py
@@ -271,6 +271,21 @@ class ModuleTest(absltest.TestCase):
     self.assertEqual(l2, 2.)
     self.assertEqual(l2_2, 2.)
 
+  def test_module_with_init_method(self):
+    class InitModel(nn.Module):
+
+      def __init__(self, features):
+        self.fc = nn.Dense.shared(features=features, name='fc',
+                                  kernel_init=initializers.ones)
+
+      def apply(self, x):
+        return self.fc(x)
+
+    model_def = InitModel.partial(features=1)
+    x = jnp.array([1., 2.])
+    y, _ = model_def.init(random.PRNGKey(0), x)
+    self.assertEqual(y.reshape(()).item(), 3.)
+
   def test_module_state(self):
     class StatefulModule(nn.Module):
 


### PR DESCRIPTION
This PR adds the following features:
- `__init__` is called on Module construction and can declare keyword arguments. these keyword arguments are not passed to apply or other module methods.
- module methods can be called like normal methods on the instance (eg. `self.encode`)

auto encoder example:
```
class AutoEncoder(nn.Module):

  def __init__(self, encoder_features, decoder_features):
    self.encoder = nn.Dense.shared(features=encoder_features, name='encoder')
    self.decoder = nn.Dense.shared(features=decoder_features, name='decoder')

  def apply(self, x):
    z = self.encode(x)
    return self.decode(z)

  @nn.module_method
  def encode(self, x):
    return self.encoder(x)

  @nn.module_method
  def decode(self, x):
    return self.decoder(x)
```