### PR TITLE
Remove explicit omnistaging enabling

### DIFF
--- a/examples/linen_design_test/attention_simple.py
+++ b/examples/linen_design_test/attention_simple.py
@@ -26,8 +26,6 @@ from flax.core import Scope
 
 from flax.linen import Module, compact, vmap
 
-# Require JAX omnistaging mode.
-jax.config.enable_omnistaging()
 
 
 class Dense(Module):

--- a/examples/linen_design_test/autoencoder.py
+++ b/examples/linen_design_test/autoencoder.py
@@ -21,8 +21,6 @@ import numpy as np
 from flax import linen as nn
 from flax.linen import Module, Dense, compact
 
-# Require JAX omnistaging mode.
-jax.config.enable_omnistaging()
 
 
 # A concise MLP defined via lazy submodule initialization

--- a/examples/linen_design_test/dense.py
+++ b/examples/linen_design_test/dense.py
@@ -18,8 +18,6 @@ from flax.linen import initializers
 from typing import Callable
 from flax.linen import Module, compact
 
-# Require JAX omnistaging mode.
-jax.config.enable_omnistaging()
 
 class Dense(Module):
   features: int

--- a/examples/linen_design_test/linear_regression.py
+++ b/examples/linen_design_test/linear_regression.py
@@ -17,8 +17,6 @@ from jax import numpy as jnp, random, lax, jit
 from flax import linen as nn
 from dense import Dense
 
-# Require JAX omnistaging mode.
-jax.config.enable_omnistaging()
 
 X = jnp.ones((1, 10))
 Y = jnp.ones((5,))

--- a/examples/linen_design_test/mlp_explicit.py
+++ b/examples/linen_design_test/mlp_explicit.py
@@ -22,8 +22,6 @@ import numpy as np
 from pprint import pprint
 from dense import Dense
 
-# Require JAX omnistaging mode.
-jax.config.enable_omnistaging()
 
 # Add `in_features` to the built-in Dense layer that normally works
 # via shape inference.

--- a/examples/linen_design_test/mlp_inline.py
+++ b/examples/linen_design_test/mlp_inline.py
@@ -21,8 +21,6 @@ import numpy as np
 from pprint import pprint
 from dense import Dense
 
-# Require JAX omnistaging mode.
-jax.config.enable_omnistaging()
 
 # Many NN layers and blocks are best described by a single function with inline variables.
 # In this case, variables are initialized during the first call.

--- a/examples/linen_design_test/mlp_lazy.py
+++ b/examples/linen_design_test/mlp_lazy.py
@@ -20,8 +20,6 @@ import numpy as np
 from pprint import pprint
 from dense import Dense
 
-# Require JAX omnistaging mode.
-jax.config.enable_omnistaging()
 
 # Here submodules are explicitly defined during init, but still materialized
 # lazily only once a first input is passed through and shapes are known.

--- a/examples/linen_design_test/tied_autoencoder.py
+++ b/examples/linen_design_test/tied_autoencoder.py
@@ -20,8 +20,6 @@ from flax.linen import Module, compact
 import numpy as np
 from dense import Dense
 
-# Require JAX omnistaging mode.
-jax.config.enable_omnistaging()
 
 # TODO(avital, levskaya): resurrect this example once interactive api is restored.
 

--- a/examples/linen_design_test/weight_std.py
+++ b/examples/linen_design_test/weight_std.py
@@ -23,8 +23,6 @@ import numpy as np
 from dense import Dense
 from flax.core.frozen_dict import freeze, unfreeze, FrozenDict
 
-# Require JAX omnistaging mode.
-jax.config.enable_omnistaging()
 
 def standardize(x, axis, eps=1e-8):
   x = x - jnp.mean(x, axis=axis, keepdims=True)

--- a/examples/mnist/train_test.py
+++ b/examples/mnist/train_test.py
@@ -26,8 +26,6 @@ import tensorflow as tf
 import tensorflow_datasets as tfds
 
 
-# Require JAX omnistaging mode.
-jax.config.enable_omnistaging()
 
 
 class MnistLibTest(absltest.TestCase):

--- a/examples/seq2seq/train_test.py
+++ b/examples/seq2seq/train_test.py
@@ -25,8 +25,6 @@ from flax import optim
 import train
 
 jax.config.parse_flags_with_absl()
-# Require JAX omnistaging mode.
-jax.config.enable_omnistaging()
 
 
 def create_test_optimizer():

--- a/tests/linen/dotgetter_test.py
+++ b/tests/linen/dotgetter_test.py
@@ -26,8 +26,6 @@ from flax import serialization
 
 # Parse absl flags test_srcdir and test_tmpdir.
 #jax.config.parse_flags_with_absl()
-# Require JAX omnistaging mode.
-jax.config.enable_omnistaging()
 
 class DotGetterTest(absltest.TestCase):
 

--- a/tests/linen/linen_attention_test.py
+++ b/tests/linen/linen_attention_test.py
@@ -30,8 +30,6 @@ import numpy as np
 
 # Parse absl flags test_srcdir and test_tmpdir.
 jax.config.parse_flags_with_absl()
-# Require JAX omnistaging mode.
-jax.config.enable_omnistaging()
 
 
 class AttentionTest(parameterized.TestCase):

--- a/tests/linen/linen_linear_test.py
+++ b/tests/linen/linen_linear_test.py
@@ -30,8 +30,6 @@ import numpy as np
 
 # Parse absl flags test_srcdir and test_tmpdir.
 jax.config.parse_flags_with_absl()
-# Require JAX omnistaging mode.
-jax.config.enable_omnistaging()
 
 
 class LinearTest(parameterized.TestCase):

--- a/tests/linen/linen_test.py
+++ b/tests/linen/linen_test.py
@@ -28,8 +28,6 @@ import numpy as np
 
 # Parse absl flags test_srcdir and test_tmpdir.
 jax.config.parse_flags_with_absl()
-# Require JAX omnistaging mode.
-jax.config.enable_omnistaging()
 
 
 class PoolTest(absltest.TestCase):

--- a/tests/linen/linen_transforms_test.py
+++ b/tests/linen/linen_transforms_test.py
@@ -27,8 +27,6 @@ from flax.core import freeze
 
 # Parse absl flags test_srcdir and test_tmpdir.
 jax.config.parse_flags_with_absl()
-# Require JAX omnistaging mode.
-jax.config.enable_omnistaging()
 
 
 id_fn = lambda x: x

--- a/tests/linen/module_test.py
+++ b/tests/linen/module_test.py
@@ -40,8 +40,6 @@ from flax.core import Scope, freeze, tracers
 
 # Parse absl flags test_srcdir and test_tmpdir.
 jax.config.parse_flags_with_absl()
-# Require JAX omnistaging mode.
-jax.config.enable_omnistaging()
 
 
 def tree_equals(x, y):

--- a/tests/linen/toplevel_test.py
+++ b/tests/linen/toplevel_test.py
@@ -27,8 +27,6 @@ from flax.core import Scope
 
 # Parse absl flags test_srcdir and test_tmpdir.
 jax.config.parse_flags_with_absl()
-# Require JAX omnistaging mode.
-jax.config.enable_omnistaging()
 
 class Dummy(nn.Module):
   @nn.compact


### PR DESCRIPTION
Jax will soon remove `jax.config.enable_omnistaging()`. We should no longer call this from examples and tests