### PR TITLE
Release 0.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,13 +35,18 @@ Possible breaking changes:
  - Bug Fix: Disallow modifying attributes in Modules after they are initialized.
  - Raise an error when saving a checkpoint which has a smaller step than the
    latest checkpoint already saved.
+ - MultiOptimizer now rejects the case where multiple sub optimizers update the
+   same parameter.
   
 Other changes:
  - Added custom error classes to many Linen errors. See: 
    https://flax.readthedocs.io/en/latest/flax.errors.html
  - Adds `Module.bind` for binding variables and RNGs to an interactive Module.
+ - Adds `nn.apply` and `nn.init` for transforming arbitrary functions that take a `linen.Module` as their first argument.
  - Add option to overwrite existing checkpoints in `save_checkpoint`.
  - Remove JAX omnistaging check for forward compatibility.
+ - Pathlib compatibility for checkpoint paths.
+ - `is_leaf` argument in `traverse_util.flatten_dict`
 
 0.3.2
 ------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,6 @@ vNext
 (Add your change to a random empty line to avoid merge conflicts)
  -
  -
- - Added custom error classes to many Linen errors. See: 
-   https://flax.readthedocs.io/en/latest/flax.errors.html
  -
  -
  -
@@ -16,19 +14,34 @@ vNext
  -
  -
  -
+ -
+ -
+ -
+ -
+ -
+ -
+ -
+ -
+ -
+ -
+ -
+ -
+
+
+0.3.3
+------
+
+Possible breaking changes:
  - Bug Fix: Disallow modifying attributes in Modules after they are initialized.
- - Adds `Module.bind` for binding variables and RNGs to an interactive Module.
- -
- -
- -
- - Add option to overwrite existing checkpoints in `save_checkpoint`.
  - Raise an error when saving a checkpoint which has a smaller step than the
    latest checkpoint already saved.
- -
- -
- -
- -
- -
+  
+Other changes:
+ - Added custom error classes to many Linen errors. See: 
+   https://flax.readthedocs.io/en/latest/flax.errors.html
+ - Adds `Module.bind` for binding variables and RNGs to an interactive Module.
+ - Add option to overwrite existing checkpoints in `save_checkpoint`.
+ - Remove JAX omnistaging check for forward compatibility.
 
 0.3.2
 ------

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ To cite this repository:
   author = {Jonathan Heek and Anselm Levskaya and Avital Oliver and Marvin Ritter and Bertrand Rondepierre and Andreas Steiner and Marc van {Z}ee},
   title = {{F}lax: A neural network library and ecosystem for {JAX}},
   url = {http://github.com/google/flax},
-  version = {0.3.2},
+  version = {0.3.3},
   year = {2020},
 }
 ```

--- a/flax/version.py
+++ b/flax/version.py
@@ -12,5 +12,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.3.2"
+__version__ = "0.3.3"
 


### PR DESCRIPTION
This release is necessary to be compatible with the upcoming removal of optional omnistaging in JAX 