### PR TITLE
Fix intermediates during init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,9 @@ vNext
  -
  -
  -
- -
- -
+ - `mutable` argument is now available on `Module.init` and `Module.init_with_outputs`
+ - When calling `init` the 'intermediates' collection is no longer mutable
+   Therefore, intermediates will no longer be returned from initialization by default. 
  -
  -
  -

--- a/docs/howtos/extracting_intermediates.rst
+++ b/docs/howtos/extracting_intermediates.rst
@@ -81,6 +81,10 @@ The CNN can be augmented with calls to ``sow`` to store intermediates as followi
       x = nn.log_softmax(x)
       return x
 
+``sow`` acts as a no-op when the variable collection is not mutable.
+Therefore, it works perfectly for debugging and optional tracking of intermediates.
+The 'intermediates' collection is also used by the ``capture_intermediates`` API (see final section).
+
 Note that, by default ``sow`` appends values every time it is called:
 
 * This is necessary because once instantiated, a module could be called multiple
@@ -103,7 +107,8 @@ Note that, by default ``sow`` appends values every time it is called:
   @jax.jit
   def init(key, x):
     variables = SowCNN2().init(key, x)
-    variables, _ = variables.pop('intermediates')
+    # By default the 'intermediates' collection is not mutable during init.
+    # So variables will only contain 'params' here.
     return variables
 
   @jax.jit

--- a/flax/core/lift.py
+++ b/flax/core/lift.py
@@ -672,7 +672,7 @@ def _hashable_filter(x):
   if isinstance(x, Iterable):
     return tuple(x)  # convert un-hashable list & sets to tuple
   if isinstance(x, DenyList):
-    return DenyList(_hashable_filter(x))  # convert inner filter recursively
+    return DenyList(_hashable_filter(x.deny))  # convert inner filter recursively
   return x
 
 def jit(fn: Callable[..., Any],

--- a/tests/linen/module_test.py
+++ b/tests/linen/module_test.py
@@ -1197,7 +1197,9 @@ class ModuleTest(absltest.TestCase):
         self.sow('intermediates', 'h', x, **sow_args)
         self.sow('intermediates', 'h', 2 * x, **sow_args)
         return 3 * x
-
+    variables = Foo().init(random.PRNGKey(0), 1)
+    # during init we should not collect intermediates by default
+    self.assertTrue('intermediates' not in variables)
     _, state = Foo().apply({}, 1, mutable=['intermediates'])
     self.assertEqual(state, {
       'intermediates': {'h': (1, 2)}

--- a/tests/linen/module_test.py
+++ b/tests/linen/module_test.py
@@ -1198,8 +1198,14 @@ class ModuleTest(absltest.TestCase):
         self.sow('intermediates', 'h', 2 * x, **sow_args)
         return 3 * x
     variables = Foo().init(random.PRNGKey(0), 1)
-    # during init we should not collect intermediates by default
+    # during init we should not collect intermediates by default...
     self.assertTrue('intermediates' not in variables)
+    # ...unless we override mutable
+    variables = Foo().init(random.PRNGKey(0), 1, mutable=True)
+    self.assertEqual(variables, {
+      'intermediates': {'h': (1, 2)}
+    })
+
     _, state = Foo().apply({}, 1, mutable=['intermediates'])
     self.assertEqual(state, {
       'intermediates': {'h': (1, 2)}


### PR DESCRIPTION
- Add  mutable arg to Module.init
- Use DenyList("intermediates") as default mutable filter during init.
When calling `init` the 'intermediates' collection is no longer mutable
Therefore, intermediates will no longer be returned from init by default. 