### PR TITLE
Flush MNIST summaries.

### DIFF
--- a/examples/mnist/train.py
+++ b/examples/mnist/train.py
@@ -199,6 +199,7 @@ def train(train_ds, test_ds):
     summary_writer.scalar('train_accuracy', train_metrics['accuracy'], epoch)
     summary_writer.scalar('eval_loss', loss, epoch)
     summary_writer.scalar('eval_accuracy', accuracy, epoch)
+  summary_writer.flush()
   return optimizer
 
 


### PR DESCRIPTION
Summary writer should flush the local cache of summaries.

The error was detected when running train_benchmark for MNIST. It fails with eval_accuracy not being found. The root cause is that the summaries aren't flushed. 

Run the following to reproduce:
`
python examples/mnist/train_benchmark.py --benchmark_output_dir=/tmp/mnist_experimental/
`