### PR TITLE
Deprecate jax utils.replicate

### DIFF
--- a/docs/flax.jax_utils.rst
+++ b/docs/flax.jax_utils.rst
@@ -13,7 +13,6 @@ flax.jax_utils package
 Multi device utilities
 ------------------------
 
-.. autofunction:: replicate
 .. autofunction:: unreplicate
 
 .. autofunction:: prefetch_to_device

--- a/docs/howtos/ensembling.rst
+++ b/docs/howtos/ensembling.rst
@@ -230,7 +230,7 @@ Next we transform the ``train_epoch`` function.
     batch_metrics = []
     for perm in perms:
       batch = {k: v[perm, ...] for k, v in train_ds.items()}
-      batch = jax_utils.replicate(batch) #!
+      batch = jax.device_put_replicated(batch) #!
       optimizer, metrics = train_step(optimizer, batch)
       batch_metrics.append(metrics)
 
@@ -281,7 +281,7 @@ than the train dataset so we can do this for the entire dataset directly.
                 epoch, loss, accuracy * 100)
   ---
   train_ds, test_ds = get_datasets()
-  test_ds = jax_utils.replicate(test_ds) #!
+  test_ds = jax.device_put_replicated(test_ds) #!
   
   rng, init_rng = random.split(random.PRNGKey(0))
   params = get_initial_params(random.split(rng, #!

--- a/docs/howtos/ensembling.rst
+++ b/docs/howtos/ensembling.rst
@@ -230,7 +230,7 @@ Next we transform the ``train_epoch`` function.
     batch_metrics = []
     for perm in perms:
       batch = {k: v[perm, ...] for k, v in train_ds.items()}
-      batch = jax.device_put_replicated(batch) #!
+      batch = jax.device_put_replicated(batch, jax.local_devices()) #!
       optimizer, metrics = train_step(optimizer, batch)
       batch_metrics.append(metrics)
 
@@ -281,7 +281,7 @@ than the train dataset so we can do this for the entire dataset directly.
                 epoch, loss, accuracy * 100)
   ---
   train_ds, test_ds = get_datasets()
-  test_ds = jax.device_put_replicated(test_ds) #!
+  test_ds = jax.device_put_replicated(test_ds, jax.local_devices()) #!
   
   rng, init_rng = random.split(random.PRNGKey(0))
   params = get_initial_params(random.split(rng, #!

--- a/examples/imagenet/train.py
+++ b/examples/imagenet/train.py
@@ -321,7 +321,7 @@ def train_and_evaluate(config: ml_collections.ConfigDict,
   state = restore_checkpoint(state, workdir)
   # step_offset > 0 if restarting from checkpoint
   step_offset = int(state.step)
-  state = jax.device_put_replicated(state)
+  state = jax.device_put_replicated(state, jax.local_devices())
 
   p_train_step = jax.pmap(
       functools.partial(train_step, learning_rate_fn=learning_rate_fn),

--- a/examples/imagenet/train.py
+++ b/examples/imagenet/train.py
@@ -321,7 +321,7 @@ def train_and_evaluate(config: ml_collections.ConfigDict,
   state = restore_checkpoint(state, workdir)
   # step_offset > 0 if restarting from checkpoint
   step_offset = int(state.step)
-  state = jax_utils.replicate(state)
+  state = jax.device_put_replicated(state)
 
   p_train_step = jax.pmap(
       functools.partial(train_step, learning_rate_fn=learning_rate_fn),

--- a/examples/lm1b/train.py
+++ b/examples/lm1b/train.py
@@ -474,7 +474,7 @@ def train_and_evaluate(config: ml_collections.ConfigDict, workdir: str):
     writer.write_hparams(dict(config))
 
   # Replicate optimizer.
-  optimizer = jax.device_put_replicated(optimizer)
+  optimizer = jax.device_put_replicated(optimizer, jax.local_devices())
 
   learning_rate_fn = create_learning_rate_scheduler(
       base_learning_rate=config.learning_rate, warmup_steps=config.warmup_steps)

--- a/examples/lm1b/train.py
+++ b/examples/lm1b/train.py
@@ -474,7 +474,7 @@ def train_and_evaluate(config: ml_collections.ConfigDict, workdir: str):
     writer.write_hparams(dict(config))
 
   # Replicate optimizer.
-  optimizer = jax_utils.replicate(optimizer)
+  optimizer = jax.device_put_replicated(optimizer)
 
   learning_rate_fn = create_learning_rate_scheduler(
       base_learning_rate=config.learning_rate, warmup_steps=config.warmup_steps)

--- a/examples/nlp_seq/train.py
+++ b/examples/nlp_seq/train.py
@@ -301,7 +301,7 @@ def main(argv):
   optimizer_def = optim.Adam(learning_rate, beta1=0.9, beta2=0.98,
       eps=1e-9, weight_decay=1e-1)
   optimizer = optimizer_def.create(init_variables['params'])
-  optimizer = jax_utils.replicate(optimizer)
+  optimizer = jax.device_put_replicated(optimizer)
 
   learning_rate_fn = create_learning_rate_scheduler(
       base_learning_rate=learning_rate)

--- a/examples/nlp_seq/train.py
+++ b/examples/nlp_seq/train.py
@@ -301,7 +301,7 @@ def main(argv):
   optimizer_def = optim.Adam(learning_rate, beta1=0.9, beta2=0.98,
       eps=1e-9, weight_decay=1e-1)
   optimizer = optimizer_def.create(init_variables['params'])
-  optimizer = jax.device_put_replicated(optimizer)
+  optimizer = jax.device_put_replicated(optimizer, jax.local_devices())
 
   learning_rate_fn = create_learning_rate_scheduler(
       base_learning_rate=learning_rate)

--- a/examples/pixelcnn/train.py
+++ b/examples/pixelcnn/train.py
@@ -182,7 +182,7 @@ def train_and_evaluate(config: ml_collections.ConfigDict, workdir: str):
   ema = initial_variables
   step_offset = int(optimizer.state.step)
 
-  optimizer, ema = jax_utils.replicate((optimizer, ema))
+  optimizer, ema = jax.device_put_replicated((optimizer, ema))
 
   # Learning rate schedule
   learning_rate_fn = lambda step: config.learning_rate * config.lr_decay**step

--- a/examples/pixelcnn/train.py
+++ b/examples/pixelcnn/train.py
@@ -182,7 +182,7 @@ def train_and_evaluate(config: ml_collections.ConfigDict, workdir: str):
   ema = initial_variables
   step_offset = int(optimizer.state.step)
 
-  optimizer, ema = jax.device_put_replicated((optimizer, ema))
+  optimizer, ema = jax.device_put_replicated((optimizer, ema), jax.local_devices())
 
   # Learning rate schedule
   learning_rate_fn = lambda step: config.learning_rate * config.lr_decay**step

--- a/examples/wmt/train.py
+++ b/examples/wmt/train.py
@@ -499,7 +499,7 @@ def train_and_evaluate(config: ml_collections.ConfigDict, workdir: str):
     writer.write_hparams(dict(config))
 
   # Replicate optimizer.
-  optimizer = jax.device_put_replicated(optimizer)
+  optimizer = jax.device_put_replicated(optimizer, jax.local_devices())
 
   learning_rate_fn = create_learning_rate_scheduler(
       base_learning_rate=config.learning_rate, warmup_steps=config.warmup_steps)

--- a/examples/wmt/train.py
+++ b/examples/wmt/train.py
@@ -499,7 +499,7 @@ def train_and_evaluate(config: ml_collections.ConfigDict, workdir: str):
     writer.write_hparams(dict(config))
 
   # Replicate optimizer.
-  optimizer = jax_utils.replicate(optimizer)
+  optimizer = jax.device_put_replicated(optimizer)
 
   learning_rate_fn = create_learning_rate_scheduler(
       base_learning_rate=config.learning_rate, warmup_steps=config.warmup_steps)

--- a/flax/jax_utils.py
+++ b/flax/jax_utils.py
@@ -72,6 +72,8 @@ def replicate(tree, devices=None):
   Returns:
     A new pytree containing the replicated arrays.
   """
+  warnings.warn('use jax.device_put_replicated',
+                DeprecationWarning)
   return jax.tree_map(lambda x: _replicate(x, devices), tree)
 
 

--- a/flax/jax_utils.py
+++ b/flax/jax_utils.py
@@ -63,7 +63,11 @@ def _replicate(x, devices=None):
 
 
 def replicate(tree, devices=None):
-  """Replicates arrays to multiple devices.
+  """DEPRECATION WARNING:
+  "The `flax.jax_utils.replicate` function is Deprecated, use `jax.device_put_replicated` 
+  instead." 
+  
+  Replicates arrays to multiple devices.
 
   Args:
     tree: a pytree containing the arrays that should be replicated.
@@ -72,7 +76,8 @@ def replicate(tree, devices=None):
   Returns:
     A new pytree containing the replicated arrays.
   """
-  warnings.warn('use jax.device_put_replicated',
+  warnings.warn('replicate() will be removed soon.'
+                'use jax.device_put_replicated instead.',
                 DeprecationWarning)
   return jax.tree_map(lambda x: _replicate(x, devices), tree)
 

--- a/flax/optim/base.py
+++ b/flax/optim/base.py
@@ -209,7 +209,7 @@ class Optimizer(struct.PyTreeNode):
     from flax import optim
     optimizer_def = optim.GradientDescent(learning_rate=0.1)
     optimizer = optimizer_def.create(model)
-    optimizer = jax.device_put_replicated(optimizer)
+    optimizer = jax.device_put_replicated(optimizer, jax.local_devices())
 
     def train_step(optimizer, data):
       def loss_fn(model):
@@ -377,9 +377,9 @@ class ReplicatedOptimizer(OptimizerDef):
 
   DEPRECATION WARNING:
   ReplicatedOptimizer will be removed soon.
-  Use `jax.device_put_replicated(optimizer)` and `lax.pmean(grad)` to explicitly
-  control the replication of the the optimizer and the cross replica averaging
-  over gradients, respectively.
+  Use `jax.device_put_replicated(optimizer, jax.local_devices())` and
+  `lax.pmean(grad)` to explicitly control the replication of the the optimizer
+  and the cross replica averaging over gradients, respectively.
   """
 
   def __init__(self, optimizer_def, devices=None, axis_name='batch'):

--- a/flax/optim/base.py
+++ b/flax/optim/base.py
@@ -209,7 +209,7 @@ class Optimizer(struct.PyTreeNode):
     from flax import optim
     optimizer_def = optim.GradientDescent(learning_rate=0.1)
     optimizer = optimizer_def.create(model)
-    optimizer = jax_utils.replicate(optimizer)
+    optimizer = jax.device_put_replicated(optimizer)
 
     def train_step(optimizer, data):
       def loss_fn(model):
@@ -319,7 +319,7 @@ class Optimizer(struct.PyTreeNode):
 
     DEPRECATION WARNING:
     replicate() is deprecated.
-    Use jax_utils.replicate() instead.
+    Use jax.device_put_replicated() instead.
 
     Args:
       devices: an optional list of devices defining which devices this optimizer
@@ -331,7 +331,7 @@ class Optimizer(struct.PyTreeNode):
     if devices is None:
       devices = jax.local_devices()
     optimizer_def = ReplicatedOptimizer(self.optimizer_def, devices, axis_name)
-    optimizer = jax_utils.replicate(self, devices=devices)
+    optimizer = jax.device_put_replicated(self, devices=devices)
     return optimizer.replace(optimizer_def=optimizer_def)
 
   def unreplicate(self):
@@ -377,7 +377,7 @@ class ReplicatedOptimizer(OptimizerDef):
 
   DEPRECATION WARNING:
   ReplicatedOptimizer will be removed soon.
-  Use `jax_utils.replicate(optimizer)` and `lax.pmean(grad)` to explicitly
+  Use `jax.device_put_replicated(optimizer)` and `lax.pmean(grad)` to explicitly
   control the replication of the the optimizer and the cross replica averaging
   over gradients, respectively.
   """
@@ -412,7 +412,7 @@ class ReplicatedOptimizer(OptimizerDef):
 
   def restore_state(self, target, opt_state, state_dict):
     # replicate the parameters and state to all devices.
-    state_dict = jax_utils.replicate(state_dict, devices=self.devices)
+    state_dict = jax.device_put_replicated(state_dict, devices=self.devices)
     return self.optimizer_def.restore_state(target, opt_state, state_dict)
 
 


### PR DESCRIPTION
# What does this PR do?

Deprecates `jax_utils.replicate` as mentioned in #1161 

Fixes #1161 

## Checklist
- [x] This PR fixes a minor issue (e.g.: typo or small bug) or improves the docs (you can dismiss the other
      checks if that's the case).
- [x] This change is discussed in a Github issue/
      [discussion](https://github.com/google/flax/discussions) (please add a
      link).
- [x] The documentation and docstrings adhere to the
      [documentation guidelines](https://github.com/google/flax/blob/master/docs/README.md#how-to-write-code-documentation).