### PR TITLE
add the silu activation

### DIFF
--- a/flax/core/nn/__init__.py
+++ b/flax/core/nn/__init__.py
@@ -21,7 +21,7 @@ from flax.nn import activation
 from flax.nn import initializers
 from flax.nn.activation import (celu, elu, gelu, glu, leaky_relu, log_sigmoid,
                                 log_softmax, relu, sigmoid, soft_sign, softmax,
-                                softplus, swish, tanh)
+                                softplus, swish, silu, tanh)
 from flax.nn.pooling import avg_pool, max_pool
 from .linear import Embedding, conv, conv_transpose, dense, dense_general, embedding
 from .normalization import batch_norm, group_norm, layer_norm

--- a/flax/linen/__init__.py
+++ b/flax/linen/__init__.py
@@ -19,7 +19,7 @@
 # re-export commonly used modules and functions
 from .activation import (celu, elu, gelu, glu, leaky_relu, log_sigmoid,
                          log_softmax, relu, sigmoid, soft_sign, softmax,
-                         softplus, swish, tanh)
+                         softplus, swish, silu, tanh)
 from .attention import (MultiHeadDotProductAttention, SelfAttention,
                         dot_product_attention, make_attention_mask,
                         make_causal_mask, combine_masks)

--- a/flax/linen/activation.py
+++ b/flax/linen/activation.py
@@ -31,6 +31,7 @@ from jax.nn import soft_sign
 from jax.nn import softmax
 from jax.nn import softplus
 from jax.nn import swish
+from jax.nn import silu
 from jax.nn import selu
 from jax.nn import hard_tanh
 from jax.nn import relu6

--- a/flax/nn/__init__.py
+++ b/flax/nn/__init__.py
@@ -18,7 +18,7 @@
 # re-export commonly used modules and functions
 from .activation import (celu, elu, gelu, glu, leaky_relu, log_sigmoid,
                          log_softmax, relu, sigmoid, soft_sign, softmax,
-                         softplus, swish, tanh)
+                         softplus, swish, silu, tanh)
 from .attention import (dot_product_attention, MultiHeadDotProductAttention,
                         SelfAttention)
 from .base import (Module, Model, Collection, capture_module_outputs,

--- a/flax/nn/activation.py
+++ b/flax/nn/activation.py
@@ -31,6 +31,7 @@ from jax.nn import soft_sign
 from jax.nn import softmax
 from jax.nn import softplus
 from jax.nn import swish
+from jax.nn import silu
 from jax.nn import selu
 from jax.nn import hard_tanh
 from jax.nn import relu6


### PR DESCRIPTION
Jax has the silu (x*sigmoid(x)) activation function. In fact, the docstring for flax.nn.swish says "silu." This pull request exposes the silu to flax users.