### PR TITLE
Updates comment on Models

### DIFF
--- a/flax/serialization.py
+++ b/flax/serialization.py
@@ -28,7 +28,7 @@
 # limitations under the License.
 """Serialization utilities for Jax.
 
-All flax classes that carry state like Model and Optimizer can be turned into a
+All Flax classes that carry state (e.g. ,Optimizer) can be turned into a
 state dict of numpy arrays for easy serialization.
 """
 import collections


### PR DESCRIPTION
Flax Modules don't carry state, but according to this comment they do. Probably a left-over from pre-Linen.