### PR TITLE
Allow restoring raw state_dict using checkpoints.restore_checkpoint().

### DIFF
--- a/flax/training/checkpoints.py
+++ b/flax/training/checkpoints.py
@@ -121,7 +121,8 @@ def restore_checkpoint(ckpt_dir, target, step=None, prefix='checkpoint_'):
 
   Args:
     ckpt_dir: str: directory of checkpoints to restore from.
-    target: matching object to rebuild via deserialized state-dict.
+    target: matching object to rebuild via deserialized state-dict. If None,
+      the deserialized state-dict is returned as-is.
     step: int: step number to load or None to load latest.
     prefix: str: name prefix of checkpoint files.
 
@@ -144,4 +145,7 @@ def restore_checkpoint(ckpt_dir, target, step=None, prefix='checkpoint_'):
 
   logging.info('Restoring checkpoint from %s', ckpt_path)
   with gfile.GFile(ckpt_path, 'rb') as fp:
-    return serialization.from_bytes(target, fp.read())
+    if target is None:
+      return serialization.msgpack_restore(fp.read())
+    else:
+      return serialization.from_bytes(target, fp.read())

--- a/tests/checkpoints_test.py
+++ b/tests/checkpoints_test.py
@@ -122,6 +122,22 @@ class CheckpointsTest(absltest.TestCase):
     self.assertIn('test_2.0', os.listdir(tmp_dir))
     jtu.check_eq(new_object, test_object2)
 
+  def test_save_restore_checkpoints_target_none(self):
+    tmp_dir = self.create_tempdir().full_path
+    test_object0 = {'a': np.array([0, 0, 0], np.int32),
+                    'b': np.array([0, 0, 0], np.int32)}
+    # Target pytree is a dictionary, so it's equal to a restored state_dict.
+    checkpoints.save_checkpoint(tmp_dir, test_object0, 0)
+    new_object = checkpoints.restore_checkpoint(tmp_dir, target=None)
+    jtu.check_eq(new_object, test_object0)
+    # Target pytree it's a tuple, check the expected state_dict is recovered.
+    test_object1 = (np.array([0, 0, 0], np.int32),
+                    np.array([1, 1, 1], np.int32))
+    checkpoints.save_checkpoint(tmp_dir, test_object1, 1)
+    new_object = checkpoints.restore_checkpoint(tmp_dir, target=None)
+    expected_new_object = {str(k): v for k, v in enumerate(test_object1)}
+    jtu.check_eq(new_object, expected_new_object)
+
 
 if __name__ == '__main__':
   absltest.main()


### PR DESCRIPTION
Currently, in order to restore a checkpoint, one needs to pass a pytree
target with the same structure as the one contained in the checkpoint.

This is problematic if one wants to restore only part of the checkpoint,
for instance, to initialize a new but slightly different model (e.g.
suppose that I just change the number of outputs in the last layer, and
want to re-use everything else). By restoring the raw state_dict, one
has more liberty to manipulate it in arbitrary ways, without needing to
instantiate a pytree with the same structure as the checkpoint.

If the raw state_dict is desired, just pass `target=None`.