### PR TITLE
Migrate TF1 compat Summary writer to TF2 in metrics/tensorboard.py

### DIFF
--- a/flax/metrics/tensorboard.py
+++ b/flax/metrics/tensorboard.py
@@ -75,6 +75,8 @@ class SummaryWriter(object):
     Args:
       tag: str: label for this data
       image: ndarray: [H,W], [H,W,1], [H,W,3] save image in greyscale or colors.
+        Pixel values could be either uint8 or float.
+        Floating point values should be in range [0, 1).
       step: int: training step
     """
     image = onp.array(image)
@@ -85,6 +87,9 @@ class SummaryWriter(object):
     # tf.summary.image expects image to have shape [k, h, w, c] where,
     # k = number of samples, h = height, w = width, c = number of channels.
     image = image[onp.newaxis, :, :, :]
+
+    # Convert to tensor value as tf.summary.image expects data to be a tensor.
+    image = tf.convert_to_tensor(image)
     with self._event_writer.as_default():
       tf.summary.image(name=tag, data=image, step=step)
 
@@ -105,9 +110,12 @@ class SummaryWriter(object):
     # tf.summary.audio expects the audio data to have floating values in
     # [-1.0, 1.0].
     audiodata = onp.clip(onp.array(audiodata), -1, 1)
+
+    # Convert to tensor value as tf.summary.audio expects data to be a tensor.
+    audio = tf.convert_to_tensor(audiodata, dtype=tf.float32)
     with self._event_writer.as_default():
       tf.summary.audio(
-          name=tag, data=audiodata, sample_rate=sample_rate, step=step,
+          name=tag, data=audio, sample_rate=sample_rate, step=step,
           max_outputs=max_outputs, encoding='wav')
 
   def histogram(self, tag, values, step, bins=None):

--- a/flax/metrics/tensorboard.py
+++ b/flax/metrics/tensorboard.py
@@ -102,14 +102,13 @@ class SummaryWriter(object):
       max_outputs: At most this many audio clips will be emitted at each
         step. Defaults to 3.
     """
-    audiodata = onp.array(audiodata)
     # tf.summary.audio expects the audio data to have floating values in
     # [-1.0, 1.0].
-    audiodata = onp.clip(onp.squeeze(audiodata), -1, 1)
+    audiodata = onp.clip(onp.array(audiodata), -1, 1)
     with self._event_writer.as_default():
-      tf.summary.audio(name=tag, data=audiodata,
-          sample_rate=sample_rate, step=step, max_outputs=max_outputs,
-          encoding='wav')
+      tf.summary.audio(
+          name=tag, data=audiodata, sample_rate=sample_rate, step=step,
+          max_outputs=max_outputs, encoding='wav')
 
   def histogram(self, tag, values, step, bins=None):
     """Saves histogram of values.

--- a/flax/metrics/tensorboard.py
+++ b/flax/metrics/tensorboard.py
@@ -88,28 +88,28 @@ class SummaryWriter(object):
     with self._event_writer.as_default():
       tf.summary.image(name=tag, data=image, step=step)
 
-  def audio(self, tag, audiodata, step, sample_rate=44100):
+  def audio(self, tag, audiodata, step, sample_rate=44100, max_outputs=3):
     """Saves audio as wave.
 
     NB: single channel only right now.
 
     Args:
       tag: str: label for this data
-      audiodata: ndarray [Nsamples,]: audio data to be saved as wave.
-        The data will be clipped to [-1, 1].
-
+      audiodata: ndarray [Nsamples, Nframes, Nchannels]: audio data to
+        be saved as wave. The data will be clipped to [-1.0, 1.0].
       step: int: training step
       sample_rate: sample rate of passed in audio buffer
+      max_outputs: At most this many audio clips will be emitted at each
+        step. Defaults to 3.
     """
     audiodata = onp.array(audiodata)
-    audiodata = onp.clip(onp.squeeze(audiodata), -1, 1)
-    if audiodata.ndim != 1:
-      raise ValueError('Audio data must be 1D.')
     # tf.summary.audio expects the audio data to have floating values in
     # [-1.0, 1.0].
+    audiodata = onp.clip(onp.squeeze(audiodata), -1, 1)
     with self._event_writer.as_default():
       tf.summary.audio(name=tag, data=audiodata,
-          sample_rate=sample_rate, step=step, encoding='wav')
+          sample_rate=sample_rate, step=step, max_outputs=max_outputs,
+          encoding='wav')
 
   def histogram(self, tag, values, step, bins=None):
     """Saves histogram of values.

--- a/flax/metrics/tensorboard.py
+++ b/flax/metrics/tensorboard.py
@@ -28,7 +28,6 @@ with warnings.catch_warnings():
 # pylint: disable=g-import-not-at-top
 import numpy as onp
 import tensorflow.compat.v2 as tf
-from tensorflow.compat.v2.io import gfile
 
 
 class SummaryWriter(object):
@@ -41,8 +40,8 @@ class SummaryWriter(object):
       log_dir: path to record tfevents files in.
     """
     # If needed, create log_dir directory as well as missing parent directories.
-    if not gfile.isdir(log_dir):
-      gfile.makedirs(log_dir)
+    if not tf.io.gfile.isdir(log_dir):
+      tf.io.gfile.makedirs(log_dir)
 
     self._event_writer = tf.summary.create_file_writer(log_dir, 10, 120, None)
     self._closed = False

--- a/flax/metrics/tensorboard.py
+++ b/flax/metrics/tensorboard.py
@@ -142,6 +142,6 @@ class SummaryWriter(object):
     Note: markdown formatting is rendered by tensorboard.
     """
     if not isinstance(textdata, (str, bytes)):
-      raise ValueError('textdata should be of the type `str` or `bytes`.')
+      raise ValueError('`textdata` should be of the type `str` or `bytes`.')
     with self._event_writer.as_default():
       tf.summary.text(name=tag, data=tf.constant(textdata), step=step)

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,9 +2,11 @@
 # RuntimeWarning is due to scipy (or another package) that was compiled against an older numpy than is installed.
 # UserWarning is due to statement: tensorflow.compat.v2.io import gfile
 # DeprecationWarning is due to statement: tensorflow.compat.v2.io import gfile
+# inspect.getargspec() is invoked in tensorboard/backend/event_processing/event_file_loader.py:61
 filterwarnings =
     error
     ignore:numpy.ufunc size changed.*:RuntimeWarning
     ignore:No GPU/TPU found, falling back to CPU.*:UserWarning
     ignore:can't resolve package from.*:ImportWarning
     ignore:the imp module is deprecated.*:DeprecationWarning
+    ignore:inspect.getargspec() is deprecated since Python 3.0.*:DeprecationWarning

--- a/tests/tensorboard_test.py
+++ b/tests/tensorboard_test.py
@@ -59,6 +59,13 @@ class TensorboardTest(absltest.TestCase):
     self.assertTrue(
         onp.allclose(trimmed_audio, expected_audio.numpy(), atol=1e-04))
 
+  def test_summarywriter_flush_after_close(self):
+    log_dir = tempfile.mkdtemp()
+    summary_writer = SummaryWriter(log_dir=log_dir)
+    summary_writer.close()
+    with self.assertRaises(AttributeError):
+      summary_writer.flush()
+
   def test_summarywriter_scalar(self):
     log_dir = tempfile.mkdtemp()
     summary_writer = SummaryWriter(log_dir=log_dir)

--- a/tests/tensorboard_test.py
+++ b/tests/tensorboard_test.py
@@ -1,0 +1,114 @@
+# Copyright 2020 The Flax Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Lint as: python3
+"""Tests for flax.metrics.tensorboard."""
+import itertools
+import tempfile
+
+from absl.testing import absltest
+
+from tensorboard.backend.event_processing import directory_watcher
+from tensorboard.backend.event_processing import event_file_loader
+from tensorboard.util import tensor_util
+import tensorflow.compat.v2 as tf
+
+from flax.metrics.tensorboard import SummaryWriter
+
+def _process_event(event):
+  for value in event.summary.value:
+    yield {'wall_time': event.wall_time, 'step': event.step, 'value': value}
+
+def _get_event_values(path):
+  event_file_generator = directory_watcher.DirectoryWatcher(
+      path, event_file_loader.EventFileLoader).Load()
+  return itertools.chain.from_iterable(map(_process_event,
+          event_file_generator))
+
+def _get_event_values_list(event_values):
+  event_value_list = []
+  for value_dict in event_values:
+    event_value_list.append(value_dict)
+  return event_value_list
+
+
+class TensorboardTest(absltest.TestCase):
+
+  def test_summarywriter_scalar(self):
+    log_dir = tempfile.mkdtemp()
+    summary_writer = SummaryWriter(log_dir=log_dir)
+    # Write the scalar and check if the event exists and check data.
+    float_value = 99.00
+    summary_writer.scalar(tag='scalar_test', value=float_value, step=1)
+    event_values = _get_event_values(path=log_dir)
+    event_values_list = _get_event_values_list(event_values=event_values)
+
+    self.assertLen(event_values_list, 1)
+    self.assertEqual(event_values_list[0]['step'], 1)
+    self.assertGreater(event_values_list[0]['wall_time'], 0.0)
+
+    summary_value = event_values_list[0]['value']
+    self.assertEqual(summary_value.tag, 'scalar_test')
+    self.assertEqual(tensor_util.make_ndarray(summary_value.tensor).item(),
+        float_value)
+
+  def test_summarywriter_text(self):
+    log_dir = tempfile.mkdtemp()
+    summary_writer = SummaryWriter(log_dir=log_dir)
+    text = 'hello world.'
+    summary_writer.text(tag='text_test', textdata=text, step=1)
+    event_values = _get_event_values(path=log_dir)
+    event_values_list = _get_event_values_list(event_values=event_values)
+
+    self.assertLen(event_values_list, 1)
+    self.assertEqual(event_values_list[0]['step'], 1)
+    self.assertGreater(event_values_list[0]['wall_time'], 0.0)
+
+    summary_value = event_values_list[0]['value']
+    self.assertEqual(summary_value.tag, 'text_test')
+    self.assertEqual(
+        tensor_util.make_ndarray(summary_value.tensor).item().decode('utf-8'),
+        text)
+
+  def test_summarywriter_image(self):
+    log_dir = tempfile.mkdtemp()
+    summary_writer = SummaryWriter(log_dir=log_dir)
+    img = tf.random.uniform(shape=[30, 30, 3])
+    img = tf.cast(255 * img, tf.uint8)
+    summary_writer.image(tag='image_test', image=img, step=1)
+    event_values = _get_event_values(path=log_dir)
+    event_values_list = _get_event_values_list(event_values=event_values)
+
+    self.assertLen(event_values_list, 1)
+    self.assertEqual(event_values_list[0]['step'], 1)
+    self.assertGreater(event_values_list[0]['wall_time'], 0.0)
+
+    summary_value = event_values_list[0]['value']
+    self.assertEqual(summary_value.tag, 'image_test')
+
+    expected_img = tf.image.decode_image(summary_value.tensor.string_val[2])
+    element_equal = tf.math.equal(img, expected_img)
+    channel_equal = tf.math.equal(
+        tf.math.reduce_sum(tf.cast(element_equal, tf.uint8), 2),
+        tf.math.reduce_sum(tf.ones_like(tf.cast(element_equal, tf.uint8)), 2))
+    width_channel_equal = tf.math.equal(
+        tf.math.reduce_sum(tf.cast(channel_equal, tf.uint8), 1),
+        tf.math.reduce_sum(tf.ones_like(tf.cast(channel_equal, tf.uint8)), 1))
+    final_equal = tf.math.equal(
+        tf.math.reduce_sum(tf.cast(width_channel_equal, tf.uint8)),
+        tf.math.reduce_sum(tf.ones_like(tf.cast(width_channel_equal, tf.uint8))))
+    self.assertTrue(final_equal)
+
+if __name__ == '__main__':
+  absltest.main()

--- a/tests/tensorboard_test.py
+++ b/tests/tensorboard_test.py
@@ -92,7 +92,7 @@ class TensorboardTest(absltest.TestCase):
 
     self.assertEqual(summary_value.tag, 'image_test')
     actual_img = tf.image.decode_image(summary_value.tensor.string_val[2])
-    self.assertTrue(onp.allclose(actual_img.numpy(), expected_img))
+    self.assertTrue(onp.allclose(actual_img, expected_img))
 
   def test_summarywriter_image_float_pixel_values(self):
     log_dir = tempfile.mkdtemp()
@@ -107,7 +107,7 @@ class TensorboardTest(absltest.TestCase):
 
     self.assertEqual(summary_value.tag, 'image_test')
     actual_img = tf.image.decode_image(summary_value.tensor.string_val[2])
-    self.assertTrue(onp.allclose(actual_img.numpy(), expected_img))
+    self.assertTrue(onp.allclose(actual_img, expected_img))
 
   def test_summarywriter_2dimage_scaled(self):
     log_dir = tempfile.mkdtemp()
@@ -153,12 +153,12 @@ class TensorboardTest(absltest.TestCase):
     actual_audio_1 = tf.audio.decode_wav(
         summary_value.tensor.string_val[0]).audio
     self.assertTrue(onp.allclose(
-        expected_audio_samples[0], actual_audio_1.numpy(), atol=1e-04))
+        expected_audio_samples[0], actual_audio_1, atol=1e-04))
 
     actual_audio_2 = tf.audio.decode_wav(
         summary_value.tensor.string_val[2]).audio
     self.assertTrue(onp.allclose(
-        expected_audio_samples[1], actual_audio_2.numpy(), atol=1e-04))
+        expected_audio_samples[1], actual_audio_2, atol=1e-04))
 
   def test_summarywriter_audio_sampled_output(self):
     log_dir = tempfile.mkdtemp()
@@ -179,7 +179,7 @@ class TensorboardTest(absltest.TestCase):
     actual_audio = tf.audio.decode_wav(summary_value.tensor.string_val[0]).audio
 
     self.assertTrue(onp.allclose(
-        expected_audio_samples[0], actual_audio.numpy(), atol=1e-04))
+        expected_audio_samples[0], actual_audio, atol=1e-04))
 
   def test_summarywriter_clipped_audio(self):
     log_dir = tempfile.mkdtemp()
@@ -200,11 +200,11 @@ class TensorboardTest(absltest.TestCase):
     actual_audio = tf.audio.decode_wav(
         summary_value.tensor.string_val[0]).audio
     self.assertFalse(onp.allclose(
-        expected_audio_samples[0], actual_audio.numpy(), atol=1e-04))
+        expected_audio_samples[0], actual_audio, atol=1e-04))
 
     clipped_audio = onp.clip(onp.array(expected_audio_samples[0]), -1, 1)
     self.assertTrue(
-        onp.allclose(clipped_audio, actual_audio.numpy(), atol=1e-04))
+        onp.allclose(clipped_audio, actual_audio, atol=1e-04))
 
   def test_summarywriter_histogram_defaultbins(self):
     log_dir = tempfile.mkdtemp()


### PR DESCRIPTION
Migrate TF1 based event files/summaries to TF2 based summaries. Adding tests for the same.

NOTE: I am not sure how to show the outputs of the logged tensorboard. I am able to check them locally and they look fine.

tensorboard.dev for scalar - https://tensorboard.dev/experiment/fNiwW36JR96ekMTRVmPLrg/#scalars

- tensorboard.dev supports only scalars so majority cannot be validated using tensorboard.dev
- uploading the event files? - difficult to validate by the reviewers.
- screenshots?