### PR TITLE
implement functional init/apply and bind.

### DIFF
--- a/docs/flax.linen.rst
+++ b/docs/flax.linen.rst
@@ -12,7 +12,15 @@ Module
 ------------------------
 
 .. autoclass:: Module
-   :members: setup, variable, param, apply, init, init_with_output, make_rng, variables, Variable, __setattr__
+   :members: setup, variable, param, bind, apply, init, init_with_output, make_rng, variables, Variable, __setattr__
+
+Init/Apply
+------------------------
+
+.. currentmodule:: flax.linen
+.. autofunction:: apply
+.. autofunction:: init
+.. autofunction:: init_with_output
 
 Variables
 ----------------------

--- a/examples/vae/train.py
+++ b/examples/vae/train.py
@@ -143,16 +143,17 @@ def train_step(optimizer, batch, z_rng):
 
 @jax.jit
 def eval(params, images, z, z_rng):
-  recon_images, mean, logvar = model().apply({'params': params}, images, z_rng)
+  def eval_model(vae):
+    recon_images, mean, logvar = vae(images, z_rng)
+    comparison = jnp.concatenate([images[:8].reshape(-1, 28, 28, 1),
+                                  recon_images[:8].reshape(-1, 28, 28, 1)])
 
-  comparison = jnp.concatenate([images[:8].reshape(-1, 28, 28, 1),
-                                recon_images[:8].reshape(-1, 28, 28, 1)])
+    generate_images = vae.generate(z)
+    generate_images = generate_images.reshape(-1, 28, 28, 1)
+    metrics = compute_metrics(recon_images, images, mean, logvar)
+    return metrics, comparison, generate_images
 
-  generate_images = model().apply({'params': params}, z, method=VAE.generate)
-  generate_images = generate_images.reshape(-1, 28, 28, 1)
-  metrics = compute_metrics(recon_images, images, mean, logvar)
-
-  return metrics, comparison, generate_images
+  return nn.apply(eval_model, model())({'params': params})
 
 
 def prepare_image(x):

--- a/flax/core/__init__.py
+++ b/flax/core/__init__.py
@@ -15,5 +15,5 @@
 from .axes_scan import broadcast
 from .frozen_dict import FrozenDict, freeze, unfreeze
 from .tracers import current_trace, trace_level, check_trace_level
-from .scope import Scope, Array, apply, init
+from .scope import Scope, Array, apply, init, bind
 from .lift import scan, vmap, jit

--- a/flax/core/scope.py
+++ b/flax/core/scope.py
@@ -586,7 +586,7 @@ def _unfreeze_variables(variables, mutable):
 def bind(variables: VariableDict,
          rngs: Optional[RNGSequences] = None,
          mutable: CollectionFilter = False):
-  """Bind variables and rngs to a new ```Scope```.
+  """Bind variables and rngs to a new ``Scope``.
   
   bind provides a ``Scope`` instance without transforming a function
   with ``apply``. This is particulary useful for debugging and

--- a/flax/core/scope.py
+++ b/flax/core/scope.py
@@ -290,7 +290,14 @@ class Scope:
     """Invalidates the Scope."""
     self._invalid = True
 
-  def variables(self) -> Collection:
+  def mutable_variables(self) -> VariableDict:
+    """Returns an immutable copy of the mutable variables belonging to this Scope."""
+    self._populate_collections()
+    xs = {k: v for k, v in self._variables.items()
+          if in_filter(self.mutable, k)}
+    return freeze(xs)
+
+  def variables(self) -> VariableDict:
     """Returns an immutable copy of the variables belonging to this Scope."""
     self._populate_collections()
     return freeze(self._variables)
@@ -576,6 +583,29 @@ def _unfreeze_variables(variables, mutable):
   return new_variables
 
 
+def bind(variables: VariableDict,
+         rngs: Optional[RNGSequences] = None,
+         mutable: CollectionFilter = False):
+  """Bind variables and rngs to a new ```Scope```.
+  
+  bind provides a ``Scope`` instance without transforming a function
+  with ``apply``. This is particulary useful for debugging and
+  interactive use cases like notebooks where a function would limit
+  the ability split up code into different cells.
+
+  a ``Scope`` instance is a stateful object. Note that idiomatic JAX is functional
+  and therefore a ``Scope` does not mix well well with vanilla JAX APIs. Therefore,
+  we recommend using ``apply`` when code should be reusable and compatible
+  across the JAX software ecosystem.
+  """
+  if not _is_valid_variables(variables):
+    raise errors.ApplyScopeInvalidVariablesError()
+  if rngs is not None and not _is_valid_rngs(rngs):
+    raise errors.ApplyScopeInvalidRngsError()
+  new_variables = _unfreeze_variables(variables, mutable)
+  return Scope(new_variables, rngs=rngs, mutable=mutable)
+
+
 def apply(fn: Callable[..., Any],
           mutable: CollectionFilter = False) -> Callable[..., Any]:
   """Functionalize a `Scope` function.
@@ -593,19 +623,10 @@ def apply(fn: Callable[..., Any],
               *args,
               rngs: Optional[RNGSequences] = None,
               **kwargs) -> Union[Any, Tuple[Any, VariableDict]]:
-
-    if not _is_valid_variables(variables):
-      raise errors.ApplyScopeInvalidVariablesError()
-    if rngs is not None and not _is_valid_rngs(rngs):
-      raise errors.ApplyScopeInvalidRngsError()
-    new_variables = _unfreeze_variables(variables, mutable)
-    with Scope(new_variables, rngs=rngs, mutable=mutable).temporary() as root:
+    with bind(variables, rngs=rngs, mutable=mutable).temporary() as root:
       y = fn(root, *args, **kwargs)
     if mutable is not False:
-      mutated_variables = {k: v
-                           for k, v in new_variables.items()
-                           if in_filter(mutable, k)}
-      return y, freeze(mutated_variables)
+      return y, root.mutable_variables()
     else:
       return y
 

--- a/flax/linen/__init__.py
+++ b/flax/linen/__init__.py
@@ -25,7 +25,7 @@ from .attention import (MultiHeadDotProductAttention, SelfAttention,
                         make_causal_mask, combine_masks)
 from ..core import broadcast
 from .linear import Conv, ConvTranspose, Dense, DenseGeneral, Embed
-from .module import Module, compact, enable_named_call, disable_named_call, Variable
+from .module import Module, compact, enable_named_call, disable_named_call, Variable, init, init_with_output, apply
 from .normalization import BatchNorm, GroupNorm, LayerNorm
 from .pooling import avg_pool, max_pool
 from .recurrent import GRUCell, LSTMCell, ConvLSTM, OptimizedLSTMCell

--- a/flax/linen/module.py
+++ b/flax/linen/module.py
@@ -32,7 +32,8 @@ import numpy as np
 import flax
 from flax import traverse_util
 from flax import serialization
-from flax.core import Scope, apply
+from flax import core
+from flax.core import Scope
 from flax.core.scope import CollectionFilter, Variable, VariableDict, FrozenVariableDict, union_filters
 from flax.core.frozen_dict import FrozenDict, freeze
 
@@ -790,9 +791,52 @@ class Module:
       raise ValueError("Can't use RNGs on unbound modules")
     return self.scope.make_rng(name)
 
+  def bind(self, variables: VariableDict, *args, rngs: RNGSequences = None,
+           mutable: CollectionFilter = False):
+    """Creates an interactive Module instance by binding variables and RNGs.
+
+    bind provides an "interactive" instance of a Module directly without
+    transforming a function with ``apply``. This is particulary useful for debugging
+    and interactive use cases like notebooks where a function would limit the ability
+    split up code into different cells.
+
+    Once the variables (and optionally RNGs) are bound to a ``Module`` it becomes a
+    stateful object. Note that idiomatic JAX is functional and therefore an interactive
+    instance does not mix well well with vanilla JAX APIs. Therefore, we recommend using
+    ``apply`` when code should be reusable and compatible across the JAX software ecosystem.
+
+    Example::
+
+      class AutoEncoder(nn.Module):
+        def setup(self):
+          self.encoder = nn.Dense(3)
+          self.decoder = nn.Dense(5)
+      
+      ae = AutoEncoder()
+      model = ae.bind(variables)
+      z = model.encode(x)
+      x_reconstructed = model.decode(z)
+
+
+    Args:
+       variables: A dictionary containing variables keyed by variable
+        collections. See :mod:`flax.core.variables` for more details
+        about variables.
+      rngs: a dict of PRNGKeys to initialize the PRNG sequences.
+        The "params" PRNG sequence is used to initialize parameters.
+      mutable: Can be bool, str, or list. Specifies which collections should be
+               treated as mutable: ``bool``: all/no collections are mutable.
+               ``str``: The name of a single mutable collection. ``list``: A
+               list of names of mutable collections.
+    Returns:
+      A copy of this instance with bound variables and RNGs.
+    """
+    scope = core.bind(variables, rngs=rngs, mutable=mutable)
+    return self.clone(parent=scope)
+
   def apply(self, variables: VariableDict, *args, rngs: RNGSequences = None,
             method: Callable[..., Any] = None, 
-            mutable: Union[bool, str, Sequence[str]] = False,
+            mutable: CollectionFilter = False,
             capture_intermediates: Union[bool, Callable[['Module', str], bool]] = False,
             **kwargs) -> Union[Any, Tuple[Any, FrozenVariableDict]]:
     """Applies a module method to variables and returns output and modified variables.
@@ -809,7 +853,8 @@ class Module:
       variables: A dictionary containing variables keyed by variable
         collections. See :mod:`flax.core.variables` for more details
         about variables.
-      rngs: The rngs for the variable collections.
+      rngs: a dict of PRNGKeys to initialize the PRNG sequences.
+        The "params" PRNG sequence is used to initialize parameters.
       method: The literal name of a method in this class. If provided, applies
         this method. If not provided, applies the ``__call__`` method.
       mutable: Can be bool, str, or list. Specifies which collections should be
@@ -831,16 +876,10 @@ class Module:
       method = self.__class__.__call__
     else:
       method = _get_unbound_fn(method)
-    fn = lambda scope: method(self.clone(parent=scope), *args, **kwargs)
-    if capture_intermediates is True:
-      capture_intermediates = capture_call_intermediates
-    if capture_intermediates:
-      mutable = union_filters(mutable, 'intermediates')
-    _context.capture_stack.append(capture_intermediates)
-    try:
-      return apply(fn, mutable=mutable)(variables, rngs=rngs)
-    finally:
-      _context.capture_stack.pop()
+    return apply(
+        method, self,
+        mutable=mutable, capture_intermediates=capture_intermediates
+    )(variables, *args, **kwargs, rngs=rngs)
     
 
   def init_with_output(self, rngs: Union[PRNGKey, RNGSequences], *args,
@@ -867,12 +906,12 @@ class Module:
            **kwargs) -> FrozenVariableDict:
     """Initializes a module method with variables and returns modified variables.
 
-    Jitting `init` initializes a model lazily using only the shapes of the 
-    provided arguments, and avoids computing the forward pass with actual 
+    Jitting `init` initializes a model lazily using only the shapes of the
+    provided arguments, and avoids computing the forward pass with actual
     values. Example::
 
       jit_init = jax.jit(SomeModule.init)
-      jit_init(rng, jnp.ones(input_shape, jnp.float32))      
+      jit_init(rng, jnp.ones(input_shape, jnp.float32))
 
     Args:
       rngs: The rngs for the variable collections.
@@ -1011,60 +1050,146 @@ def merge_param(name: str, a: Optional[T], b: Optional[T]) -> T:
     return a
 
 
-  # THE PART BELOW IS STILL UNDER DEVELOPMENT, PLEASE IGNORE
-  # ===========================================================
-  # @contextmanager
-  # def mutate(self, mutable=True, **updates):
-  #   cloned = self.clone(**updates)
-  #   try:
-  #     cloned.scope._variables = _unfreeze_variables(
-  #         cloned.scope._variables, mutable)
-  #     yield cloned
-  #   finally:
-  #     cloned.scope._variables = freeze(cloned.scope._variables)
+def apply(fn: Callable[..., Any], module: Module,
+          mutable: CollectionFilter = False,
+          capture_intermediates: Union[bool, Callable[[Module, str], bool]] = False) -> Callable[..., Any]:
+  """Creates an apply function for the given function and ``Module`` instance.
 
-  # def initialized(self, rngs, *args, method='__call__', **kwargs):
-  #   if self.parent is not None:
-  #     raise ValueError("Pattern for initialized is "
-  #                      "`Module(parent=None, ...attrs...).initialized(...)`")
-  #   scope = Scope(variables={}, rngs=rngs)
-  #   with self.mutate(parent=scope) as initialized:
-  #     if method is not None:
-  #       getattr(initialized, method)(*args, **kwargs)
-  #   return initialized
+  Unlike ``Module.apply`` this function returns a new function with the signature
+  ``(variables, *args, rngs=None, **kwargs) -> T`` where `T` is the return type
+  of ``fn``. If ``mutable`` is not ``False`` the return type is a tuple where the
+  second item is a ``FrozenDict`` with the mutated variables.
 
-  # @property
-  # def variables(self):
-  #   """Get a view of Module variables with easy dot-syntax navigation."""
-  #   return DotGetter(self.scope.variables())
+  The apply function that is returned can be directly composed with
+  JAX transformations like ``jax.jit``::
 
-  # def __getattr__(self, name):
-  #   # Used for easy colab/jupyter introspection, and to provide a
-  #   # consistent top-level interface to self.<attr> for both simple
-  #   # and multi-method modules.
-  #   if name in self.children:
-  #     val = self.children[name]
-  #     if isinstance(val, str):  # variable
-  #       return self.variables[val][name]
-  #     else:  # submodule
-  #       val.scope = self.scope.push(name)
-  #       self.scope.reservations.remove(name)
-  #       return val
-  #   else:
-  #     raise AttributeError(
-  #         f"'{self.__class__.__name__}' object has no attribute '{name}'")
+    def f(foo, x):
+      z = foo.encode(x)
+      y = foo.decode(z)
+      # ...
+      return y
+    
+    foo = Foo()
+    f_jitted = jax.jit(nn.apply(f, foo))
+    f_jitted(variables, x)
 
-  # def __dir__(self):
-  #   return list(self.children.keys()) + object.__dir__(self)
+  Args:
+    fn: The function that should be applied. The first argument passed will
+      be an module instance of the ``module`` with variables and RNGs bound
+      to it.
+    module: The ``Module`` that will be used to bind variables and RNGs to.
+      The ``Module`` passed as the first argument to ``fn`` will be a clone
+      of module.
+    method: The literal name of a method in this class. If provided, applies
+      this method. If not provided, applies the ``__call__`` method.
+    mutable: Can be bool, str, or list. Specifies which collections should be
+      treated as mutable: ``bool``: all/no collections are mutable.
+      ``str``: The name of a single mutable collection. ``list``: A
+      list of names of mutable collections.
+    capture_intermediates: If `True`, captures intermediate return values
+      of all Modules inside the "intermediates" collection. By default only
+      the return values of all `__call__` methods are stored. A function can
+      be passed to change the filter behavior. The filter function takes
+      the Module instance and method name and returns a bool indicating
+      whether the output of that method invocation should be stored.
+  Returns:
+    The apply function wrapping ``fn``.
+  """
+  @functools.wraps(fn)
+  def scope_fn(scope, *args, **kwargs):
+    _context.capture_stack.append(capture_intermediates)
+    try:
+      return fn(module.clone(parent=scope), *args, **kwargs)
+    finally:
+      _context.capture_stack.pop()
 
-  # TODO: Should this be what `clone` always does if you don't pass in an explicit
-  # parent?
-  # def detached(self):
-  #   return self.clone(parent=None)
+  if capture_intermediates is True:
+    capture_intermediates = capture_call_intermediates
+  if capture_intermediates:
+    mutable = union_filters(mutable, 'intermediates')
+  return core.apply(scope_fn, mutable=mutable)
 
-  # # TODO: Consider whether this is a helpful abstraction, and think about naming.
-  # # See its use in design_test/linen/weight_std.py
-  # def materialized(self, variables={}, rngs={}):
-  #   assert self.scope is None, ("Can't attach a module twice."
-  #                               " Maybe you want to clone first?")
-  #   return self.clone(parent=Scope(variables, rngs))
+
+def init_with_output(fn: Callable[..., Any], module: Module,
+                     mutable: CollectionFilter = True) -> Callable[..., Tuple[Any, FrozenVariableDict]]:
+  """Creates an init function for the given function and ``Module`` instance that also returns output.
+
+  Unlike ``Module.init_with_output`` this function returns a new function with the signature
+  ``(rngs, *args, **kwargs) -> (T, variables)`` where `T` is the return type of ``fn``.
+  The rngs can be a dict of PRNGKeys or a single ```PRNGKey`` which is
+  equivalant to passing a dict with one PRNGKey with the name "params".
+
+  The init function that is returned can be directly composed with
+  JAX transformations like ``jax.jit``::
+
+    def f(foo, x):
+      z = foo.encode(x)
+      y = foo.decode(z)
+      # ...
+      return y
+    
+    foo = Foo()
+    f_jitted = jax.jit(nn.init_with_output(f, foo))
+    y, variables = f_jitted(rng, x)
+
+  Args:
+    fn: The function that should be applied. The first argument passed will
+      be an module instance of the ``module`` with variables and RNGs bound
+      to it.
+    module: The ``Module`` that will be used to bind variables and RNGs to.
+      The ``Module`` passed as the first argument to ``fn`` will be a clone
+      of module.
+    mutable: Can be bool, str, or list. Specifies which collections should be
+      treated as mutable: ``bool``: all/no collections are mutable.
+      ``str``: The name of a single mutable collection. ``list``: A
+      list of names of mutable collections.
+  Returns:
+    The init function wrapping ``fn``.
+  """
+  @functools.wraps(fn)
+  def scope_fn(scope, *args, **kwargs):
+    return fn(module.clone(parent=scope), *args, **kwargs)
+  return core.init(scope_fn, mutable=mutable)
+
+
+def init(fn: Callable[..., Any], module: Module,
+         mutable: CollectionFilter = True) -> Callable[..., FrozenVariableDict]:
+  """Creates an init function for the given function and ``Module`` instance.
+
+  Unlike ``Module.init`` this function returns a new function with the signature
+  ``(rngs, *args, **kwargs) -> variables``.
+  The rngs can be a dict of PRNGKeys or a single ```PRNGKey`` which is
+  equivalant to passing a dict with one PRNGKey with the name "params".
+
+  The init function that is returned can be directly composed with
+  JAX transformations like ``jax.jit``::
+
+    def f(foo, x):
+      z = foo.encode(x)
+      y = foo.decode(z)
+      # ...
+      return y
+    
+    foo = Foo()
+    f_jitted = jax.jit(nn.init(f, foo))
+    variables = f_jitted(rng, x)
+
+  Args:
+    fn: The function that should be applied. The first argument passed will
+      be an module instance of the ``module`` with variables and RNGs bound
+      to it.
+    module: The ``Module`` that will be used to bind variables and RNGs to.
+      The ``Module`` passed as the first argument to ``fn`` will be a clone
+      of module.
+    mutable: Can be bool, str, or list. Specifies which collections should be
+      treated as mutable: ``bool``: all/no collections are mutable.
+      ``str``: The name of a single mutable collection. ``list``: A
+      list of names of mutable collections.
+  Returns:
+    The init function wrapping ``fn``.
+  """
+  init_fn = init_with_output(fn, module, mutable)
+  @functools.wraps(init_fn)
+  def init_wrapper(*args, **kwargs):
+    return init_fn(*args, **kwargs)[1]
+  return init_wrapper

--- a/flax/linen/module.py
+++ b/flax/linen/module.py
@@ -1080,8 +1080,6 @@ def apply(fn: Callable[..., Any], module: Module,
     module: The ``Module`` that will be used to bind variables and RNGs to.
       The ``Module`` passed as the first argument to ``fn`` will be a clone
       of module.
-    method: The literal name of a method in this class. If provided, applies
-      this method. If not provided, applies the ``__call__`` method.
     mutable: Can be bool, str, or list. Specifies which collections should be
       treated as mutable: ``bool``: all/no collections are mutable.
       ``str``: The name of a single mutable collection. ``list``: A


### PR DESCRIPTION
- adds init/apply as functional APIs so you can use `apply_fn = nn.apply(fn, module)` making it easier to combine apply with jax transforms and making it more obvious that you can make arbitrary functions that operate on a bound module
- adds `Module.bind` which gives you an interactive instance. It fully supports RNGs and mutability but the docstrings explicitly warns users not to use stateful training loops outside of notebook/debug code.
