### PR TITLE
Add test requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,8 @@ install_requires = [
 ]
 
 tests_require = [
+    "pytest",
+    "tensorflow_datasets",
 ]
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ install_requires = [
 
 tests_require = [
     "pytest",
+    "pytest-xdist",
     "tensorflow_datasets",
 ]
 

--- a/tests/run_all_tests.sh
+++ b/tests/run_all_tests.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 pytest -n 4 tests -W ignore
 
 # we apply pytest within each example to avoid pytest's annoying test-filename collision.


### PR DESCRIPTION
Hi from Google Princeton! Just started to look at `flax`; thanks for working on this! Tiny, tiny contribution, but it did take a moment for me to figure out how to run tests.

Additions:
1. **Added test requirements to `setup.py`**: there should also probably be some documentation on how to set up a development environment, but I didn't add because I'm not sure where you'd want to add (e.g., `dev`, `contributing.md`, somewhere else)
2. **Added `bash` to `tests/run_all_tests.sh`**: very minor detail, but I use `zsh` and the test script fails for me without this line. Shouldn't break anything existing.

I did notice that running `pytest tests` via `pytest-xdist` caused a lot of failures related to `cuda`, but haven't looked into them yet. Running `pytest` without the `-n 4` flag works fine.