### PR TITLE
Update MNIST input pipeline

### DIFF
--- a/examples/mnist/README.md
+++ b/examples/mnist/README.md
@@ -8,8 +8,8 @@ Trains a simple convolutional network on the MNIST dataset.
 ### Example output
 
 ```
-I0314 19:48:55.696393 140216908515136 train.py:155] train epoch: 10, loss: 0.0085, accuracy: 99.75
-I0314 19:48:55.718828 140216908515136 train.py:191] eval epoch: 10, loss: 0.0285, accuracy: 99.13
+I0413 01:38:37.660479 4484091328 train.py:149] train epoch: 10, loss: 0.0077, accuracy: 99.74
+I0413 01:38:51.978743 4484091328 train.py:189] eval epoch: 10, loss: 0.0313, accuracy: 99.02
 ```
 
 ### How to run

--- a/examples/mnist/train.py
+++ b/examples/mnist/train.py
@@ -55,12 +55,6 @@ flags.DEFINE_integer(
     help=('Number of training epochs.'))
 
 
-def load_split(split):
-  ds = tfds.load('mnist', split=split, batch_size=-1)
-  data = tfds.as_numpy(ds)
-  data['image'] = onp.float32(data['image']) / 255.
-  return data
-
 
 class CNN(nn.Module):
   """A simple CNN model."""
@@ -166,8 +160,12 @@ def eval_model(model, test_ds):
 
 def get_datasets():
   """Load MNIST train and test datasets into memory."""
-  train_ds = load_split(tfds.Split.TRAIN)
-  test_ds = load_split(tfds.Split.TEST)
+  ds_builder = tfds.builder('mnist')
+  ds_builder.download_and_prepare()
+  train_ds = tfds.as_numpy(ds_builder.as_dataset(split='train', batch_size=-1))
+  test_ds = tfds.as_numpy(ds_builder.as_dataset(split='test', batch_size=-1))
+  train_ds['image'] = jnp.float32(train_ds['image']) / 255.
+  test_ds['image'] = jnp.float32(test_ds['image']) / 255.
   return train_ds, test_ds
 
 


### PR DESCRIPTION
## Diff Report
### Old : 
```
train epoch: 10, loss: 0.0085, accuracy: 99.75
eval epoch: 10, loss: 0.0285, accuracy: 99.13
```
### New:
```
train epoch: 10, loss: 0.0077, accuracy: 99.74
eval epoch: 10, loss: 0.0313, accuracy: 99.02
```
**Related issues:** #136, #138
**Old pr:** #185 