### PR TITLE
Fix NamedTuples being converted to tuples in Module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ vNext
  -
  -
  -
- -
+ - NamedTuples are no longer converted to tuples on assingment to a `linen.Module`.
  -
  -
  -

--- a/flax/linen/module.py
+++ b/flax/linen/module.py
@@ -184,6 +184,9 @@ def _all_names_on_object(obj: Any) -> Set[str]:
 def _freeze_attr(val: Any) -> Any:
   if isinstance(val, (dict, FrozenDict)):
     return FrozenDict({k: _freeze_attr(v) for k, v in val.items()})
+  elif  isinstance(val, tuple) and hasattr(val, '_fields'):
+    # Special case named tuple otherwise they would be downgraded to normal tuples.
+    return type(val)(*[_freeze_attr(v) for v in val])
   elif isinstance(val, (list, tuple)):
     return tuple(_freeze_attr(v) for v in val)
   else:

--- a/tests/linen/module_test.py
+++ b/tests/linen/module_test.py
@@ -29,7 +29,7 @@ from jax.nn import initializers
 import jax.numpy as jnp
 
 import numpy as np
-from typing import Any, Tuple, Iterable, Callable, Mapping
+from typing import Any, Tuple, Iterable, Callable, Mapping, NamedTuple
 
 from flax import linen as nn
 from flax import errors
@@ -1358,6 +1358,17 @@ class ModuleTest(absltest.TestCase):
     variables = Bar().init(k, x)
     y = Bar().apply(variables, x)
     self.assertEqual(y.shape, (4, 3))
+  
+  def test_freeze_attr(self):
+    class Foo(NamedTuple):
+      a: int
+      b: int
+
+    self.assertEqual(nn.module._freeze_attr([1, 2]), (1, 2))
+    xs = nn.module._freeze_attr(Foo(1, 2))
+    self.assertEqual(xs, (1, 2))
+    self.assertEqual(type(xs), Foo)  # equality test for NamedTuple doesn't check class!
+
 
 if __name__ == '__main__':
   absltest.main()


### PR DESCRIPTION
NamedTuples are constructed differently so they
have to be special cased by the freezing logic
in Module (*args instead of Iterable)