### PR TITLE
✍️ Expand the Flax annotated MNIST image classification tutorial, port to the Linen API

### DIFF
--- a/docs/annotated_mnist.md
+++ b/docs/annotated_mnist.md
@@ -71,19 +71,13 @@ class CNN(nn.Module):
 
 ## Create a loss function, an optimizer, a parameter initializer, and a metrics function
 
-1. Next, create a loss function—such as [cross-entropy](https://en.wikipedia.org/wiki/Cross_entropy)—using just [`jax.numpy`](https://jax.readthedocs.io/en/latest/jax.numpy.html) that takes the model's logits and label vectors and returns a scalar loss. The labels need to be one-hot encoded, so define a separate function for that task, as demonstrated below.
-
-
-```python
-def onehot(labels, num_classes=10): # There are 10 classes in MNIST
-  x = (labels[..., None] == jnp.arange(num_classes)[None])
-  return x.astype(jnp.float32) # Convert to float32 data type (JAX's default `dtype`)
-```
+1. Next, create a loss function—such as [cross-entropy](https://en.wikipedia.org/wiki/Cross_entropy)—using just [`jax.numpy`](https://jax.readthedocs.io/en/latest/jax.numpy.html) that takes the model's logits and label vectors and returns a scalar loss. The labels can be one-hot encoded with [`jax.nn.one_hot`](https://jax.readthedocs.io/en/latest/_autosummary/jax.nn.one_hot.html), as demonstrated below.
 
 
 ```python
 def cross_entropy_loss(logits, labels):
-  return -jnp.mean(jnp.sum(onehot(labels) * logits, axis=-1))
+  one_hot_labels = jax.nn.one_hot(labels, num_classes=10)
+  return -jnp.mean(jnp.sum(one_hot_labels * logits, axis=-1))
 ```
 
 2. Define a function for your optimizer that takes the model parameters, the learning rate, and a beta argument (for the [Momentum optimizer](http://www.columbia.edu/~nq6/publications/momentum.pdf)):

--- a/docs/annotated_mnist.md
+++ b/docs/annotated_mnist.md
@@ -24,11 +24,6 @@ If you're using [Google Colaboratory](https://colab.research.google.com/notebook
 !pip install --upgrade -q pip jax jaxlib flax tensorflow-datasets
 ```
 
-    [K     |████████████████████████████████| 1.5MB 15.7MB/s 
-    [K     |████████████████████████████████| 163kB 53.2MB/s 
-    [K     |████████████████████████████████| 3.6MB 55.6MB/s 
-    [?25h
-
 2. Import JAX, [JAX NumPy](https://jax.readthedocs.io/en/latest/jax.numpy.html) (which lets you run code on GPUs and TPUs), Flax, ordinary NumPy, and TFDS. Flax can use any data-loading pipeline and this example demonstrates how to utilize TFDS.
 
 
@@ -150,7 +145,7 @@ def get_datasets():
   - Applies a [pytree](https://jax.readthedocs.io/en/latest/pytrees.html#pytrees-and-jax-functions) of gradients ([`flax.optim.Optimizer.apply_gradient`](https://flax.readthedocs.io/en/latest/flax.optim.html#flax.optim.Optimizer.apply_gradient)) to the optimizer to update the model's parameters.
   - Computes the metrics using `compute_metrics` (defined earlier).
 
-  Use JAX's [`@jit`](https://jax.readthedocs.io/en/latest/jax.html#jax.jit) decorator to trace the entire `train_step` function` and just-in-time([`jit`]-compile with [XLA](https://www.tensorflow.org/xla) into fused device operations that run faster and more efficiently on hardware accelerators.
+  Use JAX's [`@jit`](https://jax.readthedocs.io/en/latest/jax.html#jax.jit) decorator to trace the entire `train_step` function and just-in-time([`jit`]-compile with [XLA](https://www.tensorflow.org/xla) into fused device operations that run faster and more efficiently on hardware accelerators.
 
 
 ```python

--- a/docs/annotated_mnist.md
+++ b/docs/annotated_mnist.md
@@ -2,7 +2,7 @@
 
 This tutorial uses Flax—a high-performance deep learning library for JAX designed for flexibility—to show you how to construct a simple convolutional neural network (CNN) using the Linen API and train the network for image classification on the MNIST dataset.
 
-If you're new to JAX, check out [JAX quickstart](https://jax.readthedocs.io/en/latest/notebooks/quickstart.html) and [JAX for the impatient](https://flax.readthedocs.io/en/latest/notebooks/jax_for_the_impatient.html). To learn more about Flax and its Linen API, refer to [Flax basics](https://flax.readthedocs.io/en/latest/notebooks/flax_basics.html), [Flax patterns: Managing state and parameters](https://flax.readthedocs.io/en/latest/patterns/state_params.html), and [Linen design principles](https://flax.readthedocs.io/en/latest/design_notes/linen_design_principles.html).
+If you're new to JAX, check out [JAX quickstart](https://jax.readthedocs.io/en/latest/notebooks/quickstart.html) and [JAX for the impatient](https://flax.readthedocs.io/en/latest/notebooks/jax_for_the_impatient.html). To learn more about Flax and its Linen API, refer to [Flax basics](https://flax.readthedocs.io/en/latest/notebooks/flax_basics.html), [Flax patterns: Managing state and parameters](https://flax.readthedocs.io/en/latest/patterns/state_params.html), [Linen design principles](https://flax.readthedocs.io/en/latest/design_notes/linen_design_principles.html), and the [Linen introduction](https://github.com/google/flax/blob/master/docs/notebooks/linen_intro.ipynb) notebook.
 
 This tutorial has the following workflow:
 

--- a/docs/annotated_mnist.md
+++ b/docs/annotated_mnist.md
@@ -242,24 +242,6 @@ Download the dataset and preprocess it with `get_datasets` you defined earlier:
 train_ds, test_ds = get_datasets()
 ```
 
-    WARNING:absl:Dataset mnist is hosted on GCS. It will automatically be downloaded to your
-    local data directory. If you'd instead prefer to read directly from our public
-    GCS bucket (recommended if you're running on GCP), you can instead pass
-    `try_gcs=True` to `tfds.load` or set `data_dir=gs://tfds-data/datasets`.
-    
-
-
-    [1mDownloading and preparing dataset mnist/3.0.1 (download: 11.06 MiB, generated: 21.00 MiB, total: 32.06 MiB) to /root/tensorflow_datasets/mnist/3.0.1...[0m
-
-
-
-    HBox(children=(FloatProgress(value=0.0, description='Dl Completed...', max=4.0, style=ProgressStyle(descriptio…
-
-
-    
-    
-    [1mDataset mnist downloaded and prepared to /root/tensorflow_datasets/mnist/3.0.1. Subsequent calls will reuse this data.[0m
-
 
 ## Initialize the weights and instantiate the optimizer
 

--- a/docs/annotated_mnist.md
+++ b/docs/annotated_mnist.md
@@ -252,7 +252,7 @@ train_ds, test_ds = get_datasets()
   - Start by getting two unsigned 32-bit integers with [`jax.random.PRNGKey`](https://jax.readthedocs.io/en/latest/_autosummary/jax.random.PRNGKey.html#jax.random.PRNGKey) as one key (`rng`).
   - Then, split the PRNG to obtain a usable subkey for parameter initialization (`init_rng` below) using [`jax.random.split`](https://jax.readthedocs.io/en/latest/_autosummary/jax.random.split.html#jax.random.split). 
 
-  Note that in JAX and Flax you can have [separate PRNG chains](https://flax.readthedocs.io/en/latest/design_notes/linen_design_principles.html#how-are-parameters-represented-and-how-do-we-handle-general-differentiable-algorithms-that-update-stateful-variables) (with different names, such as `rng` and `init_rng` below) inside `Module`s for different applications.
+  Note that in JAX and Flax you can have [separate PRNG chains](https://flax.readthedocs.io/en/latest/design_notes/linen_design_principles.html#how-are-parameters-represented-and-how-do-we-handle-general-differentiable-algorithms-that-update-stateful-variables) (with different names, such as `rng` and `init_rng` below) inside `Module`s for different applications. (Find out more about [JAX PRNG design](https://github.com/google/jax/blob/master/design_notes/prng.md).)
 
 
 ```python
@@ -287,9 +287,9 @@ num_epochs = 10
 batch_size = 32
 ```
 
-2. Finally, begin training and evaluating the model:
+2. Finally, begin training and evaluating the model over 10 epochs:
 
-  - Similar to the parameter initialization stage, [split](https://jax.readthedocs.io/en/latest/notebooks/Common_Gotchas_in_JAX.html#JAX-PRNG) the PRNG key to get a new subkey—`input_rng`—with [`jax.random.split`](https://jax.readthedocs.io/en/latest/_autosummary/jax.random.split.html#jax.random.split). `input_rng` will be used to permute image data during the shuffling stage when training.
+  - For your training function (`train_epoch`), you need to pass a PRNG key used to permute image data during shuffling. Since you have created a PRNG key when initializing the parameters in your nework, you just need to [split](https://jax.readthedocs.io/en/latest/notebooks/Common_Gotchas_in_JAX.html#JAX-PRNG) or "fork" the PRNG state into two (while maintaining the usual desirable PRNG properties) to get a new subkey (`input_rng`, in this example) and the previous key (`rng`). Use [`jax.random.split`](https://jax.readthedocs.io/en/latest/_autosummary/jax.random.split.html#jax.random.split) to carry this out. (Learn more about [JAX PRNG design](https://github.com/google/jax/blob/master/design_notes/prng.md).)
   - Run an optimization step over a training batch (`train_epoch`).
   - Evaluate on the test set after each training epoch (`eval_model`).
   - Retrieve the metrics from the device and print them.

--- a/docs/annotated_mnist.md
+++ b/docs/annotated_mnist.md
@@ -87,6 +87,7 @@ def cross_entropy_loss(logits, labels):
 ```
 
 2. Define a function for your optimizer that takes the model parameters, the learning rate, and a beta argument (for the [Momentum optimizer](http://www.columbia.edu/~nq6/publications/momentum.pdf)):
+
   - Choose `Momentum` from the [`flax.optim`](https://flax.readthedocs.io/en/latest/flax.optim.html) package; and
   - Wrap the model parameters (`params`) with the [`flax.optim.OptimizerDef.create`](https://flax.readthedocs.io/en/latest/flax.optim.html#flax.optim.OptimizerDef.create) method and initialize with parameter dicts.
 
@@ -99,8 +100,9 @@ def create_optimizer(params, learning_rate, beta):
 ```
 
 3. Create a function for parameter initialization:
+
   - Set the initial shape of the kernel (note that JAX and Flax are [row-based](https://flax.readthedocs.io/en/latest/notebooks/flax_basics.html#Model-parameters-&-initialization)); and
-  - Initialize the module parameters of your network (`CNN`) with the [`flax.linen.Module.init`](https://flax.readthedocs.io/en/latest/flax.linen.html#flax.linen.Module.init) method using the PRNGKey and parameters (note that the weights aren't stored with the models). 
+  - Initialize the module parameters of your network (`CNN`) with the [`flax.linen.Module.init`](https://flax.readthedocs.io/en/latest/flax.linen.html#flax.linen.Module.init) method using the PRNGKey and parameters (note that the weights aren't stored with the models).
 
 
 ```python
@@ -182,6 +184,7 @@ def eval_step(params, batch):
 ```
 
 3. Define a training function for one epoch that:
+
   - Shuffles the training data before each epoch using [`jax.random.permutation`](https://jax.readthedocs.io/en/latest/_autosummary/jax.random.permutation.html) that takes a PRNGKey as a parameter (discussed in more detail later in this tutorial and in [JAX - the sharp bits](https://jax.readthedocs.io/en/latest/notebooks/Common_Gotchas_in_JAX.html#JAX-PRNG)).
   - Runs an optimization step for each batch.
   - Retrieves the training metrics from the device with `jax.device_get` and computes their mean across each batch in an epoch.
@@ -303,6 +306,7 @@ batch_size = 32
 ```
 
 2. Finally, begin training and evaluating the model:
+
   - Similar to the parameter initialization stage, [split](https://jax.readthedocs.io/en/latest/notebooks/Common_Gotchas_in_JAX.html#JAX-PRNG) the PRNG key to get a new subkey—`input_rng`—with [`jax.random.split`](https://jax.readthedocs.io/en/latest/_autosummary/jax.random.split.html#jax.random.split). `input_rng` will be used to permute image data during the shuffling stage when training.
   - Run an optimization step over a training batch (`train_epoch`).
   - Evaluate on the test set after each training epoch (`eval_model`).

--- a/docs/annotated_mnist.md
+++ b/docs/annotated_mnist.md
@@ -102,7 +102,7 @@ def create_optimizer(params, learning_rate, beta):
 3. Create a function for parameter initialization:
 
   - Set the initial shape of the kernel (note that JAX and Flax are [row-based](https://flax.readthedocs.io/en/latest/notebooks/flax_basics.html#Model-parameters-&-initialization)); and
-  - Initialize the module parameters of your network (`CNN`) with the [`flax.linen.Module.init`](https://flax.readthedocs.io/en/latest/flax.linen.html#flax.linen.Module.init) method using the PRNGKey and parameters (note that the weights aren't stored with the models).
+  - Initialize the module parameters of your network (`CNN`) with the [`flax.linen.Module.init`](https://flax.readthedocs.io/en/latest/flax.linen.html#flax.linen.Module.init) method using the PRNGKey and parameters (note that the parameters aren't stored with the models).
 
 
 ```python
@@ -156,7 +156,7 @@ def get_datasets():
   - Applies a [pytree](https://jax.readthedocs.io/en/latest/pytrees.html#pytrees-and-jax-functions) of gradients ([`flax.optim.Optimizer.apply_gradient`](https://flax.readthedocs.io/en/latest/flax.optim.html#flax.optim.Optimizer.apply_gradient)) to the optimizer to update the model's parameters.
   - Computes the metrics using `compute_metrics` (defined earlier).
 
-  Use the `@jit` decorator—the entire function is now just-in-time([`jit`](https://jax.readthedocs.io/en/latest/jax.html#jax.jit))-compiled with [XLA](https://www.tensorflow.org/xla) to make your code run faster and more efficiently.
+  Use JAX's [`@jit`](https://jax.readthedocs.io/en/latest/jax.html#jax.jit) decorator to trace the entire `train_step` function` and just-in-time([`jit`]-compile with [XLA](https://www.tensorflow.org/xla) into fused device operations that run faster and more efficiently on hardware accelerators.
 
 
 ```python
@@ -243,9 +243,9 @@ train_ds, test_ds = get_datasets()
 ```
 
 
-## Initialize the weights and instantiate the optimizer
+## Initialize the parameters and instantiate the optimizer
 
-1. Before you start training the model, you need to randomly initialize the weights/parameters.
+1. Before you start training the model, you need to randomly initialize the parameters.
 
   In NumPy, you would usually use the stateful pseudorandom number generators (PRNG). JAX, however, uses an explicit PRNG (refer to [JAX - the sharp bits](https://jax.readthedocs.io/en/latest/notebooks/Common_Gotchas_in_JAX.html#JAX-PRNG) for details):
 
@@ -260,7 +260,7 @@ rng = jax.random.PRNGKey(0)
 rng, init_rng = jax.random.split(rng)
 ```
 
-2. You can now use the PRNG subkey—`init_rng`—to initialize the model's weights by calling the predefined `get_initial_params` function:
+2. You can now use the PRNG subkey—`init_rng`—to initialize the model's parameters by calling the predefined `get_initial_params` function:
 
 
 ```python

--- a/docs/annotated_mnist.md
+++ b/docs/annotated_mnist.md
@@ -1,157 +1,342 @@
-# Annotated full end-to-end MNIST example
+# The annotated MNIST image classification example with Flax
 
-```py
+This tutorial uses Flax—a high-performance deep learning library for JAX designed for flexibility—to show you how to construct a simple convolutional neural network (CNN) using the Linen API and train the network for image classification on the MNIST dataset.
+
+If you're new to JAX, check out [JAX quickstart](https://jax.readthedocs.io/en/latest/notebooks/quickstart.html) and [JAX for the impatient](https://flax.readthedocs.io/en/latest/notebooks/jax_for_the_impatient.html). To learn more about Flax and its Linen API, refer to [Flax basics](https://flax.readthedocs.io/en/latest/notebooks/flax_basics.html), [Flax patterns: Managing state and parameters](https://flax.readthedocs.io/en/latest/patterns/state_params.html), and [Linen design principles](https://flax.readthedocs.io/en/latest/design_notes/linen_design_principles.html).
+
+This tutorial has the following workflow:
+
+- Perform a quick setup.
+- Create a neural network model with the Linen API that classifies images.
+- Define a loss function, an optimizer, a parameter initializer, and a metrics function.
+- Create a dataset function, then load the dataset.
+- Initialize the parameters and the optimizer.
+- And, finally, train the network and evaluate it.
+
+If you're using [Google Colaboratory](https://colab.research.google.com/notebooks/welcome.ipynb) (Colab), enable the GPU acceleration (**Runtime** > **Change runtime type** > **Hardware accelerator**:**GPU**).
+
+## Setup
+
+1. Download and install JAX, Jaxlib, Flax, and TensorFlow Datasets (TFDS) (to download MNIST). Check the Flax [docs](https://flax.readthedocs.io/en/latest/installation.html) and the JAX [README](https://github.com/google/jax/blob/master/README.md) for additional information.
+
+
+```python
+!pip install --upgrade -q pip jax jaxlib flax tensorflow-datasets
+```
+
+    [K     |████████████████████████████████| 1.5MB 15.7MB/s 
+    [K     |████████████████████████████████| 163kB 53.2MB/s 
+    [K     |████████████████████████████████| 3.6MB 55.6MB/s 
+    [?25h
+
+2. Import JAX, [JAX NumPy](https://jax.readthedocs.io/en/latest/jax.numpy.html) (which lets you run code on GPUs and TPUs), Flax, ordinary NumPy, and TFDS. Flax can use any data-loading pipeline and this example demonstrates how to utilize TFDS.
+
+
+```python
 import jax
-import flax
+import jax.numpy as jnp            # JAX NumPy
+
+from flax import linen as nn        # The Linen API
+from flax import optim              # Optimizers
+
+import numpy as np                 # Ordinary NumPy
+import tensorflow_datasets as tfds  # TFDS for MNIST
 ```
 
-Load vanilla NumPy for use on host.
+## Build the Linen model
 
-```py
-import numpy as onp
-```
+Build a convolutional neural network with the Flax Linen API by subclassing [`flax.linen.Module`](https://flax.readthedocs.io/en/latest/flax.linen.html#core-module-abstraction). Because the architecture in this example is relatively simple—you're just stacking layers—you can define the inlined submodules directly within the `__call__` method and wrap it with the `@compact` decorator ([`flax.linen.compact`](https://flax.readthedocs.io/en/latest/flax.linen.html#compact-methods)).
 
-JAX has a re-implemented NumPy that runs on GPU and TPU
 
-```py
-import jax.numpy as jnp
-```
+```python
+class CNN(nn.Module):
 
-Flax can use any data loading pipeline. We use TF datasets.
-
-```py
-import tensorflow as tf
-import tensorflow_datasets as tfds
-```
-
-A Flax "module" lets you write a normal function, which
-defines learnable parameters in-line. In this case,
-we define a simple convolutional neural network.
-
-Each call to `flax.nn.Conv` defines a learnable kernel.
-
-```py
-class CNN(flax.nn.Module):
-  def apply(self, x):
-    x = flax.nn.Conv(x, features=32, kernel_size=(3, 3))
-    x = flax.nn.relu(x)
-    x = flax.nn.avg_pool(x, window_shape=(2, 2), strides=(2, 2))
-    x = flax.nn.Conv(x, features=64, kernel_size=(3, 3))
-    x = flax.nn.relu(x)
-    x = flax.nn.avg_pool(x, window_shape=(2, 2), strides=(2, 2))
-    x = x.reshape((x.shape[0], -1))
-    x = flax.nn.Dense(x, features=256)
-    x = flax.nn.relu(x)
-    x = flax.nn.Dense(x, features=10)
-    x = flax.nn.log_softmax(x)
+  @nn.compact
+  # Provide a constructor to register a new parameter 
+  # and return its initial value
+  def __call__(self, x):
+    x = nn.Conv(features=32, kernel_size=(3, 3))(x)
+    x = nn.relu(x)
+    x = nn.avg_pool(x, window_shape=(2, 2), strides=(2, 2))
+    x = nn.Conv(features=64, kernel_size=(3, 3))(x)
+    x = nn.relu(x)
+    x = nn.avg_pool(x, window_shape=(2, 2), strides=(2, 2))
+    x = x.reshape((x.shape[0], -1)) # Flatten
+    x = nn.Dense(features=256)(x)
+    x = nn.relu(x)
+    x = nn.Dense(features=10)(x)    # There are 10 classes in MNIST
+    x = nn.log_softmax(x)
     return x
 ```
 
-`jax.vmap` allows us to define the `cross_entropy_loss`
-function as if it acts on a single sample. `jax.vmap`
-automatically vectorizes code efficiently to run on entire
-batches.
+## Create a loss function, an optimizer, a parameter initializer, and a metrics function
 
-```py
-@jax.vmap
-def cross_entropy_loss(logits, label):
-  return -logits[label]
+1. Next, create a loss function—such as [cross-entropy](https://en.wikipedia.org/wiki/Cross_entropy)—using just [`jax.numpy`](https://jax.readthedocs.io/en/latest/jax.numpy.html) that takes the model's logits and label vectors and returns a scalar loss. The labels need to be one-hot encoded, so define a separate function for that task, as demonstrated below.
+
+
+```python
+def onehot(labels, num_classes=10): # There are 10 classes in MNIST
+  x = (labels[..., None] == jnp.arange(num_classes)[None])
+  return x.astype(jnp.float32) # Convert to float32 data type (JAX's default `dtype`)
 ```
 
-Compute loss and accuracy. We use `jnp` (`jax.numpy`) which can run on
-device (GPU or TPU).
 
-```py
-def compute_metrics(logits, labels):
-  loss = jnp.mean(cross_entropy_loss(logits, labels))
-  accuracy = jnp.mean(jnp.argmax(logits, -1) == labels)
-  return {'loss': loss, 'accuracy': accuracy}
+```python
+def cross_entropy_loss(logits, labels):
+  return -jnp.mean(jnp.sum(onehot(labels) * logits, axis=-1))
 ```
 
-`jax.jit` traces the `train_step` function and compiles into fused device
-operations that run on GPU or TPU.
+2. Define a function for your optimizer that takes the model parameters, the learning rate, and a beta argument (for the [Momentum optimizer](http://www.columbia.edu/~nq6/publications/momentum.pdf)):
+  - Choose `Momentum` from the [`flax.optim`](https://flax.readthedocs.io/en/latest/flax.optim.html) package; and
+  - Wrap the model parameters (`params`) with the [`flax.optim.OptimizerDef.create`](https://flax.readthedocs.io/en/latest/flax.optim.html#flax.optim.OptimizerDef.create) method and initialize with parameter dicts.
 
-```py
-@jax.jit
-def train_step(optimizer, batch):
-  def loss_fn(model):
-    logits = model(batch['image'])
-    loss = jnp.mean(cross_entropy_loss(
-        logits, batch['label']))
-    return loss
-  grad = jax.grad(loss_fn)(optimizer.target)
-  optimizer = optimizer.apply_gradient(grad)
+
+```python
+def create_optimizer(params, learning_rate, beta):
+  optimizer_def = optim.Momentum(learning_rate=learning_rate, beta=beta)
+  optimizer = optimizer_def.create(params)
   return optimizer
 ```
 
-Making model predictions is as simple as calling `model(input)`:
+3. Create a function for parameter initialization:
+  - Set the initial shape of the kernel (note that JAX and Flax are [row-based](https://flax.readthedocs.io/en/latest/notebooks/flax_basics.html#Model-parameters-&-initialization)); and
+  - Initialize the module parameters of your network (`CNN`) with the [`flax.linen.Module.init`](https://flax.readthedocs.io/en/latest/flax.linen.html#flax.linen.Module.init) method using the PRNGKey and parameters (note that the weights aren't stored with the models). 
 
-```py
+
+```python
+def get_initial_params(key):
+  init_shape = jnp.ones((1, 28, 28, 1), jnp.float32)
+  initial_params = CNN().init(key, init_shape)['params']
+  return initial_params
+```
+
+4. For loss and accuracy metrics, create a separate function:
+
+
+```python
+def compute_metrics(logits, labels):
+  loss = cross_entropy_loss(logits, labels)
+  accuracy = jnp.mean(jnp.argmax(logits, -1) == labels)
+  metrics = {
+      'loss': loss,
+      'accuracy': accuracy
+  }
+  return metrics
+```
+
+## The dataset
+
+Define a function that:
+  - Uses TFDS to load and prepare the MNIST dataset; and
+  - Converts the samples to floating-point numbers.
+
+
+```python
+def get_datasets():
+  ds_builder = tfds.builder('mnist')
+  ds_builder.download_and_prepare()
+  # Split into training/test sets
+  train_ds = tfds.as_numpy(ds_builder.as_dataset(split='train', batch_size=-1))
+  test_ds = tfds.as_numpy(ds_builder.as_dataset(split='test', batch_size=-1))
+  # Convert to floating-points
+  train_ds['image'] = jnp.float32(train_ds['image']) / 255.0
+  test_ds['image'] = jnp.float32(test_ds['image']) / 255.0
+  return train_ds, test_ds
+```
+
+## Training and evaluation functions
+
+1. Write a training step function that:
+
+  - Evaluates the neural network given the parameters and a batch of input images with the [`flax.linen.apply`](https://flax.readthedocs.io/en/latest/flax.linen.html#flax.linen.Module.apply) method.
+  - Computes the `cross_entropy_loss` loss function.
+  - Evaluates the loss function and its gradient using [`jax.value_and_grad`](https://jax.readthedocs.io/en/latest/jax.html#jax.value_and_grad) (check the [JAX autodiff cookbook](https://jax.readthedocs.io/en/latest/notebooks/autodiff_cookbook.html#Evaluate-a-function-and-its-gradient-using-value_and_grad) to learn more).
+  - Applies a [pytree](https://jax.readthedocs.io/en/latest/pytrees.html#pytrees-and-jax-functions) of gradients ([`flax.optim.Optimizer.apply_gradient`](https://flax.readthedocs.io/en/latest/flax.optim.html#flax.optim.Optimizer.apply_gradient)) to the optimizer to update the model's parameters.
+  - Computes the metrics using `compute_metrics` (defined earlier).
+
+  Use the `@jit` decorator—the entire function is now just-in-time([`jit`](https://jax.readthedocs.io/en/latest/jax.html#jax.jit))-compiled with [XLA](https://www.tensorflow.org/xla) to make your code run faster and more efficiently.
+
+
+```python
 @jax.jit
-def eval(model, eval_ds):
-  logits = model(eval_ds['image'] / 255.0)
-  return compute_metrics(logits, eval_ds['label'])
+def train_step(optimizer, batch):
+  def loss_fn(params):
+    logits = CNN().apply({'params': params}, batch['image'])
+    loss = cross_entropy_loss(logits, batch['label'])
+    return loss, logits
+  grad_fn = jax.value_and_grad(loss_fn, has_aux=True)
+  (_, logits), grad = grad_fn(optimizer.target)
+  optimizer = optimizer.apply_gradient(grad)
+  metrics = compute_metrics(logits, batch['label'])
+  return optimizer, metrics
 ```
 
-## Main train loop
+2. Create a [`jit`](https://jax.readthedocs.io/en/latest/jax.html#jax.jit)-compiled function that evaluates the model on the test set using [`flax.linen.apply`](https://flax.readthedocs.io/en/latest/flax.linen.html#flax.linen.Module.apply):
 
-```py
-def train():
+
+```python
+@jax.jit
+def eval_step(params, batch):
+  logits = CNN().apply({'params': params}, batch['image'])
+  return compute_metrics(logits, batch['label'])
 ```
 
-Load, convert dtypes, and shuffle MNIST.
+3. Define a training function for one epoch that:
+  - Shuffles the training data before each epoch using [`jax.random.permutation`](https://jax.readthedocs.io/en/latest/_autosummary/jax.random.permutation.html) that takes a PRNGKey as a parameter (discussed in more detail later in this tutorial and in [JAX - the sharp bits](https://jax.readthedocs.io/en/latest/notebooks/Common_Gotchas_in_JAX.html#JAX-PRNG)).
+  - Runs an optimization step for each batch.
+  - Retrieves the training metrics from the device with `jax.device_get` and computes their mean across each batch in an epoch.
+  - Returns the optimizer with updated parameters and the training loss and accuracy metrics.
 
-```py
-  train_ds = tfds.load('mnist', split=tfds.Split.TRAIN)
-  train_ds = train_ds.map(lambda x: {'image': tf.cast(x['image'], tf.float32),
-                                     'label': tf.cast(x['label'], tf.int32)})
-  train_ds = train_ds.cache().shuffle(1000).batch(128)
-  test_ds = tfds.as_numpy(tfds.load(
-      'mnist', split=tfds.Split.TEST, batch_size=-1))
-  test_ds = {'image': test_ds['image'].astype(jnp.float32),
-             'label': test_ds['label'].astype(jnp.int32)}
+
+```python
+def train_epoch(optimizer, train_ds, batch_size, epoch, rng):
+  train_ds_size = len(train_ds['image'])
+  steps_per_epoch = train_ds_size // batch_size
+
+  perms = jax.random.permutation(rng, len(train_ds['image']))
+  perms = perms[:steps_per_epoch * batch_size]  # Skip an incomplete batch
+  perms = perms.reshape((steps_per_epoch, batch_size))
+
+  batch_metrics = []
+
+  for perm in perms:
+    batch = {k: v[perm, ...] for k, v in train_ds.items()}
+    optimizer, metrics = train_step(optimizer, batch)
+    batch_metrics.append(metrics)
+
+  training_batch_metrics = jax.device_get(batch_metrics)
+  training_epoch_metrics = {
+      k: np.mean([metrics[k] for metrics in training_batch_metrics])
+      for k in training_batch_metrics[0]}
+
+  print('Training - epoch: %d, loss: %.4f, accuracy: %.2f' % (epoch, training_epoch_metrics['loss'], training_epoch_metrics['accuracy'] * 100))
+
+  return optimizer, training_epoch_metrics
 ```
 
-Create a new model, running all necessary initializers.
+4. Create a model evaluation function that:
 
-The parameters are stored as nested dicts on `model.params`.
+  - Evalues the model on the test set.
+  - Retrieves the evaluation metrics from the device with `jax.device_get`.
+  - Copies the metrics [data stored](https://flax.readthedocs.io/en/latest/design_notes/linen_design_principles.html#how-are-parameters-represented-and-how-do-we-handle-general-differentiable-algorithms-that-update-stateful-variables) in a JAX [pytree](https://jax.readthedocs.io/en/latest/pytrees.html#pytrees-and-jax-functions).
+  - Returns the test loss and accuracy.
 
-```py
-  _, initial_params = CNN.init_by_shape(
-  jax.random.PRNGKey(0),
-   [((1, 28, 28, 1), jnp.float32)])
-  model = flax.nn.Model(CNN, initial_params)
+
+```python
+def eval_model(model, test_ds):
+  metrics = eval_step(model, test_ds)
+  metrics = jax.device_get(metrics)
+  eval_summary = jax.tree_map(lambda x: x.item(), metrics)
+  return eval_summary['loss'], eval_summary['accuracy']
 ```
 
-Define an optimizer. At any particular optimzation step,
-`optimizer.target` contains the model.
+## Load the dataset
 
-```py
-  optimizer = flax.optim.Momentum(
-      learning_rate=0.1, beta=0.9).create(model)
+Download the dataset and preprocess it with `get_datasets` you defined earlier:
+
+
+```python
+train_ds, test_ds = get_datasets()
 ```
 
-Run an optimization step for each batch of training
+    WARNING:absl:Dataset mnist is hosted on GCS. It will automatically be downloaded to your
+    local data directory. If you'd instead prefer to read directly from our public
+    GCS bucket (recommended if you're running on GCP), you can instead pass
+    `try_gcs=True` to `tfds.load` or set `data_dir=gs://tfds-data/datasets`.
+    
 
-```py
-  for epoch in range(10):
-    for batch in tfds.as_numpy(train_ds):
-      batch['image'] = batch['image'] / 255.0
-      optimizer = train_step(optimizer, batch)
+
+    [1mDownloading and preparing dataset mnist/3.0.1 (download: 11.06 MiB, generated: 21.00 MiB, total: 32.06 MiB) to /root/tensorflow_datasets/mnist/3.0.1...[0m
+
+
+
+    HBox(children=(FloatProgress(value=0.0, description='Dl Completed...', max=4.0, style=ProgressStyle(descriptio…
+
+
+    
+    
+    [1mDataset mnist downloaded and prepared to /root/tensorflow_datasets/mnist/3.0.1. Subsequent calls will reuse this data.[0m
+
+
+## Initialize the weights and instantiate the optimizer
+
+1. Before you start training the model, you need to randomly initialize the weights/parameters.
+
+  In NumPy, you would usually use the stateful pseudorandom number generators (PRNG). JAX, however, uses an explicit PRNG (refer to [JAX - the sharp bits](https://jax.readthedocs.io/en/latest/notebooks/Common_Gotchas_in_JAX.html#JAX-PRNG) for details):
+
+  - Start by getting two unsigned 32-bit integers with [`jax.random.PRNGKey`](https://jax.readthedocs.io/en/latest/_autosummary/jax.random.PRNGKey.html#jax.random.PRNGKey) as one key (`rng`).
+  - Then, split the PRNG to obtain a usable subkey for parameter initialization (`init_rng` below) using [`jax.random.split`](https://jax.readthedocs.io/en/latest/_autosummary/jax.random.split.html#jax.random.split). 
+
+  Note that in JAX and Flax you can have [separate PRNG chains](https://flax.readthedocs.io/en/latest/design_notes/linen_design_principles.html#how-are-parameters-represented-and-how-do-we-handle-general-differentiable-algorithms-that-update-stateful-variables) (with different names, such as `rng` and `init_rng` below) inside `Module`s for different applications.
+
+
+```python
+rng = jax.random.PRNGKey(0)
+rng, init_rng = jax.random.split(rng)
 ```
 
-Once an epoch, evaluate on the test set.
+2. You can now use the PRNG subkey—`init_rng`—to initialize the model's weights by calling the predefined `get_initial_params` function:
 
-```py
-    metrics = eval(optimizer.target, test_ds)
+
+```python
+params = get_initial_params(init_rng)
 ```
 
-`metrics` are only retrieved from device when needed on host
-(like in this `print` statement)
+3. Next, set the default learning rate and beta arguments for the Momentum optimizer and instantiate it:
 
-```py
-    print('eval epoch: %d, loss: %.4f, accuracy: %.2f'
-         % (epoch+1,
-          metrics['loss'], metrics['accuracy'] * 100))
+
+```python
+learning_rate = 0.1
+beta = 0.9
+
+optimizer = create_optimizer(params, learning_rate=learning_rate, beta=beta)
 ```
 
+## Train the network and evaluate it
+
+1. Set the default number of epochs and the size of each batch:
+
+
+```python
+num_epochs = 10
+batch_size = 32
+```
+
+2. Finally, begin training and evaluating the model:
+  - Similar to the parameter initialization stage, [split](https://jax.readthedocs.io/en/latest/notebooks/Common_Gotchas_in_JAX.html#JAX-PRNG) the PRNG key to get a new subkey—`input_rng`—with [`jax.random.split`](https://jax.readthedocs.io/en/latest/_autosummary/jax.random.split.html#jax.random.split). `input_rng` will be used to permute image data during the shuffling stage when training.
+  - Run an optimization step over a training batch (`train_epoch`).
+  - Evaluate on the test set after each training epoch (`eval_model`).
+  - Retrieve the metrics from the device and print them.
+
+
+```python
+for epoch in range(1, num_epochs + 1):
+  rng, input_rng = jax.random.split(rng)
+  optimizer, train_metrics = train_epoch(optimizer, train_ds, batch_size, epoch, input_rng)
+  test_loss, test_accuracy = eval_model(optimizer.target, test_ds)
+  print('Testing - epoch: %d, loss: %.2f, accuracy: %.2f' % (epoch, test_loss, test_accuracy * 100))
+```
+
+    Training - epoch: 1, loss: 0.1326, accuracy: 95.94
+    Testing - epoch: 1, loss: 0.05, accuracy: 98.24
+    Training - epoch: 2, loss: 0.0468, accuracy: 98.58
+    Testing - epoch: 2, loss: 0.04, accuracy: 98.62
+    Training - epoch: 3, loss: 0.0325, accuracy: 98.99
+    Testing - epoch: 3, loss: 0.03, accuracy: 99.09
+    Training - epoch: 4, loss: 0.0228, accuracy: 99.25
+    Testing - epoch: 4, loss: 0.03, accuracy: 99.03
+    Training - epoch: 5, loss: 0.0178, accuracy: 99.46
+    Testing - epoch: 5, loss: 0.03, accuracy: 99.17
+    Training - epoch: 6, loss: 0.0188, accuracy: 99.39
+    Testing - epoch: 6, loss: 0.03, accuracy: 99.04
+    Training - epoch: 7, loss: 0.0133, accuracy: 99.55
+    Testing - epoch: 7, loss: 0.05, accuracy: 98.98
+    Training - epoch: 8, loss: 0.0136, accuracy: 99.58
+    Testing - epoch: 8, loss: 0.04, accuracy: 99.07
+    Training - epoch: 9, loss: 0.0090, accuracy: 99.73
+    Testing - epoch: 9, loss: 0.03, accuracy: 99.18
+    Training - epoch: 10, loss: 0.0073, accuracy: 99.78
+    Testing - epoch: 10, loss: 0.03, accuracy: 99.20
+
+
+Once the training and testing is done after 10 epochs, the output should show that your model was able to achieve approximately 99% accuracy.


### PR DESCRIPTION
Hi @avital 👋 PTAL 🎄

- I annotated the Flax image classification example with the Linen API from the Linen examples (https://github.com/google/flax/blob/master/linen_examples/mnist/train.py) and addressed issue https://github.com/google/flax/issues/659 (porting the old MNIST notebook).
- Format: Markdown, converted using [Jupytext](https://jupytext.readthedocs.io/en/latest/install.html) from a Jupyter notebook (Colab) (to make the review process easier https://github.com/google/flax/issues/659; I have a Jupyter notebook ready).
- I researched the documentation (thanks @avital @mattjj @skye and everyone for awesome docs) and included various references to JAX and Flax guides and API references on RTD to help new users (e.g. Managing state and params, Flax basics, using/splitting PRNG keys (the JAX sharp bits), JAX pytrees).
- I've used the [Google](https://developers.google.com/style), [Microsoft](https://docs.microsoft.com/en-us/style-guide/welcome/), and NumPy style guidelines as much as possible to help with user experience.

LMKWYT 👍 

Example snippets:

> This tutorial uses Flax—a high-performance deep learning library for JAX designed for flexibility—to show you how to construct a simple convolutional neural network (CNN) using the Linen API and train the network for image classification on the MNIST dataset.
> 
> If you're new to JAX, check out [JAX quickstart](https://jax.readthedocs.io/en/latest/notebooks/quickstart.html) and [JAX for the impatient](https://flax.readthedocs.io/en/latest/notebooks/jax_for_the_impatient.html). To learn more about Flax and its Linen API, refer to [Flax basics](https://flax.readthedocs.io/en/latest/notebooks/flax_basics.html), [Flax patterns: Managing state and parameters](https://flax.readthedocs.io/en/latest/patterns/state_params.html), and [Linen design principles](https://flax.readthedocs.io/en/latest/design_notes/linen_design_principles.html).

...

> ## Build the Linen model
> 
> Build a convolutional neural network with the Flax Linen API by subclassing [`flax.linen.Module`](https://flax.readthedocs.io/en/latest/flax.linen.html#core-module-abstraction). Because the architecture in this example is relatively simple—you're just stacking layers—you can define the inlined submodules directly within the `__call__` method and wrap it with the `@compact` decorator ([`flax.linen.compact`](https://flax.readthedocs.io/en/latest/flax.linen.html#compact-methods)).

...

> 2. Define a function for your optimizer that takes the model parameters, the learning rate, and a beta argument (for the [Momentum optimizer](http://www.columbia.edu/~nq6/publications/momentum.pdf)):
>   - Choose `Momentum` from the [`flax.optim`](https://flax.readthedocs.io/en/latest/flax.optim.html) package; and
>   - Wrap the model parameters (`params`) with the [`flax.optim.OptimizerDef.create`](https://flax.readthedocs.io/en/latest/flax.optim.html#flax.optim.OptimizerDef.create) method and initialize with parameter dicts.
> 
> 
> ```python
> def create_optimizer(params, learning_rate, beta):
>   optimizer_def = optim.Momentum(learning_rate=learning_rate, beta=beta)
>   optimizer = optimizer_def.create(params)
>   return optimizer
> ```

...

> ## Training and evaluation functions
> 
> 1. Write a training step function that:
> 
>   - Evaluates the neural network given the parameters and a batch of input images with the [`flax.linen.apply`](https://flax.readthedocs.io/en/latest/flax.linen.html#flax.linen.Module.apply) method.
>   - Computes the `cross_entropy_loss` loss function.
>   - Evaluates the loss function and its gradient using [`jax.value_and_grad`](https://jax.readthedocs.io/en/latest/jax.html#jax.value_and_grad) (check the [JAX autodiff cookbook](https://jax.readthedocs.io/en/latest/notebooks/autodiff_cookbook.html#Evaluate-a-function-and-its-gradient-using-value_and_grad) to learn more).
>   - Applies a [pytree](https://jax.readthedocs.io/en/latest/pytrees.html#pytrees-and-jax-functions) of gradients ([`flax.optim.Optimizer.apply_gradient`](https://flax.readthedocs.io/en/latest/flax.optim.html#flax.optim.Optimizer.apply_gradient)) to the optimizer to update the model's parameters.
>   - Computes the metrics using `compute_metrics` (defined earlier).
> 
>   Use the `@jit` decorator—the entire function is now just-in-time([`jit`](https://jax.readthedocs.io/en/latest/jax.html#jax.jit))-compiled with [XLA](https://www.tensorflow.org/xla) to make your code run faster and more efficiently.
> 
> 
> ```python
> @jax.jit
> def train_step(optimizer, batch):
>   def loss_fn(params):
>     logits = CNN().apply({'params': params}, batch['image'])
>     loss = cross_entropy_loss(logits, batch['label'])
>     return loss, logits
>   grad_fn = jax.value_and_grad(loss_fn, has_aux=True)
>   (_, logits), grad = grad_fn(optimizer.target)
>   optimizer = optimizer.apply_gradient(grad)
>   metrics = compute_metrics(logits, batch['label'])
>   return optimizer, metrics
> ```

...

> 4. Create a model evaluation function that:
> 
>   - Evalues the model on the test set.
>   - Retrieves the evaluation metrics from the device with `jax.device_get`.
>   - Copies the metrics [data stored](https://flax.readthedocs.io/en/latest/design_notes/linen_design_principles.html#how-are-parameters-represented-and-how-do-we-handle-general-differentiable-algorithms-that-update-stateful-variables) in a JAX [pytree]([pytrees](https://jax.readthedocs.io/en/latest/pytrees.html#pytrees-and-jax-functions)).
>   - Returns the test loss and accuracy.
> 
> 
> ```python
> def eval_model(model, test_ds):
>   metrics = eval_step(model, test_ds)
>   metrics = jax.device_get(metrics)
>   eval_summary = jax.tree_map(lambda x: x.item(), metrics)
>   return eval_summary['loss'], eval_summary['accuracy']
> ```

...

> ## Initialize the weights and instantiate the optimizer
> 
> 1. Before you start training the model, you need to randomly initialize the weights/parameters.
> 
>   In NumPy, you would usually use the stateful pseudorandom number generators (PRNG). JAX, however, uses an explicit PRNG (refer to [JAX - the sharp bits](https://jax.readthedocs.io/en/latest/notebooks/Common_Gotchas_in_JAX.html#JAX-PRNG) for details):
> 
>   - Start by getting two unsigned 32-bit integers with [`jax.random.PRNGKey`](https://jax.readthedocs.io/en/latest/_autosummary/jax.random.PRNGKey.html#jax.random.PRNGKey) as one key (`rng`).
>   - Then, split the PRNG to obtain a usable subkey for parameter initialization (`init_rng` below) using [`jax.random.split`](https://jax.readthedocs.io/en/latest/_autosummary/jax.random.split.html#jax.random.split). 
> 
>   Note that in JAX and Flax you can have [separate PRNG chains](https://flax.readthedocs.io/en/latest/design_notes/linen_design_principles.html#how-are-parameters-represented-and-how-do-we-handle-general-differentiable-algorithms-that-update-stateful-variables) (with different names, such as `rng` and `init_rng` below) inside `Module`s for different applications.
> 
> 
> ```python
> rng = jax.random.PRNGKey(0)
> rng, init_rng = jax.random.split(rng)
> ```