### PR TITLE
Add the centered version of RMSProp

### DIFF
--- a/flax/optim/rmsprop.py
+++ b/flax/optim/rmsprop.py
@@ -58,7 +58,8 @@ class RMSProp(OptimizerDef):
 
   def init_param_state(self, param):
     """Initialize parameter state"""
-    return _RMSPropParamState(jnp.zeros_like(param), jnp.zeros_like(param))
+    mg = jnp.zeros_like(param) if self.hyper_params.centered else None
+    return _RMSPropParamState(jnp.zeros_like(param), mg)
 
   def apply_param_gradient(self, step, hyper_params, param, state, grad):
     """Apply per-parameter gradients"""

--- a/tests/optim_test.py
+++ b/tests/optim_test.py
@@ -412,13 +412,14 @@ class RMSPropTest(absltest.TestCase):
     params = onp.zeros((1,))
     optimizer_def = optim.RMSProp(learning_rate=0.1,
                                   beta2=0.9,
-                                  eps=0.01)
+                                  eps=0.01,
+                                  centered=False)
     state = optimizer_def.init_state(params)
 
-    expected_hyper_params = _RMSPropHyperParams(0.1, 0.9, 0.01)
+    expected_hyper_params = _RMSPropHyperParams(0.1, 0.9, 0.01, False)
     self.assertEqual(optimizer_def.hyper_params, expected_hyper_params)
     expected_state = optim.OptimizerState(
-        0, _RMSPropParamState(onp.zeros((1,))))
+        0, _RMSPropParamState(onp.zeros((1,)), onp.zeros((1,))))
     self.assertEqual(state, expected_state)
 
   def test_apply_gradient(self):
@@ -427,12 +428,12 @@ class RMSPropTest(absltest.TestCase):
                                   eps=0.01)
     params = onp.array([1.])
     state = optim.OptimizerState(
-        1, _RMSPropParamState(onp.array([0.1])))
+        1, _RMSPropParamState(onp.array([0.1]), onp.array([1.0])))
     grads = onp.array([4.])
     new_params, new_state = optimizer_def.apply_gradient(
         optimizer_def.hyper_params, params, state, grads)
     expected_new_state = optim.OptimizerState(
-        2, _RMSPropParamState(onp.array([1.69])))
+        2, _RMSPropParamState(onp.array([1.69]), onp.array([1.0])))
     expected_new_params = onp.array([0.6946565])
     onp.testing.assert_allclose(new_params, expected_new_params)
     self.assertEqual(new_state, expected_new_state)


### PR DESCRIPTION
This is based on the RMSProp implementation in TF.Keras: https://github.com/tensorflow/tensorflow/blob/v2.3.1/tensorflow/python/keras/optimizer_v2/rmsprop.py

Having a centered RMSProp is necessary for proper performance of certain algorithms, such as the original DQN: https://github.com/google/dopamine/blob/master/dopamine/agents/dqn/configs/dqn_nature.gin#L23