### PR TITLE
Don't update batch statistics during initialization.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ vNext
  -
  -
  -
- -
+ - `BatchNorm` instances will behave correctly during init when called multiple times.
  -
  -
  -

--- a/tests/linen/linen_test.py
+++ b/tests/linen/linen_test.py
@@ -156,11 +156,13 @@ class NormalizationTest(absltest.TestCase):
             axis_name="batch",
         )
         x = norm(x)
-        return norm(x)
+        return x, norm(x)
 
     key = random.PRNGKey(0)
     model = Foo()
-    variables = model.init(key, jnp.ones((10,)))
+    x = random.normal(random.PRNGKey(1), (2, 4))
+    (y1, y2), variables = model.init_with_output(key, x)
+    np.testing.assert_allclose(y1, y2, rtol=1e-4)
 
 class StochasticTest(absltest.TestCase):
 

--- a/tests/linen/linen_test.py
+++ b/tests/linen/linen_test.py
@@ -146,6 +146,21 @@ class NormalizationTest(absltest.TestCase):
     with self.assertRaises(ValueError):
       model_cls.init_with_output(key2, x)
 
+  def test_batch_norm_multi_init(self):
+    class Foo(nn.Module):
+      @nn.compact
+      def __call__(self, x):
+        norm = nn.BatchNorm(
+            name="norm",
+            use_running_average=False,
+            axis_name="batch",
+        )
+        x = norm(x)
+        return norm(x)
+
+    key = random.PRNGKey(0)
+    model = Foo()
+    variables = model.init(key, jnp.ones((10,)))
 
 class StochasticTest(absltest.TestCase):
 


### PR DESCRIPTION
- This PR switches to checking if params is mutable to determine whether the running average of batch stats should be updated.
- Previously init behavior failed / was inconsistent when a batchnorm layer was used multiple times. 

Fixes #1250