### PR TITLE
Add *.rej to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ docs/_build
 dist/
 build/
 *.egg-info
+*.rej


### PR DESCRIPTION
Tiny housekeeping thing; now that the [HOWTOs HOWTO](https://flax.readthedocs.io/en/latest/howtos-howto.html) suggests using `git apply --reject`, adding `*.rej` files to `.gitignore`. I noticed that `*.rej` files were making their way into commits.