### PR TITLE
Fix jax bfloat16 array handling in msgpack serialization.

### DIFF
--- a/flax/serialization.py
+++ b/flax/serialization.py
@@ -178,7 +178,7 @@ register_serialization_state(_NamedTuple,
 # https://github.com/msgpack/msgpack/blob/master/spec.md
 #
 # - ndarrays and DeviceArrays are serialized to nested msgpack-encoded string
-#   of (shape-tuple, full-dtype-string (e.g. '<i8'), row-major array-bytes).
+#   of (shape-tuple, dtype-name (e.g. 'float32'), row-major array-bytes).
 #   Note: only simple ndarray types are supported, no objects or fields.
 #
 # - native complex scalars are converted to nested msgpack-encoded tuples
@@ -192,15 +192,23 @@ def _ndarray_to_bytes(arr):
   if arr.dtype.hasobject or arr.dtype.isalignedstruct:
     raise ValueError('Object and structured dtypes not supported '
                      'for serialization of ndarrays.')
-  tpl = (arr.shape, arr.dtype.str, arr.tobytes('C'))
+  tpl = (arr.shape, arr.dtype.name, arr.tobytes('C'))
   return msgpack.packb(tpl, use_bin_type=True)
+
+
+def _dtype_from_name(name):
+  """Handle JAX bfloat16 dtype correctly."""
+  if name == b'bfloat16':
+    return jax.numpy.bfloat16
+  else:
+    return np.dtype(name)
 
 
 def _ndarray_from_bytes(data):
   """Load ndarray from simple msgpack encoding."""
-  shape, dtype_str, buffer = msgpack.unpackb(data, raw=True)
+  shape, dtype_name, buffer = msgpack.unpackb(data, raw=True)
   return np.frombuffer(buffer,
-                       dtype=dtype_str,
+                       dtype=_dtype_from_name(dtype_name),
                        count=-1,
                        offset=0).reshape(shape, order='C')
 

--- a/tests/serialization_test.py
+++ b/tests/serialization_test.py
@@ -173,6 +173,20 @@ class SerializationTest(absltest.TestCase):
         self.assertEqual(restored_arr.dtype, arr.dtype)
         onp.testing.assert_array_equal(restored_arr, arr)
 
+  def test_jax_numpy_serialization(self):
+    jax_dtypes = [jnp.bool_, jnp.uint8, jnp.uint16, jnp.uint32,
+                  jnp.int8, jnp.int16, jnp.int32,
+                  jnp.bfloat16, jnp.float16, jnp.float32,
+                  jnp.complex64]
+    for dtype in jax_dtypes:
+      for shape in [(), (5,), (10, 10), (1, 20, 30, 1)]:
+        arr = jnp.array(
+            onp.random.uniform(-100, 100, size=shape)).astype(dtype)
+        restored_arr = serialization.msgpack_restore(
+            serialization.msgpack_serialize(arr))
+        self.assertEqual(restored_arr.dtype, arr.dtype)
+        onp.testing.assert_array_equal(restored_arr, arr)
+
   def test_complex_serialization(self):
     for x in [1j, 1+2j]:
       restored_x = serialization.msgpack_restore(


### PR DESCRIPTION
JAX's bfloat16 extension dtype doesn't report the correct `arr.dtype.str` but does report the correct `arr.dtype.name`.  We use that to special-case fetching the `jnp.bfloat16` dtype for restoration.