### PR TITLE
Enable broadcast in lift.scan

### DIFF
--- a/flax/core/__init__.py
+++ b/flax/core/__init__.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from .axes_scan import broadcast
 from .frozen_dict import FrozenDict, freeze, unfreeze
 from .tracers import current_trace, trace_level, check_trace_level
 from .scope import Scope, Array, apply, init

--- a/flax/core/lift.py
+++ b/flax/core/lift.py
@@ -426,7 +426,8 @@ def scan(fn: Callable[..., Any],
     split_rngs: Split PRNG sequences will be different for each loop iterations.
       If split is False the PRNGs will be the same across iterations.
     in_axes: Specifies the axis to scan over for the arguments. Should be a prefix
-      tree of the arguments.
+      tree of the arguments. Use `flax.core.broadcast` to feed an entire input
+      to each iteration of the scan body.
     out_axes: Specifies the axis to scan over for the return value. Should be a prefix
       tree of the return value.
     length: Specifies the number of loop iterations. This only needs
@@ -446,7 +447,7 @@ def scan(fn: Callable[..., Any],
             variable_groups, rng_groups,
             init, *args):
     def find_length(axis, x):
-      if axis is not None:
+      if axis is not axes_scan.broadcast:
         leaves = jax.tree_leaves(x)
         if leaves:
           return leaves[0].shape[axis]

--- a/flax/linen/__init__.py
+++ b/flax/linen/__init__.py
@@ -23,6 +23,7 @@ from .activation import (celu, elu, gelu, glu, leaky_relu, log_sigmoid,
 from .attention import (MultiHeadDotProductAttention, SelfAttention,
                         dot_product_attention, make_attention_mask,
                         make_causal_mask, combine_masks)
+from ..core import broadcast
 from .linear import Conv, ConvTranspose, Dense, DenseGeneral, Embed
 from .module import Module, compact, enable_named_call, disable_named_call, Variable
 from .normalization import BatchNorm, GroupNorm, LayerNorm


### PR DESCRIPTION
Fixes a bug that made broadcast impossible to use with `lift.scan`