### PR TITLE
Make README and Module docstring examples runnable

### DIFF
--- a/flax/linen/module.py
+++ b/flax/linen/module.py
@@ -846,15 +846,24 @@ class Module:
 
     Example::
 
+      import jax
+      import jax.numpy as jnp
+      import flax.linen as nn
+
       class AutoEncoder(nn.Module):
         def setup(self):
           self.encoder = nn.Dense(3)
           self.decoder = nn.Dense(5)
-      
+
+        def __call__(self, x):
+          return self.decoder(self.encoder(x))
+
+      x = jnp.ones((16, 9))
       ae = AutoEncoder()
+      variables = ae.init(jax.random.PRNGKey(0), x)
       model = ae.bind(variables)
-      z = model.encode(x)
-      x_reconstructed = model.decode(z)
+      z = model.encoder(x)
+      x_reconstructed = model.decoder(z)
 
 
     Args:
@@ -1037,13 +1046,21 @@ class Module:
 
     Example::
 
+      import jax
+      import jax.numpy as jnp
+      import flax.linen as nn
+
       class Foo(nn.Module):
         @nn.compact
         def __call__(self, x):
           h = nn.Dense(4)(x)
           self.sow('intermediates', 'h', h)
           return nn.Dense(2)(h)
-      y, state = Foo.apply(params, x, mutable=['intermediates'])
+
+      x = jnp.ones(((16, 9)))
+      model = Foo()
+      variables, _ = model.init(jax.random.PRNGKey(0), x).pop('intermediates')
+      y, state = model.apply(variables, x, mutable=['intermediates'])
       print(state['intermediates'])  # {'h': (...,)}
     
     By default the values are stored in a tuple and each stored value
@@ -1051,7 +1068,7 @@ class Module:
     the same module is called multiple times. Alternatively, a custom
     init/reduce function can be passed::
 
-      class Foo(nn.Module):
+      class Foo2(nn.Module):
         @nn.compact
         def __call__(self, x):
           init_fn = lambda: 0
@@ -1061,8 +1078,11 @@ class Module:
           self.sow('intermediates', 'h', x * 2,
                    init_fn=init_fn, reduce_fn=reduce_fn)
           return x
-      y, state = Foo.apply(params, 1, mutable=['intermediates'])
-      print(state['intermediates'])  # ==> {'h': 3}
+
+      model = Foo2()
+      variables, _ = model.init(jax.random.PRNGKey(0), x).pop('intermediates')
+      y, state = model.apply(variables, jnp.ones((1, 1)), mutable=['intermediates'])
+      print(state['intermediates'])  # ==> {'h': [[3.]]}
 
     Args:
       col: The name of the variable collection.

--- a/flax/linen/module.py
+++ b/flax/linen/module.py
@@ -1059,7 +1059,7 @@ class Module:
 
       x = jnp.ones(((16, 9)))
       model = Foo()
-      variables, _ = model.init(jax.random.PRNGKey(0), x).pop('intermediates')
+      variables = model.init(jax.random.PRNGKey(0), x)
       y, state = model.apply(variables, x, mutable=['intermediates'])
       print(state['intermediates'])  # {'h': (...,)}
     

--- a/flax/linen/module.py
+++ b/flax/linen/module.py
@@ -1057,7 +1057,7 @@ class Module:
           self.sow('intermediates', 'h', h)
           return nn.Dense(2)(h)
 
-      x = jnp.ones(((16, 9)))
+      x = jnp.ones((16, 9))
       model = Foo()
       variables = model.init(jax.random.PRNGKey(0), x)
       y, state = model.apply(variables, x, mutable=['intermediates'])
@@ -1080,7 +1080,7 @@ class Module:
           return x
 
       model = Foo2()
-      variables, _ = model.init(jax.random.PRNGKey(0), x).pop('intermediates')
+      variables = model.init(jax.random.PRNGKey(0), x)
       y, state = model.apply(variables, jnp.ones((1, 1)), mutable=['intermediates'])
       print(state['intermediates'])  # ==> {'h': [[3.]]}
 


### PR DESCRIPTION
This includes fixing minor typos, imports, code initialize variables + a forward pass.

## Checklist
- [x] This PR fixes a minor issue (e.g.: typo or small bug) or improves the docs (you can dismiss the other
      checks if that's the case).
- [x] This change is discussed in #1325 (doesn't close this issue, though)
- [x] The documentation and docstrings adhere to the
      [documentation guidelines](https://github.com/google/flax/blob/master/docs/README.md#how-to-write-code-documentation).
- [ ] This change includes necessary high-coverage tests.
      (No quality testing = no merge!)