### PR TITLE
Improve submodule handling for transforms and top-level usage

### DIFF
--- a/flax/core/lift.py
+++ b/flax/core/lift.py
@@ -52,7 +52,8 @@ def _dedup_scopes(scopes):
       path.append(scope.name)
       scope = scope.parent
     if max_parent is not leaf:
-      del minimal_set[leaf]
+      if leaf in minimal_set:
+        del minimal_set[leaf]
     paths.append((max_parent, max_parent_path))
   return tuple(minimal_set), tuple(paths)
 
@@ -67,8 +68,10 @@ def _dup_scopes(orig_scopes, scopes, paths):
     scopes.append(scope)
   return scopes
 
+
 def _transpose(xs):
   return tuple(zip(*xs))
+
 
 def pack(fn: Callable[..., Any],
          in_variable_filters: Sequence[CollectionFilter],

--- a/tests/linen/linen_transforms_test.py
+++ b/tests/linen/linen_transforms_test.py
@@ -16,6 +16,7 @@
 
 from functools import partial
 from typing import Any, Tuple, Iterable, Callable, Sequence
+import operator
 
 from absl.testing import absltest
 import jax
@@ -461,14 +462,14 @@ class TransformTest(absltest.TestCase):
     class Foo(nn.Module):
       def setup(self):
         self.test = self.param('test', nn.initializers.ones, ())
-      
+
       def __call__(self, x):
         return x * self.test
-      
-    FooVmap = nn.vmap(Foo, in_axes=0, out_axes=0, variable_axes={'params': 0}, split_rngs={'params': True})
+
+    FooVmap = nn.vmap(Foo, in_axes=0, out_axes=0,
+                      variable_axes={'params': 0}, split_rngs={'params': True})
     variables = FooVmap().init(random.PRNGKey(0), jnp.ones((4,)))
     self.assertEqual(variables['params']['test'].shape, (4,))
-
 
   def test_nested_module_args_vmap(self):
     class A(nn.Module):
@@ -554,6 +555,109 @@ class TransformTest(absltest.TestCase):
     self.assertEqual(
         variable_shapes['params']['A_1']['Dense_0']['bias'],
         (10, 3))
+
+  def test_toplevel_submodule_adoption_transform(self):
+    class A(nn.Module):
+      @nn.compact
+      def __call__(self, x):
+        return nn.Dense(3)(x)
+    class B(nn.Module):
+      A: nn.Module
+      @nn.compact
+      def __call__(self, x):
+        return self.A(x)
+    class C(nn.Module):
+      A: nn.Module
+      B: nn.Module
+      @partial(
+          nn.vmap,
+          variable_axes={'params': 0},
+          split_rngs={'params': True})
+      @nn.compact
+      def __call__(self, x):
+        return self.B(x) + self.A(x)
+    class Csimple(nn.Module):
+      A: nn.Module
+      B: nn.Module
+      @nn.compact
+      def __call__(self, x):
+        return self.B(x) + self.A(x)
+    class D(nn.Module):
+      @nn.compact
+      def __call__(self, x):
+        a1 = A()
+        a2 = A()
+        b = B(a1)
+        c = C(a2, b)
+        return c(x)
+
+    key = random.PRNGKey(0)
+    x = jnp.ones((10, 10))
+    p1 = D().init(key, x)
+    y1 = D().apply(p1, x)
+
+    a1 = A()
+    a2 = A()
+    b = B(a1)
+    p2 = freeze({'params':
+        {'A': p1['params']['A_0'],
+         'B_A': p1['params']['A_1']}
+        })
+    # Test method wrapper transform.
+    y2 = C(a2, b).apply(p2, x)
+    np.testing.assert_allclose(y1, y2, atol=1e-7)
+    # Test class transform.
+    Ctrafo = nn.vmap(Csimple,
+                     variable_axes={'params': 0},
+                     split_rngs={'params': True})
+
+    y3 = Ctrafo(a2, b).apply(p2, x)
+    np.testing.assert_allclose(y1, y3, atol=1e-7)
+
+
+  def test_toplevel_submodule_adoption_pytree_transform(self):
+    class A(nn.Module):
+      @nn.compact
+      def __call__(self, c, x):
+        counter = self.variable('counter', 'i', jnp.zeros, ())
+        counter.value += 1
+        x = nn.Dense(1)(x)
+        return c, x
+
+    class B(nn.Module):
+      A: Any
+      @nn.compact
+      def __call__(self, c, x):
+        return self.A['foo'](*self.A['bar'](c, x))
+
+    a = A()
+    As = {'foo': A(), 'bar': A()}
+    b = nn.scan(B,
+                in_axes=0,
+                variable_carry='counter',
+                variable_broadcast='params',
+                split_rngs={'params': False})(As)
+
+    key = random.PRNGKey(0)
+    x = jnp.ones((10, 2))
+
+    p = B(As).init(key, x, x)
+    y, cntrs = b.apply(p, x, x, mutable='counter')
+    ref_cntrs = freeze({
+        'counter': {
+            'A_bar': {
+                'i': jnp.array(11.0),
+            },
+            'A_foo': {
+                'i': jnp.array(11.0),
+            },
+        },
+      })
+    self.assertTrue(jax.tree_util.tree_all(
+        jax.tree_multimap(
+            lambda x, y: np.testing.assert_allclose(x, y, atol=1e-7),
+            cntrs, ref_cntrs)
+        ))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR includes two changes:
1. Fixing the module scope collection and setting for use with multi-scope functional-core transforms to be properly recursive to handle complex, nested aliasing edge-cases.
2. Introducing the ability to use top-level instantiated modules as attributes in another top-level module.  This is a very common workflow during interactive development and it has been cited as a pain-point and a badly confusing gotcha a number of times by our users. All top-level instantiated  modules passed in as attributes are 'adopted' or 'reparented' onto the root, top-level module they are passed into.  Effectively this function registers any such top-level instantiated submodule as if they had been defined in the top setup() function, taking care to avoid name collisions.
