### PR TITLE
Renaming master to main. Step 1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,9 +7,12 @@ on:
   push:
     branches:
       - master
+      - main
       - 'test_*'
   pull_request:
-    branches: [ master ]
+    branches:
+      - master
+      - main
 
 jobs:
   build:


### PR DESCRIPTION
Here we just enable GitHub to watch both master and main.
