### PR TITLE
disable LLVM optimization on tests with long compilation times

### DIFF
--- a/linen_examples/imagenet/models_test.py
+++ b/linen_examples/imagenet/models_test.py
@@ -22,6 +22,9 @@ from jax import numpy as jnp
 import models
 
 
+jax.config.update('jax_disable_most_optimizations', True)
+
+
 class ResNetV1Test(absltest.TestCase):
   """Test cases for ResNet v1 model definition."""
 

--- a/linen_examples/imagenet/train_test.py
+++ b/linen_examples/imagenet/train_test.py
@@ -19,6 +19,7 @@ import tempfile
 
 from absl.testing import absltest
 
+import jax
 from jax import random
 
 import tensorflow as tf
@@ -28,6 +29,9 @@ import tensorflow_datasets as tfds
 import models
 import train
 from configs import default as default_lib
+
+
+jax.config.update('jax_disable_most_optimizations', True)
 
 
 class TrainTest(absltest.TestCase):

--- a/linen_examples/wmt/train_test.py
+++ b/linen_examples/wmt/train_test.py
@@ -24,6 +24,9 @@ import tensorflow as tf
 import tensorflow_datasets as tfds
 
 
+jax.config.update('jax_disable_most_optimizations', True)
+
+
 class TrainTest(absltest.TestCase):
   """Test cases for WMT library."""
 


### PR DESCRIPTION
timings:
imagenet  226s -> 52s (timed before the model changed)
wmt 63 -> 37s