### PR TITLE
Change unhashable module exception type to TypeError.

### DIFF
--- a/flax/linen/module.py
+++ b/flax/linen/module.py
@@ -299,7 +299,7 @@ def _wrap_hash(hash_fn: Callable[..., Any]) -> Callable[..., Any]:
   @functools.wraps(hash_fn)
   def wrapped(self):
     if self.scope is not None:
-      raise ValueError('Can\'t call __hash__ on modules that hold variables.')
+      raise TypeError('Can\'t call __hash__ on modules that hold variables.')
     return hash_fn(self)
   return wrapped
 

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ tests_require = [
     "pytest",
     "pytest-cov",
     "pytest-xdist==1.34.0",  # upgrading to 2.0 broke tests, need to investigate
-    "pytype",
+    "pytype==2021.5.25",  # pytype 2021.6.17 complains on recurrent.py, need to investigate!
     "sentencepiece",  # WMT example.
     "svn",
     "tensorflow-cpu>=2.4.0",

--- a/tests/linen/module_test.py
+++ b/tests/linen/module_test.py
@@ -632,7 +632,7 @@ class ModuleTest(absltest.TestCase):
   def test_module_with_scope_is_not_hashable(self):
     module_a = nn.Dense(10, parent=Scope({}))
     msg = 'Can\'t call __hash__ on modules that hold variables.'
-    with self.assertRaisesWithLiteralMatch(ValueError, msg):
+    with self.assertRaisesWithLiteralMatch(TypeError, msg):
       hash(module_a)
 
   def test_module_trace(self):


### PR DESCRIPTION
Other libraries when checking whether or not an object
is hashable do so by guarding against a TypeError rather than a
ValueError, so this change brings our unhashable exception in line with
python conventions.