### PR TITLE
seq2seq example in the Linen API

### DIFF
--- a/examples/seq2seq/train.py
+++ b/examples/seq2seq/train.py
@@ -19,7 +19,7 @@ import random
 from absl import app
 from absl import flags
 from absl import logging
-from functools import partial
+import functools
 
 from flax import jax_utils
 from flax import linen as nn
@@ -30,8 +30,11 @@ from typing import Any, Callable, Tuple
 
 import jax
 import jax.numpy as jnp
+from jax.config import config
+config.enable_omnistaging()
 
 import numpy as np
+
 
 FLAGS = flags.FLAGS
 

--- a/examples/seq2seq/train.py
+++ b/examples/seq2seq/train.py
@@ -319,7 +319,6 @@ def get_examples(num_examples):
 def get_batch(batch_size):
   """Returns a batch of example of size @batch_size."""
   inputs, outputs = zip(*get_examples(batch_size))
-  #print(inputs[0], '|', outputs[0])
   return {
       'query': encode_onehot(inputs, max_len=get_max_input_len()),
       'answer': encode_onehot(outputs, max_len=get_max_output_len())

--- a/examples/seq2seq/train.py
+++ b/examples/seq2seq/train.py
@@ -19,10 +19,14 @@ import random
 from absl import app
 from absl import flags
 from absl import logging
+from functools import partial
 
 from flax import jax_utils
-from flax import nn
+from flax import linen as nn
 from flax import optim
+from flax.core import Scope, init, apply, unfreeze, lift
+
+from typing import Any, Callable, Tuple
 
 import jax
 import jax.numpy as jnp
@@ -40,6 +44,9 @@ flags.DEFINE_integer(
     'batch_size', default=128, help=('Batch size for training.'))
 
 flags.DEFINE_integer(
+    'hidden_size', default=128, help=('Hidden size of the LSTM.'))
+
+flags.DEFINE_integer(
     'num_train_steps', default=10000, help=('Number of train steps.'))
 
 flags.DEFINE_integer(
@@ -52,6 +59,10 @@ flags.DEFINE_integer(
     default=3,
     help=('Maximum length of a single input digit.'))
 
+PRNGKey = Any
+Shape = Tuple[int]
+Dtype = Any
+Array = Any
 
 class CharacterTable(object):
   """Encode/decodes between strings and integer representations."""
@@ -149,100 +160,112 @@ def mask_sequences(sequence_batch, lengths):
       lengths[:, np.newaxis] > np.arange(sequence_batch.shape[1]))
 
 
+class EncoderLSTM(nn.Module):
+  eos_id: int = 1
+
+  @functools.partial(
+    nn.transforms.scan,
+    variable_modes={'param': 'broadcast'},
+    split_rngs={'param': False})
+  @nn.compact
+  def __call__(self, carry, x):
+    lstm_state, is_eos = carry
+    new_lstm_state, y = nn.LSTMCell(self, name='lstm_cell')(lstm_state, x)
+    # Pass forward the previous state if EOS has already been reached.
+    def select_carried_state(new_state, old_state):
+      return jnp.where(is_eos[:, np.newaxis], old_state, new_state)
+    # LSTM state is a tuple (c, h).
+    carried_lstm_state = tuple(
+        select_carried_state(*s) for s in zip(new_lstm_state, lstm_state))
+    # Update `is_eos`.
+    is_eos = jnp.logical_or(is_eos, x[:, self.eos_id])
+    return (carried_lstm_state, is_eos), y
+
+  @staticmethod
+  def initialize_carry(batch_size, hidden_size):
+    # use dummy key since default state init fn is just zeros.
+    return nn.LSTMCell.initialize_carry(
+      jax.random.PRNGKey(0), (batch_size,), hidden_size)
+
+
 class Encoder(nn.Module):
   """LSTM encoder, returning state after EOS is input."""
+  eos_id: int = 1
+  hidden_size: int = 512
 
   @nn.compact
-  def apply(self, inputs, eos_id=1, hidden_size=512):
+  def __call__(self, inputs):
     # inputs.shape = (batch_size, seq_length, vocab_size).
     batch_size = inputs.shape[0]
-
-    lstm_cell = nn.LSTMCell.shared(name='lstm')
-    init_lstm_state = nn.LSTMCell.initialize_carry(
-        nn.make_rng(),
-        (batch_size,),
-        hidden_size)
-
-    def encode_step_fn(carry, x):
-      lstm_state, is_eos = carry
-      new_lstm_state, y = lstm_cell(lstm_state, x)
-      # Pass forward the previous state if EOS has already been reached.
-      def select_carried_state(new_state, old_state):
-        return jnp.where(is_eos[:, np.newaxis], old_state, new_state)
-      # LSTM state is a tuple (c, h).
-      carried_lstm_state = tuple(
-          select_carried_state(*s) for s in zip(new_lstm_state, lstm_state))
-      # Update `is_eos`.
-      is_eos = jnp.logical_or(is_eos, x[:, eos_id])
-      return (carried_lstm_state, is_eos), y
-
-    init_carry = (init_lstm_state, jnp.zeros(batch_size, dtype=np.bool))
-    if self.is_initializing():
-      # initialize parameters before scan
-      encode_step_fn(init_carry, inputs[:, 0])
-
-    (final_state, _), _ = jax_utils.scan_in_dim(
-        encode_step_fn,
-        init=init_carry,
-        xs=inputs,
-        axis=1)
+    lstm = EncoderLSTM(self, eos_id=self.eos_id, name='encoder_lstm')
+    init_lstm_state = lstm.initialize_carry(batch_size, self.hidden_size)
+    init_carry = (init_lstm_state, jnp.zeros(batch_size, dtype=np.bool))    
+    # scan over input axis 1 - we should make scan accept an axis argument again.
+    inputs = jax.tree_map(lambda x: jnp.moveaxis(x, 0, 1), inputs)
+    (final_state, _), _ = lstm(init_carry, inputs)
     return final_state
+
+
+class DecoderLSTM(nn.Module):
+  vocab_size: int
+  teacher_force: bool = False
+
+  @functools.partial(
+    nn.transforms.scan,
+    variable_modes={'param': 'broadcast'},
+    split_rngs={'param': False})
+  @nn.compact
+  def __call__(self, carry, x):
+    rng, lstm_state, last_prediction = carry
+    carry_rng, categorical_rng = jax.random.split(rng, 2)
+    if not self.teacher_force:
+      x = last_prediction
+    lstm_cell = nn.LSTMCell(self, name='lstm_cell')
+    projection = nn.Dense(self, features=self.vocab_size, name='projection')
+    lstm_state, y = lstm_cell(lstm_state, x)
+    logits = projection(y)
+    predicted_tokens = jax.random.categorical(categorical_rng, logits)
+    prediction = onehot(predicted_tokens, self.vocab_size)
+    return (carry_rng, lstm_state, prediction), (logits, prediction)
 
 
 class Decoder(nn.Module):
   """LSTM decoder."""
+  init_state: Tuple[Any]
+  teacher_force: bool = False
 
   @nn.compact
-  def apply(self, init_state, inputs, teacher_force=False):
+  def __call__(self, inputs):
     # inputs.shape = (batch_size, seq_length, vocab_size).
-    vocab_size = inputs.shape[2]
-    lstm_cell = nn.LSTMCell.shared(name='lstm')
-    projection = nn.Dense.shared(features=vocab_size, name='projection')
-
-    def decode_step_fn(carry, x):
-      rng, lstm_state, last_prediction = carry
-      carry_rng, categorical_rng = jax.random.split(rng, 2)
-      if not teacher_force:
-        x = last_prediction
-      lstm_state, y = lstm_cell(lstm_state, x)
-      logits = projection(y)
-      predicted_tokens = jax.random.categorical(categorical_rng, logits)
-      prediction = onehot(predicted_tokens, vocab_size)
-      return (carry_rng, lstm_state, prediction), (logits, prediction)
-    init_carry = (nn.make_rng(), init_state, inputs[:, 0])
-
-    if self.is_initializing():
-      # initialize parameters before scan
-      decode_step_fn(init_carry, inputs[:, 0])
-
-    _, (logits, predictions) = jax_utils.scan_in_dim(
-        decode_step_fn,
-        init=init_carry,  # rng, lstm_state, last_pred
-        xs=inputs,
-        axis=1)
+    lstm = DecoderLSTM(self,
+                       vocab_size=inputs.shape[2], 
+                       teacher_force=self.teacher_force)
+    init_carry = (self.make_rng('lstm'), self.init_state, inputs[:, 0])
+    # scan over input axis 1 - we should make scan accept an axis argument again.
+    inputs = jax.tree_map(lambda x: jnp.moveaxis(x, 0, 1), inputs)
+    _, (logits, predictions) = lstm(init_carry, inputs)
+    logits, predictions = jax.tree_map(lambda x: jnp.moveaxis(x, 0, 1), (logits, predictions))
     return logits, predictions
 
 
 class Seq2seq(nn.Module):
-  """Sequence-to-sequence class using encoder/decoder architecture."""
-
-  def _create_modules(self, eos_id, hidden_size):
-    encoder = Encoder.partial(
-        eos_id=eos_id, hidden_size=hidden_size).shared(name='encoder')
-    decoder = Decoder.shared(name='decoder')
-    return encoder, decoder
+  """Sequence-to-sequence class using encoder/decoder architecture.
+  Attributes:
+    teacher_force: bool, whether to use `decoder_inputs` as input to the
+        decoder at every step. If False, only the first input is used, followed
+        by samples taken from the previous output logits.
+    eos_id: int, the token signaling when the end of a sequence is reached.
+    hidden_size: int, the number of hidden dimensions in the encoder and
+      decoder LSTMs.
+  """
+  teacher_force: bool = True
+  eos_id: int = 1
+  hidden_size: int = 512
 
   @nn.compact
-  def apply(self,
-            encoder_inputs,
-            decoder_inputs,
-            teacher_force=True,
-            eos_id=1,
-            hidden_size=512):
+  def __call__(self, encoder_inputs, decoder_inputs):
     """Run the seq2seq model.
-
     Args:
-      rng_key: key for seeding the random numbers.
       encoder_inputs: padded batch of input sequences to encode, shaped
         `[batch_size, max(encoder_input_lengths), vocab_size]`.
       decoder_inputs: padded batch of expected decoded sequences for teacher
@@ -251,44 +274,32 @@ class Seq2seq(nn.Module):
         forced into the model and samples are used for the following inputs. The
         second dimension of this tensor determines how many steps will be
         decoded, regardless of the value of `teacher_force`.
-      teacher_force: bool, whether to use `decoder_inputs` as input to the
-        decoder at every step. If False, only the first input is used, followed
-        by samples taken from the previous output logits.
-      eos_id: int, the token signaling when the end of a sequence is reached.
-      hidden_size: int, the number of hidden dimensions in the encoder and
-        decoder LSTMs.
     Returns:
       Array of decoded logits.
     """
-    encoder, decoder = self._create_modules(eos_id, hidden_size)
-
     # Encode inputs
-    init_decoder_state = encoder(encoder_inputs)
+    init_decoder_state = Encoder(
+        self, eos_id=self.eos_id, hidden_size=self.hidden_size)(
+            encoder_inputs)
     # Decode outputs.
-    logits, predictions = decoder(
-        init_decoder_state,
-        decoder_inputs[:, :-1],
-        teacher_force=teacher_force)
+    logits, predictions = Decoder(
+        self, init_state=init_decoder_state, teacher_force=self.teacher_force)(
+            decoder_inputs[:, :-1])
 
     return logits, predictions
 
 
-def create_model():
+def model(teacher_force=True):
+  return Seq2seq(parent=None, eos_id=CTABLE.eos_id, teacher_force=teacher_force,
+                 hidden_size=FLAGS.hidden_size)
+
+
+def get_param(key):
   """Creates a seq2seq model."""
   vocab_size = CTABLE.vocab_size
-  _, initial_params = Seq2seq.partial(eos_id=CTABLE.eos_id).init_by_shape(
-      nn.make_rng(),
-      [((1, get_max_input_len(), vocab_size), jnp.float32),
-       ((1, get_max_output_len(), vocab_size), jnp.float32)])
-  model = nn.Model(Seq2seq, initial_params)
-  return model
-
-
-def create_optimizer(model, learning_rate):
-  """Creates an Adam optimizer for @model."""
-  optimizer_def = optim.Adam(learning_rate=learning_rate)
-  optimizer = optimizer_def.create(model)
-  return optimizer
+  encoder_shape = jnp.ones((1, get_max_input_len(), vocab_size), jnp.float32)
+  decoder_shape = jnp.ones((1, get_max_output_len(), vocab_size), jnp.float32)
+  return model().init({'param': key, 'lstm': key}, encoder_shape, decoder_shape)['param']
 
 
 def get_examples(num_examples):
@@ -305,7 +316,7 @@ def get_examples(num_examples):
 def get_batch(batch_size):
   """Returns a batch of example of size @batch_size."""
   inputs, outputs = zip(*get_examples(batch_size))
-
+  #print(inputs[0], '|', outputs[0])
   return {
       'query': encode_onehot(inputs, max_len=get_max_input_len()),
       'answer': encode_onehot(outputs, max_len=get_max_output_len())
@@ -338,16 +349,19 @@ def compute_metrics(logits, labels):
 
 
 @jax.jit
-def train_step(optimizer, batch, rng):
+def train_step(optimizer, batch, lstm_key):
   """Train one step."""
   labels = batch['answer'][:, 1:]  # remove '=' start token
 
-  def loss_fn(model):
+  def loss_fn(params):
     """Compute cross-entropy loss."""
-    with nn.stochastic(rng):
-      logits, _ = model(batch['query'], batch['answer'])
+    logits, _ = model().apply({'param': params},
+                              batch['query'],
+                              batch['answer'],
+                              rngs={'lstm': lstm_key})
     loss = cross_entropy_loss(logits, labels, get_sequence_lengths(labels))
     return loss, logits
+
   grad_fn = jax.value_and_grad(loss_fn, has_aux=True)
   (_, logits), grad = grad_fn(optimizer.target)
   optimizer = optimizer.apply_gradient(grad)
@@ -363,21 +377,23 @@ def log_decode(question, inferred, golden):
 
 
 @jax.jit
-def decode(model, inputs, rng):
+def decode(params, inputs, key):
   """Decode inputs."""
   init_decoder_input = onehot(CTABLE.encode('=')[0:1], CTABLE.vocab_size)
   init_decoder_inputs = jnp.tile(init_decoder_input,
                                  (inputs.shape[0], get_max_output_len(), 1))
-  with nn.stochastic(rng):
-    _, predictions = model(inputs, init_decoder_inputs, teacher_force=False)
+  _, predictions = model(teacher_force=False).apply({'param': params},
+                                                    inputs,
+                                                    init_decoder_inputs,
+                                                    rngs={'lstm': key})
   return predictions
 
 
-def decode_batch(model, batch_size):
+def decode_batch(params, batch_size, key):
   """Decode and log results for a batch."""
   batch = get_batch(batch_size)
   inputs, outputs = batch['query'], batch['answer'][:, 1:]
-  inferred = decode(model, inputs, nn.make_rng())
+  inferred = decode(params, inputs, key)
   questions = decode_onehot(inputs)
   infers = decode_onehot(inferred)
   goldens = decode_onehot(outputs)
@@ -387,16 +403,18 @@ def decode_batch(model, batch_size):
 
 def train_model():
   """Train for a fixed number of steps and decode during training."""
-  with nn.stochastic(jax.random.PRNGKey(0)):
-    model = create_model()
-    optimizer = create_optimizer(model, FLAGS.learning_rate)
-    for step in range(FLAGS.num_train_steps):
-      batch = get_batch(FLAGS.batch_size)
-      optimizer, metrics = train_step(optimizer, batch, nn.make_rng())
-      if step % FLAGS.decode_frequency == 0:
-        logging.info('train step: %d, loss: %.4f, accuracy: %.2f', step,
-                     metrics['loss'], metrics['accuracy'] * 100)
-        decode_batch(optimizer.target, 5)
+  param = get_param(jax.random.PRNGKey(0))
+  optimizer = optim.Adam(learning_rate=FLAGS.learning_rate).create(param)
+  key = jax.random.PRNGKey(0)
+  for step in range(FLAGS.num_train_steps):
+    key, lstm_key = jax.random.split(key)
+    batch = get_batch(FLAGS.batch_size)
+    optimizer, metrics = train_step(optimizer, batch, lstm_key)
+    if step % FLAGS.decode_frequency == 0:
+      key, decode_key = jax.random.split(key)
+      logging.info('train step: %d, loss: %.4f, accuracy: %.2f', step,
+                   metrics['loss'], metrics['accuracy'] * 100)
+      decode_batch(optimizer.target, 5, decode_key)
   return optimizer.target
 
 

--- a/flax/jax_utils.py
+++ b/flax/jax_utils.py
@@ -117,7 +117,8 @@ def partial_eval_by_shape(fn, input_spec, *args, **kwargs):
   if config.omnistaging_enabled:
     _, out_pvals, _ = pe.trace_to_jaxpr(f_flat, in_pvals)
   else:
-    _, out_pvals, _ = pe.trace_to_jaxpr(f_flat, in_pvals, stage_out=True)
+    with jax.core.initial_style_staging():
+      _, out_pvals, _ = pe.trace_to_jaxpr(f_flat, in_pvals, stage_out=True)
   out_flat = [const if pv is None else jax.ShapeDtypeStruct(pv.shape, pv.dtype)
               for pv, const in out_pvals]
   return jax.tree_unflatten(out_tree(), out_flat)


### PR DESCRIPTION
Anselm managed to get `transforms.scan` working in this PR, very cool!

I also added a fix related to Jax omnistaging to `jax_utils.py`, which is in the master branch but not in linen2.