### PR TITLE
Allow passing in unbound modules into other modules

### DIFF
--- a/flax/linen/module.py
+++ b/flax/linen/module.py
@@ -438,6 +438,10 @@ class Module:
             raise ValueError(
                 "You can only assign submodules to self in setup().")
           if subvalue.parent is _unspecified_parent:
+            raise ValueError("Unexpected -- parent should have been assigned during __post_init__")
+          elif subvalue.parent is None:
+            # Attaching unbound modules -- this pattern is used
+            # for "model surgery" on `nn.Sequential` type models.
             subvalue.parent = self
           elif subvalue.parent is not self:
             raise ValueError("Can't attach to remote parent in setup, pass in "


### PR DESCRIPTION
This change enables a `nn.Sequential` type pattern.

(though it's still confusing that you have to separately assign
submodules in `setup` -- #864 explores automating this somewhat.)

The original code was designed to allow using unbound modules as
"module templates" which you could bound arbitrarily in your tree,
but if people want that after this PR, they can always pass in lambdas.