### PR TITLE
Hide diffs from test files in howto documentation

### DIFF
--- a/docs/format_howtos.py
+++ b/docs/format_howtos.py
@@ -53,21 +53,21 @@ def format_howto(input_file, output_file):
   with open(input_file) as f:
     diff = f.read()
 
-  # Remove all portions of diff related to testing
+  # Remove all portions of diff related to testing.
   chunks = []
   skip_next = False
 
-  # Delimiter for new diff file
+  # Loop through the different files in the diff.
   # - By compiling a grouped expression, we ensure re.split returns both
   # delimiter and delimited strings (i.e., an array of alternating delimiters
-  # and delimited strings)
+  # and delimited strings).
   # - Assume we only want to ignore tests that are Python files
-  file_delimiter_regexp = re.compile("(^diff.*--git.*py$)", re.MULTILINE)
+  file_delimiter_regexp = re.compile("(^diff.*--git.*py$)", re.MULTILINE).
 
   for chunk in file_delimiter_regexp.split(diff):
     # If we see a diff line and it has the word `test`, assume we want to
-    # ignore (i.e., skip the string following this delimiter)
-    # NOTE: this may not always be true, depending on how files are named
+    # ignore (i.e., skip the string following this delimiter).
+    # NOTE: this may not always be true, depending on how files are named.
     if chunk.find("diff --git") == 0:
       if chunk.find("test") > -1:
         skip_next = True

--- a/docs/format_howtos.py
+++ b/docs/format_howtos.py
@@ -75,7 +75,8 @@ def format_howto(input_file, output_file):
     elif skip_next:
       skip_next = False
       continue
-    # Append the chunk after the section "index 9b64f88..69bed4f"
+    # The first two elements in chunk are the empty string and "index
+    # 9b64f88..69bed4f". Remove them.
     chunks.extend(chunk.split("\n")[2:])
 
   # Remove double newlines of diff context from `diff` (which is a

--- a/docs/format_howtos.py
+++ b/docs/format_howtos.py
@@ -51,7 +51,32 @@ def main():
 def format_howto(input_file, output_file):
   # Load one of our HOWTO diff files.
   with open(input_file) as f:
-    diff = f.readlines()
+    diff = f.read()
+
+  # Remove all portions of diff related to testing
+  chunks = []
+  skip_next = False
+
+  # Delimiter for new diff file
+  # - By compiling a grouped expression, we ensure re.split returns both
+  # delimiter and delimited strings (i.e., an array of alternating delimiters
+  # and delimited strings)
+  # - We don't assume any particular file extension or form
+  file_delimiter_regexp = re.compile("(diff.*--git)")
+
+  for chunk in file_delimiter_regexp.split(diff):
+    # If we see a diff line and it has the word `test`, assume we want to
+    # ignore (i.e., skip the string following this delimiter)
+    # NOTE: this may not always be true, depending on how files are named
+    if chunk.find("diff --git") == 0 and chunk.find("test") > -1:
+        skip_next = True
+        continue
+    elif skip_next:
+      skip_next = False
+      continue
+    chunks.append(chunk)
+
+  diff = "".join(chunks).split("\n")
 
   # Ignore the first two line, which look like:
   #

--- a/docs/format_howtos.py
+++ b/docs/format_howtos.py
@@ -61,8 +61,8 @@ def format_howto(input_file, output_file):
   # - By compiling a grouped expression, we ensure re.split returns both
   # delimiter and delimited strings (i.e., an array of alternating delimiters
   # and delimited strings).
-  # - Assume we only want to ignore tests that are Python files
-  file_delimiter_regexp = re.compile("(^diff.*--git.*py$)", re.MULTILINE).
+  # - Assume we only want to ignore tests that are Python files.
+  file_delimiter_regexp = re.compile("(^diff.*--git.*py$)", re.MULTILINE)
 
   for chunk in file_delimiter_regexp.split(diff):
     # If we see a diff line and it has the word `test`, assume we want to


### PR DESCRIPTION
We parse the diff file. Another way to do this would be to
1. Apply the howto diff
2. Undo any diffs on test files
3. Update the howto
4. Format the updated howto

This alternative way is better in the build environment, but makes building documentation locally more difficult (e.g., what if my local copy has changes?).