### PR TITLE
remove jaxlib dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,6 @@ except IOError:
 
 install_requires = [
     "numpy>=1.12",
-    "jaxlib>=0.1.41",
     "jax>=0.1.59",
     "matplotlib",  # only needed for tensorboard export
     "dataclasses",  # will only install on py3.6


### PR DESCRIPTION
jaxlib should not be installed automatically because users have a choice between
cpu-only/gpu and different cuda versions.

Jax also doesn't include jaxlib as a dependency in setup.py