### PR TITLE
Change RMSProp beta2 default to 0.9

### DIFF
--- a/flax/optim/rmsprop.py
+++ b/flax/optim/rmsprop.py
@@ -37,13 +37,13 @@ class _RMSPropParamState:
 
 class RMSProp(OptimizerDef):
   """RMSProp optimizer"""
-  def __init__(self, learning_rate: float = None, beta2=0.999, eps=1e-8):
+  def __init__(self, learning_rate: float = None, beta2=0.9, eps=1e-8):
     """Constructor for the RMSProp optimizer
     
     Args:
       learning_rate: the step size used to update the parameters.
       beta2: the coefficient used for the moving average of the
-        gradient magnitude (default: 0.999).
+        gradient magnitude (default: 0.9).
       eps: the term added to the gradient magnitude estimate for
         numerical stability.
     """


### PR DESCRIPTION
Looks like the 0.999 is meant to mirror Adam's. But I don't recall seeing RMSProp ever used with such high value. In [the original slides introducing it they use 0.9](http://www.cs.toronto.edu/~tijmen/csc321/slides/lecture_slides_lec6.pdf), which is also the default in both tf.train and tf.keras. [PyTorch defaults to 0.99](https://pytorch.org/docs/stable/optim.html#torch.optim.RMSprop) which I haven't seen before either, and [Alex Grave's seminal paper](https://arxiv.org/abs/1308.0850) that introduces it uses 0.95, although it  is actually a slightly different formulation.

My point is that 0.999 as default is a bad idea here.