### PR TITLE
force upgrade pygments

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,6 @@
 sphinx
 sphinx_rtd_theme
+Pygments>=2.6.1
 jax>=0.1.59
 jaxlib>=0.1.41
 ipykernel


### PR DESCRIPTION
An outdated version of pygments caused our build to fail.