### PR TITLE
set __qualname__ for partial, shared, and module_method.

### DIFF
--- a/flax/nn/base.py
+++ b/flax/nn/base.py
@@ -181,6 +181,7 @@ def module_method(fn):
       class ModuleMethod(cls):
         apply = fn
       ModuleMethod.__name__ = fn.__name__
+      ModuleMethod.__qualname__ = f'{cls.__qualname__}.{fn.__name__}'
       cache[cls] = ModuleMethod
     return cache[cls]
 
@@ -321,6 +322,7 @@ class Module(metaclass=_ModuleMeta):
         return parent
 
     SharedModule.__name__ = class_.__name__
+    SharedModule.__qualname__ = class_.__qualname__
 
     return SharedModule
 
@@ -373,6 +375,7 @@ class Module(metaclass=_ModuleMeta):
         return super()._extend_kwargs(extended_kwargs)
     # __doc__ is handled by the Module meta class
     PartialModule.__name__ = class_.__name__
+    PartialModule.__qualname__ = class_.__qualname__
 
     return PartialModule
 

--- a/tests/nn_test.py
+++ b/tests/nn_test.py
@@ -197,6 +197,8 @@ class ModuleTest(absltest.TestCase):
     rng = random.PRNGKey(0)
     x = jnp.array([1.])
     dummy_module = DummyModule.partial(x=x)  # partially apply the inputs
+    self.assertEqual(DummyModule.__name__, dummy_module.__name__)
+    self.assertEqual(DummyModule.__qualname__, dummy_module.__qualname__)
     y, initial_params = dummy_module.init(rng)
     model = nn.Model(dummy_module, initial_params)
     y2 = model()
@@ -264,6 +266,10 @@ class ModuleTest(absltest.TestCase):
         layer = MultiMethod.shared()
         layer(x)  # init
         return layer.l2()
+
+    self.assertEqual(
+        MultiMethod.l2.__qualname__,
+        MultiMethod.__qualname__ + '.l2')
 
     x = jnp.array([1., 2.])
     y, _ = MultiMethodModel.init(random.PRNGKey(0), x)


### PR DESCRIPTION
Closes issue #123 