### PR TITLE
Add support for single example pooling

### DIFF
--- a/flax/linen/pooling.py
+++ b/flax/linen/pooling.py
@@ -44,6 +44,16 @@ def pool(inputs, init, reduce_fn, window_shape, strides, padding):
   strides = strides or (1,) * len(window_shape)
   strides = (1,) + strides + (1,)
   dims = (1,) + window_shape + (1,)
+  assert len(dims) == len(strides)
+
+  is_single_input = False
+  if inputs.ndim == len(dims) - 1:
+    # add singleton batch dimension because lax.reduce_window always
+    # needs a batch dimension.
+    inputs = inputs[None]
+    is_single_input = True
+
+  assert inputs.ndim == len(dims)
   if not isinstance(padding, str):
     padding = tuple(map(tuple, padding))
     assert(len(padding) == len(window_shape)), (
@@ -52,7 +62,10 @@ def pool(inputs, init, reduce_fn, window_shape, strides, padding):
     assert(all([len(x) == 2 for x in padding])), (
       f"each entry in padding {padding} must be length 2")
     padding = ((0,0),) + padding + ((0,0),)
-  return lax.reduce_window(inputs, init, reduce_fn, dims, strides, padding)
+  y = lax.reduce_window(inputs, init, reduce_fn, dims, strides, padding)
+  if is_single_input:
+    y = jnp.squeeze(y, axis=0)
+  return y
 
 
 def avg_pool(inputs, window_shape, strides=None, padding="VALID"):

--- a/tests/linen/linen_test.py
+++ b/tests/linen/linen_test.py
@@ -53,6 +53,19 @@ class PoolTest(absltest.TestCase):
     ]).reshape((1, 3, 3, 1))
     np.testing.assert_allclose(y_grad, expected_grad)
 
+  def test_avg_pool_no_batch(self):
+    x = jnp.full((3, 3, 1), 2.)
+    pool = lambda x: nn.avg_pool(x, (2, 2))
+    y = pool(x)
+    np.testing.assert_allclose(y, np.full((2, 2, 1), 2.))
+    y_grad = jax.grad(lambda x: pool(x).sum())(x)
+    expected_grad = jnp.array([
+        [0.25, 0.5, 0.25],
+        [0.5, 1., 0.5],
+        [0.25, 0.5, 0.25],
+    ]).reshape((3, 3, 1))
+    np.testing.assert_allclose(y_grad, expected_grad)
+
   def test_max_pool(self):
     x = jnp.arange(9).reshape((1, 3, 3, 1)).astype(jnp.float32)
     pool = lambda x: nn.max_pool(x, (2, 2))


### PR DESCRIPTION
recognizes batch free inputs in pooling layers see. Fixes https://github.com/google/flax/issues/739