### PR TITLE
Attention: require `deterministic` only if using dropout.

### DIFF
--- a/flax/linen/attention.py
+++ b/flax/linen/attention.py
@@ -177,7 +177,8 @@ class MultiHeadDotProductAttention(Module):
     Returns:
       output of shape `[batch_sizes..., length, features]`.
     """
-    deterministic = merge_param('deterministic', self.deterministic, deterministic)
+    if self.dropout_rate > 0.:  # Require `deterministic` only if using dropout.
+      deterministic = merge_param('deterministic', self.deterministic, deterministic)
     features = self.out_features or inputs_q.shape[-1]
     qkv_features = self.qkv_features or inputs_q.shape[-1]
     assert qkv_features % self.num_heads == 0, (


### PR DESCRIPTION
It's annoying to have to specify `deterministic` in the case of not actually using any non-determinism (eg dropout). This is the standard case at least in vision transformers, but I also stumble on this whenever I quick-prototype in colabs.