### PR TITLE
Add code coverage, upload report to codecov.io, and display badge

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,15 +28,19 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        python -m pip install absl-py opt_einsum numpy scipy pytest-xdist pytest-benchmark jaxlib jax tensorflow tensorflow-datasets
         pip install -v .
+        pip install -v .[testing]
         pip install -r docs/requirements.txt
     - name: Build documentation
       run: |
         sphinx-build -M html docs docs/_build
-    - name: Test with pytest
+    - name: Test with pytest and generate coverage report
       run: |
-        tests/run_all_tests.sh
+        tests/run_all_tests.sh --with-cov
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v1
+      with:
+        file: ./coverage.xml
     # The below step just reports the success or failure of tests as a "commit status".
     # This is needed for copybara integration.
     - name: Report success or failure as github status

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Flax: A neural network library for JAX designed for flexibility
 
+[![coverage](https://badgen.net/codecov/c/github/google/flax)](https://codecov.io/github/google/flax)
 
 **NOTE**: Flax is being actively improved and has a growing community
 of researchers and engineers at Google who happily use Flax for their

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,4 @@
+[report]
+exclude_lines = 
+	@abc.abstractmethod
+	raise NotImplementedError

--- a/setup.py
+++ b/setup.py
@@ -35,8 +35,11 @@ install_requires = [
 ]
 
 tests_require = [
+    "jaxlib",
     "pytest",
+    "pytest-cov",
     "pytest-xdist",
+    "tensorflow",
     "tensorflow_datasets",
 ]
 

--- a/tests/run_all_tests.sh
+++ b/tests/run_all_tests.sh
@@ -8,7 +8,7 @@ trap handle_errors ERR
 handle_errors () {
     ret="$?"
     if [[ "$ret" == 5 ]]; then
-      echo "error code $ret == no tests found"
+      echo "error code $ret == no tests found in $egd"
     else
       echo "error code $ret"
       exit 1
@@ -16,7 +16,11 @@ handle_errors () {
 }
 
 # Run battery of core FLAX API tests.
-pytest -n 4 tests
+PYTEST_OPTS=
+if [[ $1 == "--with-cov" ]]; then
+    PYTEST_OPTS+="--cov=flax --cov-report=xml --cov-report=term --cov-config=setup.cfg"
+fi
+pytest -n 4 tests $PYTEST_OPTS
 
 # Per-example tests.
 # we apply pytest within each example to avoid pytest's annoying test-filename collision.


### PR DESCRIPTION
Relatively straight-forward. Adds a test coverage report plus a badge. Tests [pass](https://github.com/danielsuo/flax/runs/627909702?check_suite_focus=true) with sample [report](https://codecov.io/gh/danielsuo/flax/branch/test_coverage) and [badge](https://github.com/danielsuo/flax/tree/test_coverage) (the badge is pointing to `google/flax`, not my personal repository, so it says `unknown`).

I had mistakenly thought the coverage was ~30%, but it's actually ~80%. Great!

Notes:
- Consolidated test requirements into `tests_require` in `setup.py` (simplifies the `build` workflow)
- Added a flag to `tests/run_all_tests.sh`. Not great, but didn't want to run `pytest tests` twice. Looked into removing `tests/run_all_tests.sh`, but that has it's own complications (happy to discuss)
- I chose `codecov.io`, but there's no reason except they provide a badge
- I added `setup.cfg`, but this isn't strictly necessary. Many of the tools we might consider in the future offer configuration via `setup.cfg` (so we don't have lots of `*.ini`, `*.cfg`, etc files floating around)