### PR TITLE
Bumps JAX version to 0.2.13

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ except IOError:
 
 install_requires = [
     "numpy>=1.12",
-    "jax>=0.2.6",
+    "jax>=0.2.13",
     "matplotlib",  # only needed for tensorboard export
     "dataclasses;python_version<'3.7'", # will only install on py3.6
     "msgpack",


### PR DESCRIPTION
This includes several new features, like for example the `jax.host_id()` -> `jax.process_index()` renaming.
