### PR TITLE
Fix broken document link in italic notation

### DIFF
--- a/docs/notebooks/flax_basics.ipynb
+++ b/docs/notebooks/flax_basics.ipynb
@@ -665,7 +665,7 @@
         "*   A `__call__` function that returns the output of the model from a given input.\n",
         "*   The model structure defines a pytree of parameters following the same tree structure as the model: the params tree contains one `layers_n` sub dict per layer, and each of those contain the parameters of the associated Dense layer. The layout is very explicit.\n",
         "\n",
-        "*Note: lists are mostly managed as you would expect (WIP), there are corner cases you should be aware of as pointed out [here](https://github.com/google/flax/issues/524)*\n",
+        "*Note: lists are mostly managed as you would expect (WIP), there are corner cases you should be aware of as pointed out* [here](https://github.com/google/flax/issues/524)\n",
         "\n",
         "Since the module structure and its parameters are not tied to each other, you can't call directly `model(x)` on a given input as it will return an error. The `__call__` function is being wrapped up in the `apply` one, which is the one to call on an input:"
       ]


### PR DESCRIPTION
a link in italic notation is breaking at [readthedocs documents (see at "Note" section)](https://flax.readthedocs.io/en/latest/notebooks/flax_basics.html#Module-basics) because nested markup (wrap `[comment](url)` by `*...*`) is not supported yet.

This maybe will be resolved in the future, but as a temporary solution, I propose to use normal style instead of italic for links.