### PR TITLE
Remove FrozenDict checks to determine mutability.

### DIFF
--- a/tests/core/scope_test.py
+++ b/tests/core/scope_test.py
@@ -45,6 +45,43 @@ class ScopeTest(absltest.TestCase):
     filter_false([], 'one')
     filter_false([], None)
 
+  def test_union_filter(self):
+    def union_check(a, b, ans):
+      self.assertEqual(scope.union_filters(a, b), ans)
+      self.assertEqual(scope.union_filters(b, a), ans)
+
+    union_check(['a', 'b'], ['b', 'c'], set(['a', 'b', 'c']))
+    union_check(True, False, True)
+    union_check(False, False, set())
+    union_check(True, True, True)
+    union_check(scope.DenyList(['a', 'b']), scope.DenyList(['b', 'c']), scope.DenyList(set(['b'])))
+    union_check(scope.DenyList(['a', 'b']), ['b', 'c'], scope.DenyList(set(['a'])))
+  
+  def test_intersect_filter(self):
+    def intersect_check(a, b, ans):
+      self.assertEqual(scope.intersect_filters(a, b), ans)
+      self.assertEqual(scope.intersect_filters(b, a), ans)
+
+    intersect_check(['a', 'b'], ['b', 'c'], set(['b']))
+    intersect_check(True, False, False)
+    intersect_check(False, False, set())
+    intersect_check(True, True, True)
+    intersect_check(scope.DenyList(['a', 'b']), scope.DenyList(['b', 'c']), scope.DenyList(set(['a', 'b', 'c'])))
+    intersect_check(scope.DenyList(['a', 'b']), ['b', 'c'], set(['c']))
+  
+  def test_subtract_filter(self):
+    def subtract_check(a, b, ans):
+      self.assertEqual(scope.subtract_filters(a, b), ans)
+
+    subtract_check(['a', 'b'], ['b', 'c'], set(['a']))
+    subtract_check(True, False, scope.DenyList(False))
+    subtract_check(False, False, set())
+    subtract_check(True, True, False)
+    subtract_check(True, 'a', scope.DenyList('a'))
+    subtract_check(scope.DenyList(['a', 'b']), scope.DenyList(['b', 'c']), set(['c']))
+    subtract_check(scope.DenyList(['a', 'b']), ['b', 'c'], scope.DenyList(set(['a', 'b', 'c'])))
+
+
   def test_group_collections(self):
     params = { 'dense1': { 'x': [10, 20] } }
     batch_stats = { 'dense1': { 'ema': 5 } }

--- a/tests/linen/module_test.py
+++ b/tests/linen/module_test.py
@@ -1137,6 +1137,17 @@ class ModuleTest(absltest.TestCase):
     bs_2 = foo_b.variables['batch_stats']
     for x, y in zip(jax.tree_leaves(bs_1), jax.tree_leaves(bs_2)):
       np.testing.assert_allclose(x, y)
+  
+  def test_passing_mutable_variables(self):
+    class Foo(nn.Module):
+      @nn.compact
+      def __call__(self, x):
+        return nn.Dense(2)(x)
+    x = jnp.ones((3,))
+    variables = Foo().init(random.PRNGKey(0), x)
+    variables = variables.unfreeze()
+    y = Foo().apply(variables, x)
+    self.assertEqual(y.shape, (2,))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Previously lift used isinstance(FrozenDict) to determine if a Collection is mutable,
because CollectionFilter did not support representing "everything but x".

- Adds DenyList as a filter
- add subtract_filter(a, b)
- Remove FrozenDict check instead consistenly use mutable filters
- Fix lift.transform by using subtraction.