### PR TITLE
Renames `train_state` to `state`.

### DIFF
--- a/docs/flip/1009-optimizer-api.md
+++ b/docs/flip/1009-optimizer-api.md
@@ -228,19 +228,19 @@ With this the [Optax Training Step] becomes:
 
 ```python
 @jax.jit
-def train_step(train_state, inputs, labels):
+def train_step(state, inputs, labels):
 
   def loss_fn(params):
-    outputs, new_model_state = train_state.apply_fn(
-        {'params': params, 'batch_stats': train_state.batch_stats},
+    outputs, new_model_state = state.apply_fn(
+        {'params': params, 'batch_stats': state.batch_stats},
         inputs,
         mutable=['batch_stats'])
     loss = xent_loss(outputs, labels)
     return loss, new_model_state
 
   (loss, new_model_state), grads = jax.value_and_grad(
-      loss_fn, has_aux=True)(train_state.params)
-  new_state = train_state.apply_gradients(
+      loss_fn, has_aux=True)(state.params)
+  new_state = state.apply_gradients(
       grads=grads,
       batch_stats=new_model_state['batch_stats'],
   )
@@ -248,40 +248,40 @@ def train_step(train_state, inputs, labels):
   return new_state, loss
 
 
-train_state = TrainState.create(
+state = TrainState.create(
     apply_fn=model.apply,
     params=variables['params'],
     tx=tx,
     batch_stats=variables['batch_stats'],
 )
 for batch in ds.as_numpy_iterator():
-  train_state, loss = train_step(train_state, batch['image'], batch['label'])
+  state, loss = train_step(state, batch['image'], batch['label'])
 ```
 
 The train step without mutable state reduces to:
 
 ```python
 @jax.jit
-def train_step(train_state, inputs, labels):
+def train_step(state, inputs, labels):
 
   def loss_fn(params):
-    outputs = train_state.apply_fn({'params': params}, inputs)
+    outputs = state.apply_fn({'params': params}, inputs)
     loss = xent_loss(outputs, labels)
     return loss
 
-  loss, grads = jax.value_and_grad(loss_fn)(train_state.params)
-  new_state = train_state.update(grads=grads)
+  loss, grads = jax.value_and_grad(loss_fn)(state.params)
+  new_state = state.update(grads=grads)
 
   return new_state, loss
 
 
-train_state = flax.training.TrainState.create(
+state = flax.training.TrainState.create(
     apply_fn=model.apply,
     params=variables['params'],
     tx=tx,
 )
 for batch in ds.as_numpy_iterator():
-  train_state, loss = train_step(train_state, batch['image'], batch['label'])
+  state, loss = train_step(state, batch['image'], batch['label'])
 ```
 
 Remarks:

--- a/docs/flip/1009-optimizer-api.md
+++ b/docs/flip/1009-optimizer-api.md
@@ -183,6 +183,7 @@ reducing the number of arguments and getting rid of the `static_argnums`.
 
 We can define a `TrainState` dataclass that wraps the common pattern of updating
 the optimizer state and parameters by applying the gradients.
+
 ```python
 # Small helper class in flax.training
 class TrainState(flax.struct.PyTreeNode):
@@ -220,7 +221,9 @@ Users can then derive from this dataclass and add more fields, for example
 mutable model state:
 
 ```python
-class TrainState(flax.training.TrainState):
+from flax.training import train_state
+
+class TrainState(train_state.TrainState):
   batch_stats: flax.core.FrozenDict[str, Any]
 ```
 
@@ -288,10 +291,10 @@ Remarks:
 
 - It is a common pattern in Flax training loops to have a `TrainState` dataclass
   that is updated with new state after every step.
-- The simple solution proposed in `flax.training.TrainState` an be extended with
-  additional data, but advanced usecases (e.g. multiple different models and/or
-  optimizers) are not supported. Users should instead fork the dataclass and
-  re-implement it to their needs.
+- The simple solution proposed in `flax.training.train_state` an be extended
+  with additional data, but advanced usecases (e.g. multiple different models
+  and/or optimizers) are not supported. Users should instead fork the dataclass
+  and re-implement it to their needs.
 - As opposed to the `Optimizer` abstraction in the [previous API], the
   `TrainState` now directly contains the `.params`, without having to to through
   `.optimizer`


### PR DESCRIPTION
As @8bitmp3 has mentioned in [a comment](https://github.com/google/flax/commit/c4b3464427ae1d7e12ef3e114dd8ed4022709ddf#commitcomment-50892606) currently it's hard to find documentation about the new `state.apply_gradients()` because we call the variable `train_state` instead of `state` as in the examples. Note that we decided to go for simply `state` in the examples because we stored the new `TrainState` in a module called `flax.training.train_state`.
