### PR TITLE
Avoid passing python collections to jax reductions in SST2 example.

### DIFF
--- a/examples/sst2/train.py
+++ b/examples/sst2/train.py
@@ -38,6 +38,7 @@ from flax import nn
 
 import jax
 import jax.numpy as jnp
+import numpy as np
 
 import tensorflow.compat.v2 as tf
 import tensorflow_datasets as tfds
@@ -148,8 +149,7 @@ def train_step(optimizer: Any, inputs: jnp.ndarray, lengths: jnp.ndarray,
 
     # L2 regularization
     l2_params = jax.tree_leaves(model.params['lstm_classifier'])
-    # TODO(mohitreddy): Convert list to a ndarray in outer jnp.sum().
-    l2_weight = jnp.sum([jnp.sum(p ** 2) for p in l2_params])
+    l2_weight = np.sum([jnp.sum(p ** 2) for p in l2_params])
     l2_penalty = l2_reg * l2_weight
 
     loss = loss + l2_penalty

--- a/pytest.ini
+++ b/pytest.ini
@@ -3,7 +3,6 @@
 # UserWarning is due to statement: tensorflow.compat.v2.io import gfile
 # DeprecationWarning is due to statement: tensorflow.compat.v2.io import gfile
 # inspect.getargspec() is invoked in tensorboard/backend/event_processing/event_file_loader.py:61
-# jnp.sum([]) in examples/sst2/train.py:L152 should be replaced with an ndarray.
 filterwarnings =
     error
     ignore:numpy.ufunc size changed.*:RuntimeWarning
@@ -11,4 +10,3 @@ filterwarnings =
     ignore:can't resolve package from.*:ImportWarning
     ignore:the imp module is deprecated.*:DeprecationWarning
     ignore:inspect.getargspec() is deprecated since Python 3.0.*:DeprecationWarning
-    ignore:jax.numpy reductions won't accept lists and tuples in future versions, only scalars and ndarrays.*:FutureWarning


### PR DESCRIPTION
* Avoid passing python collections to jax reductions in SST2 example.

* Remove pytest.ini entry for the same. The example has unit test coverage which executes a single step of training and evaluation.