### PR TITLE
Make the tests run by transforming warnings into errors

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,10 @@
+[pytest]
+# RuntimeWarning is due to scipy (or another package) that was compiled against an older numpy than is installed.
+# UserWarning is due to statement: tensorflow.compat.v2.io import gfile
+# DeprecationWarning is due to statement: tensorflow.compat.v2.io import gfile
+filterwarnings =
+    error
+    ignore:numpy.ufunc size changed.*:RuntimeWarning
+    ignore:No GPU/TPU found, falling back to CPU.*:UserWarning
+    ignore:can't resolve package from.*:ImportWarning
+    ignore:the imp module is deprecated.*:DeprecationWarning

--- a/tests/nn_attention_test.py
+++ b/tests/nn_attention_test.py
@@ -158,7 +158,7 @@ class AttentionTest(parameterized.TestCase):
 
     def get_receptive_field_1d(pos):
       g = grad_fn(inputs, pos)[0, :, :]
-      return jnp.any((jnp.abs(g) > 1e-5).astype(int), axis=-1)
+      return jnp.any((jnp.abs(g) > 1e-5).astype(jnp.uint32), axis=-1)
 
     length = 10
     dim = 1

--- a/tests/run_all_tests.sh
+++ b/tests/run_all_tests.sh
@@ -16,14 +16,14 @@ handle_errors () {
 }
 
 # Run battery of core FLAX API tests.
-pytest -n 4 tests -W ignore
+pytest -n 4 tests
 
 # Per-example tests.
 # we apply pytest within each example to avoid pytest's annoying test-filename collision.
 # In pytest foo/bar/baz_test.py and baz/bleep/baz_test.py will collide and error out when
 # /foo/bar and /baz/bleep aren't set up as packages.
 for egd in $(find examples -maxdepth 1 -mindepth 1 -type d); do
-    pytest $egd -W ignore
+    pytest $egd
 done
 
 # Return error code 0 if no real failures happened.


### PR DESCRIPTION
Introduce pytest.ini and introduce configuration to filter and transform warnings into errors.

Few exceptions are documented in the same file. We filter out the specific warning using regex and its type instead of ignoring a generic type of warning which might lead to us missing out on something newly introduced in the flax codebase. Notably causing due to:
- Importing tensorflow.compat.v2.io import gfile in training/checkpoints.py
- XLA level Warning.
- RuntimeWarning due to scipy compiled against an older numpy than installed.

@avital PTAL. 