### PR TITLE
Update CIFAR10 example

### DIFF
--- a/examples/cifar10/README.md
+++ b/examples/cifar10/README.md
@@ -1,142 +1,52 @@
-# CIFAR-10 examples for Flax
+## CIFAR10 classification
+Trains a **family** ResNet-style models (He *et al.*, 2015; Zagoruyko and Komodakis, 2017; Han *et al.*, 2017) for the CIFAR10 classification task (Krizhevsky, 2009).
 
-Adapted from the Flax ImageNet example by Geoff French.
+This example implements several architectures, regularization methods (Gastaldi, 2017; Yamada *et al.*, 2018) and learning rate schedules that can be used in various combinations.
 
-We provide various experiments you can run to re-create Wide ResNet results
-found in the literature. We also provide a PyramidNet implementation,
-although it does not achieve published results.
+### Requirements
+* TensorFlow dataset `cifar10`
 
+### Supported setups
+The model should run with other configurations and hardware, but explicitly tested on the following.
 
-## How to run
+#### Wide ResNet: 26 layers, 10x width (Zagoruyko and Komodakis, 2017)
+| Hardware | Epochs | Learning rate | Training time | Error rate | TensorBoard.dev |
+| --- | --- | --- | --- | --- | --- |
+| 1 x Nvidia V100 (16GB) | 200 | Piece-wise constant | 4h 36m | 4.45% | [2020-03-22](https://tensorboard.dev/experiment/1kE2bq9RR7WrT7Zw14fNpg/) |
+| 8 x Nvidia V100 (16GB) | 200 | Piece-wise constant | 57m | 3.93% | [2020-03-22](https://tensorboard.dev/experiment/IpzU0txnR7uZnExGmk7IEA/) |
 
-A full description of the command line arguments available is given later.
-We will now give some examples for re-creating results from various papers.
+#### Wide ResNet: 26 layers, 6x width, Shake-Shake regularization (Gastaldi, 2017)
+| Hardware | Epochs | Learning rate | Training time | Error rate | TensorBoard.dev |
+| 1 x Nvidia V100 (16GB) | 200 | Piece-wise constant | 3h 38m | 3.43% | [2020-03-22](https://tensorboard.dev/experiment/dJc9e4k1R5mC0DPVZyYrpg/) |
+| 8 x Nvidia V100 (16GB) | 200 | Piece-wise constant | 54m | 3.39% | [2020-03-26](https://tensorboard.dev/experiment/l2CPAqpnTlCjjZKbnuOomg/) |
+| 1 x Nvidia V100 (16GB) | 1800 | Cosine | 1d 9h 25m | 2.97% | [2020-03-22](https://tensorboard.dev/experiment/aXyhYX2oSxKH5lIlj4Ao5g/) |
+| 8 x Nvidia V100 (16GB) | 1800 | Cosine | 8h 5m | 2.82% | [2020-03-26](https://tensorboard.dev/experiment/kq303ri1RHygWxb5YrLp1Q/) |
 
+#### PyramidNet, Shake-drop regularization (Han *et al.*, 2017; Yamada *et al.*, 2018)
+| 8 x Nvidia V100 (16GB) | 300 | Piece-wise constant | 6h 41m | 3.25% | [2020-03-24](https://tensorboard.dev/experiment/OpZLDnVjRhmJKXq62RoaUQ/) |
+| 8 x Nvidia V100 (16GB) | 1800 | Cosine | 1d 16h 27m | 2.75% | [2020-03-24](https://tensorboard.dev/experiment/MNyJ2ixAROmFlVnbUxp29w/) |
 
-### Wide ResNet
+### How to run
+All models were trained with a global batch size of `256`.
 
-See https://arxiv.org/abs/1605.07146
+#### Wide ResNet: 26 layers, 10x width
+`python train.py --arch=wrn26_10 --model_dir=./cifar10_wrn26_10_bs=256_lr=0.1`
 
-We provide a Wide ResNet architecture, implemented in `models/wideresnet.py`.
-A wide ResNet with 26 layers and 10x width is chosen by passing the value
-`wrn26_10` as the `arch` command line argument. We use the default training
-schedule; we train for 200 epochs and drop the learning rate by a factor of
-0.2 at epochs 60, 120 and 160. Training on 8 TPUv2 cores took 1 hour 10
-minutes. We got 3.87% error, the paper reports 3.89%:
+#### Wide ResNet: 26 layers, 6x width, Shake-shake regularization
+`python train.py --arch=wrn26_6_ss --model_dir=./cifar10_wrn26_6_ss_bs=256_lr=0.1`
+or
+`python train.py --arch=wrn26_6_ss --lr_schedule=cosine --num_epochs=1800 --model_dir=./cifar10_wrn26_6_ss_bs=256_lr=cosine_epochs=1800`
 
-```
-> python train.py --arch=wrn26_10
-```
+#### PyramidNet, Shake-drop regularization
+`python train.py --arch=pyramid --lr_sched_steps="[[150,0.1],[225,0.01]]" --num_epochs=300 --l2_reg=0.0001 --model_dir=./cifar10_pyramid_bs=256_lr=0.1_l2=0.0001_epoch=300`
+or
+`python train.py --arch=pyramid --lr_sched_steps=cosine --num_epochs=1800 --l2_reg=0.0001 --model_dir=./cifar10_pyramid_bs=256_lr=cosine_l2=0.0001_epochs=1800`
 
+## Known issues
+L2 regularization is applied to model kernels *and* biases, instead of only being applied to kernels.
 
-### Wide ResNet with shake-shake regularization
-
-See https://arxiv.org/abs/1705.07485
-
-We provide a Wide ResNet architecture with shake-shake. It is implemented in
-`models/wideresnet_shakeshake.py`. Pass `wrn26_6_ss` as the `arch` command line
-argument to use it.
-
-To re-create the results in the paper, we apply cosine annealing to the
-learning rate and run for 1800 epochs. Training on 8 TPUv2 cores took 7 hours
-57 minutes. We got 2.7% error, the paper reports 2.86%:
-
-```
-> python train.py --arch=wrn26_6_ss --lr_schedule=cosine --num_epochs=1800
-```
-
-Alternatively you can use a standard Wide ResNet learning rate schedule
-described above. Training on 8 TPUv2 cores took 53 minutes. We got
-3.29% error:
-
-```
-> python train.py --arch=wrn26_6_ss
-```
-
-
-### Pyramid Net with ShakeDrop regularization
-
-PyramidNet: https://arxiv.org/abs/1610.02915
-ShakeDrop regularization: https://arxiv.org/abs/1802.02375
-
-We provide a Pyramid net architecture with shake-drop. It is implemented in
-`models/pyramidnet.py`. Pass `pyramid` as the `arch` command line
-argument to use it.
-
-Unfortunately we do not match the results in the literature.
-
-To re-create the experimental conditions in the ShakeDrop paper, use a value
-of 0.0001 for L2-regularization, train for 300 epochs and drop the learning
-rate by a factor of 0.1 at epochs 150 and 225. Training on 8 TPUv2 cores
-took 12 hours. We got 3.26% error, the PyramidNet paper reports 3.31%, and
-the ShakeDrop paper reports 3.08% for this configuration.
-
-```
-> python train.py --arch=pyramid --lr_sched_steps="[[150,0.1],[225,0.01]]" \
-    --num_epochs=300 --l2_reg=0.0001
-```
-
-Alternatively you can apply cosine annealing to the learning rate and run for
-1800 epochs. Training on 8 TPUv2 cores took 3 days 26 minutes. We got 2.64%
-error. The Fast AutoAugment code repo reports 2.7% error
-(https://github.com/kakaobrain/fast-autoaugment).
-
-```
-> python train.py --arch=pyramid --lr_schedule=cosine --num_epochs=1800 \
-    --l2_reg=0.0001
-```
-
-
-## Command line arguments
-
-The network architecture and training regime and be controlled via command
-line arguments:
-
-- `--learning_rate` (default=0.1): set the initial learning rate
-- `--momentum` (default=0.9): the momentum value used for SGD
-- `--lr_schedule`: Choose the learning rate schedule:
-  -  `constant`: a constant learning rate
-  -  `stepped` (default): a stepped learning rate that
-        changes the learning rate at specific points during training
-  -  `cosine`: anneal the learning rate with half a cosine wave
-- `--lr_sched_steps` (default=`[[60, 0.2], [120, 0.04], [160, 0.008]]`):
-    Define the steps used for a stepped learning rate the steps are specified
-    using Python syntax; e.g. to drop the LR by a factor of 0.1 at epochs 60,
-    120 and 160 use:
-    `--lr_sched_steps="[[60, 0.1], [120, 0.01], [160, 0.001]]"`
-- `--num_epochs` (default=200): the number of epochs to train for
-- `--l2_reg` (default=0.005): the amount of L2 regularization to apply
-    (on all parameters)
-- `--batch_size` (default=256): mini-batch size
-- `--arch` (default=wrn26_10): network architecture
-  -  `wrn26_10`: Wide ResNet, 26 layers, 10x width
-  -  `wrn26_6_ss`: Wide ResNeXt, 26 2x96d with shake-shake regularization
-  -  `pyramid`: PyramidNet, pyramid alpha=200, 272 layers, ShakeDrop
-        regularization
-- `--wrn_dropout_rate` (default=0.3): DropOut rate used in Wide ResNet
-    (on all residual blocks)
-- `--rng` (default=0): Random seed used for network initialization and
-    stochasticity during training
-
-
-## Issues
-
-We apply L2 regularization to weights and biases, whereas it is mostly *not*
-applied to biases.
-
-
-## References
-
-Various code was used as a reference to help replicate baseline results.
-In particular the Fast AutoAugment codebase was particularly helpful
-as its config files describe training regimes for the wide ResNet
-with shake-shake and PyramidNet baselines.
-
-Shake-shake author's implementation:
-https://github.com/xgastaldi/shake-shake
-
-PyTorch implementation of shake-shake:
-https://github.com/owruby/shake-shake_pytorch
-
-Fast AutoAugment that uses a number of different models:
-https://github.com/kakaobrain/fast-autoaugment
+### References
+This example consulted the following open-source repositories for implementation details and hyper-parameters:
+* [Shake-shake author's implementation](https://github.com/xgastaldi/shake-shake)
+* [PyTorch implementation of shake-shake](https://github.com/owruby/shake-shake_pytorch)
+* [Fast AutoAugment that uses a number of different models](https://github.com/kakaobrain/fast-autoaugment)

--- a/examples/cifar10/README.md
+++ b/examples/cifar10/README.md
@@ -17,12 +17,15 @@ The model should run with other configurations and hardware, but explicitly test
 
 #### Wide ResNet: 26 layers, 6x width, Shake-Shake regularization (Gastaldi, 2017)
 | Hardware | Epochs | Learning rate | Training time | Error rate | TensorBoard.dev |
+| --- | --- | --- | --- | --- | --- |
 | 1 x Nvidia V100 (16GB) | 200 | Piece-wise constant | 3h 38m | 3.43% | [2020-03-22](https://tensorboard.dev/experiment/dJc9e4k1R5mC0DPVZyYrpg/) |
 | 8 x Nvidia V100 (16GB) | 200 | Piece-wise constant | 54m | 3.39% | [2020-03-26](https://tensorboard.dev/experiment/l2CPAqpnTlCjjZKbnuOomg/) |
 | 1 x Nvidia V100 (16GB) | 1800 | Cosine | 1d 9h 25m | 2.97% | [2020-03-22](https://tensorboard.dev/experiment/aXyhYX2oSxKH5lIlj4Ao5g/) |
 | 8 x Nvidia V100 (16GB) | 1800 | Cosine | 8h 5m | 2.82% | [2020-03-26](https://tensorboard.dev/experiment/kq303ri1RHygWxb5YrLp1Q/) |
 
 #### PyramidNet, Shake-drop regularization (Han *et al.*, 2017; Yamada *et al.*, 2018)
+| Hardware | Epochs | Learning rate | Training time | Error rate | TensorBoard.dev |
+| --- | --- | --- | --- | --- | --- |
 | 8 x Nvidia V100 (16GB) | 300 | Piece-wise constant | 6h 41m | 3.25% | [2020-03-24](https://tensorboard.dev/experiment/OpZLDnVjRhmJKXq62RoaUQ/) |
 | 8 x Nvidia V100 (16GB) | 1800 | Cosine | 1d 16h 27m | 2.75% | [2020-03-24](https://tensorboard.dev/experiment/MNyJ2ixAROmFlVnbUxp29w/) |
 

--- a/examples/cifar10/input_pipeline.py
+++ b/examples/cifar10/input_pipeline.py
@@ -12,8 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""CIFAR-10 input pipeline.
-"""
+"""CIFAR-10 input pipeline."""
 
 import tensorflow.compat.v2 as tf
 import tensorflow_datasets as tfds

--- a/examples/cifar10/models/pyramidnet.py
+++ b/examples/cifar10/models/pyramidnet.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""PyramidNet with Shake-Drop."""
+"""PyramidNet with shake-drop."""
 
 from flax import nn
 from models import utils

--- a/examples/cifar10/models/utils.py
+++ b/examples/cifar10/models/utils.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Shake-shake and dhake-drop functions."""
+"""Shake-shake and shake-drop functions."""
 
 import flax.nn
 import jax

--- a/examples/cifar10/models/utils.py
+++ b/examples/cifar10/models/utils.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Shake-shake and ShakeDrop functions."""
+"""Shake-shake and dhake-drop functions."""
 
 import flax.nn
 import jax

--- a/examples/cifar10/models/wideresnet.py
+++ b/examples/cifar10/models/wideresnet.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Wide Resnet Model for CIFAR-10 image classification."""
+"""Wide ResNet model for CIFAR-10 image classification."""
 
 from flax import nn
 import jax

--- a/examples/cifar10/models/wideresnet_shakeshake.py
+++ b/examples/cifar10/models/wideresnet_shakeshake.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Wide Resnet Model with shake-shake regularization."""
+"""Wide ResNet model with shake-shake regularization."""
 
 from flax import nn
 from models import utils

--- a/examples/cifar10/train.py
+++ b/examples/cifar10/train.py
@@ -12,29 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""CIFAR-10 example.
-
-This script trains a classifier on the CIFAR-10 dataset.
-
-One of the following models can be used:
-- Wide ResNet, 26 layers, 2x width factor
-- Wide ResNet, 26 layers, 10x width factor
-- Wide ResNet, 26 layers, 6x width factor with shake-shake regularization
-- PyramidNet with Shake-Drop regularization
-
-The data is loaded using tensorflow_datasets.
-
-References used:
-
-Shake-shake author's implementation:
-https://github.com/xgastaldi/shake-shake
-
-PyTorch implementation of shake-shake:
-https://github.com/owruby/shake-shake_pytorch
-
-Fast AutoAugment that uses a number of different models:
-https://github.com/kakaobrain/fast-autoaugment
-"""
+"""CIFAR-10 example."""
 
 import ast
 import functools

--- a/examples/nlp_seq/README.md
+++ b/examples/nlp_seq/README.md
@@ -19,13 +19,13 @@ From|ADP the|DT AP|PROPN comes|VBZ this|DT story|NN :|:
 ### Supported setups
 The model should run with other configurations and hardware, but explicitly tested on the following.
 
-| Hardware |  Batch size  | Learning rate | Steps/Second | Accuracy  | TensorBoard |
+| Hardware |  Batch size  | Learning rate | Training time | Accuracy  | TensorBoard.dev |
 |:---:|:---:|:---:|:---:|:---:|:---:|
-| TITAN V  | 64  |  0.05 | 3.3  | 71.73% | comming soon |
+| Nvidia V100 (16GB) | 64  |  0.05 |  1d 11h 11m  | 72.20% | [2020-03-22](https://tensorboard.dev/experiment/IyswaKpRQbOpk0AfLwBu3A/) |
 
 ### Running 
 ```
 python train.py --batch_size=64 --model_dir=model_dir \
-    --dev=ud-treebanks-conll2017/UD_Ancient_Greek/grc-ud-dev.conll \
-    --train=ud-treebanks-conll2017/UD_Ancient_Greek/grc-ud-train.conllu
+    --dev=ud-treebanks-v2.0/UD_Ancient_Greek/grc-ud-dev.conllu \
+    --train=ud-treebanks-v2.0/UD_Ancient_Greek/grc-ud-train.conllu
 ```


### PR DESCRIPTION
* Added TB.dev logs for 8x and 1x V100 GPU runs
* Added corresponding wall time
* Nit changes to the training scripts
* Re-structured the README