### PR TITLE
Adopt toplevel modules and fix setup deferred handling.

### DIFF
--- a/flax/core/lift.py
+++ b/flax/core/lift.py
@@ -52,7 +52,8 @@ def _dedup_scopes(scopes):
       path.append(scope.name)
       scope = scope.parent
     if max_parent is not leaf:
-      del minimal_set[leaf]
+      if leaf in minimal_set:
+        del minimal_set[leaf]
     paths.append((max_parent, max_parent_path))
   return tuple(minimal_set), tuple(paths)
 

--- a/tests/linen/linen_transforms_test.py
+++ b/tests/linen/linen_transforms_test.py
@@ -16,6 +16,7 @@
 
 from functools import partial
 from typing import Any, Tuple, Iterable, Callable, Sequence
+import operator
 
 from absl.testing import absltest
 import jax
@@ -465,10 +466,10 @@ class TransformTest(absltest.TestCase):
       def __call__(self, x):
         return x * self.test
 
-    FooVmap = nn.vmap(Foo, in_axes=0, out_axes=0, variable_axes={'params': 0}, split_rngs={'params': True})
+    FooVmap = nn.vmap(Foo, in_axes=0, out_axes=0,
+                      variable_axes={'params': 0}, split_rngs={'params': True})
     variables = FooVmap().init(random.PRNGKey(0), jnp.ones((4,)))
     self.assertEqual(variables['params']['test'].shape, (4,))
-
 
   def test_nested_module_args_vmap(self):
     class A(nn.Module):
@@ -610,6 +611,109 @@ class TransformTest(absltest.TestCase):
     (y1, y2), _ = B().init_with_output(key, x)
     np.testing.assert_array_equal(y1, y2)
     self.assertEqual(cntr, 2)
+
+  def test_toplevel_submodule_adoption_transform(self):
+    class A(nn.Module):
+      @nn.compact
+      def __call__(self, x):
+        return nn.Dense(3)(x)
+    class B(nn.Module):
+      A: nn.Module
+      @nn.compact
+      def __call__(self, x):
+        return self.A(x)
+    class C(nn.Module):
+      A: nn.Module
+      B: nn.Module
+      @partial(
+          nn.vmap,
+          variable_axes={'params': 0},
+          split_rngs={'params': True})
+      @nn.compact
+      def __call__(self, x):
+        return self.B(x) + self.A(x)
+    class Csimple(nn.Module):
+      A: nn.Module
+      B: nn.Module
+      @nn.compact
+      def __call__(self, x):
+        return self.B(x) + self.A(x)
+    class D(nn.Module):
+      @nn.compact
+      def __call__(self, x):
+        a1 = A()
+        a2 = A()
+        b = B(a1)
+        c = C(a2, b)
+        return c(x)
+
+    key = random.PRNGKey(0)
+    x = jnp.ones((10, 10))
+    p1 = D().init(key, x)
+    y1 = D().apply(p1, x)
+
+    a1 = A()
+    a2 = A()
+    b = B(a1)
+    p2 = freeze({'params':
+        {'A': p1['params']['A_0'],
+         'B_A': p1['params']['A_1']}
+        })
+    # Test method wrapper transform.
+    y2 = C(a2, b).apply(p2, x)
+    np.testing.assert_allclose(y1, y2, atol=1e-7)
+    # Test class transform.
+    Ctrafo = nn.vmap(Csimple,
+                     variable_axes={'params': 0},
+                     split_rngs={'params': True})
+
+    y3 = Ctrafo(a2, b).apply(p2, x)
+    np.testing.assert_allclose(y1, y3, atol=1e-7)
+
+  def test_toplevel_submodule_adoption_pytree_transform(self):
+    class A(nn.Module):
+      @nn.compact
+      def __call__(self, c, x):
+        counter = self.variable('counter', 'i', jnp.zeros, ())
+        counter.value += 1
+        x = nn.Dense(1)(x)
+        return c, x
+
+    class B(nn.Module):
+      A: Any
+      @nn.compact
+      def __call__(self, c, x):
+        return self.A['foo'](*self.A['bar'](c, x))
+
+    a = A()
+    As = {'foo': A(), 'bar': A()}
+    b = nn.scan(B,
+                in_axes=0,
+                variable_carry='counter',
+                variable_broadcast='params',
+                split_rngs={'params': False})(As)
+
+    key = random.PRNGKey(0)
+    x = jnp.ones((10, 2))
+
+    p = B(As).init(key, x, x)
+    y, cntrs = b.apply(p, x, x, mutable='counter')
+    ref_cntrs = freeze({
+        'counter': {
+            'A_bar': {
+                'i': jnp.array(11.0),
+            },
+            'A_foo': {
+                'i': jnp.array(11.0),
+            },
+        },
+      })
+    self.assertTrue(jax.tree_util.tree_all(
+        jax.tree_multimap(
+            lambda x, y: np.testing.assert_allclose(x, y, atol=1e-7),
+            cntrs, ref_cntrs)
+        ))
+
 
 if __name__ == '__main__':
   absltest.main()

--- a/tests/linen/module_test.py
+++ b/tests/linen/module_test.py
@@ -15,6 +15,8 @@
 """Tests for flax.linen."""
 
 import dataclasses
+import functools
+import operator
 
 from absl.testing import absltest
 
@@ -36,6 +38,10 @@ jax.config.parse_flags_with_absl()
 # Require JAX omnistaging mode.
 jax.config.enable_omnistaging()
 
+
+def tree_equals(x, y):
+  return jax.tree_util.tree_all(
+      jax.tree_multimap(operator.eq, x, y))
 
 class DummyModule(nn.Module):
   @compact
@@ -761,6 +767,199 @@ class ModuleTest(absltest.TestCase):
     x = jnp.ones((2,))
     _ = B().init_with_output(key, x)
 
+  def test_toplevel_submodule_adoption(self):
+    class Encoder(nn.Module):
+      n_layers: int
+      ch: int
+      def setup(self):
+        self.layers = [nn.Dense(self.ch) for _ in range(self.n_layers)]
+      def __call__(self, x):
+        for layer in self.layers:
+          x = layer(x)
+          x = nn.relu(x)
+        return x
+
+    class Model(nn.Module):
+      encoder: nn.Module
+      n_out: int
+      def setup(self):
+        self.dense_out = nn.Dense(self.n_out)
+      def __call__(self, x):
+        x = self.encoder(x)
+        return self.dense_out(x)
+
+    # Define model.
+    encoder = Encoder(n_layers=1, ch=8)
+    model = Model(encoder=encoder, n_out=5)
+
+    # Initialize.
+    key = jax.random.PRNGKey(0)
+    x = random.uniform(key, (4, 4))
+
+    variables = model.init(key, x)
+    y = model.apply(variables, x)
+    self.assertEqual(y.shape, (4, 5))
+
+    var_shapes = jax.tree_map(jnp.shape, variables)
+    ref_var_shapes = freeze({
+      'params': {
+          'dense_out': {
+              'bias': (5,),
+              'kernel': (8, 5),
+          },
+          'encoder': {
+              'layers_0': {
+                  'bias': (8,),
+                  'kernel': (4, 8),
+              },
+          },
+      },
+    })
+    self.assertTrue(tree_equals(var_shapes, ref_var_shapes))
+
+  def test_toplevel_submodule_adoption_pytree(self):
+    class A(nn.Module):
+      @nn.compact
+      def __call__(self, c, x):
+        counter = self.variable('counter', 'i', jnp.zeros, ())
+        counter.value += 1
+        x = nn.Dense(1)(x)
+        return c, x
+    class B(nn.Module):
+      A: Any
+      @nn.compact
+      def __call__(self, c, x):
+        return self.A['foo'](*self.A['bar'](c, x))
+
+    a = A()
+    As = {'foo': A(), 'bar': A()}
+    b = B(As)
+
+    key = random.PRNGKey(0)
+    x = jnp.ones((2, 2))
+
+    p = B(As).init(key, x, x)
+    y, cntrs = b.apply(p, x, x, mutable='counter')
+    ref_cntrs = freeze({
+      'counter': {
+          'A_bar': {
+              'i': jnp.array(2.0),
+          },
+          'A_foo': {
+              'i': jnp.array(2.0),
+          },
+      },
+    })
+    self.assertTrue(jax.tree_util.tree_all(
+        jax.tree_multimap(
+            lambda x, y: np.testing.assert_allclose(x, y, atol=1e-7),
+            cntrs, ref_cntrs)
+          ))
+
+  def test_toplevel_submodule_adoption_sharing(self):
+    dense = functools.partial(nn.Dense, use_bias=False)
+
+    class A(nn.Module):
+      @nn.compact
+      def __call__(self, x):
+        return dense(2)(x)
+
+    class B(nn.Module):
+      a: nn.Module
+      @nn.compact
+      def __call__(self, x):
+        return dense(2)(x) + self.a(x)
+
+    class C(nn.Module):
+      a: nn.Module
+      b: nn.Module
+      @nn.compact
+      def __call__(self, x):
+        return dense(2)(x) + self.b(x) + self.a(x)
+
+    key = random.PRNGKey(0)
+    x = jnp.ones((2, 2))
+    a = A()
+    b = B(a)
+    c = C(a, b)
+    p = c.init(key, x)
+    var_shapes = jax.tree_map(jnp.shape, p)
+    ref_var_shapes = freeze({
+        'params': {
+            'Dense_0': {
+                'kernel': (2, 2),
+            },
+            'a': {
+                'Dense_0': {
+                    'kernel': (2, 2),
+                },
+            },
+            'b': {
+                'Dense_0': {
+                    'kernel': (2, 2),
+                },
+            },
+        },
+    })
+    self.assertTrue(tree_equals(var_shapes, ref_var_shapes))
+
+  def test_toplevel_submodule_pytree_adoption_sharing(self):
+
+    class A(nn.Module):
+      @nn.compact
+      def __call__(self, x):
+        counter = self.variable('counter', 'i', jnp.zeros, ())
+        counter.value += 1
+        x = nn.Dense(1)(x)
+        return x
+
+    class B(nn.Module):
+      A: Any
+      @nn.compact
+      def __call__(self, x):
+        return self.A['foo'](x) + self.A['bar'](x) + self.A['baz'](x)
+
+    key = random.PRNGKey(0)
+    x = jnp.ones((2, 2))
+
+    a = A()
+    As = {'foo': a, 'bar': a, 'baz': a}
+    b = B(As)
+
+    p = b.init(key, x)
+    _, cntrs = b.apply(p, x, mutable='counter')
+    ref_cntrs = freeze({
+      'counter': {
+          'A_foo': {
+              'i': jnp.array(6.0),
+          },
+      },
+    })
+    self.assertTrue(tree_equals(cntrs, ref_cntrs))
+
+
+  def test_nested_init_in_setup(self):
+    class Bar(nn.Module):
+      bar: Any
+      def __call__(self, x):
+        return self.bar(x)
+    class Foo(nn.Module):
+      def setup(self):
+        self.foo = Bar(bar=nn.Dense(1))
+      def __call__(self, x):
+        return self.foo(x)
+
+    key = random.PRNGKey(0)
+    x = jnp.ones((2,))
+    p = Foo().init(key, x)
+    ref = freeze({
+      'params': {
+          'foo_bar': {
+              'bias': (1,),
+              'kernel': (2, 1),
+          },
+      }})
+    self.assertTrue(tree_equals(jax.tree_map(jnp.shape, p), ref))
 
 if __name__ == '__main__':
   absltest.main()


### PR DESCRIPTION
Two things:

1. Introduces the ability to use top-level instantiated modules as attributes in another top-level module.  This is a very common workflow during interactive development and it has been cited as a pain-point and a badly confusing gotcha a number of times by our users.

All top-level instantiated  modules passed in as attributes are 'adopted' or 'reparented' onto the root, top-level module they are passed into.  Effectively this function registers any such top-level instantiated submodule as if they had been defined in the top setup() function, taking care to avoid name collisions.

2. In `setup()` code like this currently breaks:
   ```python
   self.foo = Bar(submod=nn.Dense(2))
   ```
  since our current `__setattr__` binding logic doesn't recurse into module attributes.  This PR as-is does not yet solve some of the weirder edgecases around shared-modules in e.g. a list of modules passed to setattr, as this would require relaxing the name override check.  With this change the above snippet will have the same variable tree as if the same code has been written in "compact" style.