### PR TITLE
HOWTO: Kernel standardization

### DIFF
--- a/howtos/diffs/kernel-std.diff
+++ b/howtos/diffs/kernel-std.diff
@@ -1,0 +1,45 @@
+diff --git a/examples/mnist/train.py b/examples/mnist/train.py
+index 9c21985..e9ea114 100644
+--- a/examples/mnist/train.py
++++ b/examples/mnist/train.py
+@@ -64,10 +64,10 @@ class CNN(nn.Module):
+   """A simple CNN model."""
+ 
+   def apply(self, x):
+-    x = nn.Conv(x, features=32, kernel_size=(3, 3))
++    x = std_kernel(nn.Conv)(x, features=32, kernel_size=(3, 3))
+     x = nn.relu(x)
+     x = nn.avg_pool(x, window_shape=(2, 2), strides=(2, 2))
+-    x = nn.Conv(x, features=64, kernel_size=(3, 3))
++    x = std_kernel(nn.Conv)(x, features=64, kernel_size=(3, 3))
+     x = nn.relu(x)
+     x = nn.avg_pool(x, window_shape=(2, 2), strides=(2, 2))
+     x = x.reshape((x.shape[0], -1))  # flatten
+@@ -78,6 +78,27 @@ class CNN(nn.Module):
+     return x
+ 
+ 
++def std_kernel(module):
++  """Standardize the kernel parameters of a module."""
++  def std(x, axis, eps=1e-10):
++    x -= jnp.mean(x, axis, keepdims=True)
++    x /= jnp.sqrt(jnp.mean(jnp.square(x), axis, keepdims=True) + eps)
++    return x
++
++  class StdModule(nn.Module):
++
++    def apply(self, *args, **kwargs):
++      def init_fn(rng, _):
++        _, params = module.init(rng, *args, **kwargs)
++        return params
++      params = self.param('kernel', None, init_fn)
++      assert 'kernel' in params
++      params['kernel'] = std(params['kernel'], axis=[0, 1, 2]) 
++      return module.call(params, *args, **kwargs)      
++  
++  return StdModule
++
++
+ def create_model(key):
+   _, initial_params = CNN.init_by_shape(key, [((1, 28, 28, 1), jnp.float32)])
+   model = nn.Model(CNN, initial_params)

--- a/howtos/diffs/kernel-std.diff
+++ b/howtos/diffs/kernel-std.diff
@@ -1,5 +1,5 @@
 diff --git a/examples/mnist/train.py b/examples/mnist/train.py
-index 9c21985..e9ea114 100644
+index 9c21985..f174329 100644
 --- a/examples/mnist/train.py
 +++ b/examples/mnist/train.py
 @@ -64,10 +64,10 @@ class CNN(nn.Module):
@@ -7,20 +7,20 @@ index 9c21985..e9ea114 100644
  
    def apply(self, x):
 -    x = nn.Conv(x, features=32, kernel_size=(3, 3))
-+    x = std_kernel(nn.Conv)(x, features=32, kernel_size=(3, 3))
++    x = std_params(nn.Conv)(x, features=32, kernel_size=(3, 3))
      x = nn.relu(x)
      x = nn.avg_pool(x, window_shape=(2, 2), strides=(2, 2))
 -    x = nn.Conv(x, features=64, kernel_size=(3, 3))
-+    x = std_kernel(nn.Conv)(x, features=64, kernel_size=(3, 3))
++    x = std_params(nn.Conv)(x, features=64, kernel_size=(3, 3))
      x = nn.relu(x)
      x = nn.avg_pool(x, window_shape=(2, 2), strides=(2, 2))
      x = x.reshape((x.shape[0], -1))  # flatten
-@@ -78,6 +78,27 @@ class CNN(nn.Module):
+@@ -78,6 +78,26 @@ class CNN(nn.Module):
      return x
  
  
-+def std_kernel(module):
-+  """Standardize the kernel parameters of a module."""
++def std_params(module):
++  """Standardize the parameters of a module."""
 +  def std(x, axis, eps=1e-10):
 +    x -= jnp.mean(x, axis, keepdims=True)
 +    x /= jnp.sqrt(jnp.mean(jnp.square(x), axis, keepdims=True) + eps)
@@ -32,8 +32,7 @@ index 9c21985..e9ea114 100644
 +      def init_fn(rng, _):
 +        _, params = module.init(rng, *args, **kwargs)
 +        return params
-+      params = self.param('kernel', None, init_fn)
-+      assert 'kernel' in params
++      params = self.param('std_params', None, init_fn)
 +      params['kernel'] = std(params['kernel'], axis=[0, 1, 2]) 
 +      return module.call(params, *args, **kwargs)      
 +  

--- a/howtos/diffs/parameter-standardization.diff
+++ b/howtos/diffs/parameter-standardization.diff
@@ -1,0 +1,45 @@
+diff --git a/examples/mnist/train.py b/examples/mnist/train.py
+index 9c21985..1944f84 100644
+--- a/examples/mnist/train.py
++++ b/examples/mnist/train.py
+@@ -64,10 +64,10 @@ class CNN(nn.Module):
+   """A simple CNN model."""
+ 
+   def apply(self, x):
+-    x = nn.Conv(x, features=32, kernel_size=(3, 3))
++    x = std_params(nn.Conv)(x, features=32, kernel_size=(3, 3))
+     x = nn.relu(x)
+     x = nn.avg_pool(x, window_shape=(2, 2), strides=(2, 2))
+-    x = nn.Conv(x, features=64, kernel_size=(3, 3))
++    x = std_params(nn.Conv)(x, features=64, kernel_size=(3, 3))
+     x = nn.relu(x)
+     x = nn.avg_pool(x, window_shape=(2, 2), strides=(2, 2))
+     x = x.reshape((x.shape[0], -1))  # flatten
+@@ -78,6 +78,27 @@ class CNN(nn.Module):
+     return x
+ 
+ 
++def std_params(module):
++  """Standardize the parameters of a module."""
++  def std(x, axis, eps=1e-10):
++    x -= jnp.mean(x, axis, keepdims=True)
++    x /= jnp.sqrt(jnp.mean(jnp.square(x), axis, keepdims=True) + eps)
++    return x
++
++  class StdModule(nn.Module):
++
++    def apply(self, *args, **kwargs):
++      def init_fn(rng):
++        _, params = module.init(rng, *args, **kwargs)
++        return params
++      kernel = self.param('kernel', None, lambda rng, _: init_fn(rng)['kernel'])
++      bias = self.param('bias', None, lambda rng, _: init_fn(rng)['bias'])
++      std_kernel = std(kernel, axis=[0, 1, 2]) 
++      return module.call({'kernel': std_kernel, 'bias': bias}, *args, **kwargs)      
++  
++  return StdModule
++
++
+ def create_model(key):
+   _, initial_params = CNN.init_by_shape(key, [((1, 28, 28, 1), jnp.float32)])
+   model = nn.Model(CNN, initial_params)


### PR DESCRIPTION
Functional take on weight standardization. 

Sources: 
https://github.com/google-research/big_transfer/blob/master/bit_jax/models.py#L61
https://arxiv.org/abs/1903.10520