### PR TITLE
Fixing pattern in examples/nlp_seq due to lack of shuffling

### DIFF
--- a/examples/nlp_seq/README.md
+++ b/examples/nlp_seq/README.md
@@ -21,7 +21,7 @@ The model should run with other configurations and hardware, but explicitly test
 
 | Hardware |  Batch size  | Learning rate | Training time | Accuracy  | TensorBoard.dev |
 |:---:|:---:|:---:|:---:|:---:|:---:|
-| Nvidia V100 (16GB) | 64  |  0.05 | 5h 15m | 72.20% | [2020-03-22](https://tensorboard.dev/experiment/YkUAdwYaQ9OtYl2IVe3MvA/) |
+| Nvidia 2080Ti (11GB) | 64  |  0.05 | 6h 25m | 71.97% | [2020-06-11](https://tensorboard.dev/experiment/1kp6O2xbRDWCJCmrmnLBgA/) |
 
 ### Running 
 ```

--- a/examples/nlp_seq/input_pipeline.py
+++ b/examples/nlp_seq/input_pipeline.py
@@ -243,4 +243,5 @@ def sentence_dataset_dict(filename,
       batch_size=batch_size, padded_shapes=(padded_shapes))
 
   dataset = dataset.prefetch(prefetch_size)
+  dataset = dataset.shuffle(16 * batch_size, reshuffle_each_iteration=True)
   return dataset


### PR DESCRIPTION
As mentioned in this [issue](https://github.com/google/flax/issues/166) nlp__seq was missing shuffling in the tf dataset. I have added it and re ran the code with the same batch size and training iterations and reproduced a similar accuracy. 