### PR TITLE
Refactor imagenet example.

### DIFF
--- a/examples/imagenet/input_pipeline.py
+++ b/examples/imagenet/input_pipeline.py
@@ -214,15 +214,13 @@ def load_split(batch_size, train, dtype=tf.float32, image_size=IMAGE_SIZE, cache
   if cache:
     ds = ds.cache()
 
+  ds = ds.repeat()
+
   if train:
-    ds = ds.repeat()
     ds = ds.shuffle(16 * batch_size, seed=0)
 
   ds = ds.map(decode_example, num_parallel_calls=tf.data.experimental.AUTOTUNE)
   ds = ds.batch(batch_size, drop_remainder=True)
-
-  if not train:
-    ds = ds.repeat()
 
   ds = ds.prefetch(10)
 

--- a/examples/imagenet/train.py
+++ b/examples/imagenet/train.py
@@ -275,7 +275,6 @@ def main(argv):
   num_steps = steps_per_epoch * num_epochs
 
   base_learning_rate = FLAGS.learning_rate * batch_size / 256.
-  base_learning_rate = base_learning_rate
 
   model, model_state = create_model(
       rng, device_batch_size, image_size, model_dtype)


### PR DESCRIPTION
- Remove no-op assignment of base learning rate in training code.
- In input pipeline, refactor to have repeat the tf dataset for both train and eval. 
  - Currently repeating of tf dataset is done for both, but is implemented as part of two different conditions.