### PR TITLE
Add overview to examples/README.md

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -10,7 +10,19 @@ Each examples is designed to be self-contained and easily forkable, while reprod
 * Adherence to Flax best practices and code updates as those best practices evolve
 * An "owner" who is a member of the Flax core team who keeps the example up-to-date
 * A minimal implementation of a single model on a single dataset (users can fork and change the configuration to run on another dataset)
- 
+
+| Example | Description | Features |
+| ------- | ----------- | -------- |
+| [cifar10](cifar10/README.md) | Wideresnet & pyramidnet implementations with shake-shake / shake-drop regularization for CIFAR-10 classification | Single host SPMD, tfds `cifar10`, custom preprocessing |
+| [graph](graph/README.md) | Graph convolutional network to label nodes in small toy dataset | Data inlined, simple code |
+| [imagenet](imagenet/README.md) | Resnet-50 on imagenet with weight decay | Multi host SPMD, tfds `imagenet`, custom preprocessing, checkpointing, dynamic scaling, mixed precision |
+| [lm1b](lm1b/README.md) | Transformer encoder for next token prediction | Single host SPMD, tfds `lm1b`, checkpointing, dynamic bucketing, attention cache, Colab |
+| [mnist](mnist/README.md) | Convolutional neural network for MNIST classification | Tfds `mnist`, simple code |
+| [pixelcnn](pixelcnn/README.md) | PixelCNN++ for CIFAR-10 generation | Single host SPMD, tfds `cifar10`, checkpointing, Polyak decay |
+| [seq2seq](seq2seq/README.md) | LSTM encoder/decoder for completing `42+1234=` sequences | On the fly data generation, LSTM state handling, simple code |
+| [vae](vae/README.md) | Variational auto-encoder for binarized MNIST images | Tfds `binarized_mnist`, vmap, simple code |
+| [wmt](wmt/REAMDE.md) | Transformer for translating en/de | Multi host SPMD, tfds `wmt1{4,7}_translate`, SentencePiece tokenization, checkpointing, dynamic bucketing, attention cache, packed sequences, recipe for TPU training on GCP |
+
 ## Flax examples from the community
  
 In addition to the curated list of official Flax examples, there is a growing community of people using Flax to build new types of machine learning models. We are happy to showcase any example built by the community here! If you want to submit your own example, we suggest that you start by forking one of the official Flax example, and start from there.

--- a/examples/README.md
+++ b/examples/README.md
@@ -21,7 +21,7 @@ Each examples is designed to be self-contained and easily forkable, while reprod
 | [pixelcnn](pixelcnn/README.md) | PixelCNN++ for CIFAR-10 generation | Single host SPMD, tfds `cifar10`, checkpointing, Polyak decay |
 | [seq2seq](seq2seq/README.md) | LSTM encoder/decoder for completing `42+1234=` sequences | On the fly data generation, LSTM state handling, simple code |
 | [vae](vae/README.md) | Variational auto-encoder for binarized MNIST images | Tfds `binarized_mnist`, vmap, simple code |
-| [wmt](wmt/REAMDE.md) | Transformer for translating en/de | Multi host SPMD, tfds `wmt1{4,7}_translate`, SentencePiece tokenization, checkpointing, dynamic bucketing, attention cache, packed sequences, recipe for TPU training on GCP |
+| [wmt](wmt/README.md) | Transformer for translating en/de | Multi host SPMD, tfds `wmt1{4,7}_translate`, SentencePiece tokenization, checkpointing, dynamic bucketing, attention cache, packed sequences, recipe for TPU training on GCP |
 
 ## Flax examples from the community
  


### PR DESCRIPTION
A step towards streamlining the Flax examples (see also issue #231) - this PR gives a short overview over the different examples that allows users to quickly find an example they might be interested in (e.g. finding an example implementing multi host SPMD with custom preprocessing vs. a simple example with inline data).

Note that the table is deliberately kept short, both in terms of description/features, as well as in number of rows (@avital mentioned `nlp_seq`, `sst`, and `wip/moco` examples were not a priority).