### PR TITLE
Allow unfrozen dataclasses.

### DIFF
--- a/flax/struct.py
+++ b/flax/struct.py
@@ -70,10 +70,9 @@ def dataclass(clz=None, *, frozen=True):
 
   Args:
     clz: the class that will be transformed by the decorator.
-    frozen: whether to freeze the dataclass (default=True). WARNING: mutating
-      instance of the dataclass from within a module is not allowed and can
-      silently cause incorrect behavior. Only change this to `False` if you
-      want to mutate the dataclass from *outside* a module.
+    frozen: whether to freeze the dataclass (default=True). WARNING: mutations
+      that occur to an unfrozen dataset within a function that has been transformed
+      by Jax (influxing Flax modules) are not visible outside of that function.
   Returns:
     The new class.
   """

--- a/flax/struct.py
+++ b/flax/struct.py
@@ -71,8 +71,8 @@ def dataclass(clz=None, *, frozen=True):
   Args:
     clz: the class that will be transformed by the decorator.
     frozen: whether to freeze the dataclass (default=True). WARNING: mutations
-      that occur to an unfrozen dataset within a function that has been transformed
-      by Jax (influxing Flax modules) are not visible outside of that function.
+      that occur to an unfrozen dataclass within a function that has been transformed
+      by Jax (including Flax modules) are not visible outside of that function.
   Returns:
     The new class.
   """

--- a/flax/struct.py
+++ b/flax/struct.py
@@ -134,9 +134,13 @@ def dataclass(clz=None, *, frozen=True):
         data_clz, to_state_dict, from_state_dict)
 
     return data_clz
-  if clz is None:
+  # If this is called as @dataclass(frozen=...), clz is will be None and
+  # and we return a function that will be later called with clz.
+  if clz is None: 
     return wrapped
-  else:
+  # Otherwise, this was called directly as @dataclass so we apply the 
+  # wrapper to the clz immediately.
+  else:  
     return wrapped(clz)
 
 


### PR DESCRIPTION
Sometimes it's convenient to have unfrozen dataclasses so that you can modify them before passing them to a Flax module. If the dataclasses are deeply nested, in can be impractical to use `replace` to set deeply-nested values. 

Hacks like turning the dataclass into a dict, modifying the dict, and turning it back into a dataclass can work, but then all the static type safety of dataclasses is lost within the code that mutates the dict. That defeats one of the main reasons of using a dataclass in the first place.

Here I propose adding a `frozen` keyword arg to `@dataclass`, just as the base Python dataclass has. However, I set the default to `frozen=True` and add a stern warning in the docstring (feel free to tweak). I do think if the user wants to opt in to using a mutable dataclass and knows the caveats, they should have the option of doing so.
