### PR TITLE
Fix dtype handling for Adam and LAMB optimizers in 64bit mode.

### DIFF
--- a/flax/optim/adam.py
+++ b/flax/optim/adam.py
@@ -39,7 +39,7 @@ class _AdamParamState:
 
 class Adam(OptimizerDef):
   """Adam optimizer.
-  
+
   See: http://arxiv.org/abs/1412.6980
   """
 
@@ -79,7 +79,7 @@ class Adam(OptimizerDef):
     grad_sq_ema = beta2 * state.grad_sq_ema + (1. - beta2) * grad_sq
 
     # bias correction
-    t = step + 1.
+    t = jnp.array(step + 1, lax.dtype(param.dtype))
     grad_ema_corr = grad_ema / (1 - beta1 ** t)
     grad_sq_ema_corr = grad_sq_ema / (1 - beta2 ** t)
 

--- a/flax/optim/lamb.py
+++ b/flax/optim/lamb.py
@@ -74,7 +74,7 @@ class LAMB(OptimizerDef):
     grad_ema = beta1 * state.grad_ema + (1. - beta1) * grad
     grad_sq_ema = beta2 * state.grad_sq_ema + (1. - beta2) * grad_sq
 
-    t = step + 1.
+    t = jnp.array(step + 1, lax.dtype(param.dtype))
     grad_ema_corr = grad_ema / (1. - beta1 ** t)
     grad_sq_ema_corr = grad_sq_ema / (1. - beta2 ** t)
 


### PR DESCRIPTION
This prevents accidental upcasting of parameters due to wonky JAX integer + floating-point py-scalar + array dtype rules:
in jax x64 mode:  `jnp.array(1) + 1.` becomes a jax array with dtype float64, that dtype then "invades" the params in the optimizer, causing dtype instability.


Should fix #924  