### PR TITLE
Use three-way merge for checking/applying howtos

### DIFF
--- a/docs/howtos.rst
+++ b/docs/howtos.rst
@@ -17,6 +17,19 @@ Note that these HOWTOs do not require special library support, they just
 demonstate how assembling the JAX and Flax primitives in different ways
 allow you to make various training loop modifications.
 
+There are currently two ways to access a HOWTO: 1) check out a branch with the HOWTO diff applied to the master branch or 2) apply the HOWTO diff yourself:
+
+.. code-block:: bash
+   # Clone repository
+   git clone https://github.com/google/flax
+   cd flax
+
+   # Method 1: Check out HOWTO (e.g., distributed-training):
+   git checkout howto/distributed-training
+
+   # Method 2: Apply HOWTO diff
+   git apply --3way howtos/diffs/distributed-training.diff
+
 Currently the following HOWTOs are available:
 
 Multi-device data-parallel training

--- a/howtos/scripts/apply_howto_diffs.sh
+++ b/howtos/scripts/apply_howto_diffs.sh
@@ -38,7 +38,7 @@ for howto in $howtos; do
   howto_branch="howto/${howto}"
   git checkout -b $howto_branch
   diff_file="${howto_diff_path}/${howto}.diff"
-  git apply $diff_file
+  git apply --3way $diff_file
 
   # Once we are satisfied with the howto, commit and push
   git commit -am "Added howto branch ${howto_branch}"

--- a/howtos/scripts/check_howto_diffs.sh
+++ b/howtos/scripts/check_howto_diffs.sh
@@ -35,9 +35,6 @@ done
 
 printf "Running unit tests for each diff...\n"
 
-# Fetch all branches.
-git fetch --all
-
 curr_branch="$(git rev-parse --abbrev-ref HEAD)"
 for howto in $howtos; do
   diff_file="${howto_diff_path}/${howto}.diff"

--- a/howtos/scripts/check_howto_diffs.sh
+++ b/howtos/scripts/check_howto_diffs.sh
@@ -65,6 +65,7 @@ for howto in $howtos; do
   git apply --3way $diff_file
 
   # Run unit test on affected examples only.
+  # NOTE: this will pick up dirty changes outside of the patch as well
   if ! git diff --name-only HEAD | xargs dirname | xargs pytest; then
     printf "\nERROR: Tests failed for howto ${howto}! ==> PLEASE FIX HOWTO\n"
 

--- a/howtos/scripts/check_howto_diffs.sh
+++ b/howtos/scripts/check_howto_diffs.sh
@@ -65,7 +65,7 @@ for howto in $howtos; do
   git apply --3way $diff_file
 
   # Run unit test on affected examples only.
-  if ! git diff --name-only | xargs dirname | xargs pytest; then
+  if ! git diff --name-only HEAD | xargs dirname | xargs pytest; then
     printf "\nERROR: Tests failed for howto ${howto}! ==> PLEASE FIX HOWTO\n"
 
     # NOTE: Originally, we undid changes, but now we leave local copy modified


### PR DESCRIPTION
After going through the exercise of implementing, I actually lean towards rejecting this PR (though a very weakly held opinion):

1. Increases burden on users (need `git apply -3` or `git apply --3way` instead of just `git apply`) without obvious benefit to them
2. Using `--3way` may actually complicate life a little for maintainers of these scripts and howto authors because we may cause conflicts in their local copies as they are working on other things. There are some hacky ways to check if a merge will cause conflicts before actually merging, which makes `--3way` more palatable.

`--3way` does save us from some howto-editing, but if we expect conflicts to happen infrequently anyway, maybe not a huge benefit.

Anyway, look forward to comments / suggestions!