### PR TITLE
Changed module visibility in optim package 

### DIFF
--- a/flax/optim/__init__.py
+++ b/flax/optim/__init__.py
@@ -34,6 +34,8 @@ __all__ = [
     "OptimizerDef",
     "Optimizer",
     "MultiOptimizer",
+    "ModelParamTraversal",
+    "DynamicScale",
     "LAMB",
     "LARS",
     "Momentum",


### PR DESCRIPTION
Although implemented, the `ModelParamTraversal` and `DynamicScale` were not accessible via an import statement of the form `from flax.optim import DynamicScale`, for example. This PR adds the aforementioned modules to the `__all__` list in `optim`'s `__init__.py` source.