### PR TITLE
Use better default names for Module tree.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ v0.1
  - Rename the following optional arguments to nn.linear.Conv:
      `lhs_dilation` -> `input_dilation`,
      `rhs_dilation` -> `kernel_dilation`
+ - Change default layer names from numbers '0', '1', etc. to
+   include the Module class name, e.g. 'Dense_0', 'LayerNorm_1'.
 
 ### More
 ...

--- a/flax/nn/base.py
+++ b/flax/nn/base.py
@@ -258,7 +258,7 @@ class Module(metaclass=_ModuleMeta):
     elif cls._is_shared():
       raise ValueError('Cannot override the name of a shared module')
     if name is None:  # also no default name
-      name = parent.create_name()
+      name = cls.__name__ + '_' + parent.create_name()
     cls._check_name(name, parent)
     if parent.is_init and name not in parent.params:
       rng = _fold_in_str(parent.rng, name)
@@ -744,7 +744,7 @@ class TruncatedModule(TransparentModule):
       raise ValueError(
           '`wrapped_module` and `truncate_path` are required keyword arguments')
     with capture_module_outputs() as module_outputs:
-      wrapped_module(*args, **kwargs)
+      wrapped_module(*args, **kwargs, name='0')
 
     def lookup_output(path):
       return module_outputs[path]


### PR DESCRIPTION
Currently the default parameter tree for Flax models is a bit opaque.  This changes the layer/parameter tree structure to use the Module classname in its 'default' layer name:

```python
{'0': {'pos_embedding': (1, 100, 64)},
 '1': {'0': {'bias': (64,), 'scale': (64,)},
  '1': {'key': {'kernel': (64, 2, 32)},
   'out': {'kernel': (2, 32, 64)},
   'query': {'kernel': (64, 2, 32)},
   'value': {'kernel': (64, 2, 32)}},
  '2': {'bias': (64,), 'scale': (64,)},
  '3': {'0': {'bias': (256,), 'kernel': (64, 256)},
   '1': {'bias': (64,), 'kernel': (256, 64)}}},
 '2': {'0': {'bias': (64,), 'scale': (64,)},
  '1': {'key': {'kernel': (64, 2, 32)},
   'out': {'kernel': (2, 32, 64)},
   'query': {'kernel': (64, 2, 32)},
   'value': {'kernel': (64, 2, 32)}},
  '2': {'bias': (64,), 'scale': (64,)},
  '3': {'0': {'bias': (256,), 'kernel': (64, 256)},
   '1': {'bias': (64,), 'kernel': (256, 64)}}},
 '3': {'bias': (64,), 'scale': (64,)},
 '4': {'bias': (256,), 'kernel': (64, 256)},
 'embed': {'embedding': (256, 64)}}
```

to this:

```python
{'AddPositionEmbs_0': {'pos_embedding': (1, 100, 64)},
 'Dense_4': {'bias': (256,), 'kernel': (64, 256)},
 'LayerNorm_3': {'bias': (64,), 'scale': (64,)},
 'Transformer1DBlock_1': {'LayerNorm_0': {'bias': (64,), 'scale': (64,)},
  'LayerNorm_2': {'bias': (64,), 'scale': (64,)},
  'MlpBlock_3': {'Dense_0': {'bias': (256,), 'kernel': (64, 256)},
   'Dense_1': {'bias': (64,), 'kernel': (256, 64)}},
  'MultiHeadDotProductAttention_1': {'key': {'kernel': (64, 2, 32)},
   'out': {'kernel': (2, 32, 64)},
   'query': {'kernel': (64, 2, 32)},
   'value': {'kernel': (64, 2, 32)}}},
 'Transformer1DBlock_2': {'LayerNorm_0': {'bias': (64,), 'scale': (64,)},
  'LayerNorm_2': {'bias': (64,), 'scale': (64,)},
  'MlpBlock_3': {'Dense_0': {'bias': (256,), 'kernel': (64, 256)},
   'Dense_1': {'bias': (64,), 'kernel': (256, 64)}},
  'MultiHeadDotProductAttention_1': {'key': {'kernel': (64, 2, 32)},
   'out': {'kernel': (2, 32, 64)},
   'query': {'kernel': (64, 2, 32)},
   'value': {'kernel': (64, 2, 32)}}},
 'embed': {'embedding': (256, 64)}}
```

note these aren't in sorted order, but the numerical suffix continues to refer to the linear position inside the parent layer.