### PR TITLE
Raise minimal version to 0.1.77

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ except IOError:
 
 install_requires = [
     "numpy>=1.12",
-    "jax>=0.1.59",
+    "jax>=0.1.77",
     "matplotlib",  # only needed for tensorboard export
     "dataclasses;python_version<'3.7'", # will only install on py3.6
     "msgpack",


### PR DESCRIPTION
Previous version constraint fails due to missing omnistaging api's.

Closes #627
