### PR TITLE
Replaces link to README with link to Github repo

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -11,8 +11,7 @@ designed for flexibility. Flax is in use by a growing community of
 researchers and engineers at Google who happily use Flax for their
 daily research.
 
-For a quick introduction and short example snippets, see our `README
-<https://github.com/google/flax/blob/master/README.md>`_.
+Official Github repository: https://github.com/google/flax
 
 .. toctree::
    :maxdepth: 1

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -11,7 +11,7 @@ designed for flexibility. Flax is in use by a growing community of
 researchers and engineers at Google who happily use Flax for their
 daily research.
 
-Official Github repository: https://github.com/google/flax
+Official Github repository with quick intro and short examples: https://github.com/google/flax
 
 .. toctree::
    :maxdepth: 1


### PR DESCRIPTION
The same README is shown as lower part of that Github repo. Having the link instead of `README` makes it more visible where the link is going. And it's a nice short link so there's no need to hide it behind a link text.

Finally, I often find it useful to navigate to Flax via `flax.readth...` (w/ Chrome autocomplete) - so it's nice having a link going from the to the Github repo.

(I know there is a "edit on Github link" - which I used for this edit -, but I don't usually want to edit anything, but rather browse the source or search things.)
