### PR TITLE
Change default initializer to Kaiming uniform

### DIFF
--- a/flax/nn/linear.py
+++ b/flax/nn/linear.py
@@ -26,7 +26,7 @@ import jax.numpy as jnp
 import numpy as onp
 
 
-default_kernel_init = initializers.lecun_normal()
+default_kernel_init = initializers.kaiming_uniform()
 
 
 def _normalize_axes(axes, ndim):


### PR DESCRIPTION
According to git history, it's been defaulting to `lecun_normal` since the beginning of times. [`lecun_normal` is essentially the same as Xavier](https://github.com/google/jax/blob/master/jax/nn/initializers.py#L71-L74), which has been derived for `tanh` units. Nowadays nobody in their right mind uses `tanh` as internal non-linearity everywhere, but instead everybody uses `ReLU` and friends, for which `kaiming_*` has been derived. So I suggest defaulting to that.

For what it's worth, PyTorch does default to Kaiming's init too ([conv](https://github.com/pytorch/pytorch/blob/master/torch/nn/modules/conv.py#L56), [linear](https://github.com/pytorch/pytorch/blob/master/torch/nn/modules/linear.py#L80)) although they even include a slight slope for leaky-relu by default. (And I'm using `kaiming_uniform` only because they use the uniform variant too, I think it doesn't really matter.)