### PR TITLE
Fix checkpoint overwrite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,9 @@ vNext
  -
  -
  -
- -
- -
+ - Add option to overwrite existing checkpoints in `save_checkpoint`.
+ - Raise an error when saving a checkpoint which has a smaller step than the
+   latest checkpoint already saved.
  -
  -
  -

--- a/flax/errors.py
+++ b/flax/errors.py
@@ -299,3 +299,15 @@ class ScopeNameInUseError(FlaxError):
   """
   def __init__(self, scope_name):
     super().__init__(f'Duplicate use of scope name: "{scope_name}"')
+
+
+class InvalidCheckpointError(FlaxError):
+  """
+  A checkpoint cannot be stored in a directory that already has
+  a checkpoint at the current or a later step.
+
+  You can pass `overwrite=True` to disable this behavior and
+  overwrite existing checkpoints in the target directory.
+  """
+  def __init__(self, path, step):
+    super().__init__(f'Trying to save an outdated checkpoint at step: "{step}" and path: "{path}".')


### PR DESCRIPTION
save_checkpoint behaviour was ill-defined when checkpoint with the same or larger step already exists.
- Add overwrite option to save_checkpoint (defaults to False)
- Raise an error  when overriding a checkpoint accidentally
- Raise an error when storing a checkpoint that has a smaller step than the latest.

Fixes #1091