### PR TITLE
fix pooling ops with explicit padding

### DIFF
--- a/flax/nn/pooling.py
+++ b/flax/nn/pooling.py
@@ -44,6 +44,14 @@ def pool(inputs, init, reduce_fn, window_shape, strides, padding):
   strides = strides or (1,) * len(window_shape)
   strides = (1,) + strides + (1,)
   dims = (1,) + window_shape + (1,)
+  if not isinstance(padding, str):
+    padding = tuple(map(tuple, padding))
+    assert(len(padding) == len(window_shape)), (
+      f"padding {padding} must specify pads for same number of dims as "
+      f"window_shape {window_shape}")
+    assert(all([len(x) == 2 for x in padding])), (
+      f"each entry in padding {padding} must be length 2")
+    padding = ((0,0),) + padding + ((0,0),)
   return lax.reduce_window(inputs, init, reduce_fn, dims, strides, padding)
 
 

--- a/tests/nn_test.py
+++ b/tests/nn_test.py
@@ -545,6 +545,24 @@ class PoolTest(absltest.TestCase):
     ]).reshape((1, 3, 3, 1))
     onp.testing.assert_allclose(y_grad, expected_grad)
 
+  def test_max_pool_explicit_pads(self):
+    x = jnp.arange(9).reshape((1, 3, 3, 1)).astype(jnp.float32)
+    pool = lambda x: nn.max_pool(x, (2, 2), padding=((1,1),(1,1)))
+    expected_y = jnp.array([
+        [0.,1.,2.,2.],
+        [3.,4.,5.,5.],
+        [6.,7.,8.,8.],
+        [6.,7.,8.,8.],
+    ]).reshape((1, 4, 4, 1))
+    y = pool(x)
+    onp.testing.assert_allclose(y, expected_y)
+    y_grad = jax.grad(lambda x: pool(x).sum())(x)
+    expected_grad = jnp.array([
+        [1., 1., 2.],
+        [1., 1., 2.],
+        [2., 2., 4.],
+    ]).reshape((1, 3, 3, 1))
+    onp.testing.assert_allclose(y_grad, expected_grad)
 
 class NormalizationTest(absltest.TestCase):
 


### PR DESCRIPTION
previous max_pool and avg_pool didn't work with explicit (e.g. `((1,1),(1,1))` padding specs) padding for the reduce window. 
fixes #356 