### PR TITLE
Add OptimizedLSTMCell to docs.

### DIFF
--- a/docs/flax.linen.rst
+++ b/docs/flax.linen.rst
@@ -98,4 +98,5 @@ RNN primitives
   :toctree: _autosummary
 
     LSTMCell
+    OptimizedLSTMCell
     GRUCell

--- a/docs/flax.nn.rst
+++ b/docs/flax.nn.rst
@@ -111,4 +111,5 @@ RNN primitives
   :toctree: _autosummary
 
     LSTMCell
+    OptimizedLSTMCell
     GRUCell


### PR DESCRIPTION
This makes OptimizedLSTMCell show up for v0.1 and linen docs.