### PR TITLE
Adds FLIPs link to main RST nav.

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -48,6 +48,7 @@ For a quick introduction and short example snippets, see our `README
    :titlesonly:
 
    design_notes/*
+   FLIPs <https://github.com/google/flax/tree/master/docs/flip>
 
 .. toctree::
    :maxdepth: 1


### PR DESCRIPTION
I also tried creating a manual index `.rst` file and inlining the markdown files in RST, but it did not look great. Simply adding the link makes FLIPs easily discoverable and it's also easy to search & browse FLIPs directly on Github.