### PR TITLE
Update install instructions for contributing.

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -48,7 +48,8 @@ Follow these steps to contribute code:
    ```bash
    git clone https://github.com/YOUR_USERNAME/flax
    cd flax
-   pip install -e . .[testing]
+   pip install ".[testing]"
+   pip install -e .
    ```
 
 5. Add the Flax repo as an upstream remote, so you can use it to sync your


### PR DESCRIPTION
Fixes #1271

- block quotes must be escaped for zsh.
- put editable flax install after `pip install .[testing]`. Joint install can causes a resolution error sometimes.