### PR TITLE
Run unit tests for each affected example in a howto

### DIFF
--- a/howtos/scripts/apply_howto_diffs.sh
+++ b/howtos/scripts/apply_howto_diffs.sh
@@ -45,6 +45,10 @@ for howto in $howtos; do
   git apply $diff_file
   git commit -am "Added howto branch ${howto_branch}"
   git push -u origin $howto_branch
+
+  # Run unit test on affected examples only
+  git diff --name-only $master_branch | xargs dirname | xargs pytest
+
   # Make sure to checkout the master branch, otherwise the next diff branch
   # will be branched off of the current diff branch.
   git checkout $master_branch

--- a/howtos/scripts/apply_howto_diffs.sh
+++ b/howtos/scripts/apply_howto_diffs.sh
@@ -43,11 +43,13 @@ for howto in $howtos; do
     exit 1
   fi
   git apply $diff_file
-  git commit -am "Added howto branch ${howto_branch}"
-  git push -u origin $howto_branch
 
   # Run unit test on affected examples only
   git diff --name-only $master_branch | xargs dirname | xargs pytest
+
+  # Once we are satisfied with the howto, commit and push
+  git commit -am "Added howto branch ${howto_branch}"
+  git push -u origin $howto_branch
 
   # Make sure to checkout the master branch, otherwise the next diff branch
   # will be branched off of the current diff branch.


### PR DESCRIPTION
From an offline discussion with @avital:

> HOWTOs can fail for two reasons -- the diff can be stale and no longer apply without conflicts, or it can apply and unit tests won't pass. Ideally, both of these should be tested on every commit in CI.

It looks like the first is already tested for during the `apply-howto-branches.yml` workflow. This line checks which files were touched by the `howto` and runs `pytest` on those directories.

It seems that the changes in this PR very narrowly resolve the issue @avital raised; the check assumes:

1. Files that are touched are accompanied by tests in the same directory (examples fall into this category)
2. The only changes a `howto` can make are testable via the tests in the same directory (example tests _should_ fall into this category)

Let me know if/how I misjudged the scope of the issue and I'll be happy to address!