### PR TITLE
Fixes a bug in Module

### DIFF
--- a/flax/linen/module.py
+++ b/flax/linen/module.py
@@ -828,9 +828,8 @@ class Module:
       of the modified collections.
     """
     if method is None:
-      method = self.__class__.__call__
-    else:
-      method = _get_unbound_fn(method)
+      method = self.__call__
+    method = _get_unbound_fn(method)
     fn = lambda scope: method(self.clone(parent=scope), *args, **kwargs)
     if capture_intermediates is True:
       capture_intermediates = capture_call_intermediates

--- a/tests/linen/module_test.py
+++ b/tests/linen/module_test.py
@@ -705,6 +705,15 @@ class ModuleTest(absltest.TestCase):
     foo = Foo()
     with self.assertRaisesWithLiteralMatch(TypeError, "Module instance is frozen outside of setup method."):
       foo.init(random.PRNGKey(0))
+
+
+  def test_module_call_not_implemented(self):
+    class Foo(nn.Module):
+      pass
+
+    foo = Foo()
+    with self.assertRaisesWithLiteralMatch(AttributeError, "'Foo' object has no attribute '__call__'"):
+      foo.init(random.PRNGKey(0))
   
   def test_is_mutable_collection(self):
     class EmptyModule(nn.Module):


### PR DESCRIPTION
Consider this code:

```
class Foo(nn.Module):
  pass

Foo().init(random.PRNGKey(0))
```

This throws the following error: "Submodules must be defined in `setup()` or in a method wrapped in `@compact`"

This is wrong: I expected an AttributeError saying `__call__` is not in `Foo`. The problem is that if we don't provide a `method` to `Module.apply()`, the `method` is set to `self.__class__.__call__`. I think this is the constructor of the class, which doesn't seem to be what we want.

Instead, I think we should just set it to `self.__call__` and always call `_get_unbound_fn` on `method`.

After this change the error is correct, I also added a test for it.