### PR TITLE
Correct typo: n --> np (numpy)

### DIFF
--- a/docs/notebooks/jax_for_the_impatient.ipynb
+++ b/docs/notebooks/jax_for_the_impatient.ipynb
@@ -122,7 +122,7 @@
         }
       },
       "source": [
-        "jnp.dot(n, m).block_until_ready() # Note: yields the same result as n.dot(m)"
+        "jnp.dot(n, m).block_until_ready() # Note: yields the same result as np.dot(m)"
       ],
       "execution_count": 3,
       "outputs": [


### PR DESCRIPTION
# What does this PR do?

In the guide "JAX for the impatient", there's a comment where rather than saying `n.dot(m)` the comment should say `np.dot(m)` (it compares `jnp` to `np`).
I directly edited the `.ipynb` file in the github text editor; I hope it looks all right like this.

Fixes # N/A (I just saw a typo)

## Checklist
- [X] This PR fixes a minor issue (e.g.: typo or small bug) or improves the docs (you can dismiss the other
      checks if that's the case)