### PR TITLE
run_all_tests.sh should die on failure.

### DIFF
--- a/tests/nn_test.py
+++ b/tests/nn_test.py
@@ -542,9 +542,9 @@ class NormalizationTest(absltest.TestCase):
       y = model(x)
     ema = state['/']
     onp.testing.assert_allclose(
-        ema['mean'], 0.1 * x.mean((0, 1), keepdims=True), atol=1e-4)
+        ema['mean'], 0.1 * x.mean((0, 1), keepdims=False), atol=1e-4)
     onp.testing.assert_allclose(
-        ema['var'], 0.9 + 0.1 * x.var((0, 1), keepdims=True), rtol=1e-4)
+        ema['var'], 0.9 + 0.1 * x.var((0, 1), keepdims=False), rtol=1e-4)
 
   def test_layer_norm(self):
     rng = random.PRNGKey(0)

--- a/tests/run_all_tests.sh
+++ b/tests/run_all_tests.sh
@@ -1,14 +1,30 @@
 #!/bin/bash
 
+# Instead of using set -e, we have a manual error trap that
+# exits for any error code != 5 since pytest returns error code 5
+# for no found tests. (We may force minimal test coverage in examples
+# in the future!)
+trap handle_errors ERR
+handle_errors () {
+    ret="$?"
+    if [[ "$ret" == 5 ]]; then
+      echo "error code $ret == no tests found"
+    else
+      echo "error code $ret"
+      exit 1
+    fi
+}
+
+# Run battery of core FLAX API tests.
 pytest -n 4 tests -W ignore
 
+# Per-example tests.
 # we apply pytest within each example to avoid pytest's annoying test-filename collision.
 # In pytest foo/bar/baz_test.py and baz/bleep/baz_test.py will collide and error out when
 # /foo/bar and /baz/bleep aren't set up as packages.
 for egd in $(find examples -maxdepth 1 -mindepth 1 -type d); do
     pytest $egd -W ignore
-    # Pytest returns error code 5 for no found tests, but don't forward this as an error.
-    # We may remove this to force minimal test coverage in the future!
-    ret=$?
-    if [[ "$ret" != 0 ]] && [[ "$ret" != 5 ]]; then exit 1; fi
 done
+
+# Return error code 0 if no real failures happened.
+echo "finished all tests."


### PR DESCRIPTION
Since factoring out the test script, we have silent failures happening now because several test commands are run - only the last one failing would be counted as a failure before.  This is the fix. (and there's an existing batchnorm test failure exposed now - that's not fixed here.)