### PR TITLE
Match the standard NumPy convention in JAX (onp -> np)

### DIFF
--- a/docs/annotated_mnist.md
+++ b/docs/annotated_mnist.md
@@ -1,157 +1,245 @@
-# Annotated full end-to-end MNIST example
+# The annotated MNIST image classification example with Flax
 
-```py
+This tutorial demonstrates how to construct a simple convolutional neural network (CNN) using the Flax Linen API and train the network for image classification on the MNIST dataset.
+
+1. Import JAX, [JAX NumPy](https://jax.readthedocs.io/en/latest/jax.numpy.html), Flax, ordinary NumPy, and TensorFlow Datasets (TFDS). Flax can use any data-loading pipeline and this example demonstrates how to utilize TFDS.
+
+```python
 import jax
-import flax
+import jax.numpy as jnp            # JAX NumPy
+
+from flax import linen as nn        # The Linen API
+from flax import optim              # Optimizers
+
+import numpy as np                 # Ordinary NumPy
+import tensorflow_datasets as tfds  # TFDS for MNIST
 ```
 
-Load vanilla NumPy for use on host.
+2. Create a convolutional neural network with the Linen API by subclassing [`Module`](https://flax.readthedocs.io/en/latest/flax.linen.html#core-module-abstraction). Because the architecture in this example is relatively simple—you're just stacking layers—you can define the inlined submodules directly within the `__call__` method and wrap it with the [`@compact`](https://flax.readthedocs.io/en/latest/flax.linen.html#compact-methods) decorator.
 
-```py
-import numpy as onp
-```
+```python
+class CNN(nn.Module):
 
-JAX has a re-implemented NumPy that runs on GPU and TPU
-
-```py
-import jax.numpy as jnp
-```
-
-Flax can use any data loading pipeline. We use TF datasets.
-
-```py
-import tensorflow as tf
-import tensorflow_datasets as tfds
-```
-
-A Flax "module" lets you write a normal function, which
-defines learnable parameters in-line. In this case,
-we define a simple convolutional neural network.
-
-Each call to `flax.nn.Conv` defines a learnable kernel.
-
-```py
-class CNN(flax.nn.Module):
-  def apply(self, x):
-    x = flax.nn.Conv(x, features=32, kernel_size=(3, 3))
-    x = flax.nn.relu(x)
-    x = flax.nn.avg_pool(x, window_shape=(2, 2), strides=(2, 2))
-    x = flax.nn.Conv(x, features=64, kernel_size=(3, 3))
-    x = flax.nn.relu(x)
-    x = flax.nn.avg_pool(x, window_shape=(2, 2), strides=(2, 2))
-    x = x.reshape((x.shape[0], -1))
-    x = flax.nn.Dense(x, features=256)
-    x = flax.nn.relu(x)
-    x = flax.nn.Dense(x, features=10)
-    x = flax.nn.log_softmax(x)
+  @nn.compact
+  def __call__(self, x):
+    x = nn.Conv(features=32, kernel_size=(3, 3))(x)
+    x = nn.relu(x)
+    x = nn.avg_pool(x, window_shape=(2, 2), strides=(2, 2))
+    x = nn.Conv(features=64, kernel_size=(3, 3))(x)
+    x = nn.relu(x)
+    x = nn.avg_pool(x, window_shape=(2, 2), strides=(2, 2))
+    x = x.reshape((x.shape[0], -1)) # Flatten
+    x = nn.Dense(features=256)(x)
+    x = nn.relu(x)
+    x = nn.Dense(features=10)(x)    # There are 10 classes in MNIST
+    x = nn.log_softmax(x)
     return x
 ```
 
-`jax.vmap` allows us to define the `cross_entropy_loss`
-function as if it acts on a single sample. `jax.vmap`
-automatically vectorizes code efficiently to run on entire
-batches.
+3. Define a cross-entropy loss function using just [`jax.numpy`](https://jax.readthedocs.io/en/latest/jax.numpy.html) that takes the model's logits and label vectors and returns a scalar loss. The labels can be one-hot encoded with [`jax.nn.one_hot`](https://jax.readthedocs.io/en/latest/_autosummary/jax.nn.one_hot.html), as demonstrated below.
 
-```py
-@jax.vmap
-def cross_entropy_loss(logits, label):
-  return -logits[label]
+```python
+def cross_entropy_loss(logits, labels):
+  one_hot_labels = jax.nn.one_hot(labels, num_classes=10)
+  return -jnp.mean(jnp.sum(one_hot_labels * logits, axis=-1))
 ```
 
-Compute loss and accuracy. We use `jnp` (`jax.numpy`) which can run on
-device (GPU or TPU).
+4. Define a function for your optimizer:
 
-```py
-def compute_metrics(logits, labels):
-  loss = jnp.mean(cross_entropy_loss(logits, labels))
-  accuracy = jnp.mean(jnp.argmax(logits, -1) == labels)
-  return {'loss': loss, 'accuracy': accuracy}
-```
+  - Choose `Momentum` from the [`flax.optim`](https://flax.readthedocs.io/en/latest/flax.optim.html) package; and
+  - Wrap the model parameters (`params`) with the [`flax.optim.OptimizerDef.create`](https://flax.readthedocs.io/en/latest/flax.optim.html#flax.optim.OptimizerDef.create) method and initialize with parameter dicts.
 
-`jax.jit` traces the `train_step` function and compiles into fused device
-operations that run on GPU or TPU.
-
-```py
-@jax.jit
-def train_step(optimizer, batch):
-  def loss_fn(model):
-    logits = model(batch['image'])
-    loss = jnp.mean(cross_entropy_loss(
-        logits, batch['label']))
-    return loss
-  grad = jax.grad(loss_fn)(optimizer.target)
-  optimizer = optimizer.apply_gradient(grad)
+```python
+def create_optimizer(params, learning_rate, beta):
+  optimizer_def = optim.Momentum(learning_rate=learning_rate, beta=beta)
+  optimizer = optimizer_def.create(params)
   return optimizer
 ```
 
-Making model predictions is as simple as calling `model(input)`:
+5. Create a function for parameter initialization:
 
-```py
+  - Set the initial shape of the kernel (note that JAX and Flax are [row-based](https://flax.readthedocs.io/en/latest/notebooks/flax_basics.html#Model-parameters-&-initialization)); and
+  - Initialize the module parameters of your network (`CNN`) with the [`init`](https://flax.readthedocs.io/en/latest/flax.linen.html#flax.linen.Module.init) method using the PRNGKey, which returns parameters (note that the parameters are explicitly tracked separately from the model defintion).
+
+```python
+def get_initial_params(key):
+  init_shape = jnp.ones((1, 28, 28, 1), jnp.float32)
+  initial_params = CNN().init(key, init_shape)['params']
+  return initial_params
+```
+
+6. For loss and accuracy metrics, create a separate function:
+
+```python
+def compute_metrics(logits, labels):
+  loss = cross_entropy_loss(logits, labels)
+  accuracy = jnp.mean(jnp.argmax(logits, -1) == labels)
+  metrics = {
+      'loss': loss,
+      'accuracy': accuracy
+  }
+  return metrics
+```
+
+7. Define a function that loads and prepares the MNIST dataset and converts the samples to floating-point numbers.
+
+```python
+def get_datasets():
+  ds_builder = tfds.builder('mnist')
+  ds_builder.download_and_prepare()
+  # Split into training/test sets
+  train_ds = tfds.as_numpy(ds_builder.as_dataset(split='train', batch_size=-1))
+  test_ds = tfds.as_numpy(ds_builder.as_dataset(split='test', batch_size=-1))
+  # Convert to floating-points
+  train_ds['image'] = jnp.float32(train_ds['image']) / 255.0
+  test_ds['image'] = jnp.float32(test_ds['image']) / 255.0
+  return train_ds, test_ds
+```
+
+8. Write a training step function that:
+
+  - Evaluates the neural network given the parameters and a batch of input images with the [`Module.apply`](https://flax.readthedocs.io/en/latest/flax.linen.html#flax.linen.Module.apply) method.
+  - Computes the `cross_entropy_loss` loss function.
+  - Evaluates the loss function and its gradient using [`jax.value_and_grad`](https://jax.readthedocs.io/en/latest/jax.html#jax.value_and_grad).
+  - Applies a [pytree](https://jax.readthedocs.io/en/latest/pytrees.html#pytrees-and-jax-functions) of gradients ([`flax.optim.Optimizer.apply_gradient`](https://flax.readthedocs.io/en/latest/flax.optim.html#flax.optim.Optimizer.apply_gradient)) to the optimizer to update the model's parameters.
+  - Computes the metrics using `compute_metrics` (defined earlier).
+
+  Use JAX's [`@jit`](https://jax.readthedocs.io/en/latest/jax.html#jax.jit) decorator to trace the entire `train_step` function and just-in-time([`jit`]-compile with [XLA](https://www.tensorflow.org/xla) into fused device operations that run faster and more efficiently on hardware accelerators.
+
+```python
 @jax.jit
-def eval(model, eval_ds):
-  logits = model(eval_ds['image'] / 255.0)
-  return compute_metrics(logits, eval_ds['label'])
+def train_step(optimizer, batch):
+  def loss_fn(params):
+    logits = CNN().apply({'params': params}, batch['image'])
+    loss = cross_entropy_loss(logits, batch['label'])
+    return loss, logits
+  grad_fn = jax.value_and_grad(loss_fn, has_aux=True)
+  (_, logits), grad = grad_fn(optimizer.target)
+  optimizer = optimizer.apply_gradient(grad)
+  metrics = compute_metrics(logits, batch['label'])
+  return optimizer, metrics
 ```
 
-## Main train loop
+9. Create a function that evaluates your model on the test set with [`Module.apply`](https://flax.readthedocs.io/en/latest/flax.linen.html#flax.linen.Module.apply):
 
-```py
-def train():
+```python
+# JIT compile
+@jax.jit
+def eval_step(params, batch):
+  logits = CNN().apply({'params': params}, batch['image'])
+  return compute_metrics(logits, batch['label'])
 ```
 
-Load, convert dtypes, and shuffle MNIST.
+10. Define a training function that:
 
-```py
-  train_ds = tfds.load('mnist', split=tfds.Split.TRAIN)
-  train_ds = train_ds.map(lambda x: {'image': tf.cast(x['image'], tf.float32),
-                                     'label': tf.cast(x['label'], tf.int32)})
-  train_ds = train_ds.cache().shuffle(1000).batch(128)
-  test_ds = tfds.as_numpy(tfds.load(
-      'mnist', split=tfds.Split.TEST, batch_size=-1))
-  test_ds = {'image': test_ds['image'].astype(jnp.float32),
-             'label': test_ds['label'].astype(jnp.int32)}
+  - Shuffles the training data before each epoch using [`jax.random.permutation`](https://jax.readthedocs.io/en/latest/_autosummary/jax.random.permutation.html) that takes a PRNGKey as a parameter (check the [JAX - the sharp bits](https://jax.readthedocs.io/en/latest/notebooks/Common_Gotchas_in_JAX.html#JAX-PRNG)).
+  - Runs an optimization step for each batch.
+  - Retrieves the training metrics from the device with `jax.device_get` and computes their mean across each batch in an epoch.
+  - Returns the optimizer with updated parameters and the training loss and accuracy metrics.
+
+```python
+def train_epoch(optimizer, train_ds, batch_size, epoch, rng):
+  train_ds_size = len(train_ds['image'])
+  steps_per_epoch = train_ds_size // batch_size
+
+  perms = jax.random.permutation(rng, len(train_ds['image']))
+  perms = perms[:steps_per_epoch * batch_size]  # Skip an incomplete batch
+  perms = perms.reshape((steps_per_epoch, batch_size))
+
+  batch_metrics = []
+
+  for perm in perms:
+    batch = {k: v[perm, ...] for k, v in train_ds.items()}
+    optimizer, metrics = train_step(optimizer, batch)
+    batch_metrics.append(metrics)
+
+  training_batch_metrics = jax.device_get(batch_metrics)
+  training_epoch_metrics = {
+      k: np.mean([metrics[k] for metrics in training_batch_metrics])
+      for k in training_batch_metrics[0]}
+
+  print('Training - epoch: %d, loss: %.4f, accuracy: %.2f' % (epoch, training_epoch_metrics['loss'], training_epoch_metrics['accuracy'] * 100))
+
+  return optimizer, training_epoch_metrics
 ```
 
-Create a new model, running all necessary initializers.
+11. Create a model evaluation function that:
 
-The parameters are stored as nested dicts on `model.params`.
+  - Retrieves the evaluation metrics from the device with `jax.device_get`.
+  - Copies the metrics [data stored](https://flax.readthedocs.io/en/latest/design_notes/linen_design_principles.html#how-are-parameters-represented-and-how-do-we-handle-general-differentiable-algorithms-that-update-stateful-variables) in a JAX [pytree](https://jax.readthedocs.io/en/latest/pytrees.html#pytrees-and-jax-functions).
 
-```py
-  _, initial_params = CNN.init_by_shape(
-  jax.random.PRNGKey(0),
-   [((1, 28, 28, 1), jnp.float32)])
-  model = flax.nn.Model(CNN, initial_params)
+```python
+def eval_model(model, test_ds):
+  metrics = eval_step(model, test_ds)    # Evalue the model on the test set
+  metrics = jax.device_get(metrics)
+  eval_summary = jax.tree_map(lambda x: x.item(), metrics)
+  return eval_summary['loss'], eval_summary['accuracy']
 ```
 
-Define an optimizer. At any particular optimzation step,
-`optimizer.target` contains the model.
+12. Download the dataset and preprocess it:
 
-```py
-  optimizer = flax.optim.Momentum(
-      learning_rate=0.1, beta=0.9).create(model)
+```python
+train_ds, test_ds = get_datasets()
 ```
 
-Run an optimization step for each batch of training
+13. Initialize the parameters and instantiate the optimizer with [PRNGs](https://jax.readthedocs.io/en/latest/notebooks/Common_Gotchas_in_JAX.html#JAX-PRNG):
 
-```py
-  for epoch in range(10):
-    for batch in tfds.as_numpy(train_ds):
-      batch['image'] = batch['image'] / 255.0
-      optimizer = train_step(optimizer, batch)
+  - Get one [PRNGKey](https://jax.readthedocs.io/en/latest/_autosummary/jax.random.PRNGKey.html#jax.random.PRNGKey) and [split](https://jax.readthedocs.io/en/latest/_autosummary/jax.random.split.html#jax.random.split) it to get a second key that you'll use for parameter initialization. (Learn more about [PRNG chains](https://flax.readthedocs.io/en/latest/design_notes/linen_design_principles.html#how-are-parameters-represented-and-how-do-we-handle-general-differentiable-algorithms-that-update-stateful-variables) and [JAX PRNG design](https://github.com/google/jax/blob/master/design_notes/prng.md).)
+
+```python
+rng = jax.random.PRNGKey(0)
+rng, init_rng = jax.random.split(rng)
 ```
 
-Once an epoch, evaluate on the test set.
+14. Initialize the model's parameters:
 
-```py
-    metrics = eval(optimizer.target, test_ds)
+```python
+params = get_initial_params(init_rng)
 ```
 
-`metrics` are only retrieved from device when needed on host
-(like in this `print` statement)
+15. Initiate the variables and instantiate the optimizer:
 
-```py
-    print('eval epoch: %d, loss: %.4f, accuracy: %.2f'
-         % (epoch+1,
-          metrics['loss'], metrics['accuracy'] * 100))
+```python
+learning_rate = 0.1
+beta = 0.9
+num_epochs = 10
+batch_size = 32
+
+optimizer = create_optimizer(params, learning_rate=learning_rate, beta=beta)
 ```
 
+16. Train the network and evaluate it:
+
+```python
+for epoch in range(1, num_epochs + 1):
+  # Use a separate PRNG key to permute image data during shuffling
+  rng, input_rng = jax.random.split(rng)
+  # Run an optimization step over a training batch
+  optimizer, train_metrics = train_epoch(optimizer, train_ds, batch_size, epoch, input_rng)
+  # Evaluate on the test set after each training epoch 
+  test_loss, test_accuracy = eval_model(optimizer.target, test_ds)
+  print('Testing - epoch: %d, loss: %.2f, accuracy: %.2f' % (epoch, test_loss, test_accuracy * 100))
+```
+
+    Training - epoch: 1, loss: 0.1326, accuracy: 95.94
+    Testing - epoch: 1, loss: 0.05, accuracy: 98.24
+    Training - epoch: 2, loss: 0.0468, accuracy: 98.58
+    Testing - epoch: 2, loss: 0.04, accuracy: 98.62
+    Training - epoch: 3, loss: 0.0325, accuracy: 98.99
+    Testing - epoch: 3, loss: 0.03, accuracy: 99.09
+    Training - epoch: 4, loss: 0.0228, accuracy: 99.25
+    Testing - epoch: 4, loss: 0.03, accuracy: 99.03
+    Training - epoch: 5, loss: 0.0178, accuracy: 99.46
+    Testing - epoch: 5, loss: 0.03, accuracy: 99.17
+    Training - epoch: 6, loss: 0.0188, accuracy: 99.39
+    Testing - epoch: 6, loss: 0.03, accuracy: 99.04
+    Training - epoch: 7, loss: 0.0133, accuracy: 99.55
+    Testing - epoch: 7, loss: 0.05, accuracy: 98.98
+    Training - epoch: 8, loss: 0.0136, accuracy: 99.58
+    Testing - epoch: 8, loss: 0.04, accuracy: 99.07
+    Training - epoch: 9, loss: 0.0090, accuracy: 99.73
+    Testing - epoch: 9, loss: 0.03, accuracy: 99.18
+    Training - epoch: 10, loss: 0.0073, accuracy: 99.78
+    Testing - epoch: 10, loss: 0.03, accuracy: 99.20
+
+Once the training and testing is done after 10 epochs, the output should show that your model was able to achieve approximately 99% accuracy.

--- a/examples/mnist/mnist_lib.py
+++ b/examples/mnist/mnist_lib.py
@@ -27,7 +27,7 @@ import jax.numpy as jnp
 
 import ml_collections
 
-import numpy as onp
+import numpy as np
 
 import tensorflow_datasets as tfds
 
@@ -122,7 +122,7 @@ def train_epoch(optimizer, train_ds, batch_size, epoch, rng):
   # compute mean of metrics across each batch in epoch.
   batch_metrics_np = jax.device_get(batch_metrics)
   epoch_metrics_np = {
-      k: onp.mean([metrics[k] for metrics in batch_metrics_np])
+      k: np.mean([metrics[k] for metrics in batch_metrics_np])
       for k in batch_metrics_np[0]}
 
   logging.info('train epoch: %d, loss: %.4f, accuracy: %.2f', epoch,

--- a/examples/pixelcnn/pixelcnn.py
+++ b/examples/pixelcnn/pixelcnn.py
@@ -37,7 +37,7 @@ published at ICLR '17 (https://openreview.net/forum?id=BJrFC6ceg).
 """
 from functools import partial
 
-import numpy as onp
+import numpy as np
 
 from jax import lax
 from jax.scipy.special import logsumexp
@@ -263,7 +263,7 @@ def ConvTransposeDown(
   """
   inputs = np.asarray(inputs, kwargs.get('dtype', np.float32))
   k_h, k_w = kernel_size
-  out_h, out_w = onp.multiply(strides, inputs.shape[1:3])
+  out_h, out_w = np.multiply(strides, inputs.shape[1:3])
   return ConvTranspose(inputs, features, kernel_size, strides, **kwargs)[
       :, :out_h, (k_w - 1) // 2:out_w + (k_w - 1) // 2, :]
 
@@ -277,7 +277,7 @@ def ConvTransposeDownRight(
   """
   inputs = np.asarray(inputs, kwargs.get('dtype', np.float32))
   k_h, k_w = kernel_size
-  out_h, out_w = onp.multiply(strides, inputs.shape[1:3])
+  out_h, out_w = np.multiply(strides, inputs.shape[1:3])
   return ConvTranspose(inputs, features, kernel_size, strides, **kwargs)[
       :, :out_h, :out_w]
 

--- a/examples/pixelcnn/sample.py
+++ b/examples/pixelcnn/sample.py
@@ -19,7 +19,7 @@ from functools import partial
 from absl import app
 from absl import flags
 
-import numpy as onp
+import numpy as np
 from PIL import Image
 
 import jax
@@ -100,8 +100,8 @@ def snap_to_grid(sample):
 
 def save_images(batch, fname):
   n_rows = batch.shape[0] // 16
-  batch = onp.uint8(jnp.round((batch + 1) * 127.5))
-  out = onp.full((1 + 33 * n_rows, 1 + 33 * 16, 3), 255, 'uint8')
+  batch = np.uint8(jnp.round((batch + 1) * 127.5))
+  out = np.full((1 + 33 * n_rows, 1 + 33 * 16, 3), 255, 'uint8')
   for i, im in enumerate(batch):
     top  = 1 + 33 * (i // 16)
     left = 1 + 33 * (i %  16)

--- a/examples/ppo/agent.py
+++ b/examples/ppo/agent.py
@@ -17,7 +17,6 @@
 import multiprocessing
 import collections
 import jax
-import numpy as onp
 
 import env_utils
 

--- a/examples/ppo/env_utils.py
+++ b/examples/ppo/env_utils.py
@@ -16,7 +16,7 @@
 
 import collections
 import gym
-import numpy as onp
+import numpy as np
 
 import seed_rl_atari_preprocessing
 
@@ -31,7 +31,7 @@ class ClipRewardEnv(gym.RewardWrapper):
 
   def reward(self, reward):
     """Bin reward to {+1, 0, -1} by its sign."""
-    return onp.sign(reward)
+    return np.sign(reward)
 
 class FrameStack:
   """Implements stacking of `num_frames` last frames of the game.
@@ -60,7 +60,7 @@ class FrameStack:
 
   def _get_array(self):
     assert len(self.frames) == self.num_frames
-    return onp.concatenate(self.frames, axis=-1)
+    return np.concatenate(self.frames, axis=-1)
 
 def create_env(game: str, clip_rewards: bool):
   """Create a FrameStack object that serves as environment for the `game`."""

--- a/examples/ppo/models.py
+++ b/examples/ppo/models.py
@@ -14,7 +14,7 @@
 
 """Class and functions to define and initialize the actor-critic model."""
 
-import numpy as onp
+import numpy as np
 import flax
 from flax import nn
 import jax.numpy as jnp
@@ -54,7 +54,7 @@ class ActorCritic(flax.nn.Module):
     value = nn.Dense(x, features=1, name='value', dtype=dtype)
     return policy_log_probabilities, value
 
-def create_model(key: onp.ndarray, num_outputs: int):
+def create_model(key: np.ndarray, num_outputs: int):
   input_dims = (1, 84, 84, 4)  # (minibatch, height, width, stacked frames)
   module = ActorCritic.partial(num_outputs=num_outputs)
   _, initial_par = module.init_by_shape(key, [(input_dims, jnp.float32)])

--- a/examples/ppo/ppo_lib_test.py
+++ b/examples/ppo/ppo_lib_test.py
@@ -17,7 +17,7 @@
 import jax
 import flax
 from flax import nn
-import numpy as onp
+import numpy as np
 import numpy.testing as onp_testing
 from absl.testing import absltest
 
@@ -30,10 +30,10 @@ class TestGAE(absltest.TestCase):
   def test_gae_shape_on_random(self):
     # create random data, simulating 4 parallel envs and 20 time_steps
     envs, steps = 10, 100
-    rewards = onp.random.choice([-1., 0., 1.], size=(steps, envs),
+    rewards = np.random.choice([-1., 0., 1.], size=(steps, envs),
                                 p=[0.01, 0.98, 0.01])
-    terminal_masks = onp.ones(shape=(steps, envs), dtype=onp.float64)
-    values = onp.random.random(size=(steps + 1, envs))
+    terminal_masks = np.ones(shape=(steps, envs), dtype=np.float64)
+    values = np.random.random(size=(steps + 1, envs))
     discount = 0.99
     gae_param = 0.95
     adv = ppo_lib.gae_advantages(rewards, terminal_masks, values, discount,
@@ -41,13 +41,13 @@ class TestGAE(absltest.TestCase):
     self.assertEqual(adv.shape, (steps, envs))
   def test_gae_hardcoded(self):
     #test on small example that can be verified by hand
-    rewards = onp.array([[1., 0.], [0., 0.], [-1., 1.]])
+    rewards = np.array([[1., 0.], [0., 0.], [-1., 1.]])
     #one of the two episodes terminated in the middle
-    terminal_masks = onp.array([[1., 1.], [0., 1.], [1., 1.]])
-    values = onp.array([[1., 1.], [1., 1.], [1., 1.], [1., 1.]])
+    terminal_masks = np.array([[1., 1.], [0., 1.], [1., 1.]])
+    values = np.array([[1., 1.], [1., 1.], [1., 1.], [1., 1.]])
     discount = 0.5
     gae_param = 0.25
-    correct_gae = onp.array([[0.375, -0.5546875], [-1., -0.4375], [-1.5, 0.5]])
+    correct_gae = np.array([[0.375, -0.5546875], [-1., -0.4375], [-1.5, 0.5]])
     actual_gae = ppo_lib.gae_advantages(rewards, terminal_masks, values,
                                         discount, gae_param)
     onp_testing.assert_allclose(actual_gae, correct_gae)
@@ -56,7 +56,7 @@ class TestEnvironmentPreprocessing(absltest.TestCase):
   def choose_random_game(self):
     games = ['BeamRider', 'Breakout', 'Pong',
              'Qbert', 'Seaquest', 'SpaceInvaders']
-    ind = onp.random.choice(len(games))
+    ind = np.random.choice(len(games))
     return games[ind] + "NoFrameskip-v4"
 
   def test_creation(self):
@@ -82,7 +82,7 @@ class TestEnvironmentPreprocessing(absltest.TestCase):
 # test the model (creation and forward pass)
 class TestModel(absltest.TestCase):
   def choose_random_outputs(self):
-    return onp.random.choice([4, 5, 6, 7, 8, 9])
+    return np.random.choice([4, 5, 6, 7, 8, 9])
 
   def test_model(self):
     key = jax.random.PRNGKey(0)
@@ -93,12 +93,12 @@ class TestModel(absltest.TestCase):
     self.assertTrue(isinstance(model, nn.base.Model))
     self.assertTrue(isinstance(optimizer, flax.optim.base.Optimizer))
     test_batch_size, obs_shape = 10, (84, 84, 4)
-    random_input = onp.random.random(size=(test_batch_size,) + obs_shape)
+    random_input = np.random.random(size=(test_batch_size,) + obs_shape)
     log_probs, values = optimizer.target(random_input)
     self.assertEqual(values.shape, (test_batch_size, 1))
-    sum_probs = onp.sum(onp.exp(log_probs), axis=1)
+    sum_probs = np.sum(np.exp(log_probs), axis=1)
     self.assertEqual(sum_probs.shape, (test_batch_size, ))
-    onp_testing.assert_allclose(sum_probs, onp.ones((test_batch_size, )),
+    onp_testing.assert_allclose(sum_probs, np.ones((test_batch_size, )),
                                 atol=1e-6)
 
 # test one optimization step
@@ -106,11 +106,11 @@ class TestOptimizationStep(absltest.TestCase):
   def generate_random_data(self, num_actions):
     data_len = 256 # equal to one default-sized batch
     state_shape = (84, 84, 4)
-    states = onp.random.randint(0, 255, size=((data_len, ) + state_shape))
-    actions = onp.random.choice(num_actions, size=data_len)
-    old_log_probs = onp.random.random(size=data_len)
-    returns = onp.random.random(size=data_len)
-    advantages = onp.random.random(size=data_len)
+    states = np.random.randint(0, 255, size=((data_len, ) + state_shape))
+    actions = np.random.choice(num_actions, size=data_len)
+    old_log_probs = np.random.random(size=data_len)
+    returns = np.random.random(size=data_len)
+    advantages = np.random.random(size=data_len)
     return states, actions, old_log_probs, returns, advantages
 
   def test_optimization_step(self):

--- a/examples/ppo/test_episodes.py
+++ b/examples/ppo/test_episodes.py
@@ -16,7 +16,7 @@
 
 import itertools
 import flax
-import numpy as onp
+import numpy as np
 
 import env_utils
 import agent
@@ -39,9 +39,9 @@ def policy_test(n_episodes: int, model: flax.nn.base.Model, game: str):
     total_reward = 0.0
     for t in itertools.count():
       log_probs, _ = agent.policy_action(model, state)
-      probs = onp.exp(onp.array(log_probs, dtype=onp.float32))
+      probs = np.exp(np.array(log_probs, dtype=np.float32))
       probabilities = probs[0] / probs[0].sum()
-      action = onp.random.choice(probs.shape[1], p=probabilities)
+      action = np.random.choice(probs.shape[1], p=probabilities)
       obs, reward, done, _ = test_env.step(action)
       total_reward += reward
       next_state = obs[None, ...] if not done else None

--- a/flax/core/flax_functional_engine.ipynb
+++ b/flax/core/flax_functional_engine.ipynb
@@ -11,7 +11,7 @@
         "import functools\n",
         "import jax\n",
         "from jax import numpy as jnp, random, lax\n",
-        "import numpy as onp\n",
+        "import numpy as np\n",
         "jax.config.enable_omnistaging()"
       ],
       "execution_count": 1,
@@ -130,7 +130,7 @@
       "source": [
         "@struct.dataclass\n",
         "class Embedding:\n",
-        "  table: onp.ndarray\n",
+        "  table: np.ndarray\n",
         "\n",
         "  def lookup(self, indices):\n",
         "    return self.table[indices]\n",
@@ -240,7 +240,7 @@
         "x = jnp.ones((1, 2))\n",
         "carry = lstm_init_carry((1,), 3)\n",
         "y, variables = init(lstm)(random.PRNGKey(0), carry, x)\n",
-        "jax.tree_map(onp.shape, (y, variables))"
+        "jax.tree_map(np.shape, (y, variables))"
       ],
       "execution_count": 6,
       "outputs": [

--- a/flax/core/nn/attention.py
+++ b/flax/core/nn/attention.py
@@ -33,7 +33,7 @@ from jax import random
 import jax.numpy as jnp
 from .linear import default_kernel_init
 from .linear import dense_general
-import numpy as onp
+import numpy as np
 
 
 def dot_product_attention(scope,
@@ -94,7 +94,7 @@ def dot_product_attention(scope,
   depth = query.shape[-1]
   n = key.ndim
   # batch_dims is  <bs, <non-attention dims>, num_heads>
-  batch_dims = tuple(onp.delete(range(n), axis + (n - 1,)))
+  batch_dims = tuple(np.delete(range(n), axis + (n - 1,)))
   # q & k -> (bs, <non-attention dims>, num_heads, <attention dims>, channels)
   qk_perm = batch_dims + axis + (n - 1,)
   key = key.transpose(qk_perm)
@@ -159,9 +159,9 @@ def _invert_perm(perm):
 
 @struct.dataclass
 class CacheEntry:
-  key: onp.ndarray
-  value: onp.ndarray
-  i: onp.ndarray
+  key: np.ndarray
+  value: np.ndarray
+  i: np.ndarray
 
 def multi_head_dot_product_attention(
     scope: Scope,
@@ -295,7 +295,7 @@ def multi_head_dot_product_attention(
       cshape = cache_entry.key.shape
       indices = [0] * len(cshape)
       i = cache_entry.i
-      attn_size = onp.prod(onp.take(cshape, attention_axis))
+      attn_size = np.prod(np.take(cshape, attention_axis))
       for attn_dim in attention_axis:
         attn_size //= cshape[attn_dim]
         indices[attn_dim] = i // attn_size
@@ -320,8 +320,8 @@ def multi_head_dot_product_attention(
   if causal_mask:
     if cache and isinstance(cache_entry, CacheEntry):
       bias_pre_shape = (1,) * (key.ndim - 1)
-      attn_shape = tuple(onp.take(key.shape, attention_axis))
-      attn_size = onp.prod(attn_shape)
+      attn_shape = tuple(np.take(key.shape, attention_axis))
+      attn_size = np.prod(attn_shape)
       ii = jnp.arange(attn_size, dtype=jnp.uint32)
       mask = ii < cache_entry.i
       mask_components.append(mask.reshape(bias_pre_shape + attn_shape))
@@ -439,7 +439,7 @@ def make_padding_mask(padding_mask_query,
 
   padding_mask_query = padding_mask_query[..., None]
   padding_mask_key = padding_mask_key[..., None]
-  perm = (0,) + tuple(onp.flip(onp.arange(padding_mask_key.ndim)))[:-1]
+  perm = (0,) + tuple(np.flip(np.arange(padding_mask_key.ndim)))[:-1]
   if segmentation_mask:
     mask = jnp.equal(padding_mask_query, padding_mask_key.transpose(perm))
   else:

--- a/flax/core/nn/linear.py
+++ b/flax/core/nn/linear.py
@@ -25,7 +25,7 @@ from flax import struct
 from jax import lax
 
 import jax.numpy as jnp
-import numpy as onp
+import numpy as np
 
 
 default_kernel_init = initializers.lecun_normal()
@@ -74,7 +74,7 @@ def dense_general(
   features, axis, batch_dims = tuple(features), tuple(axis), tuple(batch_dims)
 
   if batch_dims:
-    max_dim = onp.max(batch_dims)
+    max_dim = np.max(batch_dims)
     if set(batch_dims) != set(range(max_dim + 1)):
       raise ValueError('batch_dims %s must be consecutive leading '
                         'dimensions starting from 0.' % str(batch_dims))
@@ -86,9 +86,9 @@ def dense_general(
   n_axis, n_features = len(axis), len(features)
 
   def kernel_init_wrap(rng, shape, dtype=jnp.float32):
-    size_batch_dims = onp.prod(shape[:n_batch_dims], dtype=onp.int32)
-    flat_shape = (onp.prod(shape[n_batch_dims:n_axis + n_batch_dims]),
-                  onp.prod(shape[-n_features:]),)
+    size_batch_dims = np.prod(shape[:n_batch_dims], dtype=np.int32)
+    flat_shape = (np.prod(shape[n_batch_dims:n_axis + n_batch_dims]),
+                  np.prod(shape[-n_features:]),)
     kernel = jnp.concatenate([kernel_init(rng, flat_shape, dtype)
                               for _ in range(size_batch_dims)], axis=0)
     return jnp.reshape(kernel, shape)
@@ -106,8 +106,8 @@ def dense_general(
                         precision=precision)
   if bias:
     def bias_init_wrap(rng, shape, dtype=jnp.float32):
-      size_batch_dims = onp.prod(shape[:n_batch_dims], dtype=onp.int32)
-      flat_shape = (onp.prod(shape[-n_features:]),)
+      size_batch_dims = np.prod(shape[:n_batch_dims], dtype=np.int32)
+      flat_shape = (np.prod(shape[-n_features:]),)
       bias = jnp.concatenate([bias_init(rng, flat_shape, dtype)
                               for _ in range(size_batch_dims)], axis=0)
       return jnp.reshape(bias, shape)
@@ -305,7 +305,7 @@ default_embed_init = initializers.variance_scaling(1.0, 'fan_in', 'normal',
 
 @struct.dataclass
 class Embedding:
-  table: onp.ndarray
+  table: np.ndarray
 
   def lookup(self, indices):
     """Embeds the inputs along the last dimension.

--- a/flax/jax_utils.py
+++ b/flax/jax_utils.py
@@ -42,7 +42,7 @@ from jax.interpreters import partial_eval as pe
 from jax.interpreters import xla
 import jax.lib.xla_bridge as xb
 import jax.numpy as jnp
-import numpy as onp
+import numpy as np
 
 
 def _replicate(x, devices=None):
@@ -227,10 +227,10 @@ def scan_in_dim(body_fn, init, xs, axis=(0,), keepdims=False):
     axis = (axis,)
 
   def transpose_in(x):
-    perm = axis + tuple(onp.delete(onp.arange(x.ndim), axis))
+    perm = axis + tuple(np.delete(np.arange(x.ndim), axis))
     return x.transpose(perm)
   def transpose_out(x):
-    perm = axis + tuple(onp.delete(onp.arange(x.ndim), axis))
+    perm = axis + tuple(np.delete(np.arange(x.ndim), axis))
     return x.transpose(_invert_perm(perm))
 
   def body_wrapper(c, xs):

--- a/flax/linen/pooling.py
+++ b/flax/linen/pooling.py
@@ -17,7 +17,7 @@
 from jax import lax
 import jax.numpy as jnp
 
-import numpy as onp
+import numpy as np
 
 
 def pool(inputs, init, reduce_fn, window_shape, strides, padding):
@@ -83,7 +83,7 @@ def avg_pool(inputs, window_shape, strides=None, padding="VALID"):
     The average for each window slice.
   """
   y = pool(inputs, 0., lax.add, window_shape, strides, padding)
-  y = y / onp.prod(window_shape)
+  y = y / np.prod(window_shape)
   return y
 
 

--- a/flax/metrics/tensorboard.py
+++ b/flax/metrics/tensorboard.py
@@ -26,7 +26,7 @@ with warnings.catch_warnings():
   else:
     mpl.use('Agg')
 # pylint: disable=g-import-not-at-top
-import numpy as onp
+import numpy as np
 
 from tensorboard.plugins.hparams import api as hparams_api
 import tensorflow.compat.v2 as tf
@@ -66,12 +66,12 @@ class SummaryWriter(object):
       value: int/float: number to log
       step: int: training step
     """
-    value = float(onp.array(value))
+    value = float(np.array(value))
     with self._event_writer.as_default():
       tf.summary.scalar(name=tag, data=value, step=step)
 
   def image(self, tag, image, step):
-    """Saves RGB image summary from onp.ndarray [H,W], [H,W,1], or [H,W,3].
+    """Saves RGB image summary from np.ndarray [H,W], [H,W,1], or [H,W,3].
 
     Args:
       tag: str: label for this data
@@ -80,14 +80,14 @@ class SummaryWriter(object):
         Floating point values should be in range [0, 1).
       step: int: training step
     """
-    image = onp.array(image)
-    if len(onp.shape(image)) == 2:
-      image = image[:, :, onp.newaxis]
-    if onp.shape(image)[-1] == 1:
-      image = onp.repeat(image, 3, axis=-1)
+    image = np.array(image)
+    if len(np.shape(image)) == 2:
+      image = image[:, :, np.newaxis]
+    if np.shape(image)[-1] == 1:
+      image = np.repeat(image, 3, axis=-1)
     # tf.summary.image expects image to have shape [k, h, w, c] where,
     # k = number of samples, h = height, w = width, c = number of channels.
-    image = image[onp.newaxis, :, :, :]
+    image = image[np.newaxis, :, :, :]
 
     # Convert to tensor value as tf.summary.image expects data to be a tensor.
     image = tf.convert_to_tensor(image)
@@ -110,7 +110,7 @@ class SummaryWriter(object):
     """
     # tf.summary.audio expects the audio data to have floating values in
     # [-1.0, 1.0].
-    audiodata = onp.clip(onp.array(audiodata), -1, 1)
+    audiodata = np.clip(np.array(audiodata), -1, 1)
 
     # Convert to tensor value as tf.summary.audio expects data to be a tensor.
     audio = tf.convert_to_tensor(audiodata, dtype=tf.float32)
@@ -128,8 +128,8 @@ class SummaryWriter(object):
       step: int: training step
       bins: number of bins in histogram
     """
-    values = onp.array(values)
-    values = onp.reshape(values, -1)
+    values = np.array(values)
+    values = np.reshape(values, -1)
     with self._event_writer.as_default():
       tf.summary.histogram(name=tag, data=values, step=step, buckets=bins)
 

--- a/flax/nn/attention.py
+++ b/flax/nn/attention.py
@@ -31,7 +31,7 @@ from jax import lax
 from jax import random
 import jax.numpy as jnp
 
-import numpy as onp
+import numpy as np
 
 
 def dot_product_attention(query,
@@ -91,7 +91,7 @@ def dot_product_attention(query,
   depth = query.shape[-1]
   n = key.ndim
   # batch_dims is  <bs, <non-attention dims>, num_heads>
-  batch_dims = tuple(onp.delete(range(n), axis + (n - 1,)))
+  batch_dims = tuple(np.delete(range(n), axis + (n - 1,)))
   # q & k -> (bs, <non-attention dims>, num_heads, <attention dims>, channels)
   qk_perm = batch_dims + axis + (n - 1,)
   key = key.transpose(qk_perm)
@@ -154,9 +154,9 @@ def _invert_perm(perm):
 
 @struct.dataclass
 class _CacheEntry:
-  key: onp.ndarray
-  value: onp.ndarray
-  i: onp.ndarray
+  key: np.ndarray
+  value: np.ndarray
+  i: np.ndarray
 
 
 def scan_in_dim(*args, **kwargs):
@@ -304,7 +304,7 @@ class MultiHeadDotProductAttention(Module):
     if cache:
       assert isinstance(cache, Cache), 'cache must be an instance of Cache'
       if self.is_initializing():
-        cache.store(onp.array((key.ndim,) + key.shape[-2:], dtype=onp.int32))
+        cache.store(np.array((key.ndim,) + key.shape[-2:], dtype=np.int32))
       else:
         cache_entry = cache.retrieve(None)
         expected_shape = list(cache_entry.key.shape[:-2])
@@ -322,7 +322,7 @@ class MultiHeadDotProductAttention(Module):
         cshape = cache_entry.key.shape
         indices = [0] * len(cshape)
         i = cache_entry.i
-        attn_size = onp.prod(onp.take(cshape, attention_axis))
+        attn_size = np.prod(np.take(cshape, attention_axis))
         for attn_dim in attention_axis:
           attn_size //= cshape[attn_dim]
           indices[attn_dim] = i // attn_size
@@ -342,8 +342,8 @@ class MultiHeadDotProductAttention(Module):
     if causal_mask:
       if cache and not self.is_initializing():
         bias_pre_shape = (1,) * (key.ndim - 1)
-        attn_shape = tuple(onp.take(key.shape, attention_axis))
-        attn_size = onp.prod(attn_shape)
+        attn_shape = tuple(np.take(key.shape, attention_axis))
+        attn_size = np.prod(attn_shape)
         ii = jnp.arange(attn_size, dtype=jnp.uint32)
         mask = ii < cache_entry.i
         mask_components.append(mask.reshape(bias_pre_shape + attn_shape))
@@ -474,7 +474,7 @@ def make_padding_mask(padding_mask_query,
 
   padding_mask_query = padding_mask_query[..., None]
   padding_mask_key = padding_mask_key[..., None]
-  perm = (0,) + tuple(onp.flip(onp.arange(padding_mask_key.ndim)))[:-1]
+  perm = (0,) + tuple(np.flip(np.arange(padding_mask_key.ndim)))[:-1]
   if segmentation_mask:
     mask = jnp.equal(padding_mask_query, padding_mask_key.transpose(perm))
   else:

--- a/flax/nn/linear.py
+++ b/flax/nn/linear.py
@@ -22,7 +22,7 @@ from . import initializers
 from jax import lax
 
 import jax.numpy as jnp
-import numpy as onp
+import numpy as np
 
 
 default_kernel_init = initializers.lecun_normal()
@@ -73,7 +73,7 @@ class DenseGeneral(base.Module):
     features, axis, batch_dims = tuple(features), tuple(axis), tuple(batch_dims)
 
     if batch_dims:
-      max_dim = onp.max(batch_dims)
+      max_dim = np.max(batch_dims)
       if set(batch_dims) != set(range(max_dim + 1)):
         raise ValueError('batch_dims %s must be consecutive leading '
                          'dimensions starting from 0.' % str(batch_dims))
@@ -85,9 +85,9 @@ class DenseGeneral(base.Module):
     n_axis, n_features = len(axis), len(features)
 
     def kernel_init_wrap(rng, shape, dtype=jnp.float32):
-      size_batch_dims = onp.prod(shape[:n_batch_dims], dtype=onp.int32)
-      flat_shape = (onp.prod(shape[n_batch_dims:n_axis + n_batch_dims]),
-                    onp.prod(shape[-n_features:]),)
+      size_batch_dims = np.prod(shape[:n_batch_dims], dtype=np.int32)
+      flat_shape = (np.prod(shape[n_batch_dims:n_axis + n_batch_dims]),
+                    np.prod(shape[-n_features:]),)
       kernel = jnp.concatenate([kernel_init(rng, flat_shape, dtype)
                                 for _ in range(size_batch_dims)], axis=0)
       return jnp.reshape(kernel, shape)
@@ -105,8 +105,8 @@ class DenseGeneral(base.Module):
                           precision=precision)
     if bias:
       def bias_init_wrap(rng, shape, dtype=jnp.float32):
-        size_batch_dims = onp.prod(shape[:n_batch_dims], dtype=onp.int32)
-        flat_shape = (onp.prod(shape[-n_features:]),)
+        size_batch_dims = np.prod(shape[:n_batch_dims], dtype=np.int32)
+        flat_shape = (np.prod(shape[-n_features:]),)
         bias = jnp.concatenate([bias_init(rng, flat_shape, dtype)
                                 for _ in range(size_batch_dims)], axis=0)
         return jnp.reshape(bias, shape)

--- a/flax/nn/pooling.py
+++ b/flax/nn/pooling.py
@@ -17,7 +17,7 @@
 from jax import lax
 import jax.numpy as jnp
 
-import numpy as onp
+import numpy as np
 
 
 def pool(inputs, init, reduce_fn, window_shape, strides, padding):
@@ -70,7 +70,7 @@ def avg_pool(inputs, window_shape, strides=None, padding="VALID"):
     The average for each window slice.
   """
   y = pool(inputs, 0., lax.add, window_shape, strides, padding)
-  y = y / onp.prod(window_shape)
+  y = y / np.prod(window_shape)
   return y
 
 

--- a/flax/optim/adafactor.py
+++ b/flax/optim/adafactor.py
@@ -25,7 +25,7 @@ from .base import OptimizerDef
 
 import jax.numpy as jnp
 
-import numpy as onp
+import numpy as np
 
 
 @struct.dataclass
@@ -45,10 +45,10 @@ class _AdafactorHyperParams:
 
 @struct.dataclass
 class _AdafactorParamState:
-  v_row: onp.ndarray  # used in normal factored version
-  v_col: onp.ndarray
-  v: onp.ndarray  # only used without factoring
-  m: onp.ndarray  # only used with momentum
+  v_row: np.ndarray  # used in normal factored version
+  v_col: np.ndarray
+  v: np.ndarray  # only used without factoring
+  m: np.ndarray  # only used with momentum
 
 
 class Adafactor(OptimizerDef):
@@ -118,7 +118,7 @@ class Adafactor(OptimizerDef):
     """
     if not self.hyper_params.factored or len(shape) < 2:
       return None
-    sorted_dims = onp.argsort(shape)
+    sorted_dims = np.argsort(shape)
     if shape[sorted_dims[-2]] < self.hyper_params.min_dim_size_to_factor:
       return None
     return int(sorted_dims[-2]), int(sorted_dims[-1])
@@ -129,8 +129,8 @@ class Adafactor(OptimizerDef):
     factored_dims = self._factored_dims(shape)
     if factored_dims is not None:
       d1, d0 = factored_dims
-      vr_shape = onp.delete(shape, d0)
-      vc_shape = onp.delete(shape, d1)
+      vr_shape = np.delete(shape, d0)
+      vc_shape = np.delete(shape, d1)
       state['v_row'] = jnp.zeros(vr_shape, dtype=jnp.float32)
       state['v_col'] = jnp.zeros(vc_shape, dtype=jnp.float32)
     else:

--- a/flax/optim/adagrad.py
+++ b/flax/optim/adagrad.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import jax.numpy as jnp
-import numpy as onp
+import numpy as np
 from .. import struct
 from .base import OptimizerDef
 
@@ -30,7 +30,7 @@ class _AdagradHyperParams:
 class _AdagradParamState:
   """Adagrad parameter state"""
 
-  G: onp.ndarray
+  G: np.ndarray
 
 
 class Adagrad(OptimizerDef):

--- a/flax/optim/adam.py
+++ b/flax/optim/adam.py
@@ -17,24 +17,24 @@ from .. import struct
 import jax.numpy as jnp
 from jax import lax
 
-import numpy as onp
+import numpy as np
 
 from .base import OptimizerDef
 
 
 @struct.dataclass
 class _AdamHyperParams:
-  learning_rate: onp.ndarray
-  beta1: onp.ndarray
-  beta2: onp.ndarray
-  eps: onp.ndarray
-  weight_decay: onp.ndarray
+  learning_rate: np.ndarray
+  beta1: np.ndarray
+  beta2: np.ndarray
+  eps: np.ndarray
+  weight_decay: np.ndarray
 
 
 @struct.dataclass
 class _AdamParamState:
-  grad_ema: onp.ndarray
-  grad_sq_ema: onp.ndarray
+  grad_ema: np.ndarray
+  grad_sq_ema: np.ndarray
 
 
 class Adam(OptimizerDef):

--- a/flax/optim/dynamic_scale.py
+++ b/flax/optim/dynamic_scale.py
@@ -24,7 +24,6 @@ import jax
 from jax import lax
 import jax.numpy as jnp
 
-import numpy as onp
 
 
 Array = Any

--- a/flax/optim/lamb.py
+++ b/flax/optim/lamb.py
@@ -17,23 +17,23 @@ from .. import struct
 from jax import lax
 import jax.numpy as jnp
 
-import numpy as onp
+import numpy as np
 
 from .base import OptimizerDef
 
 @struct.dataclass
 class _LAMBHyperParams:
-  learning_rate: onp.ndarray
-  beta1: onp.ndarray
-  beta2: onp.ndarray
-  weight_decay: onp.ndarray
-  eps: onp.ndarray
+  learning_rate: np.ndarray
+  beta1: np.ndarray
+  beta2: np.ndarray
+  weight_decay: np.ndarray
+  eps: np.ndarray
 
 
 @struct.dataclass
 class _LAMBParamState:
-  grad_ema: onp.ndarray
-  grad_sq_ema: onp.ndarray
+  grad_ema: np.ndarray
+  grad_sq_ema: np.ndarray
 
 
 class LAMB(OptimizerDef):

--- a/flax/optim/lars.py
+++ b/flax/optim/lars.py
@@ -16,24 +16,24 @@ from .. import struct
 
 import jax.numpy as jnp
 
-import numpy as onp
+import numpy as np
 
 from .base import OptimizerDef
 
 
 @struct.dataclass
 class _LARSHyperParams:
-  learning_rate: onp.ndarray
-  beta: onp.ndarray
-  weight_decay: onp.ndarray
-  trust_coefficient: onp.ndarray
-  eps: onp.ndarray
+  learning_rate: np.ndarray
+  beta: np.ndarray
+  weight_decay: np.ndarray
+  trust_coefficient: np.ndarray
+  eps: np.ndarray
   nesterov: bool
 
 
 @struct.dataclass
 class _LARSParamState:
-  momentum: onp.ndarray
+  momentum: np.ndarray
 
 
 class LARS(OptimizerDef):

--- a/flax/optim/momentum.py
+++ b/flax/optim/momentum.py
@@ -16,22 +16,22 @@ from .. import struct
 
 import jax.numpy as jnp
 
-import numpy as onp
+import numpy as np
 
 from .base import OptimizerDef
 
 
 @struct.dataclass
 class _MomentumHyperParams:
-  learning_rate: onp.ndarray
-  beta: onp.ndarray
-  weight_decay: onp.ndarray
+  learning_rate: np.ndarray
+  beta: np.ndarray
+  weight_decay: np.ndarray
   nesterov: bool
 
 
 @struct.dataclass
 class _MomentumParamState:
-  momentum: onp.ndarray
+  momentum: np.ndarray
 
 
 class Momentum(OptimizerDef):

--- a/flax/optim/rmsprop.py
+++ b/flax/optim/rmsprop.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import jax.numpy as jnp
-import numpy as onp
+import numpy as np
 from .. import struct
 from .base import OptimizerDef
 
@@ -32,8 +32,8 @@ class _RMSPropHyperParams:
 class _RMSPropParamState:
   """RMSProp parameter state"""
 
-  v: onp.ndarray
-  mg: onp.ndarray
+  v: np.ndarray
+  mg: np.ndarray
 
 
 class RMSProp(OptimizerDef):

--- a/flax/optim/sgd.py
+++ b/flax/optim/sgd.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import numpy as onp
+import numpy as np
 
 from .. import struct
 
@@ -21,7 +21,7 @@ from .base import OptimizerDef
 
 @struct.dataclass
 class _GradientDescentHyperParams:
-  learning_rate: onp.ndarray
+  learning_rate: np.ndarray
 
 
 class GradientDescent(OptimizerDef):

--- a/flax/optim/weight_norm.py
+++ b/flax/optim/weight_norm.py
@@ -19,7 +19,7 @@ from .. import struct
 import jax
 import jax.numpy as jnp
 
-import numpy as onp
+import numpy as np
 
 from .base import OptimizerDef
 
@@ -27,15 +27,15 @@ from .base import OptimizerDef
 @struct.dataclass
 class _WeightNormHyperParams:
   inner: Any
-  wn_decay: onp.ndarray
-  wn_eps: onp.ndarray
+  wn_decay: np.ndarray
+  wn_eps: np.ndarray
 
 
 @struct.dataclass
 class _WeightNormParamState:
   direction_state: Any
   scale_state: Any
-  mult: onp.ndarray
+  mult: np.ndarray
 
 
 class WeightNorm(OptimizerDef):

--- a/flax/training/common_utils.py
+++ b/flax/training/common_utils.py
@@ -17,7 +17,7 @@
 import jax
 from jax import lax
 import jax.numpy as jnp
-import numpy as onp
+import numpy as np
 
 
 def shard(xs):
@@ -41,7 +41,7 @@ def onehot(labels, num_classes, on_value=1.0, off_value=0.0):
 
 
 def stack_forest(forest):
-  stack_args = lambda *args: onp.stack(args)
+  stack_args = lambda *args: np.stack(args)
   return jax.tree_multimap(stack_args, *forest)
 
 

--- a/flax/training/lr_schedule.py
+++ b/flax/training/lr_schedule.py
@@ -16,7 +16,7 @@
 """
 
 import jax.numpy as jnp
-import numpy as onp
+import numpy as np
 
 
 def _piecewise_constant(boundaries, values, t):
@@ -84,9 +84,9 @@ def create_stepped_learning_rate_schedule(base_learning_rate, steps_per_epoch,
   """
   boundaries = [step[0] for step in lr_sched_steps]
   decays = [step[1] for step in lr_sched_steps]
-  boundaries = onp.array(boundaries) * steps_per_epoch
-  boundaries = onp.round(boundaries).astype(int)
-  values = onp.array([1.0] + decays) * base_learning_rate
+  boundaries = np.array(boundaries) * steps_per_epoch
+  boundaries = np.round(boundaries).astype(int)
+  values = np.array([1.0] + decays) * base_learning_rate
 
   def learning_rate_fn(step):
     lr = _piecewise_constant(boundaries, values, step)

--- a/howtos/diffs/ensembling.diff
+++ b/howtos/diffs/ensembling.diff
@@ -11,7 +11,7 @@ index dbe6254..e540a1e 100644
  import jax
  from jax import random
  
-@@ -31,6 +33,7 @@ import numpy as onp
+@@ -31,6 +33,7 @@ import numpy as np
  
  import tensorflow_datasets as tfds
  
@@ -65,14 +65,14 @@ index dbe6254..e540a1e 100644
 +  # stack all of the metrics from each devioce into
 +  # numpy arrays directly on a dict, such that, e.g.
 +  # `batch_metrics_np['loss']` has shape (jax.device_count(), )
-+  batch_metrics_np = jax.tree_multimap(lambda *xs: onp.array(xs),
++  batch_metrics_np = jax.tree_multimap(lambda *xs: np.array(xs),
 +                                       *batch_metrics_np)
    epoch_metrics_np = {
--      k: onp.mean([metrics[k] for metrics in batch_metrics_np])
+-      k: np.mean([metrics[k] for metrics in batch_metrics_np])
 -      for k in batch_metrics_np[0]}
 -
 -  logging.info('train epoch: %d, loss: %.4f, accuracy: %.2f', epoch,
-+      k: onp.mean(batch_metrics_np[k], axis=0)
++      k: np.mean(batch_metrics_np[k], axis=0)
 +      for k in batch_metrics_np
 +  }
 +  # `epoch_metrics_np` now contains 1D arrays of length `jax.device_count()`
@@ -114,10 +114,10 @@ index dbe6254..e540a1e 100644
 -    summary_writer.scalar('train_accuracy', train_metrics['accuracy'], epoch)
 -    summary_writer.scalar('eval_loss', loss, epoch)
 -    summary_writer.scalar('eval_accuracy', accuracy, epoch)
-+    summary_writer.scalar('train_loss', onp.mean(train_metrics['loss']), epoch)
-+    summary_writer.scalar('train_accuracy', onp.mean(train_metrics['accuracy']), epoch)
-+    summary_writer.scalar('eval_loss', onp.mean(loss), epoch)
-+    summary_writer.scalar('eval_accuracy', onp.mean(accuracy), epoch)
++    summary_writer.scalar('train_loss', np.mean(train_metrics['loss']), epoch)
++    summary_writer.scalar('train_accuracy', np.mean(train_metrics['accuracy']), epoch)
++    summary_writer.scalar('eval_loss', np.mean(loss), epoch)
++    summary_writer.scalar('eval_accuracy', np.mean(accuracy), epoch)
  
    summary_writer.flush()
    return optimizer

--- a/linen_examples/mnist/train.py
+++ b/linen_examples/mnist/train.py
@@ -28,7 +28,7 @@ from flax.metrics import tensorboard
 import jax
 import jax.numpy as jnp
 import ml_collections
-import numpy as onp
+import numpy as np
 import tensorflow_datasets as tfds
 
 
@@ -119,7 +119,7 @@ def train_epoch(optimizer, train_ds, batch_size, epoch, rng):
   # compute mean of metrics across each batch in epoch.
   batch_metrics_np = jax.device_get(batch_metrics)
   epoch_metrics_np = {
-      k: onp.mean([metrics[k] for metrics in batch_metrics_np])
+      k: np.mean([metrics[k] for metrics in batch_metrics_np])
       for k in batch_metrics_np[0]}
 
   logging.info('train epoch: %d, loss: %.4f, accuracy: %.2f', epoch,

--- a/linen_examples/pixelcnn/pixelcnn.py
+++ b/linen_examples/pixelcnn/pixelcnn.py
@@ -46,7 +46,7 @@ import jax
 from jax import lax
 import jax.numpy as jnp
 from jax.scipy.special import logsumexp
-import numpy as onp
+import numpy as np
 
 
 class PixelCNNPP(nn.Module):
@@ -277,7 +277,7 @@ class ConvTransposeDown(nn.Module):
   @nn.compact
   def __call__(self, inputs):
     _, k_w = self.kernel_size
-    out_h, out_w = onp.multiply(self.strides, inputs.shape[1:3])
+    out_h, out_w = np.multiply(self.strides, inputs.shape[1:3])
     return ConvTranspose(self.features, self.kernel_size, self.strides)(inputs)[
         :, :out_h, (k_w - 1) // 2:out_w + (k_w - 1) // 2, :]
 
@@ -293,7 +293,7 @@ class ConvTransposeDownRight(nn.Module):
 
   @nn.compact
   def __call__(self, inputs):
-    out_h, out_w = onp.multiply(self.strides, inputs.shape[1:3])
+    out_h, out_w = np.multiply(self.strides, inputs.shape[1:3])
     return ConvTranspose(self.features, self.kernel_size,
                          self.strides)(inputs)[:, :out_h, :out_w]
 

--- a/linen_examples/pixelcnn/sample.py
+++ b/linen_examples/pixelcnn/sample.py
@@ -25,7 +25,7 @@ import jax
 from jax import random
 import jax.numpy as jnp
 import ml_collections
-import numpy as onp
+import numpy as np
 from PIL import Image
 
 
@@ -105,8 +105,8 @@ def snap_to_grid(sample):
 
 def save_images(batch, fname):
   n_rows = batch.shape[0] // 16
-  batch = onp.uint8(jnp.round((batch + 1) * 127.5))
-  out = onp.full((1 + 33 * n_rows, 1 + 33 * 16, 3), 255, 'uint8')
+  batch = np.uint8(jnp.round((batch + 1) * 127.5))
+  out = np.full((1 + 33 * n_rows, 1 + 33 * 16, 3), 255, 'uint8')
   for i, im in enumerate(batch):
     top  = 1 + 33 * (i // 16)
     left = 1 + 33 * (i %  16)

--- a/linen_examples/ppo/agent.py
+++ b/linen_examples/ppo/agent.py
@@ -17,7 +17,7 @@
 import functools
 import multiprocessing
 import collections
-import numpy as onp
+import numpy as np
 import jax
 import flax
 
@@ -28,7 +28,7 @@ import models
 def policy_action(
   params: flax.core.frozen_dict.FrozenDict,
   module: models.ActorCritic,
-  state: onp.ndarray):
+  state: np.ndarray):
   """Forward pass of the network.
 
   Args:

--- a/linen_examples/ppo/env_utils.py
+++ b/linen_examples/ppo/env_utils.py
@@ -16,7 +16,7 @@
 
 import collections
 import gym
-import numpy as onp
+import numpy as np
 
 import seed_rl_atari_preprocessing
 
@@ -31,7 +31,7 @@ class ClipRewardEnv(gym.RewardWrapper):
 
   def reward(self, reward):
     """Bin reward to {+1, 0, -1} by its sign."""
-    return onp.sign(reward)
+    return np.sign(reward)
 
 class FrameStack:
   """Implements stacking of `num_frames` last frames of the game.
@@ -60,7 +60,7 @@ class FrameStack:
 
   def _get_array(self):
     assert len(self.frames) == self.num_frames
-    return onp.concatenate(self.frames, axis=-1)
+    return np.concatenate(self.frames, axis=-1)
 
 def create_env(game: str, clip_rewards: bool):
   """Create a FrameStack object that serves as environment for the `game`."""

--- a/linen_examples/ppo/models.py
+++ b/linen_examples/ppo/models.py
@@ -15,7 +15,7 @@
 """Class and functions to define and initialize the actor-critic model."""
 
 import functools
-import numpy as onp
+import numpy as np
 from flax import linen as nn
 from flax import optim
 import jax
@@ -64,7 +64,7 @@ class ActorCritic(nn.Module):
     return policy_log_probabilities, value
 
 @functools.partial(jax.jit, static_argnums=1)
-def get_initial_params(key: onp.ndarray, module: ActorCritic):
+def get_initial_params(key: np.ndarray, module: ActorCritic):
   input_dims = (1, 84, 84, 4)  # (minibatch, height, width, stacked frames)
   init_shape = jnp.ones(input_dims, jnp.float32)
   initial_params = module.init(key, init_shape)['params']

--- a/linen_examples/ppo/ppo_lib.py
+++ b/linen_examples/ppo/ppo_lib.py
@@ -19,7 +19,7 @@ from typing import Tuple, List
 import jax
 import jax.random
 import jax.numpy as jnp
-import numpy as onp
+import numpy as np
 import flax
 
 from flax.metrics import tensorboard
@@ -33,9 +33,9 @@ import test_episodes
 @jax.jit
 @functools.partial(jax.vmap, in_axes=(1, 1, 1, None, None), out_axes=1)
 def gae_advantages(
-    rewards: onp.ndarray,
-    terminal_masks: onp.ndarray,
-    values: onp.ndarray,
+    rewards: np.ndarray,
+    terminal_masks: np.ndarray,
+    values: np.ndarray,
     discount: float,
     gae_param: float):
   """Use Generalized Advantage Estimation (GAE) to compute advantages.
@@ -183,13 +183,13 @@ def get_experience(
     for sim in simulators:
       state = sim.conn.recv()
       states.append(state)
-    states = onp.concatenate(states, axis=0)
+    states = np.concatenate(states, axis=0)
     log_probs, values = agent.policy_action(params, module, states)
     log_probs, values = jax.device_get((log_probs, values))
-    probs = onp.exp(onp.array(log_probs))
+    probs = np.exp(np.array(log_probs))
     for i, sim in enumerate(simulators):
       probabilities = probs[i]
-      action = onp.random.choice(probs.shape[1], p=probabilities)
+      action = np.random.choice(probs.shape[1], p=probabilities)
       sim.conn.send(action)
     experiences = []
     for i, sim in enumerate(simulators):
@@ -222,12 +222,12 @@ def process_experience(
   obs_shape = (84, 84, 4)
   exp_dims = (actor_steps, num_agents)
   values_dims = (actor_steps + 1, num_agents)
-  states = onp.zeros(exp_dims + obs_shape, dtype=onp.float32)
-  actions = onp.zeros(exp_dims, dtype=onp.int32)
-  rewards = onp.zeros(exp_dims, dtype=onp.float32)
-  values = onp.zeros(values_dims, dtype=onp.float32)
-  log_probs = onp.zeros(exp_dims, dtype=onp.float32)
-  dones = onp.zeros(exp_dims, dtype=onp.float32)
+  states = np.zeros(exp_dims + obs_shape, dtype=np.float32)
+  actions = np.zeros(exp_dims, dtype=np.int32)
+  rewards = np.zeros(exp_dims, dtype=np.float32)
+  values = np.zeros(values_dims, dtype=np.float32)
+  log_probs = np.zeros(exp_dims, dtype=np.float32)
+  dones = np.zeros(exp_dims, dtype=np.float32)
 
   for t in range(len(experience) - 1):  # experience[-1] only for next_values
     for agent_id, exp_agent in enumerate(experience[t]):
@@ -246,7 +246,7 @@ def process_experience(
   trajectories = (states, actions, log_probs, returns, advantages)
   trajectory_len = num_agents * actor_steps
   trajectories = tuple(map(
-      lambda x: onp.reshape(x, (trajectory_len,) + x.shape[2:]), trajectories))
+      lambda x: np.reshape(x, (trajectory_len,) + x.shape[2:]), trajectories))
   return trajectories
 
 def train(
@@ -295,7 +295,7 @@ def train(
     lr = config.learning_rate * alpha
     clip_param = config.clip_param * alpha
     for e in range(config.num_epochs):
-      permutation = onp.random.permutation(
+      permutation = np.random.permutation(
           config.num_agents * config.actor_steps)
       trajectories = tuple(map(lambda x: x[permutation], trajectories))
       optimizer, loss = train_step(

--- a/linen_examples/ppo/ppo_lib_test.py
+++ b/linen_examples/ppo/ppo_lib_test.py
@@ -16,7 +16,7 @@
 
 import jax
 import flax
-import numpy as onp
+import numpy as np
 import numpy.testing as onp_testing
 from absl.testing import absltest
 
@@ -30,10 +30,10 @@ class TestGAE(absltest.TestCase):
   def test_gae_shape_on_random(self):
     # create random data, simulating 4 parallel envs and 20 time_steps
     envs, steps = 10, 100
-    rewards = onp.random.choice([-1., 0., 1.], size=(steps, envs),
+    rewards = np.random.choice([-1., 0., 1.], size=(steps, envs),
                                 p=[0.01, 0.98, 0.01])
-    terminal_masks = onp.ones(shape=(steps, envs), dtype=onp.float64)
-    values = onp.random.random(size=(steps + 1, envs))
+    terminal_masks = np.ones(shape=(steps, envs), dtype=np.float64)
+    values = np.random.random(size=(steps + 1, envs))
     discount = 0.99
     gae_param = 0.95
     adv = ppo_lib.gae_advantages(rewards, terminal_masks, values, discount,
@@ -42,13 +42,13 @@ class TestGAE(absltest.TestCase):
 
   def test_gae_hardcoded(self):
     #test on small example that can be verified by hand
-    rewards = onp.array([[1., 0.], [0., 0.], [-1., 1.]])
+    rewards = np.array([[1., 0.], [0., 0.], [-1., 1.]])
     #one of the two episodes terminated in the middle
-    terminal_masks = onp.array([[1., 1.], [0., 1.], [1., 1.]])
-    values = onp.array([[1., 1.], [1., 1.], [1., 1.], [1., 1.]])
+    terminal_masks = np.array([[1., 1.], [0., 1.], [1., 1.]])
+    values = np.array([[1., 1.], [1., 1.], [1., 1.], [1., 1.]])
     discount = 0.5
     gae_param = 0.25
-    correct_gae = onp.array([[0.375, -0.5546875], [-1., -0.4375], [-1.5, 0.5]])
+    correct_gae = np.array([[0.375, -0.5546875], [-1., -0.4375], [-1.5, 0.5]])
     actual_gae = ppo_lib.gae_advantages(rewards, terminal_masks, values,
                                         discount, gae_param)
     onp_testing.assert_allclose(actual_gae, correct_gae)
@@ -57,7 +57,7 @@ class TestEnvironmentPreprocessing(absltest.TestCase):
   def choose_random_game(self):
     games = ['BeamRider', 'Breakout', 'Pong',
              'Qbert', 'Seaquest', 'SpaceInvaders']
-    ind = onp.random.choice(len(games))
+    ind = np.random.choice(len(games))
     return games[ind] + "NoFrameskip-v4"
 
   def test_creation(self):
@@ -83,7 +83,7 @@ class TestEnvironmentPreprocessing(absltest.TestCase):
 # test the model (creation and forward pass)
 class TestModel(absltest.TestCase):
   def choose_random_outputs(self):
-    return onp.random.choice([4, 5, 6, 7, 8, 9])
+    return np.random.choice([4, 5, 6, 7, 8, 9])
 
   def test_model(self):
     key = jax.random.PRNGKey(0)
@@ -95,13 +95,13 @@ class TestModel(absltest.TestCase):
     optimizer = models.create_optimizer(initial_params, lr)
     self.assertTrue(isinstance(optimizer, flax.optim.base.Optimizer))
     test_batch_size, obs_shape = 10, (84, 84, 4)
-    random_input = onp.random.random(size=(test_batch_size,) + obs_shape)
+    random_input = np.random.random(size=(test_batch_size,) + obs_shape)
     log_probs, values = agent.policy_action(optimizer.target, module,
         random_input)
     self.assertEqual(values.shape, (test_batch_size, 1))
-    sum_probs = onp.sum(onp.exp(log_probs), axis=1)
+    sum_probs = np.sum(np.exp(log_probs), axis=1)
     self.assertEqual(sum_probs.shape, (test_batch_size, ))
-    onp_testing.assert_allclose(sum_probs, onp.ones((test_batch_size, )),
+    onp_testing.assert_allclose(sum_probs, np.ones((test_batch_size, )),
                                 atol=1e-6)
 
 # test one optimization step
@@ -109,11 +109,11 @@ class TestOptimizationStep(absltest.TestCase):
   def generate_random_data(self, num_actions):
     data_len = 256 # equal to one default-sized batch
     state_shape = (84, 84, 4)
-    states = onp.random.randint(0, 255, size=((data_len, ) + state_shape))
-    actions = onp.random.choice(num_actions, size=data_len)
-    old_log_probs = onp.random.random(size=data_len)
-    returns = onp.random.random(size=data_len)
-    advantages = onp.random.random(size=data_len)
+    states = np.random.randint(0, 255, size=((data_len, ) + state_shape))
+    actions = np.random.choice(num_actions, size=data_len)
+    old_log_probs = np.random.random(size=data_len)
+    returns = np.random.random(size=data_len)
+    advantages = np.random.random(size=data_len)
     return states, actions, old_log_probs, returns, advantages
 
   def test_optimization_step(self):

--- a/linen_examples/ppo/test_episodes.py
+++ b/linen_examples/ppo/test_episodes.py
@@ -16,7 +16,7 @@
 
 import itertools
 import flax
-import numpy as onp
+import numpy as np
 
 import env_utils
 import agent
@@ -45,9 +45,9 @@ def policy_test(
     total_reward = 0.0
     for t in itertools.count():
       log_probs, _ = agent.policy_action(params, module, state)
-      probs = onp.exp(onp.array(log_probs, dtype=onp.float32))
+      probs = np.exp(np.array(log_probs, dtype=np.float32))
       probabilities = probs[0] / probs[0].sum()
-      action = onp.random.choice(probs.shape[1], p=probabilities)
+      action = np.random.choice(probs.shape[1], p=probabilities)
       obs, reward, done, _ = test_env.step(action)
       total_reward += reward
       next_state = obs[None, ...] if not done else None

--- a/tests/linen/module_test.py
+++ b/tests/linen/module_test.py
@@ -24,7 +24,7 @@ from jax import lax
 from jax.nn import initializers
 import jax.numpy as jnp
 
-import numpy as onp
+import numpy as np
 from typing import Any, Tuple, Iterable, Callable
 
 from flax import linen as nn
@@ -63,8 +63,8 @@ class ModuleTest(absltest.TestCase):
     y = DummyModule(parent=scope)(x)
     params = scope.variables()['params']
     y2 = DummyModule(parent=scope.rewound())(x)
-    onp.testing.assert_allclose(y, y2)
-    onp.testing.assert_allclose(y, jnp.array([2.]))
+    np.testing.assert_allclose(y, y2)
+    np.testing.assert_allclose(y, jnp.array([2.]))
     self.assertEqual(params, {'bias': jnp.array([1.])})
 
   def test_arg_module(self):
@@ -74,7 +74,7 @@ class ModuleTest(absltest.TestCase):
     y = Dense(3, parent=scope)(x)
     params = scope.variables()['params']
     y2 = Dense(3, parent=scope.rewound())(x)
-    onp.testing.assert_allclose(y, y2)
+    np.testing.assert_allclose(y, y2)
     self.assertEqual(params['kernel'].shape, (10, 3))
 
   def test_util_fun(self):
@@ -92,7 +92,7 @@ class ModuleTest(absltest.TestCase):
     y = MLP(parent=scope)(x)
     params = scope.variables()['params']
     y2 = MLP(parent=scope.rewound())(x)
-    onp.testing.assert_allclose(y, y2)
+    np.testing.assert_allclose(y, y2)
     param_shape = jax.tree_map(jnp.shape, params)
     self.assertEqual(param_shape,
       {'Dense_0': {'kernel': (10, 3)},
@@ -120,7 +120,7 @@ class ModuleTest(absltest.TestCase):
     y = Top(parent=scope)(x)
     params = scope.variables()['params']
     y2 = Top(parent=scope.rewound())(x)
-    onp.testing.assert_allclose(y, y2)
+    np.testing.assert_allclose(y, y2)
     param_shape = jax.tree_map(jnp.shape, params)
     self.assertEqual(param_shape,
       {'MLP_0':
@@ -143,7 +143,7 @@ class ModuleTest(absltest.TestCase):
     y = MLP(parent=scope)(x)
     params = scope.variables()['params']
     y2 = MLP(parent=scope.rewound())(x)
-    onp.testing.assert_allclose(y, y2)
+    np.testing.assert_allclose(y, y2)
     param_shape = jax.tree_map(jnp.shape, params)
     self.assertEqual(param_shape,
       {'lyrs1_a': {'kernel': (10, 3)},
@@ -199,8 +199,8 @@ class ModuleTest(absltest.TestCase):
     y = DummyModule(x.shape, parent=scope)(x)
     params = scope.variables()['params']
     y2 = DummyModule(x.shape, parent=scope.rewound())(x)
-    onp.testing.assert_allclose(y, y2)
-    onp.testing.assert_allclose(y, jnp.array([2.]))
+    np.testing.assert_allclose(y, y2)
+    np.testing.assert_allclose(y, jnp.array([2.]))
     self.assertEqual(params, {'bias': jnp.array([1.])})
 
   def test_init_outside_setup_without_compact(self):
@@ -465,7 +465,7 @@ class ModuleTest(absltest.TestCase):
         for width in self.widths[:-1]:
           x = nn.relu(nn.Dense(width)(x))
         return nn.Dense(self.widths[-1])(x)
-    test = MLP(onp.array([3, 3], onp.int32))
+    test = MLP(np.array([3, 3], np.int32))
     params = test.init({'params': random.PRNGKey(42)}, jnp.ones((3, 3)))
     _ = test.apply(params, jnp.ones((3, 3)))
 

--- a/tests/nn_attention_test.py
+++ b/tests/nn_attention_test.py
@@ -26,7 +26,7 @@ from jax import random
 from jax.nn import initializers
 import jax.numpy as jnp
 
-import numpy as onp
+import numpy as np
 
 # Parse absl flags test_srcdir and test_tmpdir.
 jax.config.parse_flags_with_absl()
@@ -84,9 +84,9 @@ class AttentionTest(parameterized.TestCase):
     mask_1d = nn.attention._make_causal_mask(
         key, attention_axis=att_axis, self_mask=False)
 
-    ts = onp.arange(key.shape[1])
+    ts = np.arange(key.shape[1])
     mask_1d_simple = (ts[:, None] >= ts[None, :])[None, None, :, :]
-    onp.testing.assert_allclose(mask_1d, mask_1d_simple,)
+    np.testing.assert_allclose(mask_1d, mask_1d_simple,)
 
   def test_causal_mask_2d(self):
     """Tests autoregresive masking for 2d attention."""
@@ -100,10 +100,10 @@ class AttentionTest(parameterized.TestCase):
 
     # masking when dealing with 1d attention weights
     # w_1d_shape = (4, 5*5, 5*5, 2)
-    ts = onp.arange(25)
+    ts = np.arange(25)
     mask_1d = (ts[:, None] >= ts[None, :])[None, None, :, :]
 
-    onp.testing.assert_allclose(mask_nd.reshape(mask_1d.shape), mask_1d,
+    np.testing.assert_allclose(mask_nd.reshape(mask_1d.shape), mask_1d,
                                 atol=1e-9)
 
   @parameterized.parameters([((5,), (1,)),
@@ -141,7 +141,7 @@ class AttentionTest(parameterized.TestCase):
     _, y = jax_utils.scan_in_dim(body_fn, cache0, inputs,
                                     axis=attn_dims, keepdims=True)
 
-    onp.testing.assert_allclose(y_ref, y, atol=1e-5)
+    np.testing.assert_allclose(y_ref, y, atol=1e-5)
 
   def test_autoregresive_receptive_field_1d(self):
     """Tests the autoregresive self-attention receptive field."""

--- a/tests/nn_linear_test.py
+++ b/tests/nn_linear_test.py
@@ -26,7 +26,7 @@ from jax import random
 from jax.nn import initializers
 import jax.numpy as jnp
 
-import numpy as onp
+import numpy as np
 
 # Parse absl flags test_srcdir and test_tmpdir.
 jax.config.parse_flags_with_absl()
@@ -44,7 +44,7 @@ class LinearTest(parameterized.TestCase):
     )
     y, _ = dense_module.init(rng, x)
     self.assertEqual(y.shape, (1, 4))
-    onp.testing.assert_allclose(y, onp.full((1, 4), 4.))
+    np.testing.assert_allclose(y, np.full((1, 4), 4.))
 
   def test_dense_extra_batch_dims(self):
     rng = random.PRNGKey(0)
@@ -55,7 +55,7 @@ class LinearTest(parameterized.TestCase):
         bias_init=initializers.ones,
     )
     y, _ = dense_module.init(rng, x)
-    onp.testing.assert_allclose(y, onp.full((1, 2, 4), 4.))
+    np.testing.assert_allclose(y, np.full((1, 2, 4), 4.))
 
   def test_dense_no_bias(self):
     rng = random.PRNGKey(0)
@@ -66,7 +66,7 @@ class LinearTest(parameterized.TestCase):
         kernel_init=initializers.ones,
     )
     y, _ = dense_module.init(rng, x)
-    onp.testing.assert_allclose(y, onp.full((1, 4), 3.))
+    np.testing.assert_allclose(y, np.full((1, 4), 3.))
 
   def test_dense_is_dense_general(self):
     x = jax.random.normal(random.PRNGKey(0), (5, 3))
@@ -83,7 +83,7 @@ class LinearTest(parameterized.TestCase):
     )
     y2, _ = dg_module.init(random.PRNGKey(1), x)
 
-    onp.testing.assert_allclose(y1, y2)
+    np.testing.assert_allclose(y1, y2)
 
   def test_dense_general_batch_dim_raises(self):
     rng = random.PRNGKey(0)
@@ -106,7 +106,7 @@ class LinearTest(parameterized.TestCase):
         bias_init=initializers.ones,
     )
     y, _ = dg_module.init(rng, x)
-    onp.testing.assert_allclose(y, onp.full((1, 2, 2), 4.))
+    np.testing.assert_allclose(y, np.full((1, 2, 2), 4.))
 
   def test_dense_general_two_in(self):
     rng = random.PRNGKey(0)
@@ -118,7 +118,7 @@ class LinearTest(parameterized.TestCase):
         bias_init=initializers.ones,
     )
     y, _ = dg_module.init(rng, x)
-    onp.testing.assert_allclose(y, onp.full((1, 3), 5.))
+    np.testing.assert_allclose(y, np.full((1, 3), 5.))
 
   def test_dense_general_batch_dim(self):
     rng = random.PRNGKey(0)
@@ -139,9 +139,9 @@ class LinearTest(parameterized.TestCase):
         kernel_init=counter_init,
     )
     y, _ = dg_module.init(rng, x)
-    target = onp.concatenate(
-        [onp.full((1, 1, 7), 16.), onp.full((1, 1, 7), 31.)], axis=0)
-    onp.testing.assert_allclose(y, target)
+    target = np.concatenate(
+        [np.full((1, 1, 7), 16.), np.full((1, 1, 7), 31.)], axis=0)
+    np.testing.assert_allclose(y, target)
 
   @parameterized.parameters([((-2, 3), (), 'bijk,jklm->bilm'),
                              ((3, -2), (), 'bijk,kjlm->bilm'),
@@ -159,8 +159,8 @@ class LinearTest(parameterized.TestCase):
     )
     y, initial_params = dg_module.init(rng, x)
     dg_module = nn.Model(dg_module, initial_params)
-    target = onp.einsum(einsum_expr, x, dg_module.params['kernel']) + 1.
-    onp.testing.assert_allclose(y, target, atol=1e-6)
+    target = np.einsum(einsum_expr, x, dg_module.params['kernel']) + 1.
+    np.testing.assert_allclose(y, target, atol=1e-6)
 
   @parameterized.parameters([((3,),), (3,)])
   def test_conv(self, kernel_size):
@@ -176,7 +176,7 @@ class LinearTest(parameterized.TestCase):
     y, initial_params = conv_module.init(rng, x)
     model = nn.Model(conv_module, initial_params)
     self.assertEqual(model.params['kernel'].shape, (3, 3, 4))
-    onp.testing.assert_allclose(y, onp.full((1, 6, 4), 10.))
+    np.testing.assert_allclose(y, np.full((1, 6, 4), 10.))
 
   @parameterized.parameters([((3,),), (3,)])
   def test_single_input_conv(self, kernel_size):
@@ -192,7 +192,7 @@ class LinearTest(parameterized.TestCase):
     y, initial_params = conv_module.init(rng, x)
     model = nn.Model(conv_module, initial_params)
     self.assertEqual(model.params['kernel'].shape, (3, 3, 4))
-    onp.testing.assert_allclose(y, onp.full((6, 4), 10.))
+    np.testing.assert_allclose(y, np.full((6, 4), 10.))
 
   @parameterized.parameters([((3,),), (3,)])
   def test_group_conv(self, kernel_size):
@@ -209,7 +209,7 @@ class LinearTest(parameterized.TestCase):
     y, initial_params = conv_module.init(rng, x)
     model = nn.Model(conv_module, initial_params)
     self.assertEqual(model.params['kernel'].shape, (3, 2, 4))
-    onp.testing.assert_allclose(y, onp.full((1, 6, 4), 7.))
+    np.testing.assert_allclose(y, np.full((1, 6, 4), 7.))
 
   @parameterized.parameters([((3,),), (3,)])
   def test_conv_transpose(self, kernel_size):
@@ -225,7 +225,7 @@ class LinearTest(parameterized.TestCase):
     y, initial_params = conv_transpose_module.init(rng, x)
     model = nn.Model(conv_transpose_module, initial_params)
     self.assertEqual(model.params['kernel'].shape, (3, 3, 4))
-    correct_ans = onp.array([[[ 4.,  4.,  4.,  4.],
+    correct_ans = np.array([[[ 4.,  4.,  4.,  4.],
                               [ 7.,  7.,  7.,  7.],
                               [10., 10., 10., 10.],
                               [10., 10., 10., 10.],
@@ -235,7 +235,7 @@ class LinearTest(parameterized.TestCase):
                               [10., 10., 10., 10.],
                               [ 7.,  7.,  7.,  7.],
                               [ 4.,  4.,  4.,  4.]]])
-    onp.testing.assert_allclose(y, correct_ans)
+    np.testing.assert_allclose(y, correct_ans)
 
   @parameterized.parameters([((3,),), (3,)])
   def test_single_input_conv_transpose(self, kernel_size):
@@ -251,7 +251,7 @@ class LinearTest(parameterized.TestCase):
     y, initial_params = conv_transpose_module.init(rng, x)
     model = nn.Model(conv_transpose_module, initial_params)
     self.assertEqual(model.params['kernel'].shape, (3, 3, 4))
-    correct_ans = onp.array([[ 4.,  4.,  4.,  4.],
+    correct_ans = np.array([[ 4.,  4.,  4.,  4.],
                               [ 7.,  7.,  7.,  7.],
                               [10., 10., 10., 10.],
                               [10., 10., 10., 10.],
@@ -261,7 +261,7 @@ class LinearTest(parameterized.TestCase):
                               [10., 10., 10., 10.],
                               [ 7.,  7.,  7.,  7.],
                               [ 4.,  4.,  4.,  4.]])
-    onp.testing.assert_allclose(y, correct_ans)
+    np.testing.assert_allclose(y, correct_ans)
 
   def test_embed(self):
     rng = random.PRNGKey(0)
@@ -275,10 +275,10 @@ class LinearTest(parameterized.TestCase):
     )
     y, initial_params = embed_module.init(rng, x)
     model = nn.Model(embed_module, initial_params)
-    onp.testing.assert_allclose(y, dummy_embedding[None])
+    np.testing.assert_allclose(y, dummy_embedding[None])
 
     z = model.attend(jnp.ones((3,)))
-    onp.testing.assert_allclose(z, 3. * jnp.arange(4))
+    np.testing.assert_allclose(z, 3. * jnp.arange(4))
 
 
 if __name__ == '__main__':

--- a/tests/nn_test.py
+++ b/tests/nn_test.py
@@ -26,7 +26,7 @@ from jax.nn import initializers
 import jax.numpy as jnp
 
 
-import numpy as onp
+import numpy as np
 
 # Parse absl flags test_srcdir and test_tmpdir.
 jax.config.parse_flags_with_absl()
@@ -341,8 +341,8 @@ class ModuleTest(absltest.TestCase):
     bias_rng = nn.base._fold_in_str(dense_rng, 'bias')
     kernel = nn.linear.default_kernel_init(kernel_rng, (1, 2))
     bias = nn.initializers.normal()(bias_rng, (2,))
-    onp.testing.assert_allclose(kernel, params['dummy']['kernel'])
-    onp.testing.assert_allclose(bias, params['dummy']['bias'])
+    np.testing.assert_allclose(kernel, params['dummy']['kernel'])
+    np.testing.assert_allclose(bias, params['dummy']['bias'])
 
 class CollectionTest(absltest.TestCase):
 
@@ -515,20 +515,20 @@ class PoolTest(absltest.TestCase):
     x = jnp.full((1, 3, 3, 1), 2.)
     mul_reduce = lambda x, y: x * y
     y = nn.pooling.pool(x, 1., mul_reduce, (2, 2), (1, 1), 'VALID')
-    onp.testing.assert_allclose(y, onp.full((1, 2, 2, 1), 2. ** 4))
+    np.testing.assert_allclose(y, np.full((1, 2, 2, 1), 2. ** 4))
 
   def test_avg_pool(self):
     x = jnp.full((1, 3, 3, 1), 2.)
     pool = lambda x: nn.avg_pool(x, (2, 2))
     y = pool(x)
-    onp.testing.assert_allclose(y, onp.full((1, 2, 2, 1), 2.))
+    np.testing.assert_allclose(y, np.full((1, 2, 2, 1), 2.))
     y_grad = jax.grad(lambda x: pool(x).sum())(x)
     expected_grad = jnp.array([
         [0.25, 0.5, 0.25],
         [0.5, 1., 0.5],
         [0.25, 0.5, 0.25],
     ]).reshape((1, 3, 3, 1))
-    onp.testing.assert_allclose(y_grad, expected_grad)
+    np.testing.assert_allclose(y_grad, expected_grad)
 
   def test_max_pool(self):
     x = jnp.arange(9).reshape((1, 3, 3, 1)).astype(jnp.float32)
@@ -538,14 +538,14 @@ class PoolTest(absltest.TestCase):
         [7., 8.],
     ]).reshape((1, 2, 2, 1))
     y = pool(x)
-    onp.testing.assert_allclose(y, expected_y)
+    np.testing.assert_allclose(y, expected_y)
     y_grad = jax.grad(lambda x: pool(x).sum())(x)
     expected_grad = jnp.array([
         [0., 0., 0.],
         [0., 1., 1.],
         [0., 1., 1.],
     ]).reshape((1, 3, 3, 1))
-    onp.testing.assert_allclose(y_grad, expected_grad)
+    np.testing.assert_allclose(y_grad, expected_grad)
 
   def test_max_pool_explicit_pads(self):
     x = jnp.arange(9).reshape((1, 3, 3, 1)).astype(jnp.float32)
@@ -557,14 +557,14 @@ class PoolTest(absltest.TestCase):
         [6.,7.,8.,8.],
     ]).reshape((1, 4, 4, 1))
     y = pool(x)
-    onp.testing.assert_allclose(y, expected_y)
+    np.testing.assert_allclose(y, expected_y)
     y_grad = jax.grad(lambda x: pool(x).sum())(x)
     expected_grad = jnp.array([
         [1., 1., 2.],
         [1., 1., 2.],
         [2., 2., 4.],
     ]).reshape((1, 3, 3, 1))
-    onp.testing.assert_allclose(y_grad, expected_grad)
+    np.testing.assert_allclose(y_grad, expected_grad)
 
 class NormalizationTest(absltest.TestCase):
 
@@ -578,14 +578,14 @@ class NormalizationTest(absltest.TestCase):
       model = nn.Model(model_cls, initial_params)
     mean = y.mean((0, 1))
     var = y.var((0, 1))
-    onp.testing.assert_allclose(mean, onp.array([0., 0.]), atol=1e-4)
-    onp.testing.assert_allclose(var, onp.array([1., 1.]), rtol=1e-4)
+    np.testing.assert_allclose(mean, np.array([0., 0.]), atol=1e-4)
+    np.testing.assert_allclose(var, np.array([1., 1.]), rtol=1e-4)
     with nn.stateful(state_0) as state:
       y = model(x)
     ema = state['/']
-    onp.testing.assert_allclose(
+    np.testing.assert_allclose(
         ema['mean'], 0.1 * x.mean((0, 1), keepdims=False), atol=1e-4)
-    onp.testing.assert_allclose(
+    np.testing.assert_allclose(
         ema['var'], 0.9 + 0.1 * x.var((0, 1), keepdims=False), rtol=1e-4)
 
   def test_layer_norm(self):
@@ -599,7 +599,7 @@ class NormalizationTest(absltest.TestCase):
     assert  isinstance(y, input_type)
     y_one_liner = ((x - x.mean(axis=-1, keepdims=True)) *
                    jax.lax.rsqrt(x.var(axis=-1, keepdims=True) + e))
-    onp.testing.assert_allclose(y_one_liner, y, atol=1e-4)
+    np.testing.assert_allclose(y_one_liner, y, atol=1e-4)
 
   def test_group_norm(self):
     rng = random.PRNGKey(0)
@@ -616,7 +616,7 @@ class NormalizationTest(absltest.TestCase):
               jax.lax.rsqrt(x_gr.var(axis=[1, 2, 3, 5], keepdims=True) + e))
     y_test = y_test.reshape([2, 5, 4, 4, 32])
 
-    onp.testing.assert_allclose(y_test, y, atol=1e-4)
+    np.testing.assert_allclose(y_test, y, atol=1e-4)
 
 
 # TODO(flax-dev): add integration tests for RNN cells
@@ -633,8 +633,8 @@ class RecurrentTest(absltest.TestCase):
     lstm = nn.Model(nn.LSTMCell, initial_params)
     self.assertEqual(carry[0].shape, (2, 4))
     self.assertEqual(carry[1].shape, (2, 4))
-    onp.testing.assert_allclose(y, carry[1])
-    param_shapes = jax.tree_map(onp.shape, lstm.params)
+    np.testing.assert_allclose(y, carry[1])
+    param_shapes = jax.tree_map(np.shape, lstm.params)
     self.assertEqual(param_shapes, {
         'ii': {'kernel': (3, 4)},
         'if': {'kernel': (3, 4)},
@@ -655,8 +655,8 @@ class RecurrentTest(absltest.TestCase):
     (carry, y), initial_params = nn.GRUCell.init(key2, carry0, x)
     gru = nn.Model(nn.GRUCell, initial_params)
     self.assertEqual(carry.shape, (2, 4))
-    onp.testing.assert_allclose(y, carry)
-    param_shapes = jax.tree_map(onp.shape, gru.params)
+    np.testing.assert_allclose(y, carry)
+    param_shapes = jax.tree_map(np.shape, gru.params)
     self.assertEqual(param_shapes, {
         'ir': {'kernel': (3, 4), 'bias': (4,)},
         'iz': {'kernel': (3, 4), 'bias': (4,)},
@@ -678,8 +678,8 @@ class RecurrentTest(absltest.TestCase):
     lstm = nn.Model(nn.ConvLSTM, initial_params)
     self.assertEqual(carry[0].shape, (2, 4, 4, 6))
     self.assertEqual(carry[1].shape, (2, 4, 4, 6))
-    onp.testing.assert_allclose(y, carry[1])
-    param_shapes = jax.tree_map(onp.shape, lstm.params)
+    np.testing.assert_allclose(y, carry[1])
+    param_shapes = jax.tree_map(np.shape, lstm.params)
     self.assertEqual(param_shapes, {
         'hh': {'bias': (6*4,), 'kernel': (3, 3, 6, 6*4)},
         'ih': {'bias': (6*4,), 'kernel': (3, 3, 3, 6*4)},
@@ -709,7 +709,7 @@ class RecurrentTest(absltest.TestCase):
     lstm_opt = nn.Model(nn.OptimizedLSTMCell.partial(name='LSTMCell'), 
       initial_params)
     
-    onp.testing.assert_allclose(y, y_opt, rtol=1e-6)
+    np.testing.assert_allclose(y, y_opt, rtol=1e-6)
     jtu.check_eq(lstm.params, lstm_opt.params)
 
 
@@ -724,8 +724,8 @@ class StochasticTest(absltest.TestCase):
     with nn.stochastic(rng):
       r1 = nn.make_rng()
       r2 = nn.make_rng()
-    self.assertTrue(onp.all(r1 == random.fold_in(rng, 1)))
-    self.assertTrue(onp.all(r2 == random.fold_in(rng, 2)))
+    self.assertTrue(np.all(r1 == random.fold_in(rng, 1)))
+    self.assertTrue(np.all(r2 == random.fold_in(rng, 2)))
 
   # TODO(jheek): re-introduce this test when the tracer check is revived.
   # def test_make_rng_in_jax_transform_check(self):
@@ -742,7 +742,7 @@ class StochasticTest(absltest.TestCase):
       rng, _ = StochasticModule.init_by_shape(random.PRNGKey(1), [])
     expected_rng = random.fold_in(random.PRNGKey(0), 1)
     expected_rng = random.fold_in(expected_rng, 1)
-    self.assertTrue(onp.all(rng == expected_rng))
+    self.assertTrue(np.all(rng == expected_rng))
 
 
 if __name__ == '__main__':

--- a/tests/serialization_test.py
+++ b/tests/serialization_test.py
@@ -28,7 +28,7 @@ import jax
 from jax import random
 import jax.numpy as jnp
 
-import numpy as onp
+import numpy as np
 
 # Parse absl flags test_srcdir and test_tmpdir.
 jax.config.parse_flags_with_absl()
@@ -67,14 +67,14 @@ class SerializationTest(absltest.TestCase):
     state = serialization.to_state_dict(model)
     self.assertEqual(state, {
         'params': {
-            'kernel': onp.ones((1, 1)),
-            'bias': onp.zeros((1,)),
+            'kernel': np.ones((1, 1)),
+            'bias': np.zeros((1,)),
         }
     })
     state = {
         'params': {
-            'kernel': onp.zeros((1, 1)),
-            'bias': onp.zeros((1,)),
+            'kernel': np.zeros((1, 1)),
+            'bias': np.zeros((1,)),
         }
     }
     restored_model = serialization.from_state_dict(model, state)
@@ -91,16 +91,16 @@ class SerializationTest(absltest.TestCase):
     expected_state = {
         'target': {
             'params': {
-                'kernel': onp.ones((1, 1)),
-                'bias': onp.zeros((1,)),
+                'kernel': np.ones((1, 1)),
+                'bias': np.zeros((1,)),
             }
         },
         'state': {
             'step': 0,
             'param_states': {
                 'params': {
-                    'kernel': {'momentum': onp.zeros((1, 1))},
-                    'bias': {'momentum': onp.zeros((1,))},
+                    'kernel': {'momentum': np.zeros((1, 1))},
+                    'bias': {'momentum': np.zeros((1,))},
                 }
             }
         },
@@ -164,20 +164,20 @@ class SerializationTest(absltest.TestCase):
                      'uintc', 'int_', 'longfloat', 'clongfloat',
                      'longcomplex', 'bool_', 'int', 'float',
                      'complex', 'bool']
-    onp.random.seed(0)
+    np.random.seed(0)
     for dtype in normal_dtypes:
-      v = onp.random.uniform(-100, 100, size=()).astype(dtype)[()]
+      v = np.random.uniform(-100, 100, size=()).astype(dtype)[()]
       restored_v = serialization.msgpack_restore(
             serialization.msgpack_serialize(v))
       self.assertEqual(restored_v.dtype, v.dtype)
-      onp.testing.assert_array_equal(restored_v, v)
+      np.testing.assert_array_equal(restored_v, v)
 
       for shape in [(), (5,), (10, 10), (1, 20, 30, 1)]:
-        arr = onp.random.uniform(-100, 100, size=shape).astype(dtype)
+        arr = np.random.uniform(-100, 100, size=shape).astype(dtype)
         restored_arr = serialization.msgpack_restore(
             serialization.msgpack_serialize(arr))
         self.assertEqual(restored_arr.dtype, arr.dtype)
-        onp.testing.assert_array_equal(restored_arr, arr)
+        np.testing.assert_array_equal(restored_arr, arr)
 
   def test_jax_numpy_serialization(self):
     jax_dtypes = [jnp.bool_, jnp.uint8, jnp.uint16, jnp.uint32,
@@ -186,19 +186,19 @@ class SerializationTest(absltest.TestCase):
                   jnp.complex64]
     for dtype in jax_dtypes:
       v = jnp.array(
-            onp.random.uniform(-100, 100, size=())).astype(dtype)[()]
+            np.random.uniform(-100, 100, size=())).astype(dtype)[()]
       restored_v = serialization.msgpack_restore(
           serialization.msgpack_serialize(v))
       self.assertEqual(restored_v.dtype, v.dtype)
-      onp.testing.assert_array_equal(restored_v, v)
+      np.testing.assert_array_equal(restored_v, v)
 
       for shape in [(), (5,), (10, 10), (1, 20, 30, 1)]:
         arr = jnp.array(
-            onp.random.uniform(-100, 100, size=shape)).astype(dtype)
+            np.random.uniform(-100, 100, size=shape)).astype(dtype)
         restored_arr = serialization.msgpack_restore(
             serialization.msgpack_serialize(arr))
         self.assertEqual(restored_arr.dtype, arr.dtype)
-        onp.testing.assert_array_equal(restored_arr, arr)
+        np.testing.assert_array_equal(restored_arr, arr)
 
   def test_complex_serialization(self):
     for x in [1j, 1+2j]:

--- a/tests/tensorboard_test.py
+++ b/tests/tensorboard_test.py
@@ -17,7 +17,7 @@ import itertools
 import tempfile
 
 from absl.testing import absltest
-import numpy as onp
+import numpy as np
 
 from tensorboard.backend.event_processing import directory_watcher
 from tensorboard.backend.event_processing import event_file_loader
@@ -65,7 +65,7 @@ class TensorboardTest(absltest.TestCase):
 
     summary_value = self.parse_and_return_summary_value(path=log_dir)
     self.assertEqual(summary_value.tag, 'scalar_test')
-    self.assertTrue(onp.allclose(
+    self.assertTrue(np.allclose(
         tensor_util.make_ndarray(summary_value.tensor).item(),
         float_value))
 
@@ -84,35 +84,35 @@ class TensorboardTest(absltest.TestCase):
   def test_summarywriter_image(self):
     log_dir = tempfile.mkdtemp()
     summary_writer = SummaryWriter(log_dir=log_dir)
-    expected_img = onp.random.uniform(low=0., high=255., size=(30, 30, 3))
-    expected_img = expected_img.astype(onp.uint8)
+    expected_img = np.random.uniform(low=0., high=255., size=(30, 30, 3))
+    expected_img = expected_img.astype(np.uint8)
     summary_writer.image(tag='image_test', image=expected_img, step=1)
     summary_value = self.parse_and_return_summary_value(path=log_dir)
 
     self.assertEqual(summary_value.tag, 'image_test')
     actual_img = tf.image.decode_image(summary_value.tensor.string_val[2])
-    self.assertTrue(onp.allclose(actual_img, expected_img))
+    self.assertTrue(np.allclose(actual_img, expected_img))
 
   def test_summarywriter_image_float_pixel_values(self):
     log_dir = tempfile.mkdtemp()
     summary_writer = SummaryWriter(log_dir=log_dir)
-    expected_img = onp.random.uniform(low=0., high=1., size=(30, 30, 3))
+    expected_img = np.random.uniform(low=0., high=1., size=(30, 30, 3))
     summary_writer.image(tag='image_test', image=expected_img, step=1)
     summary_value = self.parse_and_return_summary_value(path=log_dir)
 
     # convert and scale expected_img appropriately to numpy uint8.
     expected_img = tf.image.convert_image_dtype(
-        image=expected_img, dtype=onp.uint8)
+        image=expected_img, dtype=np.uint8)
 
     self.assertEqual(summary_value.tag, 'image_test')
     actual_img = tf.image.decode_image(summary_value.tensor.string_val[2])
-    self.assertTrue(onp.allclose(actual_img, expected_img))
+    self.assertTrue(np.allclose(actual_img, expected_img))
 
   def test_summarywriter_2dimage_scaled(self):
     log_dir = tempfile.mkdtemp()
     summary_writer = SummaryWriter(log_dir=log_dir)
-    img = onp.random.uniform(low=0., high=255., size=(30, 30))
-    img = img.astype(onp.uint8)
+    img = np.random.uniform(low=0., high=255., size=(30, 30))
+    img = img.astype(np.uint8)
     summary_writer.image(tag='2dimage_test', image=img, step=1)
     summary_value = self.parse_and_return_summary_value(path=log_dir)
 
@@ -124,8 +124,8 @@ class TensorboardTest(absltest.TestCase):
   def test_summarywriter_single_channel_image_scaled(self):
     log_dir = tempfile.mkdtemp()
     summary_writer = SummaryWriter(log_dir=log_dir)
-    img = onp.random.uniform(low=0., high=255., size=(30, 30, 1))
-    img = img.astype(onp.uint8)
+    img = np.random.uniform(low=0., high=255., size=(30, 30, 1))
+    img = img.astype(np.uint8)
     summary_writer.image(tag='2dimage_1channel_test', image=img, step=1)
     summary_value = self.parse_and_return_summary_value(path=log_dir)
 
@@ -137,7 +137,7 @@ class TensorboardTest(absltest.TestCase):
   def test_summarywriter_audio(self):
     log_dir = tempfile.mkdtemp()
     summary_writer = SummaryWriter(log_dir=log_dir)
-    expected_audio_samples = onp.random.uniform(
+    expected_audio_samples = np.random.uniform(
         low=-1., high=1., size=(2, 48000, 2))
     summary_writer.audio(
         tag='audio_test', audiodata=expected_audio_samples, step=1)
@@ -151,18 +151,18 @@ class TensorboardTest(absltest.TestCase):
     # Assert values.
     actual_audio_1 = tf.audio.decode_wav(
         summary_value.tensor.string_val[0]).audio
-    self.assertTrue(onp.allclose(
+    self.assertTrue(np.allclose(
         expected_audio_samples[0], actual_audio_1, atol=1e-04))
 
     actual_audio_2 = tf.audio.decode_wav(
         summary_value.tensor.string_val[1]).audio
-    self.assertTrue(onp.allclose(
+    self.assertTrue(np.allclose(
         expected_audio_samples[1], actual_audio_2, atol=1e-04))
 
   def test_summarywriter_audio_sampled_output(self):
     log_dir = tempfile.mkdtemp()
     summary_writer = SummaryWriter(log_dir=log_dir)
-    expected_audio_samples = onp.random.uniform(
+    expected_audio_samples = np.random.uniform(
         low=-1., high=1., size=(2, 48000, 2))
     summary_writer.audio(
         tag='audio_test', audiodata=expected_audio_samples, step=1,
@@ -177,13 +177,13 @@ class TensorboardTest(absltest.TestCase):
     # Assert values.
     actual_audio = tf.audio.decode_wav(summary_value.tensor.string_val[0]).audio
 
-    self.assertTrue(onp.allclose(
+    self.assertTrue(np.allclose(
         expected_audio_samples[0], actual_audio, atol=1e-04))
 
   def test_summarywriter_clipped_audio(self):
     log_dir = tempfile.mkdtemp()
     summary_writer = SummaryWriter(log_dir=log_dir)
-    expected_audio_samples = onp.random.uniform(
+    expected_audio_samples = np.random.uniform(
         low=-2., high=2., size=(2, 48000, 2))
     summary_writer.audio(
         tag='audio_test', audiodata=expected_audio_samples, step=1,
@@ -198,17 +198,17 @@ class TensorboardTest(absltest.TestCase):
     # actual_audio is clipped.
     actual_audio = tf.audio.decode_wav(
         summary_value.tensor.string_val[0]).audio
-    self.assertFalse(onp.allclose(
+    self.assertFalse(np.allclose(
         expected_audio_samples[0], actual_audio, atol=1e-04))
 
-    clipped_audio = onp.clip(onp.array(expected_audio_samples[0]), -1, 1)
+    clipped_audio = np.clip(np.array(expected_audio_samples[0]), -1, 1)
     self.assertTrue(
-        onp.allclose(clipped_audio, actual_audio, atol=1e-04))
+        np.allclose(clipped_audio, actual_audio, atol=1e-04))
 
   def test_summarywriter_histogram_defaultbins(self):
     log_dir = tempfile.mkdtemp()
     summary_writer = SummaryWriter(log_dir=log_dir)
-    histogram = onp.arange(1000)
+    histogram = np.arange(1000)
     # Histogram will be created for 30 (default) bins.
     summary_writer.histogram(tag='histogram_test', values=histogram, step=1)
 
@@ -217,12 +217,12 @@ class TensorboardTest(absltest.TestCase):
     actual_histogram = tensor_util.make_ndarray(summary_value.tensor)
     self.assertTrue(actual_histogram.shape, (30, 3))
     self.assertTrue(
-        onp.allclose(actual_histogram[0], (0.0, 33.3, 34.0), atol=1e-01))
+        np.allclose(actual_histogram[0], (0.0, 33.3, 34.0), atol=1e-01))
 
   def test_summarywriter_histogram_2bins(self):
     log_dir = tempfile.mkdtemp()
     summary_writer = SummaryWriter(log_dir=log_dir)
-    histogram = onp.arange(1000)
+    histogram = np.arange(1000)
     summary_writer.histogram(
         tag='histogram_test', values=histogram, step=1, bins=2)
 
@@ -231,9 +231,9 @@ class TensorboardTest(absltest.TestCase):
     actual_histogram = tensor_util.make_ndarray(summary_value.tensor)
     self.assertTrue(actual_histogram.shape, (2, 3))
     self.assertTrue(
-        onp.allclose(actual_histogram[0], (0.0, 499.5, 500.0), atol=1e-01))
+        np.allclose(actual_histogram[0], (0.0, 499.5, 500.0), atol=1e-01))
     self.assertTrue(
-        onp.allclose(actual_histogram[1], (499.5, 999.0, 500.0), atol=1e-01))
+        np.allclose(actual_histogram[1], (499.5, 999.0, 500.0), atol=1e-01))
 
 if __name__ == '__main__':
   absltest.main()


### PR DESCRIPTION
Switching away from using `onp` for ordinary NumPy towards `np`, as discussed with @avital in https://github.com/google/flax/discussions/730.

This is in line with JAX https://github.com/google/jax/pull/3760 (by @jakevdp) and https://github.com/google/jax/pull/2370 (by @hawkinsp) 

(See @mattjj 's comment https://github.com/google/jax/pull/2370#pullrequestreview-370624520: _"...The feedback from internal users was overwhelmingly in favor of this convention (for user code, and we should be consistent internally to avoid confusion)....The confusion can grow in a larger codebase that involves not only JAX code but also, say, TF code; the latter files may naturally have import numpy as np already. Another reason is that this is a convention followed by many other projects that present the NumPy API."_)

```diff
- import numpy as onp
+ import numpy as np
...
```
