### PR TITLE
make jax_utils.replicate match pmap devices

### DIFF
--- a/flax/jax_utils.py
+++ b/flax/jax_utils.py
@@ -40,12 +40,15 @@ import numpy as onp
 import jax
 from jax import lax
 import jax.numpy as jnp
-import jax.xla_bridge as xb
+import jax.lib.xla_bridge as xb
 
 
 def _replicate(x, devices=None):
   x = jax.numpy.array(x)
   if devices is None:
+    # match the default device assignments used in pmap:
+    # for single-host, that's the XLA default device assignment
+    # for multi-host, it's the order of jax.local_devices()
     if jax.host_count() == 1:
       devices = [d for d in xb.get_backend().get_default_device_assignment(
           jax.device_count()) if d.host_id == jax.host_id()]


### PR DESCRIPTION
Currently `jax_utils.replicate` creates a `ShardedDeviceArray` with devices in the order of `jax.local_devices()`, but this is not always the same as the device assignment used for pmaps (it's the same for multi-host setups, but not for single-host, where we use the default XLA device assignment). Having it match also in the single-host case will avoid unnecessary device-to-device copies to re-shard the array when launching the pmap.