### PR TITLE
Git ignores .devcontainer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ build/
 *.rej
 .pytype
 .vscode/*
+/.devcontainer


### PR DESCRIPTION
The files are already version controlled in the directory
`dev/.devcontainer`. Users would usually copy that directory into the
main repo directory and then modify it there. If there are changes to
be pushed upstream, they can always be applied into `dev/.devcontainer`.

