### PR TITLE
Linen Conv and ConvTranspose support batch free input

### DIFF
--- a/flax/linen/linear.py
+++ b/flax/linen/linear.py
@@ -244,6 +244,11 @@ class Conv(Module):
 
     inputs = jnp.asarray(inputs, self.dtype)
 
+    is_single_input = False
+    if inputs.ndim == len(self.kernel_size) + 1:
+      is_single_input = True
+      inputs = jnp.expand_dims(inputs, axis=0)
+
     if self.strides is None:
       self.strides = (1,) * (inputs.ndim - 2)
 
@@ -266,6 +271,8 @@ class Conv(Module):
         feature_group_count=self.feature_group_count,
         precision=self.precision)
 
+    if is_single_input:
+      y = jnp.squeeze(y, axis=0)
     if self.use_bias:
       bias = self.param('bias', self.bias_init, (self.features,))
       bias = jnp.asarray(bias, self.dtype)
@@ -318,6 +325,11 @@ class ConvTranspose(Module):
       The convolved data.
     """
     inputs = jnp.asarray(inputs, self.dtype)
+    is_single_input = False
+    if inputs.ndim == len(self.kernel_size) + 1:
+      is_single_input = True
+      inputs = jnp.expand_dims(inputs, axis=0)
+
     strides = self.strides or (1,) * (inputs.ndim - 2)
 
     in_features = inputs.shape[-1]
@@ -332,6 +344,8 @@ class ConvTranspose(Module):
                            rhs_dilation=self.kernel_dilation,
                            precision=self.precision)
 
+    if is_single_input:
+      y = jnp.squeeze(y, axis=0)
     if self.use_bias:
       bias = self.param('bias', self.bias_init, (self.features,))
       bias = jnp.asarray(bias, self.dtype)

--- a/tests/linen/linen_linear_test.py
+++ b/tests/linen/linen_linear_test.py
@@ -15,6 +15,7 @@
 """Tests for flax.nn.linear."""
 
 import functools
+from itertools import product
 
 from absl.testing import absltest
 from absl.testing import parameterized
@@ -177,6 +178,20 @@ class LinearTest(parameterized.TestCase):
     self.assertEqual(initial_params['params']['kernel'].shape, (3, 3, 4))
     np.testing.assert_allclose(y, np.full((1, 6, 4), 10.))
 
+  def test_single_input_conv(self):
+      rng = dict(params=random.PRNGKey(0))
+      x = jnp.ones((8, 3))
+      conv_module = nn.Conv(
+          features=4,
+          kernel_size=(3,),
+          padding='VALID',
+          kernel_init=initializers.ones,
+          bias_init=initializers.ones,
+      )
+      y, initial_params = conv_module.init_with_output(rng, x)
+      self.assertEqual(initial_params['params']['kernel'].shape, (3, 3, 4))
+      np.testing.assert_allclose(y, np.full((6, 4), 10.))
+
   def test_group_conv(self):
     rng = dict(params=random.PRNGKey(0))
     x = jnp.ones((1, 8, 4))
@@ -214,6 +229,30 @@ class LinearTest(parameterized.TestCase):
                               [10., 10., 10., 10.],
                               [ 7.,  7.,  7.,  7.],
                               [ 4.,  4.,  4.,  4.]]])
+    np.testing.assert_allclose(y, correct_ans)
+
+  def test_single_input_conv_transpose(self):
+    rng = dict(params=random.PRNGKey(0))
+    x = jnp.ones((8, 3))
+    conv_transpose_module = nn.ConvTranspose(
+        features=4,
+        kernel_size=(3,),
+        padding='VALID',
+        kernel_init=initializers.ones,
+        bias_init=initializers.ones,
+    )
+    y, initial_params = conv_transpose_module.init_with_output(rng, x)
+    self.assertEqual(initial_params['params']['kernel'].shape, (3, 3, 4))
+    correct_ans = np.array([[ 4.,  4.,  4.,  4.],
+                              [ 7.,  7.,  7.,  7.],
+                              [10., 10., 10., 10.],
+                              [10., 10., 10., 10.],
+                              [10., 10., 10., 10.],
+                              [10., 10., 10., 10.],
+                              [10., 10., 10., 10.],
+                              [10., 10., 10., 10.],
+                              [ 7.,  7.,  7.,  7.],
+                              [ 4.,  4.,  4.,  4.]])
     np.testing.assert_allclose(y, correct_ans)
 
   def test_embed(self):

--- a/tests/linen/linen_linear_test.py
+++ b/tests/linen/linen_linear_test.py
@@ -15,7 +15,6 @@
 """Tests for flax.nn.linear."""
 
 import functools
-from itertools import product
 
 from absl.testing import absltest
 from absl.testing import parameterized


### PR DESCRIPTION
This PR adds support for single-example (no batch dim) inputs to linen's Conv and ConvTranspose. 