### PR TITLE
Only install dataclasses dep in python 3.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ install_requires = [
     "numpy>=1.12",
     "jax>=0.1.59",
     "matplotlib",  # only needed for tensorboard export
-    "dataclasses",  # will only install on py3.6
+    "dataclasses;python_version<'3.7'", # will only install on py3.6
     "msgpack",
 ]
 


### PR DESCRIPTION
Use the [PEP508](https://www.python.org/dev/peps/pep-0508/) `python_version` environment marker in our setup.py file to correctly install the pypi `dataclasses` dependency _only_ for python3.6 and not for python3.7 and above where the builtin dataclasses library must be used.

Fixes #269 