### PR TITLE
Add unit test for sst2 training and evaluation loop by executing single epoch.

### DIFF
--- a/examples/sst2/train.py
+++ b/examples/sst2/train.py
@@ -305,7 +305,24 @@ def train_and_evaluate(
   seed, model_dir, num_epochs, batch_size, embedding_size, hidden_size,
   min_freq, max_seq_len, dropout, emb_dropout, word_dropout_rate,
   learning_rate, checkpoints_to_keep, l2_reg):
-  """Executes model training and evaluation loop."""
+  """Executes model training and evaluation loop.
+  
+  Args:
+    seed: Random seed for network initialization.
+    model_dir: Directory to store model data.
+    num_epochs: Number of training epochs.
+    batch_size: Batch size for training.
+    embedding_size: Size of the word embeddings.
+    hidden_size: Hidden size for the LSTM and MLP.
+    min_freq: Minimum frequency for training set words to be in vocabulary.
+    max_seq_len: Maximum sequence length in the dataset.
+    dropout: Dropout rate.
+    emb_dropout: Embedding dropout rate.
+    word_dropout_rate: Word dropout rate.
+    learning_rate: The learning rate for the Adam optimizer.
+    checkpoints_to_keep: Number of checkpoints to keep.
+    l2_reg: L2 regularization to keep. 
+  """
   tf.enable_v2_behavior()
 
   # Prepare data.

--- a/examples/sst2/train_test.py
+++ b/examples/sst2/train_test.py
@@ -26,12 +26,10 @@ import train as sst2_train
 
 
 class Sst2TrainTest(absltest.TestCase):
-  """Test cases for train."""
+  """Test cases for SST2 train file."""
 
   def test_train_and_evaluate(self):
-    """Tests training and evaluation code by running a single step with
-       mocked data for MNIST dataset.
-    """
+    """Tests training and evaluation loop using TFDS mocked data."""
     # Create a temporary directory where tensorboard metrics are written.
     model_dir = tempfile.mkdtemp()
 
@@ -42,7 +40,7 @@ class Sst2TrainTest(absltest.TestCase):
     with tfds.testing.mock_data(num_examples=8, data_dir=data_dir):
       sst2_train.train_and_evaluate(
           seed=0, model_dir=model_dir, num_epochs=1, batch_size=8,
-          embedding_size=8, hidden_size=8, min_freq=5, max_seq_len=55,
+          embedding_size=256, hidden_size=256, min_freq=5, max_seq_len=55,
           dropout=0.5, emb_dropout=0.5, word_dropout_rate=0.1,
           learning_rate=0.0005, checkpoints_to_keep=0, l2_reg=1e-6)
 

--- a/examples/sst2/train_test.py
+++ b/examples/sst2/train_test.py
@@ -1,0 +1,51 @@
+# Copyright 2020 The Flax Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Lint as: python3
+"""Tests for flax.examples.sst2.train."""
+
+import pathlib
+import tempfile
+
+from absl.testing import absltest
+
+import tensorflow_datasets as tfds
+
+import train as sst2_train
+
+
+class Sst2TrainTest(absltest.TestCase):
+  """Test cases for train."""
+
+  def test_train_and_evaluate(self):
+    """Tests training and evaluation code by running a single step with
+       mocked data for MNIST dataset.
+    """
+    # Create a temporary directory where tensorboard metrics are written.
+    model_dir = tempfile.mkdtemp()
+
+    # Go two directories up to the root of the flax directory.
+    flax_root_dir = pathlib.Path(__file__).parents[2]
+    data_dir = str(flax_root_dir) + '/.tfds/metadata'
+
+    with tfds.testing.mock_data(num_examples=8, data_dir=data_dir):
+      sst2_train.train_and_evaluate(
+          seed=0, model_dir=model_dir, num_epochs=1, batch_size=8,
+          embedding_size=8, hidden_size=8, min_freq=5, max_seq_len=55,
+          dropout=0.5, emb_dropout=0.5, word_dropout_rate=0.1,
+          learning_rate=0.0005, checkpoints_to_keep=0, l2_reg=1e-6)
+
+
+if __name__ == '__main__':
+  absltest.main()

--- a/pytest.ini
+++ b/pytest.ini
@@ -3,6 +3,7 @@
 # UserWarning is due to statement: tensorflow.compat.v2.io import gfile
 # DeprecationWarning is due to statement: tensorflow.compat.v2.io import gfile
 # inspect.getargspec() is invoked in tensorboard/backend/event_processing/event_file_loader.py:61
+# jnp.sum([]) in examples/sst2/train.py:L152 should be replaced with an ndarray.
 filterwarnings =
     error
     ignore:numpy.ufunc size changed.*:RuntimeWarning
@@ -10,3 +11,4 @@ filterwarnings =
     ignore:can't resolve package from.*:ImportWarning
     ignore:the imp module is deprecated.*:DeprecationWarning
     ignore:inspect.getargspec() is deprecated since Python 3.0.*:DeprecationWarning
+    ignore:jax.numpy reductions won't accept lists and tuples in future versions, only scalars and ndarrays.*:FutureWarning


### PR DESCRIPTION
Add unit test for SST2 as part of #176 

* Run the model training and evaluation loop for a single epoch on 8 examples randomly generated using tfds.testing.mock_data.
* Minor refactoring in train.py to skip setting flag values in the test (this will be beneficial in the future as well with #231 )