### PR TITLE
Use notify_all instead of notifyAll method that was deprecated in Python 3.10.

### DIFF
--- a/flax/training/prefetch_iterator.py
+++ b/flax/training/prefetch_iterator.py
@@ -55,7 +55,7 @@ class PrefetchIterator:
       self._cond.wait_for(lambda: self._buffer or not self._active)
       if self._buffer:
         item = self._buffer.pop(0)
-        self._cond.notifyAll()
+        self._cond.notify_all()
         return item
       if self._error:
         raise self._error  # pylint: disable=raising-bad-type
@@ -65,7 +65,7 @@ class PrefetchIterator:
   def close(self):
     with self._cond:
       self._active = False
-      self._cond.notifyAll()
+      self._cond.notify_all()
 
   def _prefetch_loop(self):
     """Prefetch loop that prefetches a tf dataset."""
@@ -77,7 +77,7 @@ class PrefetchIterator:
         item = next(self._data_iter)
         with self._cond:
           self._buffer.append(item)
-          self._cond.notifyAll()
+          self._cond.notify_all()
           self._cond.wait_for(_predicate)
           if not self._active:
             return
@@ -85,5 +85,5 @@ class PrefetchIterator:
         with self._cond:
           self._error = e
           self._active = False
-          self._cond.notifyAll()
+          self._cond.notify_all()
           return


### PR DESCRIPTION
# What does this PR do?

Use notify_all instead of notifyAll method that was deprecated in Python 3.10.

Fixes #1310 

## Checklist
- [x] This PR fixes a minor issue (e.g.: typo or small bug) or improves the docs (you can dismiss the other
      checks if that's the case).
- [ ] This change is discussed in a Github issue/
      [discussion](https://github.com/google/flax/discussions) (please add a
      link).
- [ ] The documentation and docstrings adhere to the
      [documentation guidelines](https://github.com/google/flax/blob/master/docs/README.md#how-to-write-code-documentation).
- [ ] This change includes necessary high-coverage tests.
      (No quality testing = no merge!)