### PR TITLE
make stateful check work on pytrees

### DIFF
--- a/flax/nn/base.py
+++ b/flax/nn/base.py
@@ -958,7 +958,7 @@ class Collection:
     self._anchor = _module_stack[-1] if _module_stack else None
 
     self._mutable = False
-    self._master = None
+    self._master_level = None
     self._root = None
 
   def as_dict(self):
@@ -977,7 +977,7 @@ class Collection:
     # pylint: disable=protected-access
     new_col = jax.tree_map(lambda x: x, self)  # clone the collection
     new_col._mutable = True
-    new_col._master = utils._current_trace()
+    new_col._master_level = utils._trace_level(utils._current_trace())
     try:
       yield new_col
     finally:
@@ -1015,10 +1015,8 @@ class Collection:
     # is ill-defined (eg. what does vmap of BatchNorm do?).
     # TODO(jheek): Add doc guide on combining jax transforms and state.
     # TODO(jheek): Should some transformations be excempt from this error?
-    master = utils._tracer_of_value(value)
-    value_level = master.level if master else float('-inf')
-    state_level = self._master.level if self._master else float('-inf')
-    if value_level > state_level:
+    value_level = utils._level_of_value(value)
+    if value_level > self._master_level:
       raise ValueError('Stateful operations are not allowed when the Collection'
                        ' is created outside of the current Jax transformation')
 

--- a/flax/nn/utils.py
+++ b/flax/nn/utils.py
@@ -86,8 +86,12 @@ def _current_trace():
   return None
 
 
-def _tracer_of_value(x):
-  """Returns the tracer associated with a value if any."""
-  if hasattr(x, '_trace'):
-    return x._trace.master
-  return None
+def _level_of_value(xs):
+  """Returns the tracer level associated with a value if any."""
+  xs = jax.tree_leaves(xs)
+  max_level = float('-inf')
+  for x in xs:
+    if hasattr(x, '_trace'):
+      level = _trace_level(x._trace.master)
+      max_level = max(level, max_level)
+  return max_level

--- a/tests/nn_test.py
+++ b/tests/nn_test.py
@@ -457,10 +457,10 @@ class CollectionTest(absltest.TestCase):
           # constants should be storable
           state.store(1.)
           # values in the same trace should be storable
-          state.store(y)
+          state.store({'a': y})
           with test.assertRaises(ValueError):
             # values depending on the vmap should not be storable
-            state.store(x)
+            state.store({'a': y, 'b': x})
         jax.vmap(inner_fn)(jnp.ones((2,)))
 
     def outer_fn(x):


### PR DESCRIPTION
The state check should look inside pytrees to find tracers when checking for illegal combinations of state and jax transforms