### PR TITLE
Updated Module docstring

### DIFF
--- a/flax/linen/module.py
+++ b/flax/linen/module.py
@@ -367,7 +367,7 @@ class Module:
     from flax import linen as nn
 
     class Module(nn.Module):
-      features: Tuple[int] = [16, 4]
+      features: Tuple[int] = (16, 4)
 
       def setup(self):
         self.dense1 = Dense(self.features[0])


### PR DESCRIPTION
change the list default parameter of the example in the docstring to a tuple, since a dataclass default parameter cannot be of type list.