### PR TITLE
Only pack examples directories when packing howtos

### DIFF
--- a/howtos/scripts/pack_howto_diffs.sh
+++ b/howtos/scripts/pack_howto_diffs.sh
@@ -58,7 +58,7 @@ if test -f "${howto_path}";  then
 fi
 
 # Add all untracked files. After this there are no untracked changes anymore.
-git add .
+git add "$examples_dir"
 # Create diff for both unstaged and staged changes. Add the diff to a temporal
 # location to ensure it won't be remove when we clean the changes.
 tmp_path=$(mktemp)


### PR DESCRIPTION
Addresses #249. After reviewing the blame history, however, I can't figure out if there was a reason why we add all untracked files and want to be sure I didn't miss something important.

@marcvanzee originally had `git add *`, which @avital then changed to `git add .` to [bring back the correct ensembling HOWTO](https://github.com/danielsuo/flax/commit/57fce50c7be2b14d17beecb7b2e0f666bde8b7f3).

Hopefully the change really is this simple, but let me know.