### PR TITLE
Ask dataclass to generate __hash__ only if not implemented yet.

### DIFF
--- a/flax/linen/module.py
+++ b/flax/linen/module.py
@@ -459,7 +459,9 @@ class Module:
     cls.name = None  # default value of name is None.
     cls.__annotations__ = annotations
     # Now apply dataclass transform (which operates in-place).
-    dataclasses.dataclass(cls, unsafe_hash=True, repr=False)  # pytype: disable=wrong-keyword-args
+    # Do generate a hash function only if not provided by the class.
+    dataclasses.dataclass(
+      cls, unsafe_hash="__hash__" not in cls.__dict__, repr=False)  # pytype: disable=wrong-keyword-args
     cls.__hash__ = _wrap_hash(cls.__hash__)
     # Restore original base class __dataclass_fields__.
     if dataclasses.is_dataclass(cls.__bases__[0]):

--- a/tests/linen/module_test.py
+++ b/tests/linen/module_test.py
@@ -597,6 +597,18 @@ class ModuleTest(absltest.TestCase):
     self.assertEqual(hash(module_a), hash(module_a_2))
     self.assertNotEqual(hash(module_a), hash(module_b))
 
+  def test_module_custom_hash(self):
+    class Test(nn.Module):
+      x: int = 3
+      y: int = 5
+      def __hash__(self):
+        return 42 + self.x
+    module_a = Test(1, 2)
+    module_a_2 = Test(1, 5)
+    module_b = Test(2, 2)
+    self.assertEqual(hash(module_a), hash(module_a_2))
+    self.assertNotEqual(hash(module_a), hash(module_b))
+
   def test_module_with_scope_is_not_hashable(self):
     module_a = nn.Dense(10, parent=Scope({}))
     msg = 'Can\'t call __hash__ on modules that hold variables.'


### PR DESCRIPTION
This allows one to define their own `__hash__` methods if desired.
