### PR TITLE
Fix the display of math expressions in document

### DIFF
--- a/docs/notebooks/jax_for_the_impatient.ipynb
+++ b/docs/notebooks/jax_for_the_impatient.ipynb
@@ -545,6 +545,7 @@
         "JAX provides first-class support for gradients and automatic differentiation in functions. This is also where the functional paradigm shines, since gradients on functions are essentially stateless operations. If we consider a simple function $f:\\mathbb{R}^n\\rightarrow\\mathbb{R}$\n",
         "\n",
         "$$f(x) = \\frac{1}{2} x^T x$$\n",
+        "\n",
         "with the (known) gradient:\n",
         "$$\\nabla f(x) = x$$"
       ]
@@ -630,6 +631,7 @@
         "\n",
         "Let's consider a map $f:\\mathbb{R}^n\\rightarrow\\mathbb{R}^m$. As a reminder, the differential of f is the map $df:\\mathbb{R}^n \\rightarrow \\mathcal{L}(\\mathbb{R}^n,\\mathbb{R}^m)$ where $\\mathcal{L}(\\mathbb{R}^n,\\mathbb{R}^m)$ is the space of linear maps from $\\mathbb{R}^n$ to $\\mathbb{R}^m$ (hence $df(x)$ is often represented as a Jacobian matrix). The linear approximation of f at point $x$ reads:\n",
         "$$f(x+v) = f(x) + df(x)\\bullet v + o(v)$$\n",
+        "\n",
         "The $\\bullet$ operator means you are applying the linear map $df(x)$ to the vector v.\n",
         "\n",
         "Even though you are rarely interested in computing the full Jacobian matrix representing the linear map $df(x)$ in a standard basis, you are often interested in the quantity $df(x)\\bullet v$. This is exactly what `jax.jvp` is for, and `jax.jvp(f, (x,), (v,))` returns the tuple:\n",
@@ -685,6 +687,7 @@
         "### Vector Jacobian product\n",
         "Keeping our $f:\\mathbb{R}^n\\rightarrow\\mathbb{R}^m$ it's often the case (for example when you are working with a scalar loss function) that you are interested in the composition $x\\rightarrow\\phi\\circ f(x)$ where $\\phi \\in \\mathcal{L}(\\mathbb{R}^m,\\mathbb{R})$ (dual space of $\\mathbb{R}^m$). In that case, the gradient reads:\n",
         "$$\\nabla(\\phi\\circ f)(x) = J_f(x)^T\\nabla\\phi(f(x))$$\n",
+        "\n",
         "Where $J_f(x)$ is the Jacobian matrix of f evaluated at x, meaning that $df(x)\\bullet v = J_f(x)v$.\n",
         "\n",
         "`jax.vjp(f,x)` returns the tuple:\n",
@@ -856,6 +859,7 @@
         "\n",
         "Let's implement one of the simplest model using everything we saw so far: linear regression. From a set of data points $\\{(x_i,y_i), i\\in \\{1,\\ldots, k\\}, x_i\\in\\mathbb{R}^n,y_i\\in\\mathbb{R}^m\\}$, we try to find a set of parameters $W\\in \\mathcal{M}_{m,n}(\\mathbb{R}), b\\in\\mathbb{R}^m$ such that the function $f_{W,b}(x)=Wx+b$ minimizes the mean squared error:\n",
         "$$\\mathcal{L}(W,b)\\rightarrow\\frac{1}{k}\\sum_{i=1}^{k} \\frac{1}{2}\\|y_i-f_{W,b}(x_i)\\|^2_2$$\n",
+        "\n",
         "(Note: depending on how you cast the regression problem you might end up with different setups. Theoretically we should be minimizing the expectation of the loss wrt to the data distribution, however for the sake of simplicity here we consider only the sampled loss)."
       ]
     },


### PR DESCRIPTION
The display of mathematical expressions in readthedocs ducument are broken (you can check at https://flax.readthedocs.io/en/latest/notebooks/jax_for_the_impatient.html#Jacobian-vector-product).

This PR fix them. Only add extra new line after math delimiters `$$...$$`, then they works correctly.

I Debugged at here (formulas put extra new line and the followings sentences are displayed correctly):
https://flax-test-tksm.readthedocs.io/en/latest/notebooks/jax_for_the_impatient.html#Jacobian-vector-product

I created mirror readthedocs document for just debug. I am going to delete after review or delete this soon if it has problem.