### PR TITLE
Revert "Fixes a bug in Module and adds test"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ vNext
  -
  -
  -
- - Bug Fix: Disallow modifying attributes in Modules after they are initialized.
+ -
  -
  -
  -

--- a/flax/linen/module.py
+++ b/flax/linen/module.py
@@ -329,16 +329,11 @@ class _ModuleInternalState:
   in_compact_method: bool = False
   in_setup: bool = False
   setup_called: bool = False
-  is_initialized: bool = False
   autoname_cursor: Optional[dict] = dataclasses.field(default_factory=dict)
   children: Dict[str, Union[str, 'Module']] = dataclasses.field(default_factory=dict)
 
   def reset(self):
-    """Resets transient state. 
-    
-    This function is called after each module method, so only attributes that
-    are method-dependent are reset.
-    """
+    """Resets transient state."""
     self.in_compact_method = False
     self.in_setup = False
     self.autoname_cursor = dict()
@@ -349,7 +344,6 @@ class _ModuleInternalState:
       in_compact_method=self.in_compact_method,
       in_setup=self.in_setup,
       setup_called=False,  # setup_called is object local, not shared.
-      is_initialized=self.is_initialized,
       autoname_cursor=dict(self.autoname_cursor))
     return cloned
 
@@ -357,7 +351,6 @@ class _ModuleInternalState:
     """Re-imports transform-preserved state from across transform boundary."""
     self.in_compact_method = other.in_compact_method
     self.in_setup = other.in_setup
-    self.is_initialized = other.is_initialized
     self.autoname_cursor = dict(other.autoname_cursor)
 
 _uninitialized_module_internal_state = _ModuleInternalState()
@@ -511,8 +504,8 @@ class Module:
       val: Value of the attribute.
     """
     is_dataclass_attr = name in self.__dataclass_fields__ and self.__dataclass_fields__[name].init  # pytype: disable=attribute-error
-
-    if not self._state.in_setup and self._state.is_initialized:
+    
+    if not self._state.in_setup and not is_dataclass_attr:
       # Raises a TypeError just like frozen python dataclasses.
       raise TypeError("Module instance is frozen outside of setup method.")
     if is_dataclass_attr:
@@ -590,8 +583,6 @@ class Module:
       object.__setattr__(self, 'scope', self.parent)
     else:
       raise ValueError("parent must be None, Module or Scope")
-
-    self._state.is_initialized = True
 
   def __repr__(self):
     return _module_repr(self)

--- a/tests/linen/module_test.py
+++ b/tests/linen/module_test.py
@@ -692,35 +692,19 @@ class ModuleTest(absltest.TestCase):
     variables = foo.init(random.PRNGKey(0), x)
     self.assertEqual(variables['params']['bar']['kernel'].shape, (2, 3))
 
-  def test_noncompact_module_frozen(self):
+  def test_module_frozen(self):
     class Foo(nn.Module):
+      bar: nn.Dense = dataclasses.field(init=False)
+
       def setup(self):
-        self.i = 1  # This is allowed (for assigning submodules).
+        self.i = 1
 
-      def __call__(self):
-        self.i = 2  # This is not allowed.
-
-    with self.assertRaisesWithLiteralMatch(TypeError, "Module instance is frozen outside of setup method."):
-      Foo().init(random.PRNGKey(0))
-
-  def test_compact_module_frozen(self):
-    class Foo(nn.Module):
-      @nn.compact
       def __call__(self):
         self.i = 2
 
+    foo = Foo()
     with self.assertRaisesWithLiteralMatch(TypeError, "Module instance is frozen outside of setup method."):
-      Foo().init(random.PRNGKey(0))
-
-  def test_submodule_frozen(self):
-    class Foo(nn.Module):
-      @nn.compact
-      def __call__(self):
-        dense = nn.Dense(10)
-        dense.features = 20  # <--- This is not allowed
-
-    with self.assertRaisesWithLiteralMatch(TypeError, "Module instance is frozen outside of setup method."):
-      Foo().init(random.PRNGKey(0))
+      foo.init(random.PRNGKey(0))
   
   def test_is_mutable_collection(self):
     class EmptyModule(nn.Module):


### PR DESCRIPTION
Reverts google/flax#1075

This broke a clients' code because they are doing something like this:

```
class Foo(nn.Module):
  ...

  def setup(self):
    self.submodule1 = ...
    ...
    self.submoduleN = ...
   
    submodules = [ self.submodule1, ..., self.submoduleN]
    attrs = ['attr1', 'attr2', 'attr3']
    for submodule in submodules:
      for attr in attrs:
        if hasattr(submodule, attr):
          setattr(submodule, attr, getattr(self, attr))
```

This is a quite convenient way to copy relevant attributes from the module to submodules, but since we were not allowing modules to be modified after being initialized, it breaks now.

I'm reverting this change for now, and let's discuss what to do over the weekend.