### PR TITLE
Add init_by_shape method usage example.

### DIFF
--- a/flax/nn/base.py
+++ b/flax/nn/base.py
@@ -482,6 +482,10 @@ class Module(metaclass=_ModuleMeta):
       **kwargs: keyword arguments passed to the module's apply function
     Returns:
       A pair consisting of the model output and the initialized parameters
+    Example:
+      input_shape = (batch_size, image_size, image_size, 3)
+      model_output, initial_params = model.init_by_shape(jax.random.PRNGKey(0),
+                                                         input_specs=[(input_shape, jnp.float32)])
     """
     stochastic_rng = None
     try:

--- a/flax/nn/base.py
+++ b/flax/nn/base.py
@@ -483,9 +483,11 @@ class Module(metaclass=_ModuleMeta):
     Returns:
       A pair consisting of the model output and the initialized parameters
     Example:
+      ```
       input_shape = (batch_size, image_size, image_size, 3)
       model_output, initial_params = model.init_by_shape(jax.random.PRNGKey(0),
-                                                         input_specs=[(input_shape, jnp.float32)])
+                                      input_specs=[(input_shape, jnp.float32)])
+      ```
     """
     stochastic_rng = None
     try:


### PR DESCRIPTION
I added the module usage example to make the doc more understandable.(This commit just a starter commit, I will continue after I understand where to add on correct way)

Will docstring be used in the future ? So should I add the examples there or to a different place?