### PR TITLE
Allow assignment of mixed Module pytrees in setup.

### DIFF
--- a/flax/linen/module.py
+++ b/flax/linen/module.py
@@ -96,8 +96,8 @@ def is_module_tree(in_tree: Any) -> bool:
   # reject trivial pytrees, {}, [], (), etc.
   if not tree_util.tree_leaves(in_tree):
     return False
-  reduce_fn = lambda prev, cur: prev and isinstance(cur, Module)
-  return jax.tree_util.tree_reduce(reduce_fn, in_tree, True)
+  reduce_fn = lambda prev, cur: prev or isinstance(cur, Module)
+  return jax.tree_util.tree_reduce(reduce_fn, in_tree, False)
 
 
 def get_suffix_module_pairs(module_tree) -> List[Tuple[str, Type["Module"]]]:
@@ -107,7 +107,7 @@ def get_suffix_module_pairs(module_tree) -> List[Tuple[str, Type["Module"]]]:
   else:
     flat_tree = traverse_util.flatten_dict(
         serialization.to_state_dict(module_tree))
-    return [('_' + '_'.join(k), v) for k, v in flat_tree.items()]
+    return [('_' + '_'.join(k), v) for k, v in flat_tree.items() if isinstance(v, Module)]
 
 
 def all_names_on_object(obj: Any) -> Set[str]:

--- a/tests/linen/module_test.py
+++ b/tests/linen/module_test.py
@@ -502,34 +502,23 @@ class ModuleTest(absltest.TestCase):
         list(Test3.__dataclass_fields__.keys()),
         ['bar', 'baz', 'parent', 'name'])
 
-  def test_is_module_tree(self):
-    for x in [(), [], {}, None]:
-      self.assertFalse(nn.module.is_module_tree(x))
-    self.assertFalse(
-        nn.module.is_module_tree(nn.relu))
-    self.assertTrue(
-        nn.module.is_module_tree(nn.Dense(3)))
-    self.assertTrue(
-        nn.module.is_module_tree([nn.Dense(3), nn.Dense(3)]))
-    self.assertTrue(
-        nn.module.is_module_tree([nn.Dense(3), nn.relu, nn.Dense(3)]))
-    self.assertFalse(
-        nn.module.is_module_tree([nn.swish, nn.relu, nn.gelu]))
-
-  def test_get_suffix_module_pairs(self):
-    for x in [(), [], {}]:
+  def test_get_suffix_value_pairs(self):
+    for x in [(), [], {}, None, 0, set()]:
       self.assertEqual(
-          nn.module.get_suffix_module_pairs(x), [])
+          nn.module.get_suffix_value_pairs(x), [('', x)])
     self.assertEqual(
-        nn.module.get_suffix_module_pairs({'a': 1, 'b': 2}), [])
+        nn.module.get_suffix_value_pairs(
+            {'a': 1, 'b': 2}), [('_a', 1), ('_b', 2)])
     self.assertEqual(
-        nn.module.get_suffix_module_pairs([1, 2, 3]), [])
+        nn.module.get_suffix_value_pairs(
+            [1, 2, 3]), [('_0', 1), ('_1', 2), ('_2', 3)])
     x1 = [nn.Dense(10), nn.relu, nn.Dense(10)]
-    y1 = nn.module.get_suffix_module_pairs(x1)
-    self.assertEqual(y1, [('_0', x1[0]), ('_2', x1[2])])
+    y1 = nn.module.get_suffix_value_pairs(x1)
+    self.assertEqual(y1, [('_0', x1[0]), ('_1', x1[1]), ('_2', x1[2])])
     x2 = {'a': 1, 'b': {'c': nn.Dense(10), 'd': nn.relu}}
-    y2 = nn.module.get_suffix_module_pairs(x2)
-    self.assertEqual(y2, [('_b_c', x2['b']['c']),])
+    y2 = nn.module.get_suffix_value_pairs(x2)
+    self.assertEqual(y2,
+        [('_a', 1), ('_b_c', x2['b']['c']), ('_b_d', x2['b']['d'])])
 
   def test_mixed_list_assignment_in_setup(self):
     class Test(nn.Module):


### PR DESCRIPTION
Previously we forced assignment of Module lists in setup() to only allow
lists containing -only- Module subclasses.  But people would like to
specify lists containing functions like nn.relu as well, and there's
absolutely no reason to force this strict convention, so it is relaxed
here.