### PR TITLE
Add --model_dir flag as the training code requires this field to be set.

### DIFF
--- a/examples/mnist/README.md
+++ b/examples/mnist/README.md
@@ -14,4 +14,4 @@ I0413 01:38:51.978743 4484091328 train.py:189] eval epoch: 10, loss: 0.0313, acc
 
 ### How to run
 
-`python train.py`
+`python train.py --model_dir=/tmp/mnist`


### PR DESCRIPTION
Set model_dir flag in README as the training code expects the flag to be set. Tensorboard summary writer otherwise fails with  

"TypeError: Expected binary or unicode string, got None"