### PR TITLE
Makes sure RHS of codediff directive blocks are tested

### DIFF
--- a/docs/_ext/codediff.py
+++ b/docs/_ext/codediff.py
@@ -100,7 +100,10 @@ class CodeDiffDirective(SphinxDirective):
 
     # Create a test node as a comment node so it won't show up in the docs.
     # We add attribute "testnodetype" so it is be picked up by the doctest
-    # builder.
+    # builder. This functionality is not officially documented but can be found
+    # in the source code: 
+    # https://github.com/sphinx-doc/sphinx/blob/3.x/sphinx/ext/doctest.py
+    # (search for 'testnodetype').
     test_code = '\n'.join(test_code)
     test_node = nodes.comment(test_code, test_code, testnodetype='testcode')
     # Set the source info so the error message is correct when testing.

--- a/docs/_ext/codediff_test.py
+++ b/docs/_ext/codediff_test.py
@@ -34,7 +34,7 @@ def get_initial_params(key):
   initial_params = CNN().init(key, init_val)['params']
   return initial_params'''
 
-    expected_output= r'''+----------------------------------------------------------+----------------------------------------------------------+
+    expected_table = r'''+----------------------------------------------------------+----------------------------------------------------------+
 | Single device                                            | Ensembling on multiple devices                           |
 +----------------------------------------------------------+----------------------------------------------------------+
 | .. code-block:: python                                   | .. code-block:: python                                   |
@@ -48,13 +48,21 @@ def get_initial_params(key):
 |     return initial_params                                |                                                          |
 +----------------------------------------------------------+----------------------------------------------------------+'''
 
+    expected_testcode = r'''@jax.pmap #!
+def get_initial_params(key):
+  init_val = jnp.ones((1, 28, 28, 1), jnp.float32)
+  initial_params = CNN().init(key, init_val)['params']
+  return initial_params'''
+
     title_left = 'Single device'
     title_right = 'Ensembling on multiple devices'
 
-    actual_output = CodeDiffParser().parse(
+    actual_table, actual_testcode = CodeDiffParser().parse(
       lines=input_text.split('\n'),
       title_left=title_left,
       title_right=title_right)
-    actual_output = '\n'.join(actual_output)
+    actual_table = '\n'.join(actual_table)
+    actual_testcode = '\n'.join(actual_testcode)
 
-    self.assertEqual(expected_output, actual_output)
+    self.assertEqual(expected_table, actual_table)
+    self.assertEqual(expected_testcode, actual_testcode)

--- a/docs/howtos/ensembling.rst
+++ b/docs/howtos/ensembling.rst
@@ -50,14 +50,16 @@ metrics computation, but they can be found in the `MNIST example`_.
       return x
 
   def get_datasets():
-    """Load Dummy MNIST train and test datasets into memory."""
-    ds_builder = tfds.testing.DummyMnist()
-    ds_builder.download_and_prepare()
-    train_ds = tfds.as_numpy(ds_builder.as_dataset(split='train', batch_size=-1))
-    test_ds = tfds.as_numpy(ds_builder.as_dataset(split='test', batch_size=-1))
+    """Load fake MNIST data."""
+    # Converts dataset from list of dicts to dict of lists.
+    to_dict = lambda x: {k: np.array([d[k] for d in x]) for k in ['image', 'label']}
+    with tfds.testing.mock_data(num_examples=100):
+      train_ds = to_dict(tfds.as_numpy(tfds.load('mnist', split='train')))
+      test_ds = to_dict(tfds.as_numpy(tfds.load('mnist', split='test')))
     train_ds['image'] = jnp.float32(train_ds['image']) / 255.
     test_ds['image'] = jnp.float32(test_ds['image']) / 255.
     return train_ds, test_ds
+
 
   def onehot(labels, num_classes=10):
     x = (labels[..., None] == jnp.arange(num_classes)[None])

--- a/docs/howtos/lr_schedule.rst
+++ b/docs/howtos/lr_schedule.rst
@@ -18,6 +18,10 @@ We will show you how to...
 The triangular schedule makes your learning rate vary as a triangle wave during training, so over the course of a period (``steps_per_cycle``
 training steps) the value will start at ``lr_min``, increase linearly to ``lr_max`` and then decrease again to ``lr_min``.
 
+.. testsetup::
+
+  import jax
+
 .. testcode::
   
   def create_triangular_schedule(lr_min, lr_max, steps_per_cycle):

--- a/docs/howtos/state_params.rst
+++ b/docs/howtos/state_params.rst
@@ -6,7 +6,19 @@ We will show you how to...
 * manage the variables from initialization to updates.
 * split and re-assemble parameters and state.
 
-.. code-block:: python
+.. testsetup::
+
+  from flax import linen as nn
+  from flax import optim
+  from jax import random
+  import jax.numpy as jnp
+  import jax
+
+  # Create some fake data and run only for one epoch for testing.
+  dummy_input = jnp.ones((3, 4))
+  num_epochs = 1
+
+.. testcode::
 
   class BiasAdderWithRunningMean(nn.Module):
     momentum: float = 0.9
@@ -21,29 +33,19 @@ We will show you how to...
                       (1.0 - self.momentum) * jnp.mean(x, axis=0, keepdims=True))
       return mean.value + bias
 
-This example model is a minimal example that contains both parameters (declared with :code:`self.param`) 
-and state variables (declared with :code:`self.variable`).
+This example model is a minimal example that contains both parameters (declared
+with :code:`self.param`) and state variables (declared with 
+:code:`self.variable`).
 
-The tricky part with initialization here is that we need to split the state variables and the parameters
-we're going to optimize for.
+The tricky part with initialization here is that we need to split the state
+variables and the parameters we're going to optimize for.
 
-.. code-block:: python
+First we define ``update_step`` as follow (with dummy loss that should be
+replaced for yours):
 
-  model = BiasAdderWithRunningMean()
-  variables = model.init(random.PRNGKey(0), x) # x is a dummy input
-  state, params = variables.pop('params') # Split state and params to optimize for
-  del variables # Delete variables to avoid wasting resources
-  optimizer = optim.sgd.GradientDescent(learning_rate=0.02).create(params)
-
-  for _ in range(10):
-    optimizer, state = update_step(model.apply, x, optimizer, state)
-
-With the update_step function defined as follow (with dummy loss that should be replaced for yours):
-
-.. code-block:: python
+.. testcode::
 
   def update_step(apply_fun, x, optimizer, state):
-
     def loss(params):
       y, updated_state = apply_fun({'params': params, **state},
                                   x, mutable=list(state.keys()))
@@ -54,3 +56,16 @@ With the update_step function defined as follow (with dummy loss that should be 
         loss, has_aux=True)(optimizer.target)
     optimizer = optimizer.apply_gradient(grads)
     return optimizer, updated_state
+
+Then we can write the actual training code.
+
+.. testcode::
+
+  model = BiasAdderWithRunningMean()
+  variables = model.init(random.PRNGKey(0), dummy_input)
+  state, params = variables.pop('params') # Split state and params to optimize for
+  del variables # Delete variables to avoid wasting resources
+  optimizer = optim.sgd.GradientDescent(learning_rate=0.02).create(params)
+
+  for _ in range(num_epochs):
+    optimizer, state = update_step(model.apply, dummy_input, optimizer, state)

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -6,8 +6,12 @@ jaxlib>=0.1.41
 ipykernel
 nbsphinx
 recommonmark
-# The next packages are for notebooks
+# The next packages are for notebooks.
 matplotlib
 sklearn
-# Must install flax itself for notebook execution and auotdocs to work
+# Must install flax itself for notebook execution and autodocs to work.
 .
+# The next packages are used in testcode blocks.
+ml_collections
+tensorflow
+tensorflow_datasets


### PR DESCRIPTION
After this change, all RHS code blocks of the `codediff` directive are tested as if they were created using the `testcode` directive.

I've also updated all HOWTOs, and fixed a few bugs that weren't picked up, which proves it is good we are using tests :-).

The wall clock time for running all HOWTO tests is about 17s on a dual core CPU:

```
$ time sphinx-build -M doctest docs docs/_build
(...)
running tests...

Document: howtos/state_params
-----------------------------
WARNING:absl:No GPU/TPU found, falling back to CPU. (Set TF_CPP_MIN_LOG_LEVEL=0 and rerun for more info.)
1 items passed all tests:
   3 tests in default
3 tests in 1 items.
3 passed and 0 failed.
Test passed.

Document: howtos/ensembling
---------------------------
WARNING:absl:No GPU/TPU found, falling back to CPU. (Set TF_CPP_MIN_LOG_LEVEL=0 and rerun for more info.)
1 items passed all tests:
   4 tests in default
4 tests in 1 items.
4 passed and 0 failed.
Test passed.

Document: howtos/lr_schedule
----------------------------
1 items passed all tests:
   3 tests in default
3 tests in 1 items.
3 passed and 0 failed.
Test passed.

Document: howtos/extracting_intermediates
-----------------------------------------
1 items passed all tests:
   7 tests in default
7 tests in 1 items.
7 passed and 0 failed.
Test passed.

Doctest summary
===============
   17 tests
    0 failures in tests
    0 failures in setup code
    0 failures in cleanup code
build succeeded, 1 warning.

Testing of doctests in the sources finished, look at the results in docs/_build/doctest/output.txt.

real    0m17.562s
user    0m16.327s
sys     0m1.038s
```