### PR TITLE
Fix non-init module attributes

### DIFF
--- a/flax/linen/module.py
+++ b/flax/linen/module.py
@@ -78,7 +78,7 @@ def _module_repr(module: 'Module', num_spaces: int = 4):
     rep += '# attributes\n'
     for attr in attributes.keys():
       # TODO(jheek): can we get a nice string representation of attribute types?
-      value = getattr(module, attr)
+      value = getattr(module, attr, None)
       value_rep = _attr_repr(value)
       rep += f'{attr} = {value_rep}\n'
   if child_modules:
@@ -412,7 +412,7 @@ class Module:
     if name == 'parent':
       pass
     # Modules have been passed in as dataclass args.
-    elif name in self.__dataclass_fields__.keys():  # pytype: disable=attribute-error
+    elif name in self.__dataclass_fields__ and self.__dataclass_fields__[name].init:  # pytype: disable=attribute-error
       pass
     # Submodules are being defined and attached in setup()
     else:
@@ -423,7 +423,7 @@ class Module:
                 "You can only assign submodules to self in setup().")
           if subvalue.parent is _unspecified_parent:
             subvalue.parent = self
-          elif subvalue.parent != self:
+          elif subvalue.parent is not self:
             raise ValueError("Can't attach to remote parent in setup, pass in "
                              "bound Modules from outside as an argument.")
           if subvalue.name is not None:

--- a/tests/linen/module_test.py
+++ b/tests/linen/module_test.py
@@ -14,6 +14,8 @@
 
 """Tests for flax.linen."""
 
+import dataclasses
+
 from absl.testing import absltest
 
 import jax
@@ -667,6 +669,23 @@ class ModuleTest(absltest.TestCase):
     # in `setup()`
     with self.assertRaisesRegex(AttributeError, "has no attribute 'setup_called'"):
       empty.bar()
+
+  def test_module_with_attrs(self):
+    class Foo(nn.Module):
+      bar: nn.Dense = dataclasses.field(init=False)
+
+      def setup(self):
+        self.bar = nn.Dense(2)
+      
+      @nn.compact
+      def __call__(self, x):
+        return self.bar(x)
+
+    foo = Foo()
+    x = jnp.ones((2,))
+    variables = foo.init(random.PRNGKey(0), x)
+    self.assertEqual(variables['params']['bar']['kernel'].shape, (2, 2))
+    
 
 
 if __name__ == '__main__':

--- a/tests/linen/module_test.py
+++ b/tests/linen/module_test.py
@@ -675,16 +675,15 @@ class ModuleTest(absltest.TestCase):
       bar: nn.Dense = dataclasses.field(init=False)
 
       def setup(self):
-        self.bar = nn.Dense(2)
+        self.bar = nn.Dense(3)
       
-      @nn.compact
       def __call__(self, x):
         return self.bar(x)
 
     foo = Foo()
     x = jnp.ones((2,))
     variables = foo.init(random.PRNGKey(0), x)
-    self.assertEqual(variables['params']['bar']['kernel'].shape, (2, 2))
+    self.assertEqual(variables['params']['bar']['kernel'].shape, (2, 3))
     
 
 


### PR DESCRIPTION
This fixes the following:
```
class Foo(nn.Module):
      bar: nn.Dense = dataclasses.field(init=False)

      def setup(self):
        self.bar = nn.Dense(2)
      
      @nn.compact
      def __call__(self, x):
        return self.bar(x)
```

because bar is a dataclass attributes the `__setattr__` logic that binds the scope didn't fire