### PR TITLE
Lint (deprecated) flax.nn.base (NN base modules for JAX)

### DIFF
--- a/flax/nn/base.py
+++ b/flax/nn/base.py
@@ -755,7 +755,7 @@ class TransparentModule(Module):
 class TruncatedModule(TransparentModule):
   """Wraps a Module and returns the requested intermediate outputs instead.
 
-  Check `Model.truncate_at` for a simple APU to get the intermediate outputs of
+  Check `Model.truncate_at` for a simple API to get the intermediate outputs of
   an existing Model.
   """
 


### PR DESCRIPTION
Hello Flax team, I was just studying https://flax.readthedocs.io/en/latest/flax.nn.html?highlight=initi_by_shape#flax.nn.Module.init_by_shape and decided to lint `flax.nn.base` to improve the docs. Also, one of the examples isn't currently rendering well, so I made a quick fix (`Example::`):

<img width="400" alt="image" src="https://user-images.githubusercontent.com/19637339/100365978-20959180-2ff8-11eb-9d07-99f9ed01d32d.png">

Can you let me know if there's a general convention for writing "Module" (a "thing", not an API, such as `Module`)? I noticed, the API docs use both "module" and "Module".

Cheers 👍 