### PR TITLE
Decreases time needed to run tests.

### DIFF
--- a/linen_examples/imagenet/configs/default.py
+++ b/linen_examples/imagenet/configs/default.py
@@ -34,6 +34,9 @@ def get_config():
   """Get the default hyperparameter configuration."""
   config = ml_collections.ConfigDict()
 
+  # As defined in the `models` module.
+  config.model = 'ResNet50'
+
   config.learning_rate = 0.1
   config.momentum = 0.9
   config.batch_size = 128

--- a/linen_examples/imagenet/models.py
+++ b/linen_examples/imagenet/models.py
@@ -130,3 +130,7 @@ ResNet152 = partial(ResNet, stage_sizes=[3, 8, 36, 3],
                     block_cls=BottleneckResNetBlock)
 ResNet200 = partial(ResNet, stage_sizes=[3, 24, 36, 3],
                     block_cls=BottleneckResNetBlock)
+
+
+# Used for testing only.
+_ResNet1 = partial(ResNet, stage_sizes=[1], block_cls=ResNetBlock)

--- a/linen_examples/imagenet/models_test.py
+++ b/linen_examples/imagenet/models_test.py
@@ -21,9 +21,6 @@ from jax import numpy as jnp
 
 import models
 
-# Parse absl flags test_srcdir and test_tmpdir.
-jax.config.parse_flags_with_absl()
-
 
 class ResNetV1Test(absltest.TestCase):
   """Test cases for ResNet v1 model definition."""

--- a/linen_examples/imagenet/train.py
+++ b/linen_examples/imagenet/train.py
@@ -20,7 +20,7 @@ The data is loaded using tensorflow_datasets.
 
 import functools
 import time
-from typing import Any, Optional
+from typing import Any
 
 from absl import logging
 

--- a/linen_examples/imagenet/train_test.py
+++ b/linen_examples/imagenet/train_test.py
@@ -26,12 +26,9 @@ import tensorflow as tf
 import tensorflow_datasets as tfds
 
 # Local imports.
+import models
 import train
 from configs import default as default_lib
-
-
-# Parse absl flags test_srcdir and test_tmpdir.
-jax.config.parse_flags_with_absl()
 
 
 class TrainTest(absltest.TestCase):
@@ -43,7 +40,7 @@ class TrainTest(absltest.TestCase):
 
   def test_create_model(self):
     """Tests creating model."""
-    model = train.create_model(half_precision=False)
+    model = train.create_model(model_cls=models._ResNet1, half_precision=False)
     params, state = train.initialized(random.PRNGKey(0), 224, model)
     variables = {'params': params, **state}
     x = random.normal(random.PRNGKey(1), (8, 224, 224, 3))
@@ -61,6 +58,7 @@ class TrainTest(absltest.TestCase):
 
     # Define training configuration
     config = default_lib.get_config()
+    config.model = '_ResNet1'
     config.batch_size = 1
     config.num_epochs = 1
     config.num_train_steps = 1

--- a/linen_examples/imagenet/train_test.py
+++ b/linen_examples/imagenet/train_test.py
@@ -19,7 +19,6 @@ import tempfile
 
 from absl.testing import absltest
 
-import jax
 from jax import random
 
 import tensorflow as tf
@@ -40,7 +39,7 @@ class TrainTest(absltest.TestCase):
 
   def test_create_model(self):
     """Tests creating model."""
-    model = train.create_model(model_cls=models._ResNet1, half_precision=False)
+    model = train.create_model(model_cls=models._ResNet1, half_precision=False)  # pylint: disable=protected-access
     params, state = train.initialized(random.PRNGKey(0), 224, model)
     variables = {'params': params, **state}
     x = random.normal(random.PRNGKey(1), (8, 224, 224, 3))

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ tests_require = [
     "sentencepiece",  # WMT example.
     "svn",
     "tensorflow-cpu==2.4.0",
-    "tensorflow_text==2.4.0",  # WMT example.
+    "tensorflow_text==2.4.0rc1",  # WMT example.
     "tensorflow_datasets",
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -45,8 +45,8 @@ tests_require = [
     "pytype",
     "sentencepiece",  # WMT example.
     "svn",
-    "tensorflow",
-    "tensorflow_text",  # WMT example.
+    "tensorflow-cpu==2.4.0",
+    "tensorflow_text==2.4.0",  # WMT example.
     "tensorflow_datasets",
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -45,8 +45,8 @@ tests_require = [
     "pytype",
     "sentencepiece",  # WMT example.
     "svn",
-    "tensorflow-cpu==2.4.0",
-    "tensorflow_text==2.4.0rc1",  # WMT example.
+    "tensorflow-cpu>=2.4.0",
+    "tensorflow_text>=2.4.0rc01",  # WMT example.
     "tensorflow_datasets",
 ]
 


### PR DESCRIPTION
See #697 and #639 for motivation.

This reduces overall build workflow from 22m to 13m. The pytest & coverage step reduces from 18m to 9m.

Note that `linen_examples/wmt` still takes ~90s to complete - I tried using `chex.fake_pmap()` but that failed with `ValueError: fake pmap does not currently support non-empty static_broadcasted_argnums=(3, 4)`. So maybe that is an idea for a later iteration ...

Note: This PR also includes a fix for TF versions that makes `wmt` example fail on master.