### PR TITLE
Adding lightweight support for community examples

### DIFF
--- a/.github/ISSUE_TEMPLATE/example_request.md
+++ b/.github/ISSUE_TEMPLATE/example_request.md
@@ -1,0 +1,18 @@
+---
+name: Example request
+about: Use this template to track new examples requests.
+title: ''
+labels: example, example request
+assignees: ''
+
+---
+
+You would like to see a new example being implemented by the Flax core team or the community? Please let us know by filling the following template.
+
+### Description of the model to be implemented
+
+
+### Dataset the model could be used on
+
+
+### Specific point to consider

--- a/.github/ISSUE_TEMPLATE/example_request.md
+++ b/.github/ISSUE_TEMPLATE/example_request.md
@@ -12,7 +12,7 @@ You would like to see a new example being implemented by the Flax core team or t
 ### Description of the model to be implemented
 
 
-### Dataset the model could be used on
+### Dataset the model could be trained on
 
 
-### Specific point to consider
+### Specific points to consider

--- a/.github/ISSUE_TEMPLATE/example_request.md
+++ b/.github/ISSUE_TEMPLATE/example_request.md
@@ -14,5 +14,6 @@ You would like to see a new example being implemented by the Flax core team or t
 
 ### Dataset the model could be trained on
 
-
 ### Specific points to consider
+
+### Reference implementations in other frameworks

--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ comes with everything you need to start your research, including:
 
 ## Try Flax now by forking one of our starter examples
 
+We keep here a limited list of canonical examples maintained by the Flax team. If you are looking for more examples, or others built by the community, please check the [examples folder](./examples/README.md) for further guidance.
+
 ### Image Classification
 ⟶ [MNIST](examples/mnist) (also see [annotated version](https://flax.readthedocs.io/en/latest/annotated_mnist.html))
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ comes with everything you need to start your research, including:
 
 ## Try Flax now by forking one of our starter examples
 
-We keep here a limited list of canonical examples maintained by the Flax team. If you are looking for more examples, or others built by the community, please check the [examples folder](./examples/README.md) for further guidance.
+We keep here a limited list of canonical examples maintained by the Flax team. If you are looking for more examples, or others built by the community, please check the [examples folder](examples/) for further guidance.
 
 ### Image Classification
 ⟶ [MNIST](examples/mnist) (also see [annotated version](https://flax.readthedocs.io/en/latest/annotated_mnist.html))

--- a/examples/README.md
+++ b/examples/README.md
@@ -5,7 +5,7 @@
 This folder contains a collection of examples of implementations of various architectures and training procedures.
  
 Each examples is designed to be self-contained and easily forkable, while reproducing "key results" in different areas of machine learning. Official Flax examples come with significant maintenance expectations, including (but not limited to since guidelines are WIP - [#231](https://github.com/google/flax/issues/231)):
-* Tested benchmarks on single-GPU, multi-GPU, and TPU configurations (e.g. [./imagenet/README](./imagenet/README.md))
+* Tested benchmarks on single-GPU, multi-GPU, and TPU configurations (e.g. [./imagenet/README](imagenet/README.md))
 * Unit tests (e.g. that one training step succeeds)
 * Adherence to Flax best practices and code updates as those best practices evolve
 * An "owner" who is a member of the Flax core team who keeps the example up-to-date

--- a/examples/README.md
+++ b/examples/README.md
@@ -20,7 +20,7 @@ Here are some of the models that people have built with Flax:
 | Link  | Author | Task type | Reference |
 | ------------- | ------------- | ------------ | ---------- |
 | [Gaussian Processes regression](https://github.com/danieljtait/ladax/tree/master/examples)  | @danieljtait | Regression | N/A |  |
-| T3D, PPO...  |   | Reinforcement learning | ... |
+| [JAX-RL](https://github.com/henry-prior/jax-rl)  | @henry-prior  | Reinforcement learning | N/A |
 
 If you are using Flax for your research, or have re-implemented interesting models in Flax, file a pull request against this README and add a link in the table.
  

--- a/examples/README.md
+++ b/examples/README.md
@@ -5,7 +5,7 @@
 This folder contains a collection of examples of implementations of various architectures and training procedures.
  
 Each examples is designed to be self-contained and easily forkable, while reproducing "key results" in different areas of machine learning. Official Flax examples come with significant maintenance expectations, including (but not limited to since guidelines are WIP - [#231](https://github.com/google/flax/issues/231)):
-* Tested benchmarks on single-GPU, multi-GPU, and TPU configurations (e.g. [./imagenet/README](imagenet/README.md))
+* Tested benchmarks on single-GPU, multi-GPU, and TPU configurations (e.g. [imagenet](imagenet/))
 * Unit tests (e.g. that one training step succeeds)
 * Adherence to Flax best practices and code updates as those best practices evolve
 * An "owner" who is a member of the Flax core team who keeps the example up-to-date

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,11 +1,35 @@
 # Flax Examples
-
+ 
+## Official examples maintained by the Flax core team
+ 
 This folder contains a collection of examples of implementations of various architectures and training procedures.
-In collecting these examples, we try to cover all key areas in machine learning, without having too much duplication.
+ 
+Each examples is designed to be self-contained and easily forkable, while reproducing "key results" in different areas of machine learning. Official Flax examples come with significant maintenance expectations, including (but not limited to since guidelines are WIP - [#231](https://github.com/google/flax/issues/231)):
+* Tested benchmarks on single-GPU, multi-GPU, and TPU configurations (e.g. [./imagenet/README](./imagenet/README.md))
+* Unit tests (e.g. that one training step succeeds)
+* Adherence to Flax best practices and code updates as those best practices evolve
+* An "owner" who is a member of the Flax core team who keeps the example up-to-date
+* A minimal implementation of a single model on a single dataset (users can fork and change the configuration to run on another dataset)
+ 
+## Flax examples from the community
+ 
+In addition to the curated list of official Flax examples, there is a growing community of people using Flax to build new types of machine learning models. We are happy to showcase any example built by the community here! If you want to submit your own example, we suggest that you start by forking one of the official Flax example, and start from there.
+ 
+Here are some of the models that people have built with Flax:
 
-NOTE: If you have an idea for an example, please file an issue first!
+| Link  | Author | Task type | Reference |
+| ------------- | ------------- | ------------ | ---------- |
+| [Gaussian Processes regression](https://github.com/danieljtait/ladax/tree/master/examples)  | @danieljtait | Regression | N/A |  |
+| T3D, PPO...  |   | Reinforcement learning | ... |
 
-We can have an open discussion on the issue as to whether it makes sense to add your example to the main Flax 
-repository. We try to keep this list of examples relatively contained.
+If you are using Flax for your research, or have re-implemented interesting models in Flax, file a pull request against this README and add a link in the table.
+ 
+## Looking for "FOO" implemented in Flax?
 
-Please be aware that if you send us large Pull Requests without discussing them first, we may not review them.
+We use GitHub issues to keep track of which models people are most interested in seeing re-implemented in Flax. If you can't find what you're looking for in the [list](https://github.com/google/flax/labels/example%20request), file an issue with this [template](https://github.com/google/flax/issues/new?assignees=&template=example_request.md&title=).
+ 
+If the model you are looking for has already been requested by others, upvote the issue to help us see which ones are the most requested.
+
+## Looking to implement something in Flax?
+ 
+Consider looking at the list of requested models in the GitHub issue tracker under the ["example requested" label](https://github.com/google/flax/labels/example%20request) and go ahead and build it!


### PR DESCRIPTION
To enable linking to community examples in a lightweight way, I changed a bit the README and example/README files to basically split between official and community example as well as giving guidance on how to request/submit new examples.

Will probably need to update with Marvin's examples guidelines later on.

I'm missing one link for the RL (@avital shared it with me but can't find it). Also mentioned a GAN example that I couldn't find. Will update before PR is merged.

P.S: also enabling me to test the workflow :)