### PR TITLE
Examples : Hide GPUs from TensorFlow and use default v2.

### DIFF
--- a/examples/cifar10/train.py
+++ b/examples/cifar10/train.py
@@ -332,8 +332,6 @@ def main(argv):
   if len(argv) > 1:
     raise app.UsageError('Too many command-line arguments.')
 
-  tf.enable_v2_behavior()
-
   train(FLAGS.model_dir, FLAGS.batch_size, FLAGS.num_epochs,
         FLAGS.learning_rate, FLAGS.momentum, FLAGS.l2_reg, FLAGS.rng)
 

--- a/examples/cifar10/train.py
+++ b/examples/cifar10/train.py
@@ -37,7 +37,8 @@ from jax import random
 import jax.nn
 import jax.numpy as jnp
 
-import tensorflow.compat.v2 as tf
+import tensorflow as tf
+tf.config.experimental.set_visible_devices([], "GPU")
 
 
 FLAGS = flags.FLAGS

--- a/examples/imagenet/imagenet_lib.py
+++ b/examples/imagenet/imagenet_lib.py
@@ -197,30 +197,9 @@ def sync_batch_stats(state):
   return state.replace(model_state=avg(state.model_state))
 
 
-def train_and_evaluate(model_dir: str, batch_size: int, num_epochs: int,
-                       learning_rate: float, momentum: float, cache: bool,
-                       half_precision: bool, num_train_steps: int = -1,
-                       num_eval_steps: int = -1):
-  """Runs model training and evaluation loop.
-
-  Args:
-    model_dir: Directory where the checkpoints and tensorboard summaries
-      should be written to.
-    batch_size: Batch size of the input.
-    num_epochs: Number of epochs to cycle through before stopping.
-    learning_rate: The learning rate in case you have batch size 256.
-      The effective learning rate is scaled linearly to the batch size.
-    momentum: Momentum value for the momentum optimizer.
-    cache: Determines whether the dataset should be cached.
-    half_precision: Determines whether bfloat16/float16 should be used
-      instead of float32.
-    num_train_steps: Number of trainings steps to be executed in a
-      single epoch. Default = -1 signifies using the entire TRAIN split.
-    num_eval_steps: Number of evaluation steps to be executed in a
-      single epoch. Default = -1 signifies using the entire VALIDATION split.
-  """
-  # make sure tf does not allocate gpu memory
-  tf.config.experimental.set_visible_devices([], 'GPU')
+def main(argv):
+  if len(argv) > 1:
+    raise app.UsageError('Too many command-line arguments.')
 
   if jax.host_id() == 0:
     summary_writer = tensorboard.SummaryWriter(model_dir)

--- a/examples/imagenet/imagenet_lib.py
+++ b/examples/imagenet/imagenet_lib.py
@@ -197,10 +197,28 @@ def sync_batch_stats(state):
   return state.replace(model_state=avg(state.model_state))
 
 
-def main(argv):
-  if len(argv) > 1:
-    raise app.UsageError('Too many command-line arguments.')
+def train_and_evaluate(model_dir: str, batch_size: int, num_epochs: int,
+                       learning_rate: float, momentum: float, cache: bool,
+                       half_precision: bool, num_train_steps: int = -1,
+                       num_eval_steps: int = -1):
+  """Runs model training and evaluation loop.
 
+  Args:
+    model_dir: Directory where the checkpoints and tensorboard summaries
+      should be written to.
+    batch_size: Batch size of the input.
+    num_epochs: Number of epochs to cycle through before stopping.
+    learning_rate: The learning rate in case you have batch size 256.
+      The effective learning rate is scaled linearly to the batch size.
+    momentum: Momentum value for the momentum optimizer.
+    cache: Determines whether the dataset should be cached.
+    half_precision: Determines whether bfloat16/float16 should be used
+      instead of float32.
+    num_train_steps: Number of trainings steps to be executed in a
+      single epoch. Default = -1 signifies using the entire TRAIN split.
+    num_eval_steps: Number of evaluation steps to be executed in a
+      single epoch. Default = -1 signifies using the entire VALIDATION split.
+  """
   if jax.host_id() == 0:
     summary_writer = tensorboard.SummaryWriter(model_dir)
 

--- a/examples/imagenet/imagenet_lib.py
+++ b/examples/imagenet/imagenet_lib.py
@@ -30,6 +30,7 @@ import jax.nn
 import jax.numpy as jnp
 
 import tensorflow as tf
+tf.config.experimental.set_visible_devices([], "GPU")
 import tensorflow_datasets as tfds
 
 import flax

--- a/examples/lm1b/train.py
+++ b/examples/lm1b/train.py
@@ -353,8 +353,6 @@ def train_and_evaluate(
     sampling_top_k: Top k cutoff for logit sampling.
     prompt_str: Prompt for language model sampling.
   """
-  tf.enable_v2_behavior()
-
   if jax.host_id() == 0:
     train_summary_writer = tensorboard.SummaryWriter(
         os.path.join(model_dir, 'train'))

--- a/examples/lm1b/train.py
+++ b/examples/lm1b/train.py
@@ -39,7 +39,9 @@ from jax import random
 import jax.nn
 import jax.numpy as jnp
 import numpy as np
-import tensorflow.compat.v2 as tf
+import tensorflow as tf
+tf.config.experimental.set_visible_devices([], "GPU")
+
 
 FLAGS = flags.FLAGS
 

--- a/examples/mnist/mnist_lib.py
+++ b/examples/mnist/mnist_lib.py
@@ -27,6 +27,8 @@ import jax.numpy as jnp
 
 import numpy as onp
 
+import tensorflow as tf
+tf.config.experimental.set_visible_devices([], "GPU")
 import tensorflow_datasets as tfds
 
 from flax import nn

--- a/examples/nlp_seq/train.py
+++ b/examples/nlp_seq/train.py
@@ -36,7 +36,9 @@ from jax import random
 import jax.nn
 import jax.numpy as jnp
 import numpy as np
-import tensorflow.compat.v2 as tf
+import tensorflow as tf
+tf.config.experimental.set_visible_devices([], "GPU")
+
 
 FLAGS = flags.FLAGS
 

--- a/examples/nlp_seq/train.py
+++ b/examples/nlp_seq/train.py
@@ -269,8 +269,6 @@ def main(argv):
   if len(argv) > 1:
     raise app.UsageError('Too many command-line arguments.')
 
-  tf.enable_v2_behavior()
-
   batch_size = FLAGS.batch_size
   learning_rate = FLAGS.learning_rate
   num_train_steps = FLAGS.num_train_steps

--- a/examples/pixelcnn/train.py
+++ b/examples/pixelcnn/train.py
@@ -48,7 +48,8 @@ from jax import lax
 import jax.numpy as jnp
 import numpy as np
 
-import tensorflow.compat.v2 as tf
+import tensorflow as tf
+tf.config.experimental.set_visible_devices([], "GPU")
 
 import input_pipeline
 import pixelcnn

--- a/examples/pixelcnn/train.py
+++ b/examples/pixelcnn/train.py
@@ -297,8 +297,6 @@ def main(argv):
   if len(argv) > 1:
     raise app.UsageError('Too many command-line arguments.')
 
-  tf.enable_v2_behavior()
-
   pcnn_module = pixelcnn.PixelCNNPP.partial(depth=FLAGS.n_resnet,
                                             features=FLAGS.n_feature,
                                             k=FLAGS.n_logistic_mix)

--- a/examples/sst2/train.py
+++ b/examples/sst2/train.py
@@ -324,8 +324,6 @@ def train_and_evaluate(
     checkpoints_to_keep: Number of checkpoints to keep.
     l2_reg: L2 regularization to keep. 
   """
-  tf.enable_v2_behavior()
-
   # Prepare data.
   data_source = input_pipeline.SST2DataSource(min_freq=min_freq)
 

--- a/examples/sst2/train.py
+++ b/examples/sst2/train.py
@@ -40,7 +40,8 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 
-import tensorflow.compat.v2 as tf
+import tensorflow as tf
+tf.config.experimental.set_visible_devices([], "GPU")
 import tensorflow_datasets as tfds
 from tensorflow.io import gfile
 

--- a/examples/vae/train.py
+++ b/examples/vae/train.py
@@ -25,6 +25,7 @@ from flax import nn
 from flax import optim
 
 import tensorflow as tf
+tf.config.experimental.set_visible_devices([], "GPU")
 import tensorflow_datasets as tfds
 
 from utils import save_image

--- a/examples/wip/moco/train_moco.py
+++ b/examples/wip/moco/train_moco.py
@@ -736,8 +736,6 @@ def main(argv):
   if len(argv) > 1:
     raise app.UsageError('Too many command-line arguments.')
 
-  tf.enable_v2_behavior()
-
   emb_size = FLAGS.emb_size
 
   if FLAGS.arch == 'resnet50':

--- a/examples/wip/moco/train_moco.py
+++ b/examples/wip/moco/train_moco.py
@@ -52,7 +52,8 @@ from jax import lax
 import jax.nn
 import jax.numpy as jnp
 
-import tensorflow.compat.v2 as tf
+import tensorflow as tf
+tf.config.experimental.set_visible_devices([], "GPU")
 
 
 FLAGS = flags.FLAGS

--- a/examples/wmt/train.py
+++ b/examples/wmt/train.py
@@ -53,7 +53,9 @@ from jax import random
 import jax.nn
 import jax.numpy as jnp
 import numpy as np
-import tensorflow.compat.v2 as tf
+import tensorflow as tf
+tf.config.experimental.set_visible_devices([], "GPU")
+
 
 FLAGS = flags.FLAGS
 

--- a/examples/wmt/train.py
+++ b/examples/wmt/train.py
@@ -506,9 +506,6 @@ def main(argv):
     jax.config.FLAGS.jax_xla_backend = 'tpu_driver'
     jax.config.FLAGS.jax_backend_target = FLAGS.jax_backend_target
 
-  # This seems to be necessary even when importing TF2?
-  tf.enable_v2_behavior()
-
   # Number of local devices for this host.
   n_devices = jax.local_device_count()
 

--- a/howtos/diffs/distributed-training.diff
+++ b/howtos/diffs/distributed-training.diff
@@ -1,5 +1,5 @@
 diff --git a/examples/mnist/mnist_lib.py b/examples/mnist/mnist_lib.py
-index 63af6e8..87c57b0 100644
+index 1ca49b2..93eaea7 100644
 --- a/examples/mnist/mnist_lib.py
 +++ b/examples/mnist/mnist_lib.py
 @@ -20,6 +20,8 @@ The data is loaded using tensorflow_datasets.
@@ -11,15 +11,15 @@ index 63af6e8..87c57b0 100644
  import jax
  from jax import random
  
-@@ -32,6 +34,7 @@ import tensorflow_datasets as tfds
+@@ -31,6 +33,7 @@ import tensorflow as tf
  tf.config.experimental.set_visible_devices([], "GPU")
  import tensorflow_datasets as tfds
-
+ 
 +from flax import jax_utils
  from flax import nn
  from flax import optim
  from flax.metrics import tensorboard
-@@ -60,6 +63,7 @@ def create_model(key):
+@@ -62,6 +65,7 @@ def create_model(key):
  def create_optimizer(model, learning_rate, beta):
    optimizer_def = optim.Momentum(learning_rate=learning_rate, beta=beta)
    optimizer = optimizer_def.create(model)
@@ -27,7 +27,7 @@ index 63af6e8..87c57b0 100644
    return optimizer
  
  
-@@ -72,6 +76,11 @@ def cross_entropy_loss(logits, labels):
+@@ -74,6 +78,11 @@ def cross_entropy_loss(logits, labels):
    return -jnp.mean(jnp.sum(onehot(labels) * logits, axis=-1))
  
  
@@ -39,7 +39,7 @@ index 63af6e8..87c57b0 100644
  def compute_metrics(logits, labels):
    loss = cross_entropy_loss(logits, labels)
    accuracy = jnp.mean(jnp.argmax(logits, -1) == labels)
-@@ -82,7 +91,7 @@ def compute_metrics(logits, labels):
+@@ -84,7 +93,7 @@ def compute_metrics(logits, labels):
    return metrics
  
  
@@ -48,7 +48,7 @@ index 63af6e8..87c57b0 100644
  def train_step(optimizer, batch):
    """Train for a single step."""
    def loss_fn(model):
-@@ -91,8 +100,10 @@ def train_step(optimizer, batch):
+@@ -93,8 +102,10 @@ def train_step(optimizer, batch):
      return loss, logits
    grad_fn = jax.value_and_grad(loss_fn, has_aux=True)
    (_, logits), grad = grad_fn(optimizer.target)
@@ -59,7 +59,7 @@ index 63af6e8..87c57b0 100644
    return optimizer, metrics
  
  
-@@ -104,6 +115,9 @@ def eval_step(model, batch):
+@@ -106,6 +117,9 @@ def eval_step(model, batch):
  
  def train_epoch(optimizer, train_ds, batch_size, epoch, rng):
    """Train for a single epoch."""
@@ -69,7 +69,7 @@ index 63af6e8..87c57b0 100644
    train_ds_size = len(train_ds['image'])
    steps_per_epoch = train_ds_size // batch_size
  
-@@ -113,6 +127,7 @@ def train_epoch(optimizer, train_ds, batch_size, epoch, rng):
+@@ -115,6 +129,7 @@ def train_epoch(optimizer, train_ds, batch_size, epoch, rng):
    batch_metrics = []
    for perm in perms:
      batch = {k: v[perm] for k, v in train_ds.items()}
@@ -77,7 +77,7 @@ index 63af6e8..87c57b0 100644
      optimizer, metrics = train_step(optimizer, batch)
      batch_metrics.append(metrics)
  
-@@ -170,7 +185,8 @@ def train_and_evaluate(model_dir: str, num_epochs: int, batch_size: int,
+@@ -172,7 +187,8 @@ def train_and_evaluate(model_dir: str, num_epochs: int, batch_size: int,
      rng, input_rng = random.split(rng)
      optimizer, train_metrics = train_epoch(
          optimizer, train_ds, batch_size, epoch, input_rng)

--- a/howtos/diffs/distributed-training.diff
+++ b/howtos/diffs/distributed-training.diff
@@ -11,10 +11,10 @@ index 63af6e8..87c57b0 100644
  import jax
  from jax import random
  
-@@ -29,6 +31,7 @@ import numpy as onp
- 
+@@ -32,6 +34,7 @@ import tensorflow_datasets as tfds
+ tf.config.experimental.set_visible_devices([], "GPU")
  import tensorflow_datasets as tfds
- 
+
 +from flax import jax_utils
  from flax import nn
  from flax import optim

--- a/howtos/diffs/ensembling.diff
+++ b/howtos/diffs/ensembling.diff
@@ -11,8 +11,8 @@ index 63af6e8..ebf9f9b 100644
  import jax
  from jax import random
  
-@@ -29,6 +31,7 @@ import numpy as onp
- 
+@@ -31,6 +33,7 @@ import tensorflow as tf
+ tf.config.experimental.set_visible_devices([], "GPU")
  import tensorflow_datasets as tfds
  
 +from flax import jax_utils

--- a/howtos/diffs/ensembling.diff
+++ b/howtos/diffs/ensembling.diff
@@ -1,5 +1,5 @@
 diff --git a/examples/mnist/mnist_lib.py b/examples/mnist/mnist_lib.py
-index 63af6e8..ebf9f9b 100644
+index 1ca49b2..1a5ed71 100644
 --- a/examples/mnist/mnist_lib.py
 +++ b/examples/mnist/mnist_lib.py
 @@ -20,6 +20,8 @@ The data is loaded using tensorflow_datasets.
@@ -19,7 +19,7 @@ index 63af6e8..ebf9f9b 100644
  from flax import nn
  from flax import optim
  from flax.metrics import tensorboard
-@@ -51,12 +54,14 @@ class CNN(nn.Module):
+@@ -53,12 +56,14 @@ class CNN(nn.Module):
      return x
  
  
@@ -34,7 +34,7 @@ index 63af6e8..ebf9f9b 100644
  def create_optimizer(model, learning_rate, beta):
    optimizer_def = optim.Momentum(learning_rate=learning_rate, beta=beta)
    optimizer = optimizer_def.create(model)
-@@ -82,7 +87,7 @@ def compute_metrics(logits, labels):
+@@ -84,7 +89,7 @@ def compute_metrics(logits, labels):
    return metrics
  
  
@@ -43,7 +43,7 @@ index 63af6e8..ebf9f9b 100644
  def train_step(optimizer, batch):
    """Train for a single step."""
    def loss_fn(model):
-@@ -96,7 +101,7 @@ def train_step(optimizer, batch):
+@@ -98,7 +103,7 @@ def train_step(optimizer, batch):
    return optimizer, metrics
  
  
@@ -52,7 +52,7 @@ index 63af6e8..ebf9f9b 100644
  def eval_step(model, batch):
    logits = model(batch['image'])
    return compute_metrics(logits, batch['label'])
-@@ -113,16 +118,23 @@ def train_epoch(optimizer, train_ds, batch_size, epoch, rng):
+@@ -115,16 +120,23 @@ def train_epoch(optimizer, train_ds, batch_size, epoch, rng):
    batch_metrics = []
    for perm in perms:
      batch = {k: v[perm] for k, v in train_ds.items()}
@@ -80,7 +80,7 @@ index 63af6e8..ebf9f9b 100644
                 epoch_metrics_np['loss'], epoch_metrics_np['accuracy'] * 100)
  
    return optimizer, epoch_metrics_np
-@@ -131,7 +143,7 @@ def train_epoch(optimizer, train_ds, batch_size, epoch, rng):
+@@ -133,7 +145,7 @@ def train_epoch(optimizer, train_ds, batch_size, epoch, rng):
  def eval_model(model, test_ds):
    metrics = eval_step(model, test_ds)
    metrics = jax.device_get(metrics)
@@ -89,7 +89,7 @@ index 63af6e8..ebf9f9b 100644
    return summary['loss'], summary['accuracy']
  
  
-@@ -163,22 +175,25 @@ def train_and_evaluate(model_dir: str, num_epochs: int, batch_size: int,
+@@ -165,22 +177,25 @@ def train_and_evaluate(model_dir: str, num_epochs: int, batch_size: int,
    summary_writer = tensorboard.SummaryWriter(model_dir)
  
    rng, init_rng = random.split(rng)

--- a/howtos/diffs/scheduled-sampling.diff
+++ b/howtos/diffs/scheduled-sampling.diff
@@ -124,7 +124,7 @@ index 60b79b5..2d946ca 100644
    return optimizer.target
  
 diff --git a/examples/seq2seq/train_test.py b/examples/seq2seq/train_test.py
-index b638d55..26fc7b8 100644
+index b638d55..006603b 100644
 --- a/examples/seq2seq/train_test.py
 +++ b/examples/seq2seq/train_test.py
 @@ -101,7 +101,7 @@ class TrainTest(absltest.TestCase):

--- a/howtos/diffs/scheduled-sampling.diff
+++ b/howtos/diffs/scheduled-sampling.diff
@@ -136,8 +136,3 @@ index b638d55..26fc7b8 100644
  
      self.assertLessEqual(train_metrics['loss'], 5)
      self.assertGreaterEqual(train_metrics['accuracy'], 0)
-@@ -113,3 +113,4 @@ class TrainTest(absltest.TestCase):
- 
- if __name__ == '__main__':
-   absltest.main()
-+

--- a/linen_examples/imagenet/train.py
+++ b/linen_examples/imagenet/train.py
@@ -41,7 +41,8 @@ from jax import random
 import jax.nn
 import jax.numpy as jnp
 
-import tensorflow.compat.v2 as tf
+import tensorflow as tf
+tf.config.experimental.set_visible_devices([], "GPU")
 
 # enable jax omnistaging
 from jax.config import config

--- a/linen_examples/imagenet/train.py
+++ b/linen_examples/imagenet/train.py
@@ -243,7 +243,6 @@ def main(argv):
   if len(argv) > 1:
     raise app.UsageError('Too many command-line arguments.')
 
-  tf.enable_v2_behavior()
   # make sure tf does not allocate gpu memory
   tf.config.experimental.set_visible_devices([], 'GPU')
 

--- a/linen_examples/mnist/mnist_lib.py
+++ b/linen_examples/mnist/mnist_lib.py
@@ -28,6 +28,8 @@ config.enable_omnistaging()
 
 import numpy as onp
 
+import tensorflow as tf
+tf.config.experimental.set_visible_devices([], "GPU")
 import tensorflow_datasets as tfds
 
 from flax import linen as nn

--- a/linen_examples/pixelcnn/train.py
+++ b/linen_examples/pixelcnn/train.py
@@ -49,6 +49,7 @@ import jax.numpy as jnp
 from jax.config import config
 
 import tensorflow as tf
+tf.config.experimental.set_visible_devices([], "GPU")
 
 import input_pipeline
 import pixelcnn

--- a/linen_examples/vae/train.py
+++ b/linen_examples/vae/train.py
@@ -27,6 +27,7 @@ from flax import linen as nn
 from flax import optim
 
 import tensorflow as tf
+tf.config.experimental.set_visible_devices([], "GPU")
 import tensorflow_datasets as tfds
 
 from utils import save_image

--- a/linen_examples/wmt/train.py
+++ b/linen_examples/wmt/train.py
@@ -489,9 +489,6 @@ def main(argv):
     jax.config.FLAGS.jax_xla_backend = 'tpu_driver'
     jax.config.FLAGS.jax_backend_target = FLAGS.jax_backend_target
 
-  # This seems to be necessary even when importing TF2?
-  tf.enable_v2_behavior()
-
   # Number of local devices for this host.
   n_devices = jax.local_device_count()
 

--- a/linen_examples/wmt/train.py
+++ b/linen_examples/wmt/train.py
@@ -28,7 +28,8 @@ from jax import random
 import jax
 import jax.numpy as jnp
 import numpy as np
-import tensorflow.compat.v2 as tf
+import tensorflow as tf
+tf.config.experimental.set_visible_devices([], "GPU")
 
 from flax import jax_utils
 from flax import linen as nn


### PR DESCRIPTION
This change hides GPUs from TensorFlow to avoid it from grabbing GPU
memory (see issue #445).

Also bumps to TensorFlow 2 has been the default for a while.