### PR TITLE
Updates README "Getting involved".

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,18 @@ When working with large-scale input data, it is important to create large enough
 TODO: Add an example for running on Google Cloud.
 
 ## Getting involved
+
+Currently, you need to install Python 3.6 and `svn` for developing Flax. After installing these prerequisites, you can clone the repository, set up your local environement, and run all tests with the following commands:
+
+```
+git clone https://github.com/google/flax
+cd flax
+python3.6 -m virtualenv env
+. env/bin/activate
+pip install -e . .[testing]
+./tests/run_all_tests.sh
+```
+
 We welcome pull requests, in particular for those issues [marked as PR-ready](https://github.com/google/flax/issues?q=is%3Aopen+is%3Aissue+label%3A%22Status%3A+pull+requests+welcome%22). For other proposals, we ask that you first open an Issue to discuss your planned contribution.
 
 ## Note

--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ TODO: Add an example for running on Google Cloud.
 
 ## Getting involved
 
-Currently, you need to install Python 3.6 and `svn` for developing Flax. After installing these prerequisites, you can clone the repository, set up your local environment, and run all tests with the following commands:
+Currently, you need to install Python 3.6 for developing Flax, and `svn` for running the `run_all_tests.sh` script. After installing these prerequisites, you can clone the repository, set up your local environment, and run all tests with the following commands:
 
 ```
 git clone https://github.com/google/flax

--- a/README.md
+++ b/README.md
@@ -234,6 +234,8 @@ pip install -e . .[testing]
 ./tests/run_all_tests.sh
 ```
 
+Alternatively, you can also develop inside a Docker container : See [`dev/README.md`](dev/README.md).
+
 We welcome pull requests, in particular for those issues [marked as PR-ready](https://github.com/google/flax/issues?q=is%3Aopen+is%3Aissue+label%3A%22Status%3A+pull+requests+welcome%22). For other proposals, we ask that you first open an Issue to discuss your planned contribution.
 
 ## Note

--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ TODO: Add an example for running on Google Cloud.
 
 ## Getting involved
 
-Currently, you need to install Python 3.6 and `svn` for developing Flax. After installing these prerequisites, you can clone the repository, set up your local environement, and run all tests with the following commands:
+Currently, you need to install Python 3.6 and `svn` for developing Flax. After installing these prerequisites, you can clone the repository, set up your local environment, and run all tests with the following commands:
 
 ```
 git clone https://github.com/google/flax

--- a/tests/download_dataset_metadata.sh
+++ b/tests/download_dataset_metadata.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 # Download TFDS metadata to flax/.tdfs/metadata directory. 
 # This allows the tests to specify the `data_dir` when using tfds.testing.mock_data().
 cd "$( dirname "$0" )"

--- a/tests/run_all_tests.sh
+++ b/tests/run_all_tests.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
 
-set -e
-
-sh $(dirname "$0")/download_dataset_metadata.sh
+sh $(dirname "$0")/download_dataset_metadata.sh || exit
 
 # Instead of using set -e, we have a manual error trap that
 # exits for any error code != 5 since pytest returns error code 5

--- a/tests/run_all_tests.sh
+++ b/tests/run_all_tests.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 sh $(dirname "$0")/download_dataset_metadata.sh
 
 # Instead of using set -e, we have a manual error trap that


### PR DESCRIPTION
The concommitant changes to the `.sh` files make sure that
`run_all_tests.sh` fails if `svn` is not installed.