### PR TITLE
Fix warning about float64 types

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -16,3 +16,4 @@ filterwarnings =
     ignore:jax.numpy reductions won't accept lists and tuples in future versions, only scalars and ndarrays.*:FutureWarning
     ignore:tostring() is deprecated. Use tobytes() instead.*:DeprecationWarning
     ignore:Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated.*:DeprecationWarning
+    ignore:Explicitly requested dtype <class 'jax.numpy.lax_numpy.float64'>*:UserWarning


### PR DESCRIPTION
This warning is causing or tests to fail