### PR TITLE
Add missing @ from function annotation in dynamic_scale.py

### DIFF
--- a/flax/optim/dynamic_scale.py
+++ b/flax/optim/dynamic_scale.py
@@ -106,7 +106,7 @@ class DynamicScale(struct.PyTreeNode):
       A function that takes the same arguments as `fun` and
       returns a DynamicScaleResult
     """
-    functools.wraps(fun)
+    @functools.wraps(fun)
     def loss_wrapper(*args):
       aux = fun(*args)
       if has_aux:


### PR DESCRIPTION
# What does this PR do?

Adds a missing `@` causing a `functools.wraps call to have no effect.

Fixes # (issue)

## Checklist
- [x] This PR fixes a minor issue (e.g.: typo or small bug) or improves the docs (you can dismiss the other
      checks if that's the case).
- [ ] This change is discussed in a Github issue/
      [discussion](https://github.com/google/flax/discussions) (please add a
      link).
- [ ] The documentation and docstrings adhere to the
      [documentation guidelines](https://github.com/google/flax/blob/master/docs/README.md#how-to-write-code-documentation).
- [ ] This change includes necessary high-coverage tests.
      (No quality testing = no merge!)