### PR TITLE
Add .style.yapf config that matches the Google internal style guide.

### DIFF
--- a/.style.yapf
+++ b/.style.yapf
@@ -1,0 +1,2 @@
+[style]
+based_on_style: yapf


### PR DESCRIPTION
Unfortunately the Google internal formatting is different from PEP8
(column limit 79 -> 80 and indent width 4 -> 2, a few things around when
and how to split lines). YAPFs own style matches this but is not the default.

YAPF will automatically pick up the config when run anywhere inside the
repository.