### PR TITLE
Fix Module dataclass handling of inheritance.

### DIFF
--- a/flax/linen/module.py
+++ b/flax/linen/module.py
@@ -222,6 +222,7 @@ class Module:
   @classmethod
   def _customized_dataclass_transform(cls):
     """Handle final optional dataclass attributes: `parent` and `name`."""
+    # Use cls.__dict__ to get annotations of cls itself (no parent class).
     annotations = dict(cls.__dict__.get('__annotations__', {}))
     if 'parent' in annotations or 'name' in annotations:
       raise ValueError(

--- a/flax/linen/module.py
+++ b/flax/linen/module.py
@@ -231,6 +231,8 @@ class Module:
     # We temporarily modify base class __dataclass_fields__ to force desired
     # argument behavior and ordering from dataclass class-transform.
     parent_dataclass_fields = dict(getattr(cls, '__dataclass_fields__', {}))
+    # Remove 'parent' and 'name' from parents because we always want parent and
+    # name to show up last in the dataclass args.
     if 'parent' in parent_dataclass_fields:
       cls.__dataclass_fields__.pop('parent')
     if 'name' in parent_dataclass_fields:

--- a/tests/linen/module_test.py
+++ b/tests/linen/module_test.py
@@ -27,7 +27,7 @@ from typing import Any, Tuple, Iterable, Callable
 
 from flax import linen as nn
 from flax.linen import compact
-from flax.core import Scope
+from flax.core import Scope, freeze
 
 # Parse absl flags test_srcdir and test_tmpdir.
 jax.config.parse_flags_with_absl()
@@ -458,6 +458,49 @@ class ModuleTest(absltest.TestCase):
     self.assertEqual(
         nn.module.get_local_method_names(Derived1, exclude=('bloop',)), ())
     self.assertEqual(nn.module.get_local_method_names(Derived2), ())
+
+  def test_inheritance_dataclass_attribs(self):
+    class Test(nn.Module):
+      bar: int
+      def __call__(self, x):
+        return x
+    class Test2(Test):
+      baz: int
+      def __call__(self, x):
+        return x
+    class Test3(Test):
+      baz: int
+      def __call__(self, x):
+        return x
+
+    key = random.PRNGKey(0)
+    x = jnp.ones((5,))
+    test1 = Test(bar=4)
+    test2 = Test2(bar=4, baz=2)
+    test3 = Test3(bar=4, baz=2)
+    self.assertEqual(test1.init_with_output(key, x), (x, freeze({})))
+    self.assertEqual(test2.init_with_output(key, x), (x, freeze({})))
+    self.assertEqual(test3.init_with_output(key, x), (x, freeze({})))
+    self.assertTrue(hasattr(test1, 'bar'))
+    self.assertTrue(hasattr(test1, 'name'))
+    self.assertTrue(hasattr(test1, 'parent'))
+    self.assertTrue(hasattr(test2, 'bar'))
+    self.assertTrue(hasattr(test2, 'baz'))
+    self.assertTrue(hasattr(test2, 'name'))
+    self.assertTrue(hasattr(test2, 'parent'))
+    self.assertTrue(hasattr(test3, 'bar'))
+    self.assertTrue(hasattr(test3, 'baz'))
+    self.assertTrue(hasattr(test3, 'name'))
+    self.assertTrue(hasattr(test3, 'parent'))
+    self.assertEqual(
+        list(Test.__dataclass_fields__.keys()),
+        ['bar', 'parent', 'name'])
+    self.assertEqual(
+        list(Test2.__dataclass_fields__.keys()),
+        ['bar', 'baz', 'parent', 'name'])
+    self.assertEqual(
+        list(Test3.__dataclass_fields__.keys()),
+        ['bar', 'baz', 'parent', 'name'])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The dataclass transform looks into the base class __dataclass_fields__
to set inherited dataclass args.  We were permanently mutating these
base class fields, which would screw up the handling of multiple separate
subclasses of a Module.  This fixes this edgecase.