### PR TITLE
Expose merge_param at top level of flax.linen.

### DIFF
--- a/flax/linen/__init__.py
+++ b/flax/linen/__init__.py
@@ -25,7 +25,8 @@ from .attention import (MultiHeadDotProductAttention, SelfAttention,
                         make_causal_mask, combine_masks)
 from ..core import broadcast, DenyList
 from .linear import Conv, ConvTranspose, Dense, DenseGeneral, Embed
-from .module import Module, compact, enable_named_call, disable_named_call, Variable, init, init_with_output, apply
+from .module import (Module, compact, enable_named_call, disable_named_call,
+                     Variable, init, init_with_output, apply, merge_param)
 from .normalization import BatchNorm, GroupNorm, LayerNorm
 from .pooling import avg_pool, max_pool
 from .recurrent import GRUCell, LSTMCell, ConvLSTM, OptimizedLSTMCell


### PR DESCRIPTION
Fixes #1319 to let users access `merge_param` through `flax.linen.merge_param`.

## Checklist
- [x] This PR fixes a minor issue (e.g.: typo or small bug) or improves the docs (you can dismiss the other
      checks if that's the case).
- [x] This change is discussed in a Github issue/
      [discussion](https://github.com/google/flax/discussions) (please add a
      link).
- [ ] The documentation and docstrings adhere to the
      [documentation guidelines](https://github.com/google/flax/blob/master/docs/README.md#how-to-write-code-documentation).
- [ ] This change includes necessary high-coverage tests.
      (No quality testing = no merge!)