### PR TITLE
Add single input conv and conv_transpose support

### DIFF
--- a/flax/nn/linear.py
+++ b/flax/nn/linear.py
@@ -220,6 +220,11 @@ class Conv(base.Module):
 
     inputs = jnp.asarray(inputs, dtype)
 
+    is_single_input = False
+    if inputs.ndim == len(kernel_size) + 1:
+      is_single_input = True
+      inputs = jnp.expand_dims(inputs, axis=0)
+      
     if strides is None:
       strides = (1,) * (inputs.ndim - 2)
 
@@ -241,6 +246,8 @@ class Conv(base.Module):
         feature_group_count=feature_group_count,
         precision=precision)
 
+    if is_single_input:
+      y = jnp.squeeze(y, axis=0)
     if bias:
       bias = self.param('bias', (features,), bias_init)
       bias = jnp.asarray(bias, dtype)
@@ -289,6 +296,12 @@ class ConvTranspose(base.Module):
       The convolved data.
     """
     inputs = jnp.asarray(inputs, dtype)
+    
+    is_single_input = False
+    if inputs.ndim == len(kernel_size) + 1:
+      is_single_input = True
+      inputs = jnp.expand_dims(inputs, axis=0)
+    
     strides = strides or (1,) * (inputs.ndim - 2)
 
     in_features = inputs.shape[-1]
@@ -299,6 +312,8 @@ class ConvTranspose(base.Module):
     y = lax.conv_transpose(inputs, kernel, strides, padding,
                            rhs_dilation=kernel_dilation, precision=precision)
 
+    if is_single_input:
+      y = jnp.squeeze(y, axis=0)
     if bias:
       bias = self.param('bias', (features,), bias_init)
       bias = jnp.asarray(bias, dtype)

--- a/tests/nn_linear_test.py
+++ b/tests/nn_linear_test.py
@@ -176,6 +176,21 @@ class LinearTest(parameterized.TestCase):
     model = nn.Model(conv_module, initial_params)
     self.assertEqual(model.params['kernel'].shape, (3, 3, 4))
     onp.testing.assert_allclose(y, onp.full((1, 6, 4), 10.))
+    
+  def test_single_input_conv(self):
+    rng = random.PRNGKey(0)
+    x = jnp.ones((8, 3))
+    conv_module = nn.Conv.partial(
+        features=4,
+        kernel_size=(3,),
+        padding='VALID',
+        kernel_init=initializers.ones,
+        bias_init=initializers.ones,
+    )
+    y, initial_params = conv_module.init(rng, x)
+    model = nn.Model(conv_module, initial_params)
+    self.assertEqual(model.params['kernel'].shape, (3, 3, 4))
+    onp.testing.assert_allclose(y, onp.full((6, 4), 10.))
 
   def test_group_conv(self):
     rng = random.PRNGKey(0)
@@ -216,6 +231,31 @@ class LinearTest(parameterized.TestCase):
                               [10., 10., 10., 10.],
                               [ 7.,  7.,  7.,  7.],
                               [ 4.,  4.,  4.,  4.]]])
+    onp.testing.assert_allclose(y, correct_ans)
+    
+  def test_single_input_conv_transpose(self):
+    rng = random.PRNGKey(0)
+    x = jnp.ones((8, 3))
+    conv_transpose_module = nn.ConvTranspose.partial(
+        features=4,
+        kernel_size=(3,),
+        padding='VALID',
+        kernel_init=initializers.ones,
+        bias_init=initializers.ones,
+    )
+    y, initial_params = conv_transpose_module.init(rng, x)
+    model = nn.Model(conv_transpose_module, initial_params)
+    self.assertEqual(model.params['kernel'].shape, (3, 3, 4))
+    correct_ans = onp.array([[ 4.,  4.,  4.,  4.],
+                              [ 7.,  7.,  7.,  7.],
+                              [10., 10., 10., 10.],
+                              [10., 10., 10., 10.],
+                              [10., 10., 10., 10.],
+                              [10., 10., 10., 10.],
+                              [10., 10., 10., 10.],
+                              [10., 10., 10., 10.],
+                              [ 7.,  7.,  7.,  7.],
+                              [ 4.,  4.,  4.,  4.]])
     onp.testing.assert_allclose(y, correct_ans)
 
   def test_embed(self):


### PR DESCRIPTION
This PR adds support and relevant test cases for single example input to conv and conv-transpose. The code changes provided by @levskaya [here](https://github.com/google/flax/issues/375) is perfect and is directly adapted into this PR. 