### PR TITLE
Improve Flax Linen API __call__ and __init__ formatting in docstrings

### DIFF
--- a/flax/linen/module.py
+++ b/flax/linen/module.py
@@ -421,7 +421,8 @@ class Module:
     # automatically transform Modules into dataclasses at subclass creation
     # time, and we set the last dataclass arguments to `parent` and `name`.
     cls._customized_dataclass_transform()
-    # We wrap user-defined methods including setup and __call__ to enforce
+    # We wrap user-defined methods including setup and _
+    to enforce
     # a number of different checks and to provide clear error messages.
     cls._verify_single_or_no_compact()
     cls._wrap_module_methods()
@@ -798,7 +799,7 @@ class Module:
     """Applies a module method to variables and returns output and modified variables.
 
     Note that `method` should be set if one would like to call `apply` on a
-    different class method than `_call__`. For instance, suppose a Transformer
+    different class method than ``__call__``. For instance, suppose a Transformer
     modules has a method called `encode`, then the following calls `apply` on
     that method::
 
@@ -818,7 +819,7 @@ class Module:
                list of names of mutable collections.
       capture_intermediates: If `True`, captures intermediate return values
         of all Modules inside the "intermediates" collection. By default only
-        the return values of all `__call__` methods are stored. A function can
+        the return values of all ``__call__`` methods are stored. A function can
         be passed to change the filter behavior. The filter function takes
         the Module instance and method name and returns a bool indicating
         whether the output of that method invocation should be stored.
@@ -980,7 +981,7 @@ def merge_param(name: str, a: Optional[T], b: Optional[T]) -> T:
   """Merges construction and call time argument.
 
   This is a utility for supporting the pattern where a Module hyper parameter
-  can be passed to `__init__` or `__call__`.
+  can be passed to ``__init__`` or ``__call__``.
 
   Example::
 

--- a/flax/linen/module.py
+++ b/flax/linen/module.py
@@ -421,8 +421,7 @@ class Module:
     # automatically transform Modules into dataclasses at subclass creation
     # time, and we set the last dataclass arguments to `parent` and `name`.
     cls._customized_dataclass_transform()
-    # We wrap user-defined methods including setup and _
-    to enforce
+    # We wrap user-defined methods including setup and __call__ to enforce
     # a number of different checks and to provide clear error messages.
     cls._verify_single_or_no_compact()
     cls._wrap_module_methods()


### PR DESCRIPTION
Noticed that the formatting varies and the "more correct" way of formatting `__call__` and `__init__` methods in the Linen API's `module.py` is to write is as with two back ticks on each side:

```
``__call__``
```

which returns:

<img width="300" alt="image" src="https://user-images.githubusercontent.com/19637339/110151506-7daf9900-7dd8-11eb-9d6d-155cd1e65bbe.png">

on the site.

Hope this helps @avital