### PR TITLE
Ignore `jax.host_{id,count}()` deprecation warning

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -18,3 +18,4 @@ filterwarnings =
     ignore:Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated.*:DeprecationWarning
     ignore:Explicitly requested dtype <class 'jax.numpy.lax_numpy.float64'>*:UserWarning
     ignore:The `flax.nn` module is Deprecated, use `flax.linen` instead.*:DeprecationWarning
+    ignore:jax.host_(id|count) has been renamed:UserWarning


### PR DESCRIPTION
These warnings were introduced recently in `jax` and fail our tests, both directly in our code, and indirectly through libraries like `clu` that have not yet been updated.