### PR TITLE
Add Linen reference docs. Mark `flax.nn` as deprecated.

### DIFF
--- a/docs/flax.linen.rst
+++ b/docs/flax.linen.rst
@@ -2,6 +2,8 @@
 flax.linen package
 ==================
 
+TODO: These docstrings need some love.
+
 .. currentmodule:: flax.linen
 .. automodule:: flax.linen
 

--- a/docs/flax.linen.rst
+++ b/docs/flax.linen.rst
@@ -1,34 +1,18 @@
 
-*NOTE*: The `flax.nn` package is deprecated. See `flax.linen` for our new module API.
+flax.linen package
+==================
 
-flax.nn package
-=================
-
-.. currentmodule:: flax.nn
-.. automodule:: flax.nn
+.. currentmodule:: flax.linen
+.. automodule:: flax.linen
 
 
 Core: Module abstraction
 ------------------------
 
 .. autoclass:: Module
-   :members: init, init_by_shape, partial, shared, apply, param, get_param, state, is_stateful, is_initializing
+   :members: setup, variable, param, init, init_with_output, variables
 
-Core: Additional
-------------------------
-
-.. autosummary::
-  :toctree: _autosummary
-
-    module
-    Model
-    Collection
-    capture_module_outputs
-    stateful
-    get_state
-    module_method
-
-
+	     
 Linear modules
 ------------------------
 
@@ -80,18 +64,6 @@ Activation functions
     softmax
     softplus
     swish
-
-
-Stochastic functions
-------------------------
-
-.. autosummary::
-  :toctree: _autosummary
-
-    make_rng
-    stochastic
-    is_stochastic
-    dropout
 
 
 Attention primitives

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -34,7 +34,8 @@ Flax is a neural network library for JAX that is designed for flexibility.
    :maxdepth: 2
    :caption: API reference
 
-   flax.nn
+   flax.linen
+   `flax.nn` (deprecated) <flax.nn>
    flax.optim
    flax.serialization
    flax.struct

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -35,7 +35,7 @@ Flax is a neural network library for JAX that is designed for flexibility.
    :caption: API reference
 
    flax.linen
-   `flax.nn` (deprecated) <flax.nn>
+   flax.nn (deprecated) <flax.nn>
    flax.optim
    flax.serialization
    flax.struct


### PR DESCRIPTION
(There's a lot of work still but this isn't too bad and I added a note that we need to improve it)