### PR TITLE
Updates examples/vae to use Optax.

### DIFF
--- a/examples/vae/README.md
+++ b/examples/vae/README.md
@@ -14,8 +14,8 @@ If you run the code by above command, you can get some generated images:
 
 ![generated_mnist](./sample.png)
 
-and reconstructions of test set digitis:
+and reconstructions of test set digits:
 
 ![reconstruction_mnist](./reconstruction.png)
 
-The test set ELBO after 10 epochs should be around `106`.
+The test set loss after 10 epochs should be around `104`.

--- a/examples/vae/requirements.txt
+++ b/examples/vae/requirements.txt
@@ -1,4 +1,5 @@
 jax
 flax
-tensorflow
+optax
 pillow
+tensorflow

--- a/examples/vae/train.py
+++ b/examples/vae/train.py
@@ -12,20 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# See issue #620.
-# pytype: disable=attribute-error
-# pytype: disable=wrong-arg-count
-# pytype: disable=wrong-keyword-args
-
 from absl import app
 from absl import flags
 import numpy as np
 import jax.numpy as jnp
 import jax
 from jax import random
-from jax.config import config
 from flax import linen as nn
-from flax import optim
+from flax.training import train_state
+import optax
 import tensorflow as tf
 import tensorflow_datasets as tfds
 
@@ -126,18 +121,16 @@ def model():
 
 
 @jax.jit
-def train_step(optimizer, batch, z_rng):
+def train_step(state, batch, z_rng):
   def loss_fn(params):
     recon_x, mean, logvar = model().apply({'params': params}, batch, z_rng)
 
     bce_loss = binary_cross_entropy_with_logits(recon_x, batch).mean()
     kld_loss = kl_divergence(mean, logvar).mean()
     loss = bce_loss + kld_loss
-    return loss, recon_x
-  grad_fn = jax.value_and_grad(loss_fn, has_aux=True)
-  _, grad = grad_fn(optimizer.target)
-  optimizer = optimizer.apply_gradient(grad)
-  return optimizer
+    return loss
+  grads = jax.grad(loss_fn)(state.params)
+  return state.apply_gradients(grads=grads)
 
 
 @jax.jit
@@ -186,10 +179,12 @@ def main(argv):
   test_ds = jax.device_put(test_ds)
 
   init_data = jnp.ones((FLAGS.batch_size, 784), jnp.float32)
-  params = model().init(key, init_data, rng)['params']
 
-  optimizer = optim.Adam(learning_rate=FLAGS.learning_rate).create(params)
-  optimizer = jax.device_put(optimizer)
+  state = train_state.TrainState.create(
+      apply_fn=model().apply,
+      params=model().init(key, init_data, rng)['params'],
+      tx=optax.adam(FLAGS.learning_rate),
+  )
 
   rng, z_key, eval_rng = random.split(rng, 3)
   z = random.normal(z_key, (64, FLAGS.latents))
@@ -200,9 +195,9 @@ def main(argv):
     for _ in range(steps_per_epoch):
       batch = next(train_ds)
       rng, key = random.split(rng)
-      optimizer = train_step(optimizer, batch, key)
+      state = train_step(state, batch, key)
 
-    metrics, comparison, sample = eval(optimizer.target, test_ds, z, eval_rng)
+    metrics, comparison, sample = eval(state.params, test_ds, z, eval_rng)
     vae_utils.save_image(
         comparison, f'results/reconstruction_{epoch}.png', nrow=8)
     vae_utils.save_image(sample, f'results/sample_{epoch}.png', nrow=8)


### PR DESCRIPTION
This is part of #1053

Tested locally:

before change:

```
eval epoch: 1, loss: 119.7388, BCE: 95.0571, KLD: 24.6818
eval epoch: 2, loss: 112.0471, BCE: 85.9042, KLD: 26.1429
eval epoch: 3, loss: 109.3355, BCE: 82.6257, KLD: 26.7098
eval epoch: 4, loss: 107.5200, BCE: 81.2980, KLD: 26.2219
eval epoch: 5, loss: 106.0630, BCE: 79.1360, KLD: 26.9270
eval epoch: 6, loss: 105.5277, BCE: 79.0156, KLD: 26.5122
eval epoch: 7, loss: 104.7966, BCE: 77.2300, KLD: 27.5666
eval epoch: 8, loss: 104.2626, BCE: 77.3730, KLD: 26.8896
eval epoch: 9, loss: 103.9320, BCE: 76.7350, KLD: 27.1970
eval epoch: 10, loss: 103.5992, BCE: 76.5406, KLD: 27.0586
eval epoch: 11, loss: 103.1814, BCE: 75.8987, KLD: 27.2827
eval epoch: 12, loss: 102.7763, BCE: 75.6173, KLD: 27.1590
eval epoch: 13, loss: 102.7012, BCE: 75.5014, KLD: 27.1998
eval epoch: 14, loss: 102.5361, BCE: 74.7993, KLD: 27.7367
eval epoch: 15, loss: 102.1777, BCE: 74.9400, KLD: 27.2377
eval epoch: 16, loss: 102.1981, BCE: 74.4873, KLD: 27.7108
eval epoch: 17, loss: 102.2480, BCE: 74.6858, KLD: 27.5622
eval epoch: 18, loss: 102.0329, BCE: 74.4017, KLD: 27.6312
eval epoch: 19, loss: 101.6671, BCE: 74.4009, KLD: 27.2662
eval epoch: 20, loss: 101.8251, BCE: 74.3291, KLD: 27.4960
eval epoch: 21, loss: 101.5264, BCE: 74.5861, KLD: 26.9403
eval epoch: 22, loss: 101.3120, BCE: 73.3562, KLD: 27.9558
eval epoch: 23, loss: 101.2275, BCE: 73.5510, KLD: 27.6765
eval epoch: 24, loss: 101.3282, BCE: 73.4732, KLD: 27.8550
eval epoch: 25, loss: 101.2186, BCE: 73.6929, KLD: 27.5257
eval epoch: 26, loss: 101.1104, BCE: 73.3796, KLD: 27.7308
eval epoch: 27, loss: 100.9810, BCE: 73.1891, KLD: 27.7920
eval epoch: 28, loss: 100.9503, BCE: 73.4646, KLD: 27.4857
eval epoch: 29, loss: 100.9579, BCE: 73.3994, KLD: 27.5586
eval epoch: 30, loss: 100.7218, BCE: 72.8474, KLD: 27.8744
```

after change:

```
eval epoch: 1, loss: 120.3942, BCE: 96.3404, KLD: 24.0538
eval epoch: 2, loss: 112.3431, BCE: 86.4929, KLD: 25.8501
eval epoch: 3, loss: 109.3994, BCE: 83.2447, KLD: 26.1547
eval epoch: 4, loss: 107.5763, BCE: 81.5863, KLD: 25.9900
eval epoch: 5, loss: 106.4025, BCE: 79.3835, KLD: 27.0190
eval epoch: 6, loss: 105.3636, BCE: 78.5357, KLD: 26.8280
eval epoch: 7, loss: 104.7143, BCE: 77.8862, KLD: 26.8280
eval epoch: 8, loss: 104.2600, BCE: 77.3799, KLD: 26.8801
eval epoch: 9, loss: 104.0370, BCE: 76.8476, KLD: 27.1894
eval epoch: 10, loss: 103.6080, BCE: 76.3819, KLD: 27.2261
eval epoch: 11, loss: 103.1740, BCE: 75.5068, KLD: 27.6673
eval epoch: 12, loss: 103.0981, BCE: 75.4708, KLD: 27.6273
eval epoch: 13, loss: 102.8414, BCE: 75.5489, KLD: 27.2925
eval epoch: 14, loss: 102.6197, BCE: 74.8024, KLD: 27.8173
eval epoch: 15, loss: 102.4028, BCE: 74.4139, KLD: 27.9889
eval epoch: 16, loss: 102.3348, BCE: 74.7602, KLD: 27.5746
eval epoch: 17, loss: 102.0597, BCE: 74.5150, KLD: 27.5447
eval epoch: 18, loss: 102.0108, BCE: 74.2556, KLD: 27.7552
eval epoch: 19, loss: 101.9537, BCE: 74.1800, KLD: 27.7737
eval epoch: 20, loss: 101.7499, BCE: 73.9748, KLD: 27.7751
eval epoch: 21, loss: 101.8456, BCE: 74.5265, KLD: 27.3191
eval epoch: 22, loss: 101.5601, BCE: 73.2418, KLD: 28.3183
eval epoch: 23, loss: 101.4814, BCE: 73.5661, KLD: 27.9152
eval epoch: 24, loss: 101.4378, BCE: 72.9566, KLD: 28.4812
eval epoch: 25, loss: 101.5319, BCE: 73.4677, KLD: 28.0642
eval epoch: 26, loss: 101.4185, BCE: 73.5147, KLD: 27.9038
eval epoch: 27, loss: 101.4243, BCE: 72.9235, KLD: 28.5008
eval epoch: 28, loss: 100.9927, BCE: 73.1934, KLD: 27.7993
eval epoch: 29, loss: 101.1934, BCE: 73.3350, KLD: 27.8584
eval epoch: 30, loss: 100.8738, BCE: 72.9291, KLD: 27.9447
```