### PR TITLE
Linen `Module` instances are now Frozen after `setup` has been called.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ vNext
  - Added OptimizedLSTM: ~33% faster than the original LSTM when using <=1024 units
  - Bug Fix `Scope.variable` mutability check, before a variable could only be initialized
    if the 'params' collection was mutable.
+ - Linen `Module` instances are now Frozen after `setup` has been called.
+   Previously mutations after setup could be dropped silently. Now the stateless requirement
+   is enforced by raising a TypeError in `__setattr__` after `setup`.
+ - Pytrees of dicts and lists are transformed into FrozenDict and tuples during attribute assignment.
+   This avoids undetected submodules and inner state. 
 
 v0.3
 -----

--- a/flax/linen/linear.py
+++ b/flax/linen/linear.py
@@ -257,8 +257,7 @@ class Conv(Module):
       is_single_input = True
       inputs = jnp.expand_dims(inputs, axis=0)
 
-    if self.strides is None:
-      self.strides = (1,) * (inputs.ndim - 2)
+    strides = self.strides or (1,) * (inputs.ndim - 2)
 
     in_features = inputs.shape[-1]
     assert in_features % self.feature_group_count == 0
@@ -271,7 +270,7 @@ class Conv(Module):
     y = lax.conv_general_dilated(
         inputs,
         kernel,
-        self.strides,
+        strides,
         self.padding,
         lhs_dilation=self.input_dilation,
         rhs_dilation=self.kernel_dilation,

--- a/flax/linen/transforms.py
+++ b/flax/linen/transforms.py
@@ -139,8 +139,6 @@ def module_class_lift_transform(
         cloned = set_module_scopes(cloned, scopes)
         cloned._state = copy.deepcopy(self._state)  # pylint: disable=protected-access
         res = fn(cloned, *args, **kwargs)
-        # preserve submodule-tree stripped of scopes/tracers for introspection
-        object.__setattr__(self, 'children', clean_clone(cloned).children)
         self._state = copy.deepcopy(cloned._state)  # pylint: disable=protected-access
         return res
       # here we apply the given lifting transform to the scope-ingesting fn
@@ -172,8 +170,6 @@ def decorator_lift_transform(transform, class_fn, *trafo_args, **trafo_kwargs):
       cloned = set_module_scopes(self, scopes)
       cloned._state = copy.deepcopy(self._state)  # pylint: disable=protected-access
       res = rewrapped_fn(cloned, *args, **kwargs)
-      # preserve submodule-tree stripped of scopes/tracers for introspection
-      object.__setattr__(self, 'children', clean_clone(cloned).children)
       self._state = copy.deepcopy(cloned._state)  # pylint: disable=protected-access
       return res
     # here we apply the given lifting transform to the scope-ingesting fn
@@ -224,8 +220,6 @@ def named_call(class_fn):
       cloned = set_module_scopes(self, scopes)
       cloned._state = copy.deepcopy(self._state)  # pylint: disable=protected-access
       res = rewrapped_fn(cloned, *args, **kwargs)
-      # preserve submodule-tree stripped of scopes/tracers for introspection
-      object.__setattr__(self, 'children', clean_clone(cloned).children)
       self._state = copy.deepcopy(cloned._state)  # pylint: disable=protected-access
       return res
     # here we apply the given lifting transform to the scope-ingesting fn

--- a/tests/linen/module_test.py
+++ b/tests/linen/module_test.py
@@ -721,6 +721,20 @@ class ModuleTest(absltest.TestCase):
     variables = foo.init(random.PRNGKey(0), x)
     self.assertEqual(variables['params']['bar']['kernel'].shape, (2, 3))
 
+  def test_module_frozen(self):
+    class Foo(nn.Module):
+      bar: nn.Dense = dataclasses.field(init=False)
+
+      def setup(self):
+        self.i = 1
+      
+      def __call__(self):
+        self.i = 2
+    
+    foo = Foo()
+    with self.assertRaisesWithLiteralMatch(TypeError, "Module instance is frozen outside of setup method."):
+      foo.init(random.PRNGKey(0))
+
 
 if __name__ == '__main__':
   absltest.main()


### PR DESCRIPTION
   Previously mutations after setup could be dropped silently. Now the stateless requirement
   is enforced by raising a TypeError in `__setattr__` after `setup`.

   Pytrees of dicts and lists are transformed into FrozenDict and tuples during attribute assignment.
   This avoids undetected submodules and inner state.

Closes #674 