### PR TITLE
Fix opencv requirement in Docker setup.

### DIFF
--- a/dev/.devcontainer/Dockerfile
+++ b/dev/.devcontainer/Dockerfile
@@ -43,7 +43,7 @@ RUN apt-get update \
     && echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME\
     && chmod 0440 /etc/sudoers.d/$USERNAME \
     # custom packages
-    && apt-get -y install pandoc vim \
+    && apt-get -y install pandoc vim libgl1-mesa-dev \
     # Clean up
     && apt-get autoremove -y \
     && apt-get clean -y \


### PR DESCRIPTION
Without libgl1-mesa-dev ppo
does not run in a docker container
because the opengl lib is missing.