### PR TITLE
Graduate Linen out of alpha

### DIFF
--- a/flax/linen/README.md
+++ b/flax/linen/README.md
@@ -1,12 +1,13 @@
 # Linen: A comfortable evolution of Flax
 
-| 🚧  NOTE: Linen is in alpha. Parts of the API will change. Some people have started using Linen, but we're still [collecting feedback](https://github.com/google/flax/discussions) before finalizing the API and moving more users over. 🚧 |
-| --- |
-
-Linen is a rewrite of Flax Modules based on learning from our users and the broader JAX community. Linen improves on much of the current `flax.nn` API, such as submodule sharing and better support for non-trainable variables. 
-Moreover, Linen build on a new "functional core", enabling direct usage of JAX transformations such as `vmap`, `remat` or `scan` inside your modules.
+Linen is a rewrite of Flax Modules based on learning from our users and the broader JAX community. Linen improves on much of the former `flax.nn` API, such as submodule sharing and better support for non-trainable variables. 
+Moreover, Linen builds on a new "functional core", enabling direct usage of JAX transformations such as `vmap`, `remat` or `scan` inside your modules.
   
 In Linen, Modules behave much closer to vanilla Python objects, while still letting you opt-in to the concise single-method pattern many of our users love.
+
+The Linen Module API is stable and currently recommended for new projects. We are already supporting users in the OSS community and within Google. Minor changes may come to the top-level `apply` and `init` patterns, which we will communicate clearly. We plan a few improvements, including writing up short design notes, adding more [design tests], and an API for interactive module instances.
+
+Please open a [discussion](https://github.com/google/flax/discussions) if you have any questions or thoughts.
 
 We're still working on documentation, but here are some references we have available now:
 * 2-page intro to the [Linen Design Principles](https://docs.google.com/document/d/1ZlL_4bXCw5Xl0WstQw1GpnZqfb9JFOeUGAPcBVk-kn8)


### PR DESCRIPTION
Given that we are actually telling people to build new codebases in Linen, we shouldn't claim that it's alpha.

The other changes we're discussing are improvements that we can and will make, but I don't think we're serving our users by waiting any longer to flip the switch.