### PR TITLE
Assert valid learning rate in LAMB optimizer

### DIFF
--- a/flax/optim/lamb.py
+++ b/flax/optim/lamb.py
@@ -65,6 +65,7 @@ class LAMB(OptimizerDef):
     return _LAMBParamState(jnp.zeros_like(param), jnp.zeros_like(param))
 
   def apply_param_gradient(self, step, hyper_params, param, state, grad):
+    assert hyper_params.learning_rate is not None, 'no learning rate provided.'
     beta1 = hyper_params.beta1
     beta2 = hyper_params.beta2
     weight_decay = hyper_params.weight_decay


### PR DESCRIPTION
All optimizers apart from LAMB use an `assert` statement to make sure that `hyper_params.learning_rate is not None`. This PR introduces such an assert also to LAMB.