### PR TITLE
Keep the behavior consistent when mutable is an empty dictionary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ vNext
  -
  -
  -
- -
+ - Bug Fix `flax.core.apply` and `Module.apply`. Now it returns a tuple containing the output and a frozen empty collection when `mutable` is specified as an empty list.
  -
  -
  -

--- a/flax/core/scope.py
+++ b/flax/core/scope.py
@@ -602,10 +602,10 @@ def apply(fn: Callable[..., Any],
     new_variables = _unfreeze_variables(variables, mutable)
     with Scope(new_variables, rngs=rngs, mutable=mutable).temporary() as root:
       y = fn(root, *args, **kwargs)
-    if mutable:
-      mutated_variables = {
-          k: v for k, v in new_variables.items() if in_filter(mutable, k)
-      }
+    if mutable is not False:
+      mutated_variables = {k: v
+                           for k, v in new_variables.items()
+                           if in_filter(mutable, k)}
       return y, freeze(mutated_variables)
     else:
       return y


### PR DESCRIPTION
`mutable` can be an empty dictionary when the network has no mutable states. In this case, `apply` should return another state even though an empty state was provided. This is the expected behavior of the API, and enables a unified approach for multiple architectures, with or without mutable latent states. The current application simply equates empty state and False, and return no state in the output. This can be surprising to many new users.