### PR TITLE
Update linen intro notebook for new mutated collection behavior of apply.

### DIFF
--- a/docs/notebooks/linen_intro.ipynb
+++ b/docs/notebooks/linen_intro.ipynb
@@ -17,8 +17,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "C1QVJFlVsxcZ",
-        "colab_type": "text"
+        "id": "C1QVJFlVsxcZ"
       },
       "source": [
         "# Preface\n",
@@ -32,8 +31,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "23zkGDayszYI",
-        "colab_type": "text"
+        "id": "23zkGDayszYI"
       },
       "source": [
         "## Useful links\n",
@@ -51,8 +49,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "vGtC_5W4mQnY",
-        "colab_type": "text"
+        "id": "vGtC_5W4mQnY"
       },
       "source": [
         "# Install and Import"
@@ -61,13 +58,7 @@
     {
       "cell_type": "code",
       "metadata": {
-        "id": "HgRZ_G8wGcoB",
-        "colab_type": "code",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 51
-        },
-        "outputId": "174074bd-e70f-4fdf-e2dc-2589bd1d367d"
+        "id": "HgRZ_G8wGcoB"
       },
       "source": [
         "# Install the newest JAXlib version.\n",
@@ -75,15 +66,13 @@
         "# Install Flax at head:\n",
         "!pip install --upgrade -q git+https://github.com/google/flax.git"
       ],
-      "execution_count": 1,
+      "execution_count": null,
       "outputs": []
     },
     {
       "cell_type": "code",
       "metadata": {
-        "id": "Kvx7GmavHZbD",
-        "colab_type": "code",
-        "colab": {}
+        "id": "Kvx7GmavHZbD"
       },
       "source": [
         "import functools\n",
@@ -93,19 +82,15 @@
         "from jax import lax, random, numpy as jnp\n",
         "import flax\n",
         "from flax.core import freeze, unfreeze\n",
-        "from flax import linen as nn\n",
-        "\n",
-        "from jax.config import config\n",
-        "config.enable_omnistaging()"
+        "from flax import linen as nn"
       ],
-      "execution_count": 1,
+      "execution_count": 2,
       "outputs": []
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "u86fYsrEfYow",
-        "colab_type": "text"
+        "id": "u86fYsrEfYow"
       },
       "source": [
         "# Invoking Modules"
@@ -114,8 +99,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "nrVbFrh1ffve",
-        "colab_type": "text"
+        "id": "nrVbFrh1ffve"
       },
       "source": [
         "Let's instantiate a `Dense` layer.\n",
@@ -125,9 +109,7 @@
     {
       "cell_type": "code",
       "metadata": {
-        "id": "EcDH20Uufc-v",
-        "colab_type": "code",
-        "colab": {}
+        "id": "EcDH20Uufc-v"
       },
       "source": [
         "model = nn.Dense(features=3)"
@@ -138,8 +120,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "hL4NgtBwgI0S",
-        "colab_type": "text"
+        "id": "hL4NgtBwgI0S"
       },
       "source": [
         "We need to initialize the Module variables, these include the parameters of the Module as well as any other state variables.\n",
@@ -151,12 +132,10 @@
       "cell_type": "code",
       "metadata": {
         "id": "Vjx0HWNcfa8h",
-        "colab_type": "code",
+        "outputId": "3adfaeaf-977e-4e82-8adf-d254fae6eb91",
         "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 119
-        },
-        "outputId": "ab2a5078-0992-4ffc-af8b-c31741f7875a"
+          "base_uri": "https://localhost:8080/"
+        }
       },
       "source": [
         "# Make RNG Keys and a fake input.\n",
@@ -171,11 +150,30 @@
       "execution_count": 4,
       "outputs": [
         {
+          "output_type": "stream",
+          "text": [
+            "WARNING:absl:No GPU/TPU found, falling back to CPU. (Set TF_CPP_MIN_LOG_LEVEL=0 and rerun for more info.)\n"
+          ],
+          "name": "stderr"
+        },
+        {
           "output_type": "execute_result",
           "data": {
-            "text/plain": "FrozenDict({'params': {'kernel': DeviceArray([[ 0.6503669 ,  0.8678979 ,  0.46042678],\n             [ 0.05673932,  0.9909285 , -0.63536596],\n             [ 0.76134115, -0.3250529 , -0.6522163 ],\n             [-0.8243032 ,  0.4150194 ,  0.19405058]], dtype=float32), 'bias': DeviceArray([0., 0., 0.], dtype=float32)}})"
+            "text/plain": [
+              "FrozenDict({\n",
+              "    params: {\n",
+              "        kernel: DeviceArray([[ 0.6503669 ,  0.8678979 ,  0.46042678],\n",
+              "                     [ 0.05673932,  0.9909285 , -0.63536596],\n",
+              "                     [ 0.76134115, -0.3250529 , -0.6522163 ],\n",
+              "                     [-0.8243032 ,  0.4150194 ,  0.19405058]], dtype=float32),\n",
+              "        bias: DeviceArray([0., 0., 0.], dtype=float32),\n",
+              "    },\n",
+              "})"
+            ]
           },
-          "metadata": {},
+          "metadata": {
+            "tags": []
+          },
           "execution_count": 4
         }
       ]
@@ -183,8 +181,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "ubFTzroGhErh",
-        "colab_type": "text"
+        "id": "ubFTzroGhErh"
       },
       "source": [
         "We call the `apply` method on the instantiated Module.  If the Module `__call__` method has args `(self, *args, **kwargs)` then we call `apply` with `(variables, *args, rngs=<RNGS>, mutable=<MUTABLEKINDS>, **kwargs)` where \n",
@@ -198,12 +195,10 @@
       "cell_type": "code",
       "metadata": {
         "id": "R9QZ6EOBg5X8",
-        "colab_type": "code",
+        "outputId": "e8c389a6-29f3-4f93-97ea-703e85a8b811",
         "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 85
-        },
-        "outputId": "5f4ad592-4fdf-456e-d656-d91e9151cba2"
+          "base_uri": "https://localhost:8080/"
+        }
       },
       "source": [
         "y = model.apply(init_variables, x)\n",
@@ -214,9 +209,16 @@
         {
           "output_type": "execute_result",
           "data": {
-            "text/plain": "DeviceArray([[ 0.5035518 ,  1.8548559 , -0.4270196 ],\n             [ 0.0279097 ,  0.5589246 , -0.43061775],\n             [ 0.35471284,  1.5741    , -0.3286552 ],\n             [ 0.5264864 ,  1.2928858 ,  0.10089308]], dtype=float32)"
+            "text/plain": [
+              "DeviceArray([[ 0.5035518 ,  1.8548559 , -0.4270196 ],\n",
+              "             [ 0.0279097 ,  0.5589246 , -0.43061775],\n",
+              "             [ 0.35471284,  1.5741    , -0.3286552 ],\n",
+              "             [ 0.5264864 ,  1.2928858 ,  0.10089308]], dtype=float32)"
+            ]
           },
-          "metadata": {},
+          "metadata": {
+            "tags": []
+          },
           "execution_count": 5
         }
       ]
@@ -224,8 +226,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "lNH06qc1hPrd",
-        "colab_type": "text"
+        "id": "lNH06qc1hPrd"
       },
       "source": [
         "Additional points:\n",
@@ -235,8 +236,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "jjsyiBjIYcAB",
-        "colab_type": "text"
+        "id": "jjsyiBjIYcAB"
       },
       "source": [
         "# Defining Basic Modules"
@@ -245,8 +245,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "UvU7416Ti_lR",
-        "colab_type": "text"
+        "id": "UvU7416Ti_lR"
       },
       "source": [
         "## Composing submodules"
@@ -255,8 +254,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "LkTy0hmJdE5G",
-        "colab_type": "text"
+        "id": "LkTy0hmJdE5G"
       },
       "source": [
         "We support declaring modules in `setup()` that can still benefit from shape inference by using __Lazy Initialization__ that sets up variables the first time the Module is called."
@@ -266,13 +264,11 @@
       "cell_type": "code",
       "metadata": {
         "id": "qB6l-9EabOwH",
-        "colab_type": "code",
+        "tags": [],
+        "outputId": "1a6c6a17-0b95-42c2-b5bf-b9ad80fd7758",
         "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 224
-        },
-        "outputId": "7c726eee-4ef5-45a3-ca36-29e18f74e354",
-        "tags": []
+          "base_uri": "https://localhost:8080/"
+        }
       },
       "source": [
         "class ExplicitMLP(nn.Module):\n",
@@ -306,16 +302,27 @@
       "outputs": [
         {
           "output_type": "stream",
-          "name": "stdout",
-          "text": "initialized parameter shapes:\n {'params': {'layers_0': {'bias': (3,), 'kernel': (4, 3)}, 'layers_1': {'bias': (4,), 'kernel': (3, 4)}, 'layers_2': {'bias': (5,), 'kernel': (4, 5)}}}\noutput:\n [[ 4.2292818e-02 -4.3807115e-02  2.9323792e-02  6.5492527e-03\n  -1.7147182e-02]\n [ 1.2967806e-01 -1.4551792e-01  9.4432175e-02  1.2521384e-02\n  -4.5417294e-02]\n [ 0.0000000e+00  0.0000000e+00  0.0000000e+00  0.0000000e+00\n   0.0000000e+00]\n [ 9.3024096e-04  2.7864411e-05  2.4478836e-04  8.1344350e-04\n  -1.0110775e-03]]\n"
+          "text": [
+            "initialized parameter shapes:\n",
+            " {'params': {'layers_0': {'bias': (3,), 'kernel': (4, 3)}, 'layers_1': {'bias': (4,), 'kernel': (3, 4)}, 'layers_2': {'bias': (5,), 'kernel': (4, 5)}}}\n",
+            "output:\n",
+            " [[ 4.2292815e-02 -4.3807115e-02  2.9323792e-02  6.5492536e-03\n",
+            "  -1.7147182e-02]\n",
+            " [ 1.2967804e-01 -1.4551792e-01  9.4432175e-02  1.2521386e-02\n",
+            "  -4.5417294e-02]\n",
+            " [ 0.0000000e+00  0.0000000e+00  0.0000000e+00  0.0000000e+00\n",
+            "   0.0000000e+00]\n",
+            " [ 9.3024090e-04  2.7864411e-05  2.4478839e-04  8.1344356e-04\n",
+            "  -1.0110775e-03]]\n"
+          ],
+          "name": "stdout"
         }
       ]
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "slwE6ULqc_t_",
-        "colab_type": "text"
+        "id": "slwE6ULqc_t_"
       },
       "source": [
         "Here we show the equivalent compact form of the MLP that declares the submodules inline using the `@compact` decorator."
@@ -325,13 +332,11 @@
       "cell_type": "code",
       "metadata": {
         "id": "UPNGIr6wcGaw",
-        "colab_type": "code",
+        "tags": [],
+        "outputId": "b3709789-e66e-4e20-f6b2-04022f8a62bb",
         "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 224
-        },
-        "outputId": "4ad133ef-fe6d-45f5-ec99-4365b894dbe5",
-        "tags": []
+          "base_uri": "https://localhost:8080/"
+        }
       },
       "source": [
         "class SimpleMLP(nn.Module):\n",
@@ -363,16 +368,27 @@
       "outputs": [
         {
           "output_type": "stream",
-          "name": "stdout",
-          "text": "initialized parameter shapes:\n {'params': {'layers_0': {'bias': (3,), 'kernel': (4, 3)}, 'layers_1': {'bias': (4,), 'kernel': (3, 4)}, 'layers_2': {'bias': (5,), 'kernel': (4, 5)}}}\noutput:\n [[ 4.2292818e-02 -4.3807115e-02  2.9323792e-02  6.5492527e-03\n  -1.7147182e-02]\n [ 1.2967806e-01 -1.4551792e-01  9.4432175e-02  1.2521384e-02\n  -4.5417294e-02]\n [ 0.0000000e+00  0.0000000e+00  0.0000000e+00  0.0000000e+00\n   0.0000000e+00]\n [ 9.3024096e-04  2.7864411e-05  2.4478836e-04  8.1344350e-04\n  -1.0110775e-03]]\n"
+          "text": [
+            "initialized parameter shapes:\n",
+            " {'params': {'layers_0': {'bias': (3,), 'kernel': (4, 3)}, 'layers_1': {'bias': (4,), 'kernel': (3, 4)}, 'layers_2': {'bias': (5,), 'kernel': (4, 5)}}}\n",
+            "output:\n",
+            " [[ 4.2292815e-02 -4.3807115e-02  2.9323792e-02  6.5492536e-03\n",
+            "  -1.7147182e-02]\n",
+            " [ 1.2967804e-01 -1.4551792e-01  9.4432175e-02  1.2521386e-02\n",
+            "  -4.5417294e-02]\n",
+            " [ 0.0000000e+00  0.0000000e+00  0.0000000e+00  0.0000000e+00\n",
+            "   0.0000000e+00]\n",
+            " [ 9.3024090e-04  2.7864411e-05  2.4478839e-04  8.1344356e-04\n",
+            "  -1.0110775e-03]]\n"
+          ],
+          "name": "stdout"
         }
       ]
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "b2OzKXYyjFSf",
-        "colab_type": "text"
+        "id": "b2OzKXYyjFSf"
       },
       "source": [
         "## Declaring and using variables"
@@ -381,8 +397,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "uYwS5KbcmYIp",
-        "colab_type": "text"
+        "id": "uYwS5KbcmYIp"
       },
       "source": [
         "Flax uses lazy initialization, which allows declared variables to be initialized only at the first site of their use, using whatever shape information is available a the local call site for shape inference.  One a variable has been initialized, and a reference to the data kept for use in subsequent calls.\n",
@@ -403,13 +418,11 @@
       "cell_type": "code",
       "metadata": {
         "id": "7OACbTFHjMvl",
-        "colab_type": "code",
+        "tags": [],
+        "outputId": "bc5cb1f2-c5e9-4159-d131-73247009e32f",
         "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 187
-        },
-        "outputId": "c7d8b6ac-6548-46b1-d18f-162438695485",
-        "tags": []
+          "base_uri": "https://localhost:8080/"
+        }
       },
       "source": [
         "class SimpleDense(nn.Module):\n",
@@ -442,16 +455,31 @@
       "outputs": [
         {
           "output_type": "stream",
-          "name": "stdout",
-          "text": "initialized parameters:\n FrozenDict({'params': {'kernel': DeviceArray([[ 0.6503669 ,  0.8678979 ,  0.46042678],\n             [ 0.05673932,  0.9909285 , -0.63536596],\n             [ 0.76134115, -0.3250529 , -0.6522163 ],\n             [-0.8243032 ,  0.4150194 ,  0.19405058]], dtype=float32), 'bias': DeviceArray([0., 0., 0.], dtype=float32)}})\noutput:\n [[ 0.5035518   1.8548559  -0.4270196 ]\n [ 0.0279097   0.5589246  -0.43061775]\n [ 0.35471284  1.5741     -0.3286552 ]\n [ 0.5264864   1.2928858   0.10089308]]\n"
+          "text": [
+            "initialized parameters:\n",
+            " FrozenDict({\n",
+            "    params: {\n",
+            "        kernel: DeviceArray([[ 0.6503669 ,  0.8678979 ,  0.46042678],\n",
+            "                     [ 0.05673932,  0.9909285 , -0.63536596],\n",
+            "                     [ 0.76134115, -0.3250529 , -0.6522163 ],\n",
+            "                     [-0.8243032 ,  0.4150194 ,  0.19405058]], dtype=float32),\n",
+            "        bias: DeviceArray([0., 0., 0.], dtype=float32),\n",
+            "    },\n",
+            "})\n",
+            "output:\n",
+            " [[ 0.5035518   1.8548559  -0.4270196 ]\n",
+            " [ 0.0279097   0.5589246  -0.43061775]\n",
+            " [ 0.35471284  1.5741     -0.3286552 ]\n",
+            " [ 0.5264864   1.2928858   0.10089308]]\n"
+          ],
+          "name": "stdout"
         }
       ]
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "KgEwkrkfdlt8",
-        "colab_type": "text"
+        "id": "KgEwkrkfdlt8"
       },
       "source": [
         "We can also declare variables in setup, though in doing so you can't take advantage of shape inference and have to provide explicit shape information at initialization.  The syntax is a little repetitive in this case right now, but we do force agreement of the assigned names.\n"
@@ -461,13 +489,11 @@
       "cell_type": "code",
       "metadata": {
         "id": "CE0CTLVvZ8Yn",
-        "colab_type": "code",
+        "tags": [],
+        "outputId": "1e822bd8-7a08-4e80-e0e6-a86637c46772",
         "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 187
-        },
-        "outputId": "06dc7eb6-9393-4f0f-97b1-1bfbbd96564c",
-        "tags": []
+          "base_uri": "https://localhost:8080/"
+        }
       },
       "source": [
         "class ExplicitDense(nn.Module):\n",
@@ -502,16 +528,31 @@
       "outputs": [
         {
           "output_type": "stream",
-          "name": "stdout",
-          "text": "initialized parameters:\n FrozenDict({'params': {'kernel': DeviceArray([[ 0.6503669 ,  0.8678979 ,  0.46042678],\n             [ 0.05673932,  0.9909285 , -0.63536596],\n             [ 0.76134115, -0.3250529 , -0.6522163 ],\n             [-0.8243032 ,  0.4150194 ,  0.19405058]], dtype=float32), 'bias': DeviceArray([0., 0., 0.], dtype=float32)}})\noutput:\n [[ 0.5035518   1.8548559  -0.4270196 ]\n [ 0.0279097   0.5589246  -0.43061775]\n [ 0.35471284  1.5741     -0.3286552 ]\n [ 0.5264864   1.2928858   0.10089308]]\n"
+          "text": [
+            "initialized parameters:\n",
+            " FrozenDict({\n",
+            "    params: {\n",
+            "        kernel: DeviceArray([[ 0.6503669 ,  0.8678979 ,  0.46042678],\n",
+            "                     [ 0.05673932,  0.9909285 , -0.63536596],\n",
+            "                     [ 0.76134115, -0.3250529 , -0.6522163 ],\n",
+            "                     [-0.8243032 ,  0.4150194 ,  0.19405058]], dtype=float32),\n",
+            "        bias: DeviceArray([0., 0., 0.], dtype=float32),\n",
+            "    },\n",
+            "})\n",
+            "output:\n",
+            " [[ 0.5035518   1.8548559  -0.4270196 ]\n",
+            " [ 0.0279097   0.5589246  -0.43061775]\n",
+            " [ 0.35471284  1.5741     -0.3286552 ]\n",
+            " [ 0.5264864   1.2928858   0.10089308]]\n"
+          ],
+          "name": "stdout"
         }
       ]
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "t4MVj1RBmxsZ",
-        "colab_type": "text"
+        "id": "t4MVj1RBmxsZ"
       },
       "source": [
         "## General Variables"
@@ -520,8 +561,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "CJatarOTpByQ",
-        "colab_type": "text"
+        "id": "CJatarOTpByQ"
       },
       "source": [
         "For declaring generally mutable _variables_ that may be mutated inside the model we use the call:\n",
@@ -541,13 +581,11 @@
       "cell_type": "code",
       "metadata": {
         "id": "u6_fbrW2XT5t",
-        "colab_type": "code",
+        "tags": [],
+        "outputId": "2a8f5453-81b1-44dc-a431-d14b372c5710",
         "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 119
-        },
-        "outputId": "3132a818-cc1a-468b-d413-a62afd2d626f",
-        "tags": []
+          "base_uri": "https://localhost:8080/"
+        }
       },
       "source": [
         "class Counter(nn.Module):\n",
@@ -567,25 +605,39 @@
         "init_variables = model.init(key1)\n",
         "print('initialized variables:\\n', init_variables)\n",
         "\n",
-        "y, updated_variables = model.apply(init_variables, mutable=['counter'])\n",
+        "y, mutated_variables = model.apply(init_variables, mutable=['counter'])\n",
         "\n",
-        "print('updated variables:\\n', updated_variables)\n",
+        "print('mutated variables:\\n', mutated_variables)\n",
         "print('output:\\n', y)"
       ],
       "execution_count": 10,
       "outputs": [
         {
           "output_type": "stream",
-          "name": "stdout",
-          "text": "initialized variables:\n FrozenDict({'counter': {'count': DeviceArray(0, dtype=int32)}})\nupdated variables:\n FrozenDict({'counter': {'count': DeviceArray(1, dtype=int32)}})\noutput:\n 1\n"
+          "text": [
+            "initialized variables:\n",
+            " FrozenDict({\n",
+            "    counter: {\n",
+            "        count: DeviceArray(0, dtype=int32),\n",
+            "    },\n",
+            "})\n",
+            "mutated variables:\n",
+            " FrozenDict({\n",
+            "    counter: {\n",
+            "        count: DeviceArray(1, dtype=int32),\n",
+            "    },\n",
+            "})\n",
+            "output:\n",
+            " 1\n"
+          ],
+          "name": "stdout"
         }
       ]
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "VLxwg2aMxUmy",
-        "colab_type": "text"
+        "id": "VLxwg2aMxUmy"
       },
       "source": [
         "## Another Mutability and RNGs Example"
@@ -594,8 +646,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "NOARPIowyeXS",
-        "colab_type": "text"
+        "id": "NOARPIowyeXS"
       },
       "source": [
         "Let's make an artificial, goofy example that mixes differentiable parameters, stochastic layers, and mutable variables:"
@@ -605,13 +656,11 @@
       "cell_type": "code",
       "metadata": {
         "id": "BBrbcEdCnQ4o",
-        "colab_type": "code",
+        "tags": [],
+        "outputId": "8f299a5c-74c8-476c-93fa-e5543901ec45",
         "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 666
-        },
-        "outputId": "d5285f3e-080a-4166-cbcc-de3542572541",
-        "tags": []
+          "base_uri": "https://localhost:8080/"
+        }
       },
       "source": [
         "class Block(nn.Module):\n",
@@ -630,12 +679,21 @@
         "model = Block(features=3, training=True)\n",
         "\n",
         "init_variables = model.init({'params': key2, 'dropout': key3}, x)\n",
-        "# When calling `apply` with mutable kinds, returns a pair of output, new_variables\n",
-        "y, updated_variables = model.apply(init_variables, x, rngs={'dropout': key4}, mutable=['batch_stats'])\n",
+        "_, init_params = init_variables.pop('params')\n",
+        "\n",
+        "# When calling `apply` with mutable kinds, returns a pair of output, \n",
+        "# mutated_variables.\n",
+        "y, mutated_variables = model.apply(\n",
+        "    init_variables, x, rngs={'dropout': key4}, mutable=['batch_stats'])\n",
+        "\n",
+        "# Now we reassemble the full variables from the updates (in a real training\n",
+        "# loop, with the updated params from an optimizer).\n",
+        "updated_variables = freeze(dict(params=init_params, \n",
+        "                                **mutated_variables))\n",
         "\n",
         "print('updated variables:\\n', updated_variables)\n",
         "print('initialized variable shapes:\\n', \n",
-        "      jax.tree_map(jnp.shape, unfreeze(init_variables)))\n",
+        "      jax.tree_map(jnp.shape, init_variables))\n",
         "print('output:\\n', y)\n",
         "\n",
         "# Let's run these model variables during \"evaluation\":\n",
@@ -647,15 +705,86 @@
       "outputs": [
         {
           "output_type": "stream",
-          "name": "stdout",
-          "text": "updated variables:\n FrozenDict({'params': {'Dense_0': {'kernel': DeviceArray([[ 0.6498898 , -0.5000124 ,  0.78573596],\n             [-0.25609785, -0.7132329 ,  0.2500864 ],\n             [-0.64630085,  0.39321756, -1.0203307 ],\n             [ 0.38721725,  0.86828285,  0.10860055]], dtype=float32), 'bias': DeviceArray([0., 0., 0.], dtype=float32)}, 'BatchNorm_0': {'scale': DeviceArray([1., 1., 1.], dtype=float32), 'bias': DeviceArray([0., 0., 0.], dtype=float32)}}, 'batch_stats': {'BatchNorm_0': {'mean': DeviceArray([ 0.00059601, -0.00103457,  0.00166948], dtype=float32), 'var': DeviceArray([0.9907686, 0.9923046, 0.992195 ], dtype=float32)}}})\ninitialized variable shapes:\n {'batch_stats': {'BatchNorm_0': {'mean': (3,), 'var': (3,)}}, 'params': {'BatchNorm_0': {'bias': (3,), 'scale': (3,)}, 'Dense_0': {'bias': (3,), 'kernel': (4, 3)}}}\noutput:\n [[[-0.21496922  0.21550177 -0.35633382]\n  [-0.21496922 -2.0458      1.3015485 ]\n  [-0.21496922 -0.925116   -0.35633382]\n  [-0.6595459   0.21550177  0.3749205 ]]\n\n [[-0.21496922  1.642865   -0.35633382]\n  [-0.21496922  1.3094063  -0.88034123]\n  [ 2.5726683   0.21550177  0.34353197]\n  [-0.21496922  0.21550177  1.6778195 ]]\n\n [[-1.6060593   0.21550177 -1.9460517 ]\n  [ 1.4126908  -1.4898677   1.2790381 ]\n  [-0.21496922  0.21550177 -0.35633382]\n  [-0.21496922  0.21550177 -0.7251308 ]]]\neval output:\n [[[ 3.2246590e-01  2.6108384e-02  4.4821960e-01]\n  [ 8.5726947e-02 -5.4385906e-01  3.8821870e-01]\n  [-2.3933809e-01 -2.7381191e-01 -1.7526165e-01]\n  [-6.2515378e-02 -5.2414006e-01  1.7029770e-01]]\n\n [[ 1.5014435e-01  3.4498507e-01 -1.3554120e-01]\n  [-3.6971044e-04  2.6463276e-01 -1.2491019e-01]\n  [ 3.8763803e-01  2.9023719e-01  1.6291586e-01]\n  [ 4.1320035e-01  4.1468274e-02  4.7670874e-01]]\n\n [[-1.9433719e-01  5.2831882e-01 -3.7554008e-01]\n  [ 2.2608691e-01 -4.0989807e-01  3.8292480e-01]\n  [-2.4945706e-01  1.6170470e-01 -2.5247774e-01]\n  [-7.2220474e-02  1.2077977e-01 -8.8408351e-02]]]\n"
+          "text": [
+            "updated variables:\n",
+            " FrozenDict({\n",
+            "    params: {\n",
+            "        Dense_0: {\n",
+            "            kernel: DeviceArray([[ 0.6498898 , -0.5000124 ,  0.78573596],\n",
+            "                         [-0.25609785, -0.7132329 ,  0.2500864 ],\n",
+            "                         [-0.64630085,  0.39321756, -1.0203307 ],\n",
+            "                         [ 0.38721725,  0.86828285,  0.10860055]], dtype=float32),\n",
+            "            bias: DeviceArray([0., 0., 0.], dtype=float32),\n",
+            "        },\n",
+            "        BatchNorm_0: {\n",
+            "            scale: DeviceArray([1., 1., 1.], dtype=float32),\n",
+            "            bias: DeviceArray([0., 0., 0.], dtype=float32),\n",
+            "        },\n",
+            "    },\n",
+            "    batch_stats: {\n",
+            "        BatchNorm_0: {\n",
+            "            mean: DeviceArray([ 0.00059601, -0.00103457,  0.00166948], dtype=float32),\n",
+            "            var: DeviceArray([0.9907686, 0.9923046, 0.992195 ], dtype=float32),\n",
+            "        },\n",
+            "    },\n",
+            "})\n",
+            "initialized variable shapes:\n",
+            " FrozenDict({\n",
+            "    batch_stats: {\n",
+            "        BatchNorm_0: {\n",
+            "            mean: (3,),\n",
+            "            var: (3,),\n",
+            "        },\n",
+            "    },\n",
+            "    params: {\n",
+            "        BatchNorm_0: {\n",
+            "            bias: (3,),\n",
+            "            scale: (3,),\n",
+            "        },\n",
+            "        Dense_0: {\n",
+            "            bias: (3,),\n",
+            "            kernel: (4, 3),\n",
+            "        },\n",
+            "    },\n",
+            "})\n",
+            "output:\n",
+            " [[[-0.21496922  0.21550177 -0.35633382]\n",
+            "  [-0.21496922 -2.0458      1.3015485 ]\n",
+            "  [-0.21496922 -0.925116   -0.35633382]\n",
+            "  [-0.6595459   0.21550177  0.3749205 ]]\n",
+            "\n",
+            " [[-0.21496922  1.642865   -0.35633382]\n",
+            "  [-0.21496922  1.3094063  -0.88034123]\n",
+            "  [ 2.5726683   0.21550177  0.34353197]\n",
+            "  [-0.21496922  0.21550177  1.6778195 ]]\n",
+            "\n",
+            " [[-1.6060593   0.21550177 -1.9460517 ]\n",
+            "  [ 1.4126908  -1.4898677   1.2790381 ]\n",
+            "  [-0.21496922  0.21550177 -0.35633382]\n",
+            "  [-0.21496922  0.21550177 -0.7251308 ]]]\n",
+            "eval output:\n",
+            " [[[ 3.2246590e-01  2.6108384e-02  4.4821960e-01]\n",
+            "  [ 8.5726947e-02 -5.4385906e-01  3.8821870e-01]\n",
+            "  [-2.3933809e-01 -2.7381191e-01 -1.7526165e-01]\n",
+            "  [-6.2515378e-02 -5.2414006e-01  1.7029770e-01]]\n",
+            "\n",
+            " [[ 1.5014435e-01  3.4498507e-01 -1.3554120e-01]\n",
+            "  [-3.6971044e-04  2.6463276e-01 -1.2491019e-01]\n",
+            "  [ 3.8763803e-01  2.9023719e-01  1.6291586e-01]\n",
+            "  [ 4.1320035e-01  4.1468274e-02  4.7670874e-01]]\n",
+            "\n",
+            " [[-1.9433719e-01  5.2831882e-01 -3.7554008e-01]\n",
+            "  [ 2.2608691e-01 -4.0989807e-01  3.8292480e-01]\n",
+            "  [-2.4945706e-01  1.6170470e-01 -2.5247774e-01]\n",
+            "  [-7.2220474e-02  1.2077977e-01 -8.8408351e-02]]]\n"
+          ],
+          "name": "stdout"
         }
       ]
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "Lcp28h72810L"
       },
       "source": [
@@ -665,8 +794,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "WEpbn8si0ATT",
-        "colab_type": "text"
+        "id": "WEpbn8si0ATT"
       },
       "source": [
         "## JIT"
@@ -675,8 +803,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "-k-5gXTJ0EpD",
-        "colab_type": "text"
+        "id": "-k-5gXTJ0EpD"
       },
       "source": [
         "It's not immediately clear what use this has, but you can compile specific submodules if there's a reason to.\n",
@@ -688,13 +815,11 @@
       "cell_type": "code",
       "metadata": {
         "id": "UEUTO8bf0Kf2",
-        "colab_type": "code",
+        "tags": [],
+        "outputId": "3f324d0f-259f-40f0-8273-103f7fc281c5",
         "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 156
-        },
-        "outputId": "89b174dd-0a1c-4ffe-8f5a-4d471f260f68",
-        "tags": []
+          "base_uri": "https://localhost:8080/"
+        }
       },
       "source": [
         "class MLP(nn.Module):\n",
@@ -724,16 +849,23 @@
       "outputs": [
         {
           "output_type": "stream",
-          "name": "stdout",
-          "text": "initialized parameter shapes:\n {'params': {'layers_0': {'bias': (3,), 'kernel': (4, 3)}, 'layers_1': {'bias': (4,), 'kernel': (3, 4)}, 'layers_2': {'bias': (5,), 'kernel': (4, 5)}}}\noutput:\n [[ 0.2524199   0.11621265  0.5246693   0.1914479   0.20965417]\n [ 0.08557512 -0.04126883  0.2502836   0.03910369  0.16575359]\n [ 0.2804383   0.2775114   0.44969672  0.26016283  0.05875341]\n [ 0.24408427  0.17069668  0.45499086  0.20377949  0.1342802 ]]\n"
+          "text": [
+            "initialized parameter shapes:\n",
+            " {'params': {'layers_0': {'bias': (3,), 'kernel': (4, 3)}, 'layers_1': {'bias': (4,), 'kernel': (3, 4)}, 'layers_2': {'bias': (5,), 'kernel': (4, 5)}}}\n",
+            "output:\n",
+            " [[ 0.2524199   0.11621253  0.5246693   0.19144788  0.2096542 ]\n",
+            " [ 0.08557513 -0.04126885  0.2502836   0.03910369  0.16575359]\n",
+            " [ 0.2804383   0.27751124  0.44969672  0.26016283  0.05875347]\n",
+            " [ 0.2440843   0.17069656  0.45499086  0.20377949  0.13428023]]\n"
+          ],
+          "name": "stdout"
         }
       ]
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "D1tfTdRjyJYK",
-        "colab_type": "text"
+        "id": "D1tfTdRjyJYK"
       },
       "source": [
         "## Remat"
@@ -742,8 +874,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "goiHMi4qyLiZ",
-        "colab_type": "text"
+        "id": "goiHMi4qyLiZ"
       },
       "source": [
         "For memory-expensive computations, we can `remat` our method to recompute a Module's output during a backwards pass.\n",
@@ -755,13 +886,11 @@
       "cell_type": "code",
       "metadata": {
         "id": "sogMxDQpyMZE",
-        "colab_type": "code",
+        "tags": [],
+        "outputId": "7fe8e13b-7dd6-4e55-ee50-ce334e8ed178",
         "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 156
-        },
-        "outputId": "13f1b382-e76a-4fef-ce1f-0f04da461fb8",
-        "tags": []
+          "base_uri": "https://localhost:8080/"
+        }
       },
       "source": [
         "class RematMLP(nn.Module):\n",
@@ -792,16 +921,23 @@
       "outputs": [
         {
           "output_type": "stream",
-          "name": "stdout",
-          "text": "initialized parameter shapes:\n {'params': {'layers_0': {'bias': (3,), 'kernel': (4, 3)}, 'layers_1': {'bias': (4,), 'kernel': (3, 4)}, 'layers_2': {'bias': (5,), 'kernel': (4, 5)}}}\noutput:\n [[-0.14814316  0.06889858 -0.19695626  0.12019285  0.02068037]\n [-0.04439102 -0.06698258 -0.11579747 -0.19906905 -0.04342325]\n [-0.08875751 -0.13392815 -0.23153093 -0.39802808 -0.0868225 ]\n [-0.01606487 -0.02424064 -0.04190648 -0.07204203 -0.01571464]]\n"
+          "text": [
+            "initialized parameter shapes:\n",
+            " {'params': {'layers_0': {'bias': (3,), 'kernel': (4, 3)}, 'layers_1': {'bias': (4,), 'kernel': (3, 4)}, 'layers_2': {'bias': (5,), 'kernel': (4, 5)}}}\n",
+            "output:\n",
+            " [[-0.14814317  0.06889858 -0.19695625  0.12019286  0.02068037]\n",
+            " [-0.04439102 -0.06698258 -0.11579747 -0.19906905 -0.04342325]\n",
+            " [-0.08875751 -0.13392815 -0.23153095 -0.39802808 -0.0868225 ]\n",
+            " [-0.01606487 -0.02424064 -0.04190649 -0.07204203 -0.01571464]]\n"
+          ],
+          "name": "stdout"
         }
       ]
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "l0pJtxVwyCgp",
-        "colab_type": "text"
+        "id": "l0pJtxVwyCgp"
       },
       "source": [
         "## Vmap"
@@ -810,8 +946,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "TqVbjhOkyEaj",
-        "colab_type": "text"
+        "id": "TqVbjhOkyEaj"
       },
       "source": [
         "You can now `vmap` Modules inside.  The transform has a lot of arguments, they have the usual jax vmap args:\n",
@@ -833,13 +968,11 @@
       "cell_type": "code",
       "metadata": {
         "id": "PIGiriD0yFXo",
-        "colab_type": "code",
+        "tags": [],
+        "outputId": "223d880e-c7b2-4210-ebb5-dbfcdd9aed09",
         "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 105
-        },
-        "outputId": "d9015ed8-cd92-42da-ddb0-e0b8c29af437",
-        "tags": []
+          "base_uri": "https://localhost:8080/"
+        }
       },
       "source": [
         "class RawDotProductAttention(nn.Module):\n",
@@ -950,16 +1083,20 @@
       "outputs": [
         {
           "output_type": "stream",
-          "name": "stdout",
-          "text": "initialized parameter shapes:\n {'params': {'attention': {'key': {'kernel': (2, 64, 32)}, 'out': {'bias': (2, 64), 'kernel': (2, 32, 64)}, 'query': {'kernel': (2, 64, 32)}, 'value': {'kernel': (2, 64, 32)}}}}\noutput:\n (3, 13, 2)\n"
+          "text": [
+            "initialized parameter shapes:\n",
+            " {'params': {'attention': {'key': {'kernel': (2, 64, 32)}, 'out': {'bias': (2, 64), 'kernel': (2, 32, 64)}, 'query': {'kernel': (2, 64, 32)}, 'value': {'kernel': (2, 64, 32)}}}}\n",
+            "output:\n",
+            " (3, 13, 2)\n"
+          ],
+          "name": "stdout"
         }
       ]
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "U-bDSQElvM09",
-        "colab_type": "text"
+        "id": "U-bDSQElvM09"
       },
       "source": [
         "## Scan"
@@ -968,8 +1105,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "8oiRXIC6xQ--",
-        "colab_type": "text"
+        "id": "8oiRXIC6xQ--"
       },
       "source": [
         "Scan allows us to apply `lax.scan` to Modules, including their parameters and mutable variables.  To use it we have to specify how we want each \"kind\" of variable to be transformed.  For scanned variables we specify similar to vmap via in `variable_in_axes`, `variable_out_axes`:\n",
@@ -985,13 +1121,11 @@
       "cell_type": "code",
       "metadata": {
         "id": "oxA_lWm7tH2B",
-        "colab_type": "code",
+        "tags": [],
+        "outputId": "7d9ebed3-64de-4ca8-9dce-4b09ba9e31a1",
         "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 343
-        },
-        "outputId": "a40f51f2-7dfe-42fb-a3ee-035778286b62",
-        "tags": []
+          "base_uri": "https://localhost:8080/"
+        }
       },
       "source": [
         "class SimpleScan(nn.Module):\n",
@@ -1018,21 +1152,28 @@
         "y = model.apply(init_variables, xs)\n",
         "print('output:\\n', y)"
       ],
-      "execution_count": 2,
+      "execution_count": 15,
       "outputs": [
         {
           "output_type": "stream",
-          "name": "stdout",
-          "text": "initialized parameter shapes:\n {'params': {'lstm_cell': {'hf': {'bias': (2,), 'kernel': (2, 2)}, 'hg': {'bias': (2,), 'kernel': (2, 2)}, 'hi': {'bias': (2,), 'kernel': (2, 2)}, 'ho': {'bias': (2,), 'kernel': (2, 2)}, 'if': {'kernel': (2, 2)}, 'ig': {'kernel': (2, 2)}, 'ii': {'kernel': (2, 2)}, 'io': {'kernel': (2, 2)}}}}\noutput:\n ((DeviceArray([[-0.562219  ,  0.92847174]], dtype=float32), DeviceArray([[-0.31570646,  0.2885693 ]], dtype=float32)), DeviceArray([[[-0.08265854,  0.01302483],\n              [-0.10249066,  0.21991298],\n              [-0.26609066,  0.22519003],\n              [-0.27982554,  0.28393182],\n              [-0.31570646,  0.2885693 ]]], dtype=float32))\n"
+          "text": [
+            "initialized parameter shapes:\n",
+            " {'params': {'lstm_cell': {'hf': {'bias': (2,), 'kernel': (2, 2)}, 'hg': {'bias': (2,), 'kernel': (2, 2)}, 'hi': {'bias': (2,), 'kernel': (2, 2)}, 'ho': {'bias': (2,), 'kernel': (2, 2)}, 'if': {'kernel': (2, 2)}, 'ig': {'kernel': (2, 2)}, 'ii': {'kernel': (2, 2)}, 'io': {'kernel': (2, 2)}}}}\n",
+            "output:\n",
+            " ((DeviceArray([[-0.562219  ,  0.92847174]], dtype=float32), DeviceArray([[-0.31570646,  0.2885693 ]], dtype=float32)), DeviceArray([[[-0.08265854,  0.01302483],\n",
+            "              [-0.10249066,  0.21991298],\n",
+            "              [-0.26609066,  0.22519003],\n",
+            "              [-0.27982554,  0.28393182],\n",
+            "              [-0.31570646,  0.2885693 ]]], dtype=float32))\n"
+          ],
+          "name": "stdout"
         }
       ]
     },
     {
       "cell_type": "code",
       "metadata": {
-        "id": "3aXsCdxGZiYq",
-        "colab_type": "code",
-        "colab": {}
+        "id": "3aXsCdxGZiYq"
       },
       "source": [
         ""


### PR DESCRIPTION
`apply()` now returns only the explicitly mutated collections, rather than a copy of all variable collections, we update the linen intro notebook to use examples showing this correctly.