### PR TITLE
Add automatic giant array chunking in msgpack checkpoints.

### DIFF
--- a/flax/serialization.py
+++ b/flax/serialization.py
@@ -12,20 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
-# Copyright 2020 The Flax Authors.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 """Serialization utilities for Jax.
 
 All flax classes that carry state like Model and Optimizer can be turned into a
@@ -246,6 +232,81 @@ def _msgpack_ext_unpack(code, data):
   return msgpack.ExtType(code, data)
 
 
+# Chunking array leaves
+
+# msgpack has a hard limit of 2**31 - 1 bytes per object leaf.  To circumvent
+# this limit for giant arrays (e.g. embedding tables), we traverse the tree
+# and break up arrays near the limit into flattened array chunks.
+
+# True limit is 2**31 - 1, but leave a margin for encoding padding.
+MAX_CHUNK_SIZE = 2**30
+
+
+def _np_convert_in_place(d):
+  """Convert any jax devicearray leaves to numpy arrays in place."""
+  if isinstance(d, dict):
+    for k, v in d.items():
+      if isinstance(v, jax.xla.DeviceArray):
+        d[k] = np.array(v)
+      elif isinstance(v, dict):
+        _np_convert_in_place(v)
+  elif isinstance(d, jax.xla.DeviceArray):
+      return np.array(d)
+  return d
+
+
+_tuple_to_dict = lambda tpl: dict([(str(x), y) for x, y in enumerate(tpl)])
+_dict_to_tuple = lambda dct: tuple(dct[str(i)] for i in range(len(dct)))
+
+
+def _chunk(arr):
+  """Convert array to a canonical dictionary of chunked arrays."""
+  chunksize = max(1, int(MAX_CHUNK_SIZE / arr.dtype.itemsize))
+  data = {'__msgpack_chunked_array__': True,
+          'shape': _tuple_to_dict(arr.shape)}
+  flatarr = arr.reshape(-1)
+  chunks = [flatarr[i: i + chunksize] for i in range(0, flatarr.size, chunksize)]
+  data['chunks'] = _tuple_to_dict(chunks)
+  return data
+
+
+def _unchunk(data):
+  """Convert canonical dictionary of chunked arrays back into array."""
+  assert '__msgpack_chunked_array__' in data
+  shape = _dict_to_tuple(data['shape'])
+  flatarr = np.concatenate(_dict_to_tuple(data['chunks']))
+  return flatarr.reshape(shape)
+
+
+def _chunk_array_leaves_in_place(d):
+  """Convert oversized array leaves to safe chunked form in place."""
+  if isinstance(d, dict):
+    for k, v in d.items():
+      if isinstance(v, np.ndarray):
+        if v.size * v.dtype.itemsize > MAX_CHUNK_SIZE:
+          d[k] = _chunk(v)
+      elif isinstance(v, dict):
+        _chunk_array_leaves_in_place(v)
+  elif isinstance(d, np.ndarray):
+    if d.size * d.dtype.itemsize > MAX_CHUNK_SIZE:
+      return _chunk(d)
+  return d
+
+
+def _unchunk_array_leaves_in_place(d):
+  """Convert chunked array leaves back into array leaves, in place."""
+  if isinstance(d, dict):
+    if '__msgpack_chunked_array__' in d:
+      return _unchunk(d)
+    else:
+      for k, v in d.items():
+        if isinstance(v, dict) and '__msgpack_chunked_array__' in v:
+          d[k] = _unchunk(v)
+        elif isinstance(v, dict):
+          _unchunk_array_leaves_in_place(v)
+  return d
+
+
 # User-facing API calls:
 
 
@@ -295,7 +356,9 @@ def from_bytes(target, encoded_bytes):
     A new object structurally isomorphic to `target` containing the updated
     leaf data from saved data.
   """
-  return from_state_dict(target, msgpack_restore(encoded_bytes))
+  state_dict = msgpack_restore(encoded_bytes)
+  state_dict = _unchunk_array_leaves_in_place(state_dict)
+  return from_state_dict(target, state_dict)
 
 
 def to_bytes(target):
@@ -308,4 +371,7 @@ def to_bytes(target):
   Returns:
     Bytes of msgpack-encoded state-dict of `target` object.
   """
-  return msgpack_serialize(to_state_dict(target))
+  state_dict = to_state_dict(target)
+  state_dict = _np_convert_in_place(state_dict)
+  state_dict = _chunk_array_leaves_in_place(state_dict)
+  return msgpack_serialize(state_dict)

--- a/tests/serialization_test.py
+++ b/tests/serialization_test.py
@@ -28,7 +28,7 @@ import jax
 from jax import random
 import jax.numpy as jnp
 
-import numpy as onp
+import numpy as np
 
 # Parse absl flags test_srcdir and test_tmpdir.
 jax.config.parse_flags_with_absl()
@@ -67,14 +67,14 @@ class SerializationTest(absltest.TestCase):
     state = serialization.to_state_dict(model)
     self.assertEqual(state, {
         'params': {
-            'kernel': onp.ones((1, 1)),
-            'bias': onp.zeros((1,)),
+            'kernel': np.ones((1, 1)),
+            'bias': np.zeros((1,)),
         }
     })
     state = {
         'params': {
-            'kernel': onp.zeros((1, 1)),
-            'bias': onp.zeros((1,)),
+            'kernel': np.zeros((1, 1)),
+            'bias': np.zeros((1,)),
         }
     }
     restored_model = serialization.from_state_dict(model, state)
@@ -91,16 +91,16 @@ class SerializationTest(absltest.TestCase):
     expected_state = {
         'target': {
             'params': {
-                'kernel': onp.ones((1, 1)),
-                'bias': onp.zeros((1,)),
+                'kernel': np.ones((1, 1)),
+                'bias': np.zeros((1,)),
             }
         },
         'state': {
             'step': 0,
             'param_states': {
                 'params': {
-                    'kernel': {'momentum': onp.zeros((1, 1))},
-                    'bias': {'momentum': onp.zeros((1,))},
+                    'kernel': {'momentum': np.zeros((1, 1))},
+                    'bias': {'momentum': np.zeros((1,))},
                 }
             }
         },
@@ -164,20 +164,20 @@ class SerializationTest(absltest.TestCase):
                      'uintc', 'int_', 'longfloat', 'clongfloat',
                      'longcomplex', 'bool_', 'int', 'float',
                      'complex', 'bool']
-    onp.random.seed(0)
+    np.random.seed(0)
     for dtype in normal_dtypes:
-      v = onp.random.uniform(-100, 100, size=()).astype(dtype)[()]
+      v = np.random.uniform(-100, 100, size=()).astype(dtype)[()]
       restored_v = serialization.msgpack_restore(
             serialization.msgpack_serialize(v))
       self.assertEqual(restored_v.dtype, v.dtype)
-      onp.testing.assert_array_equal(restored_v, v)
+      np.testing.assert_array_equal(restored_v, v)
 
       for shape in [(), (5,), (10, 10), (1, 20, 30, 1)]:
-        arr = onp.random.uniform(-100, 100, size=shape).astype(dtype)
+        arr = np.random.uniform(-100, 100, size=shape).astype(dtype)
         restored_arr = serialization.msgpack_restore(
             serialization.msgpack_serialize(arr))
         self.assertEqual(restored_arr.dtype, arr.dtype)
-        onp.testing.assert_array_equal(restored_arr, arr)
+        np.testing.assert_array_equal(restored_arr, arr)
 
   def test_jax_numpy_serialization(self):
     jax_dtypes = [jnp.bool_, jnp.uint8, jnp.uint16, jnp.uint32,
@@ -186,19 +186,19 @@ class SerializationTest(absltest.TestCase):
                   jnp.complex64]
     for dtype in jax_dtypes:
       v = jnp.array(
-            onp.random.uniform(-100, 100, size=())).astype(dtype)[()]
+            np.random.uniform(-100, 100, size=())).astype(dtype)[()]
       restored_v = serialization.msgpack_restore(
           serialization.msgpack_serialize(v))
       self.assertEqual(restored_v.dtype, v.dtype)
-      onp.testing.assert_array_equal(restored_v, v)
+      np.testing.assert_array_equal(restored_v, v)
 
       for shape in [(), (5,), (10, 10), (1, 20, 30, 1)]:
         arr = jnp.array(
-            onp.random.uniform(-100, 100, size=shape)).astype(dtype)
+            np.random.uniform(-100, 100, size=shape)).astype(dtype)
         restored_arr = serialization.msgpack_restore(
             serialization.msgpack_serialize(arr))
         self.assertEqual(restored_arr.dtype, arr.dtype)
-        onp.testing.assert_array_equal(restored_arr, arr)
+        np.testing.assert_array_equal(restored_arr, arr)
 
   def test_complex_serialization(self):
     for x in [1j, 1+2j]:
@@ -233,6 +233,33 @@ class SerializationTest(absltest.TestCase):
     serialized_bytes = serialization.to_bytes(optimizer)
     restored_optimizer = serialization.from_bytes(optimizer, serialized_bytes)
     self.assertEqual(restored_optimizer, optimizer)
+
+  def test_serialization_chunking(self):
+    old_chunksize = serialization.MAX_CHUNK_SIZE
+    serialization.MAX_CHUNK_SIZE = 91 * 8
+    try:
+      tmp = {'a': np.ones((10, 10))}
+      tmp = serialization._chunk_array_leaves_in_place(tmp)
+    finally:
+      serialization.MAX_CHUNK_SIZE = old_chunksize
+    test = jax.tree_map(jnp.shape, tmp)
+    ref = {'a': {
+        '__msgpack_chunked_array__': (),
+        'chunks': {'0': (91,), '1': (9,)},
+        'shape': {'0': (), '1': ()}}
+        }
+    self.assertEqual(test, ref)
+
+  def test_serialization_chunking2(self):
+    old_chunksize = serialization.MAX_CHUNK_SIZE
+    serialization.MAX_CHUNK_SIZE = 91 * 8
+    try:
+      tmp = {'a': np.ones((10, 10))}
+      tmpbytes = serialization.to_bytes(tmp)
+      newtmp = serialization.from_bytes(tmp, tmpbytes)
+    finally:
+      serialization.MAX_CHUNK_SIZE = old_chunksize
+    jax.tree_multimap(np.testing.assert_array_equal, tmp, newtmp)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
msgpack can only support total leaf encoded buffers sizes of max length 2^32-1  Some giant embedding arrays exceed this, so add an automatic reversible array chunking pass to msgpack serialization.

This PR should -not- break compatibility with existing checkpoints.