### PR TITLE
Small update to annotated_mnist notebook

### DIFF
--- a/docs/notebooks/annotated_mnist.ipynb
+++ b/docs/notebooks/annotated_mnist.ipynb
@@ -347,7 +347,7 @@
     "  train_ds_size = len(train_ds['image'])\n",
     "  steps_per_epoch = train_ds_size // batch_size\n",
     "\n",
-    "  perms = jax.random.permutation(rng, len(train_ds['image']))\n",
+    "  perms = jax.random.permutation(rng, train_ds_size)\n",
     "  perms = perms[:steps_per_epoch * batch_size]  # skip incomplete batch\n",
     "  perms = perms.reshape((steps_per_epoch, batch_size))\n",
     "  batch_metrics = []\n",


### PR DESCRIPTION
# What does this PR do?
Updates the annotated_mnist.ipynb notebook to use the existing local variable `train_ds_size` appropriately inside `train_epoch()` function

## Checklist
- [x] This PR fixes a minor issue (e.g.: typo or small bug) or improves the docs (you can dismiss the other
      checks if that's the case).