### PR TITLE
Add functionality for capturing intermediates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,6 +36,7 @@ jobs:
         sphinx-build -M doctest docs docs/_build
     - name: Build documentation
       run: |
+        sphinx-build -M doctest docs docs/_build
         sphinx-build -M html docs docs/_build
     - name: Test with pytest and generate coverage report
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,6 @@ jobs:
         sphinx-build -M doctest docs docs/_build
     - name: Build documentation
       run: |
-        sphinx-build -M doctest docs docs/_build
         sphinx-build -M html docs docs/_build
     - name: Test with pytest and generate coverage report
       run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ vNext
  - Bug Fix `flax.core.apply` and `Module.apply`. Now it returns a tuple containing the output and a frozen empty collection when `mutable` is specified as an empty list.
  -
  -
- -
+ - Add `sow` method to `Module` and `capture_intermediates` argument to `Module.apply`.
+   See [howto](https://flax.readthedocs.io/en/latest/howtos/extracting_intermediates.html) for usage patterns.
  -
  -
  -

--- a/docs/howtos/extracting_intermediates.rst
+++ b/docs/howtos/extracting_intermediates.rst
@@ -219,7 +219,7 @@ In the following code example we check if any intermediate activations are non-f
   all_finite = all(jax.tree_leaves(is_finite))
   assert all_finite, "non finite intermediate detected!"
 
-By default only the intermediates of `__call__` methods are collected.
+By default only the intermediates of ``__call__`` methods are collected.
 Alternatively, you can pass a custom filter based on the ``Module`` instance and the method name.
 
 .. testcode::
@@ -231,13 +231,13 @@ Alternatively, you can pass a custom filter based on the ``Module`` instance and
   dense_intermediates = state['intermediates']
 
 
-Use ``nn.Sequential``
+Use ``Sequential``
 ---------------------
 
 You could also define ``CNN`` using a simple implementation of a ``Sequential`` combinator (this is quite common in more stateful approaches). This may be useful
 for very simple models and gives you arbitrary model
 surgery. But it can be very limiting -- if you even want to add one conditional, you are 
-forced to refactor away from ``nn.Sequential`` and structure
+forced to refactor away from ``Sequential`` and structure
 your model more explicitly.
 
 .. testcode::

--- a/docs/howtos/extracting_intermediates.rst
+++ b/docs/howtos/extracting_intermediates.rst
@@ -14,6 +14,27 @@ Let's start with this simple CNN that uses :code:`nn.compact`.
 
   batch = jnp.ones((4, 32, 32, 3))
 
+  class SowCNN(nn.Module):
+    @nn.compact
+    def __call__(self, x):
+      x = nn.Conv(features=32, kernel_size=(3, 3))(x)
+      self.sow('intermediates', 'conv1', x)
+      x = nn.relu(x)
+      x = nn.avg_pool(x, window_shape=(2, 2), strides=(2, 2))
+      x = nn.Conv(features=64, kernel_size=(3, 3))(x)
+      self.sow('intermediates', 'conv2', x)
+      x = nn.relu(x)
+      x = nn.avg_pool(x, window_shape=(2, 2), strides=(2, 2))
+      x = x.reshape((x.shape[0], -1))  # flatten
+      self.sow('intermediates', 'features', x)
+      x = nn.Dense(features=256)(x)
+      self.sow('intermediates', 'conv3', x)
+      x = nn.relu(x)
+      x = nn.Dense(features=10)(x)
+      self.sow('intermediates', 'dense', x)
+      x = nn.log_softmax(x)
+      return x
+
 .. testcode::
 
   class CNN(nn.Module):
@@ -39,42 +60,68 @@ intermediate values. There are a few ways to expose them:
 Store intermediate values in a new variable collection
 ------------------------------------------------------
 
-You can augment any module with calls to ``sow``
-which store any intermediate values. ``sow`` only
-stores a value if the given variable collection is passed in
-as "mutable" in the call to :code:`Module.apply`.
+The CNN can be augmented with calls to ``sow`` to store intermediates as following:
 
-.. testcode::
 
+.. codediff:: 
+  :title_left: Default CNN
+  :title_right: CNN using sow API
+  
   class CNN(nn.Module):
     @nn.compact
     def __call__(self, x):
       x = nn.Conv(features=32, kernel_size=(3, 3))(x)
-      self.sow('intermediates', 'conv1', x)
+      
       x = nn.relu(x)
       x = nn.avg_pool(x, window_shape=(2, 2), strides=(2, 2))
       x = nn.Conv(features=64, kernel_size=(3, 3))(x)
-      self.sow('intermediates', 'conv2', x)
+
       x = nn.relu(x)
       x = nn.avg_pool(x, window_shape=(2, 2), strides=(2, 2))
       x = x.reshape((x.shape[0], -1))  # flatten
-      self.sow('intermediates', 'features', x)
+
       x = nn.Dense(features=256)(x)
-      self.sow('intermediates', 'conv3', x)
+
       x = nn.relu(x)
       x = nn.Dense(features=10)(x)
-      self.sow('intermediates', 'dense', x)
+
+      x = nn.log_softmax(x)
+      return x
+  ---
+  class SowCNN(nn.Module):
+    @nn.compact
+    def __call__(self, x):
+      x = nn.Conv(features=32, kernel_size=(3, 3))(x)
+      self.sow('intermediates', 'conv1', x) #!
+      x = nn.relu(x)
+      x = nn.avg_pool(x, window_shape=(2, 2), strides=(2, 2))
+      x = nn.Conv(features=64, kernel_size=(3, 3))(x)
+      self.sow('intermediates', 'conv2', x) #!
+      x = nn.relu(x)
+      x = nn.avg_pool(x, window_shape=(2, 2), strides=(2, 2))
+      x = x.reshape((x.shape[0], -1))  # flatten
+      self.sow('intermediates', 'features', x) #!
+      x = nn.Dense(features=256)(x)
+      self.sow('intermediates', 'conv3', x) #!
+      x = nn.relu(x)
+      x = nn.Dense(features=10)(x)
+      self.sow('intermediates', 'dense', x) #!
       x = nn.log_softmax(x)
       return x
 
+``sow`` only stores a value if the given variable collection is passed in
+as "mutable" in the call to :code:`Module.apply`.
+
+.. testcode::
+
   @jax.jit
   def init(key, x):
-    variables = CNN().init(key, x)
+    variables = SowCNN().init(key, x)
     return variables
 
   @jax.jit
   def predict(variables, x):
-    return CNN().apply(variables, x)
+    return SowCNN().apply(variables, x)
 
   @jax.jit
   def features(variables, x):
@@ -82,7 +129,7 @@ as "mutable" in the call to :code:`Module.apply`.
     # mutable during `apply`. The variables aren't actually mutated, instead
     # `apply` returns a second value, which is a dictionary of the modified
     # collections.
-    output, modified_variables = CNN().apply(variables, x, mutable=['intermediates'])
+    output, modified_variables = SowCNN().apply(variables, x, mutable=['intermediates'])
     return modified_variables['intermediates']['features']
 
   variables = init(jax.random.PRNGKey(0), batch)
@@ -98,7 +145,7 @@ can define all submodules in ``setup`` and avoid using ``nn.compact`` altogether
 
 .. testcode::
 
-  class CNN(nn.Module):
+  class RefactoredCNN(nn.Module):
     def setup(self):
       self.features = Features()
       self.classifier = Classifier()
@@ -131,14 +178,12 @@ can define all submodules in ``setup`` and avoid using ``nn.compact`` altogether
 
   @jax.jit
   def init(key, x):
-    variables = CNN().init(key, x)
+    variables = RefactoredCNN().init(key, x)
     return variables['params']
 
   @jax.jit
   def features(params, x):
-    # Proposal #686 should allow for this alternative:
-    #   return CNN().features.apply({"params": params['features']})
-    return CNN().apply({"params": params}, x,
+    return RefactoredCNN().apply({"params": params}, x,
       method=lambda module, x: module.features(x))
 
   params = init(jax.random.PRNGKey(0), batch)
@@ -156,22 +201,6 @@ As a debugging and inspection tool it is very useful but using the other pattern
 In the following code example we check if any intermediate activations are non-finite (NaN or infinite):
 
 .. testcode::
-
-  class CNN(nn.Module):
-    @nn.compact
-    def __call__(self, x):
-      x = nn.Conv(features=32, kernel_size=(3, 3))(x)
-      x = nn.relu(x)
-      x = nn.avg_pool(x, window_shape=(2, 2), strides=(2, 2))
-      x = nn.Conv(features=64, kernel_size=(3, 3))(x)
-      x = nn.relu(x)
-      x = nn.avg_pool(x, window_shape=(2, 2), strides=(2, 2))
-      x = x.reshape((x.shape[0], -1))  # flatten
-      x = nn.Dense(features=256)(x)
-      x = nn.relu(x)
-      x = nn.Dense(features=10)(x)
-      x = nn.log_softmax(x)
-      return x
 
   @jax.jit
   def init(key, x):
@@ -215,7 +244,7 @@ your model more explicitly.
         x = layer(x)
       return x
 
-  def CNN():
+  def SeqCNN():
     return Sequential([
       nn.Conv(features=32, kernel_size=(3, 3)),
       nn.relu,
@@ -232,12 +261,12 @@ your model more explicitly.
 
   @jax.jit
   def init(key, x):
-    variables = CNN().init(key, x)
+    variables = SeqCNN().init(key, x)
     return variables['params']
 
   @jax.jit
   def features(params, x):
-    return Sequential(CNN().submodules[0:7]).apply({"params": params}, x)
+    return Sequential(SeqCNN().submodules[0:7]).apply({"params": params}, x)
 
   params = init(jax.random.PRNGKey(0), batch)
   features(params, batch)

--- a/docs/howtos/extracting_intermediates.rst
+++ b/docs/howtos/extracting_intermediates.rst
@@ -243,12 +243,7 @@ your model more explicitly.
 .. testcode::
 
   class Sequential(nn.Module):
-    submodules: Sequence[nn.Module]
-
-    def setup(self):
-      # Bind layers to `self` -- `__setattr__` gives submodules
-      # names and connects their variables through `self.variables`
-      self.layers = self.submodules
+    layers: Sequence[nn.Module]
 
     def __call__(self, x):
       for layer in self.layers:
@@ -277,7 +272,7 @@ your model more explicitly.
 
   @jax.jit
   def features(params, x):
-    return Sequential(SeqCNN().submodules[0:7]).apply({"params": params}, x)
+    return Sequential(SeqCNN().layers[0:7]).apply({"params": params}, x)
 
   params = init(jax.random.PRNGKey(0), batch)
   features(params, batch)

--- a/docs/howtos/extracting_intermediates.rst
+++ b/docs/howtos/extracting_intermediates.rst
@@ -71,7 +71,7 @@ The CNN can be augmented with calls to ``sow`` to store intermediates as followi
     @nn.compact
     def __call__(self, x):
       x = nn.Conv(features=32, kernel_size=(3, 3))(x)
-      
+
       x = nn.relu(x)
       x = nn.avg_pool(x, window_shape=(2, 2), strides=(2, 2))
       x = nn.Conv(features=64, kernel_size=(3, 3))(x)
@@ -218,6 +218,17 @@ In the following code example we check if any intermediate activations are non-f
   y, is_finite = predict(variables, batch)
   all_finite = all(jax.tree_leaves(is_finite))
   assert all_finite, "non finite intermediate detected!"
+
+By default only the intermediates of `__call__` methods are collected.
+Alternatively, you can pass a custom filter based on the ``Module`` instance and the method name.
+
+.. testcode::
+
+  filter_Dense = lambda mdl, method_name: isinstance(mdl, nn.Dense)
+  filter_encodings = lambda mdl, method_name: method_name == "encode"
+
+  y, state = CNN().apply(variables, batch, capture_intermediates=filter_Dense, mutable=["intermediates"])
+  dense_intermediates = state['intermediates']
 
 
 Use ``nn.Sequential``

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -38,6 +38,7 @@ For a quick introduction and short example snippets, see our `README
    howtos/state_params
    howtos/ensembling
    howtos/lr_schedule
+   howtos/extracting_intermediates
 
 .. toctree::
    :maxdepth: 1

--- a/flax/linen/module.py
+++ b/flax/linen/module.py
@@ -115,6 +115,7 @@ class _DynamicContext:
   
   @property
   def capture_stack(self):
+    """Keeps track of the active capture_intermediates filter functions."""
     if not hasattr(self._thread_data, 'capture_stack'):
       self._thread_data.capture_stack = []
     return self._thread_data.capture_stack
@@ -360,6 +361,9 @@ _UNDEFINED_COPY_PICKLE_METHODS = (
     '__reduce__', '__reduce_ex__', '__copy__', '__deepcopy__')
 
 
+_caches = weakref.WeakKeyDictionary()
+
+
 tuple_reduce = lambda xs, x: xs + (x,)
 tuple_init = lambda: ()
 
@@ -369,9 +373,6 @@ capture_call_intermediates = lambda _, method_name: method_name == '__call__'
 
 # Base Module definition.
 # -----------------------------------------------------------------------------
-
-
-_caches = weakref.WeakKeyDictionary()
 
 
 class Module:
@@ -796,13 +797,13 @@ class Module:
             **kwargs) -> Union[Any, Tuple[Any, FrozenVariableDict]]:
     """Applies a module method to variables and returns output and modified variables.
 
-    Note that `method` should be set if one would like to call `apply` on a 
+    Note that `method` should be set if one would like to call `apply` on a
     different class method than `_call__`. For instance, suppose a Transformer
     modules has a method called `encode`, then the following calls `apply` on
     that method::
 
       model = models.Transformer(config)
-      encoded = model.apply({'params': params}, inputs, method=model.encode) 
+      encoded = model.apply({'params': params}, inputs, method=model.encode)
 
     Args:
       variables: A dictionary containing variables keyed by variable
@@ -817,7 +818,7 @@ class Module:
                list of names of mutable collections.
       capture_intermediates: If `True`, captures intermediate return values
         of all Modules inside the "intermediates" collection. By default only
-        the return value of the `__call__` method is stored. A function can
+        the return values of all `__call__` methods are stored. A function can
         be passed to change the filter behavior. The filter function takes
         the Module instance and method name and returns a bool indicating
         whether the output of that method invocation should be stored.

--- a/flax/linen/module.py
+++ b/flax/linen/module.py
@@ -44,7 +44,7 @@ Array = Any    # pylint: disable=invalid-name
 
 
 T = TypeVar('T')
-K = TypeVar('T')
+K = TypeVar('K')
 _CallableT = TypeVar('_CallableT', bound=Callable)
 
 

--- a/tests/linen/module_test.py
+++ b/tests/linen/module_test.py
@@ -1027,14 +1027,22 @@ class ModuleTest(absltest.TestCase):
   def test_sow(self):
     class Foo(nn.Module):
       @nn.compact
-      def __call__(self, x):
-        self.sow('intermediates', 'h', x)
-        self.sow('intermediates', 'h', 2 * x)
+      def __call__(self, x, **sow_args):
+        self.sow('intermediates', 'h', x, **sow_args)
+        self.sow('intermediates', 'h', 2 * x, **sow_args)
         return 3 * x
 
     _, state = Foo().apply({}, 1, mutable=['intermediates'])
     self.assertEqual(state, {
       'intermediates': {'h': (1, 2)}
+    })
+    _, state = Foo().apply(
+        {}, 1,
+        init_fn=lambda: 0,
+        reduce_fn=lambda a, b: a + b,
+        mutable=['intermediates'])
+    self.assertEqual(state, {
+      'intermediates': {'h': 3}
     })
     self.assertEqual(Foo().apply({}, 1), 3)
 


### PR DESCRIPTION
- `Module.sow` tracks values in a collection if it's mutable and acts as a no-op otherwise
- `Module.apply(capture_intermediates=...)` can be used to track return values of submodules (by default from the __call__ method) but a custom filter can be passed if necessary.