### PR TITLE
unify variable_in_axes and variable_out_axes

### DIFF
--- a/flax/core/tests/lift_test.py
+++ b/flax/core/tests/lift_test.py
@@ -32,11 +32,9 @@ class ScopeTest(absltest.TestCase):
         scope, a = scopes
         self.assertEqual(a.parent, scope)
       
-      lift.vmap(g, variable_in_axes={}, variable_out_axes={}, split_rngs={})((scope, a), jnp.ones((1,)))
+      lift.vmap(g, variable_axes={}, split_rngs={})((scope, a), jnp.ones((1,)))
 
     init(f)(random.PRNGKey(0))
-
-  
 
 
 if __name__ == '__main__':

--- a/linen_examples/core_design_test/attention_simple.py
+++ b/linen_examples/core_design_test/attention_simple.py
@@ -119,15 +119,13 @@ def multi_head_dot_product_attention(
       attn_fn,
       in_axes=(None, None, None), out_axes=-2,
       axis_size=num_heads,
-      variable_in_axes={'param': 0},
-      variable_out_axes={'param': 0},
+      variable_axes={'param': 0},
       split_rngs={'param': True, 'dropout': not broadcast_dropout})
   for axis in reversed(sorted(batch_axes)):
     attn_fn = lift.vmap(
         attn_fn,
         in_axes=(axis, axis, axis), out_axes=axis,
-        variable_in_axes={'param': None},
-        variable_out_axes={'param': None},
+        variable_axes={'param': None},
         split_rngs={'param': False, 'dropout': not broadcast_dropout})
 
   y = attn_fn(scope, inputs_q, inputs_kv, bias)

--- a/linen_examples/core_design_test/big_resnets.py
+++ b/linen_examples/core_design_test/big_resnets.py
@@ -59,8 +59,7 @@ def big_resnet(scope: Scope, x, blocks=(10, 10), dtype=jnp.float32,
 
   return lift.remat_scan(
       body_fn, scope, x, lengths=blocks,
-      variable_in_axes={'param': 0, 'batch_stats': 0},
-      variable_out_axes={'param': 0, 'batch_stats': 0},
+      variable_axes={'param': 0, 'batch_stats': 0},
       split_rngs={'param': True})
 
 if __name__ == "__main__":

--- a/linen_examples/core_design_test/scan.py
+++ b/linen_examples/core_design_test/scan.py
@@ -40,15 +40,13 @@ def mlp_scan(scope: Scope, xs: Array,
     carry, ys = lift.scan(
         body_fn,
         variable_carry='counter',
-        variable_in_axes={'param': lift.broadcast},
-        variable_out_axes={'param': lift.broadcast},
+        variable_axes={'param': lift.broadcast},
         split_rngs={'param': False})(scope, (), xs)
   else:
     carry, ys = lift.scan(
         body_fn,
         variable_carry='counter',
-        variable_in_axes={'param': 0},
-        variable_out_axes={'param': 0},
+        variable_axes={'param': 0},
         split_rngs={'param': True})(scope, (), xs)
 
   # output layer

--- a/linen_examples/core_design_test/vmap.py
+++ b/linen_examples/core_design_test/vmap.py
@@ -31,14 +31,12 @@ def mlp_vmap(scope: Scope, x: Array,
   if share_params:
     dense_vmap = lift.vmap(nn.dense,
                            in_axes=(0, None),
-                           variable_in_axes={'param': None},
-                           variable_out_axes={'param': None},
+                           variable_axes={'param': None},
                            split_rngs={'param': False})
   else:
     dense_vmap = lift.vmap(nn.dense,
                            in_axes=(0, None),
-                           variable_in_axes={'param': 0},
-                           variable_out_axes={'param': 0},
+                           variable_axes={'param': 0},
                            split_rngs={'param': True})
 
   # hidden layers

--- a/linen_examples/seq2seq/train.py
+++ b/linen_examples/seq2seq/train.py
@@ -168,8 +168,7 @@ class EncoderLSTM(nn.Module):
 
   @functools.partial(
       nn.transforms.scan,
-      variable_in_axes={'param': nn.broadcast},
-      variable_out_axes={'param': nn.broadcast},
+      variable_axes={'param': nn.broadcast},
       split_rngs={'param': False})
   @nn.compact
   def __call__(self, carry, x):
@@ -216,8 +215,7 @@ class DecoderLSTM(nn.Module):
 
   @functools.partial(
       nn.transforms.scan,
-      variable_in_axes={'param': nn.broadcast},
-      variable_out_axes={'param': nn.broadcast},
+      variable_axes={'param': nn.broadcast},
       split_rngs={'param': False})
   @nn.compact
   def __call__(self, carry, x):

--- a/tests/linen/linen_transforms_test.py
+++ b/tests/linen/linen_transforms_test.py
@@ -124,8 +124,7 @@ class TransformTest(absltest.TestCase):
     def vmap(cls):
       return nn.vmap(cls,
                      in_axes=(0,),
-                     variable_in_axes={'param': None},
-                     variable_out_axes={'param': None},
+                     variable_axes={'param': None},
                      split_rngs={'param': False})
     normal_model = TransformedMLP(features=[3, 4, 5])
     vmap_model = TransformedMLP(features=[3, 4, 5], transform=vmap)
@@ -144,8 +143,7 @@ class TransformTest(absltest.TestCase):
     def vmap(fn):
       return nn.vmap(fn,
                      in_axes=(0,),
-                     variable_in_axes={'param': None},
-                     variable_out_axes={'param': None},
+                     variable_axes={'param': None},
                      split_rngs={'param': False})
     normal_model = decorated_MLP()(features=[3, 4, 5])
     vmap_model = decorated_MLP(vmap)(features=[3, 4, 5])
@@ -161,8 +159,7 @@ class TransformTest(absltest.TestCase):
       @nn.compact
       def __call__(self, c, xs):
         LSTM = nn.scan(nn.LSTMCell,
-                       variable_in_axes={'param': nn.broadcast},
-                       variable_out_axes={'param': nn.broadcast},
+                       variable_axes={'param': nn.broadcast},
                        split_rngs={'param': False})
         return LSTM(name="lstm_cell")(c, xs)
 
@@ -191,8 +188,7 @@ class TransformTest(absltest.TestCase):
   def test_scan_decorated(self):
     class SimpleScan(nn.Module):
       @partial(nn.scan,
-               variable_in_axes={'param': nn.broadcast},
-               variable_out_axes={'param': nn.broadcast},
+               variable_axes={'param': nn.broadcast},
                split_rngs={'param': False})
       @nn.compact
       def __call__(self, c, xs):
@@ -434,8 +430,7 @@ class TransformTest(absltest.TestCase):
       outer_module: nn.Module
       @partial(nn.vmap,
                in_axes=(0,),
-               variable_in_axes={'param': 0},
-               variable_out_axes={'param': 0},
+               variable_axes={'param': 0},
                split_rngs={'param': True})
       @nn.jit
       @nn.compact


### PR DESCRIPTION
Remove variable_in_axes and `variable_out_axes` in favor of `variable_axes` If only one axes should be mapped you can use 
 `variable_axes={'debug': Out(0)}`