### PR TITLE
Add configdict for mnist linen example to configure HP.

### DIFF
--- a/linen_examples/mnist/README.md
+++ b/linen_examples/mnist/README.md
@@ -8,10 +8,24 @@ Trains a simple convolutional network on the MNIST dataset.
 ### Example output
 
 ```
-I0828 08:51:41.821526 139971964110656 mnist_lib.py:128] train epoch: 10, loss: 0.0097, accuracy: 99.69
-I0828 08:51:42.248714 139971964110656 mnist_lib.py:178] eval epoch: 10, loss: 0.0299, accuracy: 99.14
+I0828 08:51:41.821526 139971964110656 mnist_lib.py:130] train epoch: 10, loss: 0.0097, accuracy: 99.69
+I0828 08:51:42.248714 139971964110656 mnist_lib.py:180] eval epoch: 10, loss: 0.0299, accuracy: 99.14
 ```
 
 ### How to run
 
 `python mnist_main.py --model_dir=/tmp/mnist`
+
+#### Overriding Hyperparameter configurations
+
+MNIST example allows specifying a hyperparameter configuration by the means of
+setting `--config` flag. Configuration flag is defined using
+[config_flags](https://github.com/google/ml_collections/tree/master#config-flags).
+`config_flags` allows overriding configuration fields. This can be done as
+follows:
+
+```shell
+python mnist_main.py \
+--model_dir=/tmp/mnist --config=configs/default.py \
+--config.learning_rate=0.05 --config.num_epochs=5
+```

--- a/linen_examples/mnist/configs/default.py
+++ b/linen_examples/mnist/configs/default.py
@@ -1,0 +1,28 @@
+# Copyright 2020 The Flax Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Default Hyperparameter configuration."""
+
+import ml_collections
+
+
+def get_config():
+  """Get the default hyperparameter configuration."""
+  config = ml_collections.ConfigDict()
+
+  config.learning_rate = 0.1
+  config.momentum = 0.9
+  config.batch_size = 128
+  config.num_epochs = 10
+  return config

--- a/linen_examples/mnist/mnist_lib.py
+++ b/linen_examples/mnist/mnist_lib.py
@@ -23,8 +23,8 @@ from absl import logging
 import jax
 from jax import random
 import jax.numpy as jnp
-from jax.config import config
-config.enable_omnistaging()
+
+jax.config.enable_omnistaging()
 
 import ml_collections
 
@@ -150,11 +150,11 @@ def get_datasets():
   return train_ds, test_ds
 
 
-def train_and_evaluate(hp_config: ml_collections.ConfigDict, model_dir: str):
+def train_and_evaluate(config: ml_collections.ConfigDict, model_dir: str):
   """Execute model training and evaluation loop.
 
   Args:
-    hp_config: Hyperparameter configuration for training and evaluation.
+    config: Hyperparameter configuration for training and evaluation.
     model_dir: Directory where the tensorboard summaries are written to.
 
   Returns:
@@ -168,12 +168,12 @@ def train_and_evaluate(hp_config: ml_collections.ConfigDict, model_dir: str):
   rng, init_rng = random.split(rng)
   params = get_initial_params(init_rng)
   optimizer = create_optimizer(
-      params, hp_config.learning_rate, hp_config.momentum)
+      params, config.learning_rate, config.momentum)
 
-  for epoch in range(1, hp_config.num_epochs + 1):
+  for epoch in range(1, config.num_epochs + 1):
     rng, input_rng = random.split(rng)
     optimizer, train_metrics = train_epoch(
-        optimizer, train_ds, hp_config.batch_size, epoch, input_rng)
+        optimizer, train_ds, config.batch_size, epoch, input_rng)
     loss, accuracy = eval_model(optimizer.target, test_ds)
 
     logging.info('eval epoch: %d, loss: %.4f, accuracy: %.2f',

--- a/linen_examples/mnist/mnist_lib.py
+++ b/linen_examples/mnist/mnist_lib.py
@@ -26,6 +26,8 @@ import jax.numpy as jnp
 from jax.config import config
 config.enable_omnistaging()
 
+import ml_collections
+
 import numpy as onp
 
 import tensorflow_datasets as tfds
@@ -148,17 +150,16 @@ def get_datasets():
   return train_ds, test_ds
 
 
-def train_and_evaluate(model_dir: str, num_epochs: int, batch_size: int,
-                       learning_rate: float, momentum: float):
+def train_and_evaluate(hp_config: ml_collections.ConfigDict, model_dir: str):
   """Execute model training and evaluation loop.
 
   Args:
+    hp_config: Hyperparameter configuration for training and evaluation.
     model_dir: Directory where the tensorboard summaries are written to.
-    num_epochs: Number of epochs to cycle through the dataset before stopping.
-    batch_size: Batch size of the input.
-    learning_rate: Learning rate for the momentum optimizer.
-    momentum: Momentum value for the momentum optimizer.
-"""
+
+  Returns:
+    The trained optimizer.
+  """
   train_ds, test_ds = get_datasets()
   rng = random.PRNGKey(0)
 
@@ -166,12 +167,13 @@ def train_and_evaluate(model_dir: str, num_epochs: int, batch_size: int,
 
   rng, init_rng = random.split(rng)
   params = get_initial_params(init_rng)
-  optimizer = create_optimizer(params, learning_rate, momentum)
+  optimizer = create_optimizer(
+      params, hp_config.learning_rate, hp_config.momentum)
 
-  for epoch in range(1, num_epochs + 1):
+  for epoch in range(1, hp_config.num_epochs + 1):
     rng, input_rng = random.split(rng)
     optimizer, train_metrics = train_epoch(
-        optimizer, train_ds, batch_size, epoch, input_rng)
+        optimizer, train_ds, hp_config.batch_size, epoch, input_rng)
     loss, accuracy = eval_model(optimizer.target, test_ds)
 
     logging.info('eval epoch: %d, loss: %.4f, accuracy: %.2f',

--- a/linen_examples/mnist/mnist_lib_test.py
+++ b/linen_examples/mnist/mnist_lib_test.py
@@ -66,7 +66,7 @@ class MnistLibTest(absltest.TestCase):
     config.batch_size = 8
 
     with tfds.testing.mock_data(num_examples=8, data_dir=data_dir):
-      mnist_lib.train_and_evaluate(hp_config=config, model_dir=model_dir)
+      mnist_lib.train_and_evaluate(config=config, model_dir=model_dir)
 
 
 if __name__ == '__main__':

--- a/linen_examples/mnist/mnist_lib_test.py
+++ b/linen_examples/mnist/mnist_lib_test.py
@@ -25,6 +25,7 @@ from jax import numpy as jnp
 import tensorflow as tf
 import tensorflow_datasets as tfds
 
+from configs import default as config_lib
 import mnist_lib
 
 
@@ -59,10 +60,13 @@ class MnistLibTest(absltest.TestCase):
     flax_root_dir = pathlib.Path(__file__).parents[2]
     data_dir = str(flax_root_dir) + '/.tfds/metadata'
 
+    # Define training configuration.
+    config = config_lib.get_config()
+    config.num_epochs = 1
+    config.batch_size = 8
+
     with tfds.testing.mock_data(num_examples=8, data_dir=data_dir):
-      mnist_lib.train_and_evaluate(
-          model_dir=model_dir, num_epochs=1, batch_size=8,
-          learning_rate=0.1, momentum=0.9)
+      mnist_lib.train_and_evaluate(hp_config=config, model_dir=model_dir)
 
 
 if __name__ == '__main__':

--- a/linen_examples/mnist/mnist_main.py
+++ b/linen_examples/mnist/mnist_main.py
@@ -43,7 +43,7 @@ def main(_):
   # Make sure tf does not allocate gpu memory.
   tf.config.experimental.set_visible_devices([], 'GPU')
 
-  mnist_lib.train_and_evaluate(hp_config=FLAGS.config,
+  mnist_lib.train_and_evaluate(config=FLAGS.config,
                                model_dir=FLAGS.model_dir)
 
 

--- a/linen_examples/mnist/mnist_main.py
+++ b/linen_examples/mnist/mnist_main.py
@@ -18,8 +18,11 @@ This script trains a simple Convolutional Neural Net on the MNIST dataset.
 
 """
 
+import os
+
 from absl import app
 from absl import flags
+from ml_collections import config_flags
 
 import tensorflow as tf
 
@@ -27,21 +30,9 @@ import mnist_lib
 
 FLAGS = flags.FLAGS
 
-flags.DEFINE_float(
-    'learning_rate', default=0.1,
-    help=('The learning rate for the momentum optimizer.'))
-
-flags.DEFINE_float(
-    'momentum', default=0.9,
-    help=('The decay rate used for the momentum optimizer.'))
-
-flags.DEFINE_integer(
-    'batch_size', default=128,
-    help=('Batch size for training.'))
-
-flags.DEFINE_integer(
-    'num_epochs', default=10,
-    help=('Number of training epochs.'))
+config_flags.DEFINE_config_file(
+    'config', os.path.join(os.path.dirname(__file__), 'configs/default.py'),
+    'File path to the Training hyperparameter configuration.')
 
 flags.DEFINE_string(
     'model_dir', default=None,
@@ -52,10 +43,8 @@ def main(_):
   # Make sure tf does not allocate gpu memory.
   tf.config.experimental.set_visible_devices([], 'GPU')
 
-  mnist_lib.train_and_evaluate(
-      model_dir=FLAGS.model_dir, num_epochs=FLAGS.num_epochs,
-      batch_size=FLAGS.batch_size, learning_rate=FLAGS.learning_rate,
-      momentum=FLAGS.momentum)
+  mnist_lib.train_and_evaluate(hp_config=FLAGS.config,
+                               model_dir=FLAGS.model_dir)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
- Done as part of #231 & #479 
- HP configuration and definition now matches examples/mnist.