### PR TITLE
Take 2: Add .style.yapf config that matches the Google internal style guide.

### DIFF
--- a/.style.yapf
+++ b/.style.yapf
@@ -1,0 +1,2 @@
+[style]
+based_on_style: yapf


### PR DESCRIPTION
Re-committing #384 after it got reverted by misconfigured Copybara

Unfortunately the Google internal formating is different from PEP8
(column limit 79 -> 80 and indent width 4 -> 2, a few things around when
and how to split lines). YAPFs own style matches this.

YAPF will automatically pick up the config when run anywhere inside the
repository.