### PR TITLE
Minor spelling corrections, JAX for the impatient docs

### DIFF
--- a/docs/notebooks/jax_for_the_impatient.ipynb
+++ b/docs/notebooks/jax_for_the_impatient.ipynb
@@ -625,7 +625,7 @@
         "id": "UHIMfchIiQMR"
       },
       "source": [
-        "As mentionned, previously, `jax.grad` only works for scalar valued functions. JAX can also handle general vector valued functions. The most useful primitives are the so-called jacobian vector product `jax.jvp` and vector jacobian product `jax.vjp`.\n",
+        "As previously mentioned, `jax.grad` only works for scalar valued functions. JAX can also handle general vector valued functions. The most useful primitives are the so-called jacobian vector product `jax.jvp` and vector jacobian product `jax.vjp`.\n",
         "\n",
         "### Jacobian vector product\n",
         "\n",
@@ -1013,7 +1013,7 @@
         "[1, {\"k1\": 2, \"k2\": (3, 4)}, 5] # 5 leaves: 1, 2, 3, 4, 5\n",
         "```\n",
         "\n",
-        "JAX provides a few utilities to work with pytrees that lives in the `tree_util` package."
+        "JAX provides a few utilities to work with pytrees that live in the `tree_util` package."
       ]
     },
     {
@@ -1070,7 +1070,7 @@
         "id": "3s167WGKUlZ9"
       },
       "source": [
-        "A more flexible version of `tree_map` would be `tree_multimap`. Instead of applying a standalone function to each of the tree leafs, you also provide a tuple of additional trees with similar shape to the input tree that will provide per leaf arguments to the function."
+        "A more flexible version of `tree_map` would be `tree_multimap`. Instead of applying a standalone function to each of the tree leaves, you also provide a tuple of additional trees with similar shape to the input tree that will provide per leaf arguments to the function."
       ]
     },
     {


### PR DESCRIPTION
# What does this PR do?

This PR fixes minor typos in the `Jax for impatient` section of the documentation.

## Checklist
- [x] This PR fixes a minor issue (e.g.: typo or small bug) or improves the docs (you can dismiss the other
      checks if that's the case).
- [ ] This change is discussed in a Github issue/
      [discussion](https://github.com/google/flax/discussions) (please add a
      link).
- [ ] The documentation and docstrings adhere to the
      [documentation guidelines](https://github.com/google/flax/blob/master/docs/README.md#how-to-write-code-documentation).
- [ ] This change includes necessary high-coverage tests.
      (No quality testing = no merge!)