### PR TITLE
[flax/core/scope.py] Rename "Arguments:" to "Args:"

### DIFF
--- a/flax/core/scope.py
+++ b/flax/core/scope.py
@@ -126,7 +126,7 @@ def filter_to_set(x: Filter) -> Set[str]:
 def union_filters(a: Filter, b: Filter) -> Filter:
   """Takes the union of two filters (similar to a logical or).
   
-  Arguments:
+  Args:
     a: a filter.
     b: a filter.
     
@@ -144,7 +144,7 @@ def union_filters(a: Filter, b: Filter) -> Filter:
 def intersect_filters(a: Filter, b: Filter) -> Filter:
   """Take the intersection of two filters (similar to a logical and).
   
-  Arguments:
+  Args:
     a: a filter.
     b: a filter.
     


### PR DESCRIPTION
I've written custom parsers and emitters for everything from docstrings to classes and functions. However, I recently came across an issue with the JAX and flax codebase: inconsistent use of `Args:` and `Arguments:` in its docstrings:

```sh
(flax#cb128e)$ for name in 'Args:' 'Arguments:'; do
    printf '%-10s %04d\n' "$name" "$(rg -IFtpy --count-matches "$name" | paste -s -d+ -- | bc)"; done
Args:      0328
Arguments: 0002
```

It is easy enough to extend my parsers to support both variants, howevever it looks like `Arguments:` is wrong anyway, as per:

  - https://google.github.io/styleguide/pyguide.html#doc-function-args @ [`ddccc0f`](https://github.com/google/styleguide/blob/ddccc0f/pyguide.md)
  - https://chromium.googlesource.com/chromiumos/docs/+/master/styleguide/python.md#describing-arguments-in-docstrings @ [`9fc0fc0`](https://chromium.googlesource.com/chromiumos/docs/+/9fc0fc0/styleguide/python.md)
  - https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html @ [`c0ae8e3`](https://github.com/sphinx-contrib/napoleon/blob/c0ae8e3/docs/source/example_google.rst)

Therefore, only `Args:` is valid. This PR replaces them throughout the JAX codebase.

PS: For similar contributed to the [TensorFlow](https://github.com/tensorflow/tensorflow), [keras-team](https://github.com/keras-team), and [PyTorch](https://github.com/pytorch/pytorch) organisations, see trackbacks at https://github.com/tensorflow/tensorflow/pull/45420.