### PR TITLE
[linen.SelfAttention] Enable auto-regressive decoding for prompt length > 1

### DIFF
--- a/flax/linen/attention.py
+++ b/flax/linen/attention.py
@@ -286,8 +286,8 @@ class MultiHeadDotProductAttention(Module):
         # not the remaining zero elements.
         mask = combine_masks(
             mask,
-            jnp.broadcast_to(jnp.arange(max_length) <= cur_index,
-                             tuple(batch_dims) + (1, 1, max_length)))
+            jnp.broadcast_to(jnp.arange(max_length) < cur_index + updated_cache_indices,
+                             tuple(batch_dims) + (1, updated_cache_indices, max_length)))
 
     # Convert the boolean attention mask to an attention bias.
     if mask is not None:


### PR DESCRIPTION
# What does this PR do?

<!--

Great, you are contributing to Flax! 

But... please read the following carefully so we can make sure your PR is merged
easily.

Replace this text block with a description of the change and which issue it
fixes (if applicable). Please also include relevant motivation/context.

Once you're done, someone in the Flax team will review your PR shortly. They may
suggest changes to make the code even better. If no one reviewed your PR after a
week has passed, don't hesitate to post a new comment @-mentioning the same
persons (sometimes notifications get lost).
-->

I think currently it is not possible to do auto-regressive decoding with `flax.linen.SelfAttention` if the input prompt is longer than 1. E.g., the following code works fine if the `prompt_length` is 1, but fails if `prompt_length` is 2, see this issue: https://github.com/google/flax/issues/1317.

This PR corrects this behavior by allowing the input length to be > 1 the very first time `cache` is used. 

For decoder-only auto-regressive models, such as GPT1-3 it is very important to be able to pass input prompts > 1. Maybe, this is also already possible and I'm using it incorrectly? 

If this PR looks like a good solution to you, then I'm more than happy to add a couple of tests to check the behavior @avital @marcvanzee 

## Checklist
- [ ] This PR fixes a minor issue (e.g.: typo or small bug) or improves the docs (you can dismiss the other
      checks if that's the case).
- [ ] This change is discussed in a Github issue/
      [discussion](https://github.com/google/flax/discussions) (please add a
      link).
- [ ] The documentation and docstrings adhere to the
      [documentation guidelines](https://github.com/google/flax/blob/master/docs/README.md#how-to-write-code-documentation).
- [ ] This change includes necessary high-coverage tests.
      (No quality testing = no merge!)