### PR TITLE
Rename master to main in code.

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -25,6 +25,6 @@ Fixes # (issue)
       [discussion](https://github.com/google/flax/discussions) (please add a
       link).
 - [ ] The documentation and docstrings adhere to the
-      [documentation guidelines](https://github.com/google/flax/blob/master/docs/README.md#how-to-write-code-documentation).
+      [documentation guidelines](https://github.com/google/flax/blob/main/docs/README.md#how-to-write-code-documentation).
 - [ ] This change includes necessary high-coverage tests.
       (No quality testing = no merge!)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,12 +6,10 @@ name: Build
 on:
   push:
     branches:
-      - master
       - main
       - 'test_*'
   pull_request:
     branches:
-      - master
       - main
 
 jobs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@ Possibly breaking changes:
 Other changes:
  - Rewrote various examples to use Optax instead of Flax optimizers (e.g., Imagenet, SST2).
  - Added an NLP text classification example (on the SST-2 dataset) to
-   [`examples/sst2`](https://github.com/google/flax/tree/master/examples/sst2).
+   [`examples/sst2`](https://github.com/google/flax/tree/main/examples/sst2).
    that uses a bidirectional LSTM (BiLSTM) to encode the input text.
  - Added `flax.training.train_state` to simplify using Optax optimizers.
  - `mutable` argument is now available on `Module.init` and `Module.init_with_outputs`
@@ -177,7 +177,7 @@ v0.2.2
  - Fix initialization RNGs to work with omnistaging for jitted inits.
  - Replaces usage of 'param' kind to 'params' collection.
  - Fix LARS optimizer for zero param initialization.
- - Added various examples in Linen API. See [README.md](https://github.com/google/flax/blob/master/flax/linen/README.md) for more information.
+ - Added various examples in Linen API. See [README.md](https://github.com/google/flax/blob/main/flax/linen/README.md) for more information.
  - Full JAX omnistaging compatibility.
 
 v0.2

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ forum](https://github.com/google/flax/discussions), or just let us
 know what you're working on!
 
 We expect to improve Flax, but we don't anticipate significant
-breaking changes to the core API. We use [Changelog](https://github.com/google/flax/tree/master/CHANGELOG.md)
+breaking changes to the core API. We use [Changelog](https://github.com/google/flax/tree/main/CHANGELOG.md)
 entries and deprecation warnings when possible.
 
 In case you want to reach us directly, we're at flax-dev@google.com.
@@ -62,7 +62,7 @@ comes with everything you need to start your research, including:
 
 ## Quick install
 
-You will need Python 3.6 or later and a working [JAX](https://github.com/google/jax/blob/master/README.md)
+You will need Python 3.6 or later and a working [JAX](https://github.com/google/jax/blob/main/README.md)
 installation (with or without GPU support, see instructions there). For a
 CPU-only version:
 
@@ -87,7 +87,7 @@ To upgrade to the latest version of Flax, you can use:
 
 We provide three examples using the Flax API: a simple multi-layer perceptron, a CNN and an auto-encoder. 
 
-To learn more about the `Module` abstraction, see our [docs](https://flax.readthedocs.io/), our [broad intro to the Module abstraction](https://github.com/google/flax/blob/master/docs/notebooks/linen_intro.ipynb). For additional concrete demonstrations of best practices, see our
+To learn more about the `Module` abstraction, see our [docs](https://flax.readthedocs.io/), our [broad intro to the Module abstraction](https://github.com/google/flax/blob/main/docs/notebooks/linen_intro.ipynb). For additional concrete demonstrations of best practices, see our
 [HOWTO guides](https://flax.readthedocs.io/en/latest/howtos.html).
 
 ```py
@@ -184,7 +184,7 @@ To cite this repository:
 ```
 
 In the above bibtex entry, names are in alphabetical order, the version number
-is intended to be that from [flax/version.py](https://github.com/google/flax/blob/master/flax/version.py), and the year corresponds to the project's open-source release.
+is intended to be that from [flax/version.py](https://github.com/google/flax/blob/main/flax/version.py), and the year corresponds to the project's open-source release.
 
 ## Note
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -108,8 +108,8 @@ nbsphinx_prolog = r"""
 
     .. nbinfo::
 
-        :raw-html:`<a href="https://colab.research.google.com/github/google/flax/blob/master/{{ docname }}"><img alt="Open In Colab" src="https://colab.research.google.com/assets/colab-badge.svg" style="vertical-align:text-bottom"></a>`
-        :raw-html:`<a href="https://github.com/google/flax/blob/master/{{ docname }}"><img alt="Open On GitHub" src="https://img.shields.io/badge/Open-on%20GitHub-blue?logo=GitHub" style="vertical-align:text-bottom"></a>`
+        :raw-html:`<a href="https://colab.research.google.com/github/google/flax/blob/main/{{ docname }}"><img alt="Open In Colab" src="https://colab.research.google.com/assets/colab-badge.svg" style="vertical-align:text-bottom"></a>`
+        :raw-html:`<a href="https://github.com/google/flax/blob/main/{{ docname }}"><img alt="Open On GitHub" src="https://img.shields.io/badge/Open-on%20GitHub-blue?logo=GitHub" style="vertical-align:text-bottom"></a>`
 
 
 """

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -31,7 +31,7 @@ Follow these steps to contribute code:
 2. Install Python >=3.6 and `svn` for running the tests (see below).
 
 3. (Optional) Create a virutal environment or a Docker container. See 
-   [`dev/README.md`](https://github.com/google/flax/blob/master/dev/README.md)
+   [`dev/README.md`](https://github.com/google/flax/blob/main/dev/README.md)
    for details on how to setup a Docker Contaner. To setup a virual environment,
    run the following:
 
@@ -87,7 +87,7 @@ Follow these steps to contribute code:
    Then sync your code with the main repo:
 
    ```bash
-   git rebase upstream/master
+   git rebase upstream/main
    ```
 
    Finally push your commit on your development branch and create a remote 
@@ -98,7 +98,7 @@ Follow these steps to contribute code:
    ```
 
 9. Make sure your PR passes the 
-   [PR checklist](https://github.com/google/flax/blob/master/.github/pull_request_template.md#checklist).
+   [PR checklist](https://github.com/google/flax/blob/main/.github/pull_request_template.md#checklist).
    If so, create a Pull Request from the Flax repository and send it for review.
    Consult [GitHub Help](https://help.github.com/articles/about-pull-requests/)
    for more information on using pull requests.

--- a/docs/deprecated_howtos/checkpointing.rst
+++ b/docs/deprecated_howtos/checkpointing.rst
@@ -1,7 +1,7 @@
 Checkpointing
 =============
 
-⟶ `View as a side-by-side diff <https://github.com/google/flax/compare/master..howto/checkpointing?diff=split>`_
+⟶ `View as a side-by-side diff <https://github.com/google/flax/compare/main..howto/checkpointing?diff=split>`_
 
 .. raw:: html
    :file: ../_formatted_howtos/checkpointing.diff.html

--- a/docs/deprecated_howtos/distributed-training.rst
+++ b/docs/deprecated_howtos/distributed-training.rst
@@ -1,7 +1,7 @@
 Multi-device data-parallel training
 ===================================
 
-⟶ `View as a side-by-side diff <https://github.com/google/flax/compare/master..howto/distributed-training?diff=split>`_
+⟶ `View as a side-by-side diff <https://github.com/google/flax/compare/main..howto/distributed-training?diff=split>`_
 
 .. raw:: html
    :file: ../_formatted_howtos/distributed-training.diff.html

--- a/docs/deprecated_howtos/ensembling.rst
+++ b/docs/deprecated_howtos/ensembling.rst
@@ -1,7 +1,7 @@
 Ensembling on multiple devices
 ==============================
 
-⟶ `View as a side-by-side diff <https://github.com/google/flax/compare/master..howto/ensembling?diff=split>`_
+⟶ `View as a side-by-side diff <https://github.com/google/flax/compare/main..howto/ensembling?diff=split>`_
 
 .. raw:: html
    :file: ../_formatted_howtos/ensembling.diff.html

--- a/docs/deprecated_howtos/howtos-howto.md
+++ b/docs/deprecated_howtos/howtos-howto.md
@@ -14,10 +14,10 @@ instance, the "ensembling howto" is represented in two ways:
 * In the file `howtos/diffs/howto-ensembling.diff` (in the repository).
 
 The branch `howto-ensembling` is simply the result of applying 
-`howto/howto-ensembling.diff` to the master branch.
+`howto/howto-ensembling.diff` to the main branch.
 
 This setup allows us to ensure all local modifications to HOWTOs can be packed
-in diff files locally, pushed to origin and applied to the master branch 
+in diff files locally, pushed to origin and applied to the main branch 
 automatically.
 
 This process is automatic, which means that users usually won't notice this, 
@@ -53,13 +53,13 @@ The workflow script for the Github action can be found at
 This is still a work in progress. Currently, conflicts are resolved by manually
 making the required fixes. The suggestions below can help speed up that process.
 
-### Start with a clean and updated copy of `master`
+### Start with a clean and updated copy of `main`
 As an example, assuming you have `https://github.com/google/flax` set as
 `upstream`:
 ```bash
-git checkout master
+git checkout main
 git fetch upstream
-git rebase upstream/master
+git rebase upstream/main
 ```
 If your local copy of `flax` isn't clean, you may need to stash your changes
 elsewhere (e.g., via `git stash`) or otherwise remove your changes.
@@ -114,7 +114,7 @@ a `howto` is the filename without the extension (e.g., the name for the
 
 ## Modifying an existing HOWTO
 
-1. Fetch upstream and rebase onto upstream/master (see above).
+1. Fetch upstream and rebase onto upstream/main (see above).
 1. Apply the HOWTO : `git apply howtos/diffs/$name.diff`.
 2. Modify the modified files, without staging them.
 3. Re-pack the HOWTO (supplying same `$name`).

--- a/docs/deprecated_howtos/polyak-averaging.rst
+++ b/docs/deprecated_howtos/polyak-averaging.rst
@@ -1,7 +1,7 @@
 Polyak averaging
 ================
 
-⟶ `View as a side-by-side diff <https://github.com/google/flax/compare/master..howto/polyak-averaging?diff=split>`_
+⟶ `View as a side-by-side diff <https://github.com/google/flax/compare/main..howto/polyak-averaging?diff=split>`_
 
 .. raw:: html
    :file: ../_formatted_howtos/polyak-averaging.diff.html

--- a/docs/deprecated_howtos/scheduled-sampling.rst
+++ b/docs/deprecated_howtos/scheduled-sampling.rst
@@ -1,7 +1,7 @@
 Scheduled Sampling
 ==================
 
-⟶ `View as a side-by-side diff <https://github.com/google/flax/compare/master..howto/scheduled-sampling?diff=split>`_
+⟶ `View as a side-by-side diff <https://github.com/google/flax/compare/main..howto/scheduled-sampling?diff=split>`_
 
 .. raw:: html
    :file: ../_formatted_howtos/scheduled-sampling.diff.html

--- a/docs/design_notes/lift.md
+++ b/docs/design_notes/lift.md
@@ -292,8 +292,8 @@ Please open a GitHub issue when you find a use case that is not supported yet by
 
 References:
 - [Linen transforms documentation](https://flax.readthedocs.io/en/latest/flax.linen.html#module-flax.linen.transforms).
-- [Linen transforms source code](https://github.com/google/flax/blob/master/flax/linen/transforms.py)
-- [Core lifting source code](https://github.com/google/flax/blob/master/flax/core/lift.py)
+- [Linen transforms source code](https://github.com/google/flax/blob/main/flax/linen/transforms.py)
+- [Core lifting source code](https://github.com/google/flax/blob/main/flax/core/lift.py)
 
 ### Linen examples
 

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -8,7 +8,7 @@ Each example is designed to be self-contained and easily forkable, while
 reproducing relevant results in different areas of machine learning. These
 examples adhere to a shared style and functionality outlined in `#231`_. All
 examples are under the folder `flax/examples/
-<https://github.com/google/flax/tree/master/examples/>`__. Some of the
+<https://github.com/google/flax/tree/main/examples/>`__. Some of the
 examples below have a link [Interactive] that lets you run them directly in
 Colab.
 
@@ -17,35 +17,35 @@ Colab.
 
 Image classification
 
-   -  `MNIST <https://github.com/google/flax/tree/master/examples/mnist/>`__ [`Interactive
-      <https://colab.research.google.com/github/google/flax/blob/master/examples/mnist/mnist.ipynb>`__] :
+   -  `MNIST <https://github.com/google/flax/tree/main/examples/mnist/>`__ [`Interactive
+      <https://colab.research.google.com/github/google/flax/blob/main/examples/mnist/mnist.ipynb>`__] :
       Convolutional neural network for MNIST classification (featuring simple code).
-   -  `ImageNet <https://github.com/google/flax/tree/master/examples/imagenet/>`__ :
+   -  `ImageNet <https://github.com/google/flax/tree/main/examples/imagenet/>`__ :
       Resnet-50 on imagenet with weight decay (featuring multi host SPMD, custom
       preprocessing, checkpointing, dynamic scaling, mixed precision).
 
 Reinforcement Learning
 
    -  `Proximal Policy
-      Optimization <https://github.com/google/flax/tree/master/examples/ppo/>`__ :
+      Optimization <https://github.com/google/flax/tree/main/examples/ppo/>`__ :
       Learning to play Atari games (featuring single host SPMD, RL setup).
 
 Natural language processing
 
    -  `Sequence to sequence for number
-      addition <https://github.com/google/flax/tree/master/examples/seq2seq/>`__
+      addition <https://github.com/google/flax/tree/main/examples/seq2seq/>`__
       (featuring simple code, LSTM state handling, on the fly data generation).
    -  `Transformer model on
-      WMT <https://github.com/google/flax/tree/master/examples/wmt/>`__ :
+      WMT <https://github.com/google/flax/tree/main/examples/wmt/>`__ :
       Translating English/German (featuring multihost SPMD, dynamic bucketing, attention cache,
       packed sequences, recipe for TPU training on GCP).
 
 Generative models
 
    -  `Variational
-      auto-encoder <https://github.com/google/flax/tree/master/examples/vae/>`__ :
+      auto-encoder <https://github.com/google/flax/tree/main/examples/vae/>`__ :
       Trained on binarized MNIST (featuring simple code, vmap).
-   -  `PixelCNN++ <https://github.com/google/flax/tree/master/examples/pixelcnn/>`__ :
+   -  `PixelCNN++ <https://github.com/google/flax/tree/main/examples/pixelcnn/>`__ :
       Trained on cifar10 (featuring single host SPMD, checkpointing, Polyak decay).
 
 

--- a/docs/flax.linen.rst
+++ b/docs/flax.linen.rst
@@ -4,7 +4,7 @@ flax.linen package
 
 .. currentmodule:: flax.linen
 
-Linen is the Flax Module system. Read more about our design goals in the `Linen README <https://github.com/google/flax/blob/master/flax/linen/README.md>`_.
+Linen is the Flax Module system. Read more about our design goals in the `Linen README <https://github.com/google/flax/blob/main/flax/linen/README.md>`_.
 
 
 

--- a/docs/howtos/ensembling.rst
+++ b/docs/howtos/ensembling.rst
@@ -304,4 +304,4 @@ arguments, and those should be positional rather then keyword arguments.
 .. _jax.pmap: https://jax.readthedocs.io/en/latest/jax.html#jax.pmap
 .. _Module.init: https://flax.readthedocs.io/en/latest/flax.linen.html#flax.linen.Module.init
 .. _`JIT mechanics: tracing and static variables`: https://jax.readthedocs.io/en/latest/notebooks/thinking_in_jax.html#JIT-mechanics:-tracing-and-static-variables
-.. _`MNIST example`: https://github.com/google/flax/blob/master/examples/mnist/train.py
+.. _`MNIST example`: https://github.com/google/flax/blob/main/examples/mnist/train.py

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,4 +1,4 @@
-.. Flax documentation master file, created by
+.. Flax documentation main file, created by
    sphinx-quickstart on Mon Feb 17 11:41:38 2020.
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
@@ -12,7 +12,7 @@ researchers and engineers at Google who happily use Flax for their
 daily research.
 
 For a quick introduction and short example snippets, see our `README
-<https://github.com/google/flax/blob/master/README.md>`_.
+<https://github.com/google/flax/blob/main/README.md>`_.
 
 .. toctree::
    :maxdepth: 1
@@ -49,7 +49,7 @@ For a quick introduction and short example snippets, see our `README
    :titlesonly:
 
    design_notes/*
-   FLIPs <https://github.com/google/flax/tree/master/docs/flip>
+   FLIPs <https://github.com/google/flax/tree/main/docs/flip>
 
 .. toctree::
    :maxdepth: 1

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -4,7 +4,7 @@ You will need Python 3.6 or later.
 
 For GPU support, first install `jaxlib`; please follow the
 instructions in the [JAX
-readme](https://github.com/google/jax/blob/master/README.md).  If they
+readme](https://github.com/google/jax/blob/main/README.md).  If they
 are not already installed, you will need to install
 [CUDA](https://developer.nvidia.com/cuda-downloads) and
 [CuDNN](https://developer.nvidia.com/cudnn) runtimes.

--- a/docs/notebooks/annotated_mnist.ipynb
+++ b/docs/notebooks/annotated_mnist.ipynb
@@ -13,7 +13,7 @@
     "the network for image classification on the MNIST dataset.\n",
     "\n",
     "Note: This notebook is based on Flax's official\n",
-    "[MNIST Example](https://github.com/google/flax/tree/master/examples/mnist).\n",
+    "[MNIST Example](https://github.com/google/flax/tree/main/examples/mnist).\n",
     "If you see any changes between the two feel free to create a\n",
     "[pull request](https://github.com/google/flax/compare)\n",
     "to synchronize this Colab with the actual example."
@@ -436,7 +436,7 @@
     "  more about\n",
     "  [PRNG chains](https://flax.readthedocs.io/en/latest/design_notes/linen_design_principles.html#how-are-parameters-represented-and-how-do-we-handle-general-differentiable-algorithms-that-update-stateful-variables)\n",
     "  and\n",
-    "  [JAX PRNG design](https://github.com/google/jax/blob/master/design_notes/prng.md).)"
+    "  [JAX PRNG design](https://github.com/google/jax/blob/main/design_notes/prng.md).)"
    ]
   },
   {
@@ -570,7 +570,7 @@
     "the same example, but structured differently as a couple of Python modules, test\n",
     "modules, config files, another Colab, and documentation in Flax's Git repo:\n",
     "\n",
-    "https://github.com/google/flax/tree/master/examples/mnist\n"
+    "https://github.com/google/flax/tree/main/examples/mnist\n"
    ]
   }
  ],

--- a/docs/notebooks/flax_basics.ipynb
+++ b/docs/notebooks/flax_basics.ipynb
@@ -402,7 +402,7 @@
         "### Optimizing with Optax\n",
         "\n",
         "Flax used to use its own `flax.optim` package for optimization, but with\n",
-        "[FLIP #1009](https://github.com/google/flax/blob/master/docs/flip/1009-optimizer-api.md)\n",
+        "[FLIP #1009](https://github.com/google/flax/blob/main/docs/flip/1009-optimizer-api.md)\n",
         "this was deprecated in favor of\n",
         "[Optax](https://github.com/deepmind/optax).\n",
         "\n",
@@ -898,7 +898,7 @@
         "\n",
         "However this is not enough to cover everything that we would need for machine learning, especially neural networks. In some cases, you might want your neural network to keep track of some internal state while it runs (e.g. batch normalization layers). There is a way to declare variables beyond the parameters of the model with the `variable` method.\n",
         "\n",
-        "For demonstration purposes, we'll implement a simplified but similar mechanism to batch normalization: we'll store running averages and subtract those to the input at training time. For proper batchnorm, you should use (and look at) the implementation [here](https://github.com/google/flax/blob/master/flax/linen/normalization.py)."
+        "For demonstration purposes, we'll implement a simplified but similar mechanism to batch normalization: we'll store running averages and subtract those to the input at training time. For proper batchnorm, you should use (and look at) the implementation [here](https://github.com/google/flax/blob/main/flax/linen/normalization.py)."
       ]
     },
     {
@@ -1108,7 +1108,7 @@
       "source": [
         "### Exporting to Tensorflow's SavedModel with jax2tf\n",
         "\n",
-        "JAX released an experimental converter called [jax2tf](https://github.com/google/jax/tree/master/jax/experimental/jax2tf), which allows converting trained Flax models into Tensorflow's SavedModel format (so it can be used for [TF Hub](https://www.tensorflow.org/hub), [TF.lite](https://www.tensorflow.org/lite), [TF.js](https://www.tensorflow.org/js), or other downstream applications). The repository contains more documentation and has various examples for Flax."
+        "JAX released an experimental converter called [jax2tf](https://github.com/google/jax/tree/main/jax/experimental/jax2tf), which allows converting trained Flax models into Tensorflow's SavedModel format (so it can be used for [TF Hub](https://www.tensorflow.org/hub), [TF.lite](https://www.tensorflow.org/lite), [TF.js](https://www.tensorflow.org/js), or other downstream applications). The repository contains more documentation and has various examples for Flax."
       ]
     }
   ]

--- a/docs/notebooks/linen_intro.ipynb
+++ b/docs/notebooks/linen_intro.ipynb
@@ -38,9 +38,9 @@
         "\n",
         "⟶ [Slides](https://docs.google.com/presentation/d/1ngKWUwsSqAwPRvATG8sAxMzu9ujv4N__cKsUofdNno0/edit?usp=sharing) for the core ideas of the new Functional Core and Linen\n",
         "\n",
-        "⟶ \"Design tests\" guided our design process. Many are available for [functional core](https://github.com/google/flax/tree/master/examples/core_design_test) and some for the [proposed Module abstraction](https://github.com/google/flax/tree/master/examples/linen_design_test/)\n",
+        "⟶ \"Design tests\" guided our design process. Many are available for [functional core](https://github.com/google/flax/tree/main/examples/core_design_test) and some for the [proposed Module abstraction](https://github.com/google/flax/tree/main/examples/linen_design_test/)\n",
         "\n",
-        "⟶ Ported examples: [ImageNet](https://github.com/google/flax/tree/master/examples/imagenet) and [WMT](https://github.com/google/flax/tree/master/examples/wmt) (to the proposed Module abstraction). TODO: Port to functional core.\n",
+        "⟶ Ported examples: [ImageNet](https://github.com/google/flax/tree/main/examples/imagenet) and [WMT](https://github.com/google/flax/tree/main/examples/wmt) (to the proposed Module abstraction). TODO: Port to functional core.\n",
         "\n",
         "⟶ Our new [discussion forums](https://github.com/google/flax/discussions/)\n",
         "\n"

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -44,7 +44,7 @@ See the [What does Flax look like](https://github.com/google/flax#what-does-flax
 
 ## TPU support
 
-We currently have a [LM1b/Wikitext-2 language model with a Transformer architecture](https://colab.research.google.com/github/google/flax/blob/master/examples/lm1b/Colab_Language_Model.ipynb)
+We currently have a [LM1b/Wikitext-2 language model with a Transformer architecture](https://colab.research.google.com/github/google/flax/blob/main/examples/lm1b/Colab_Language_Model.ipynb)
 that's been tuned. You can run it directly via Colab.
 
 At present, Cloud TPUs are network-attached, and Flax users typically feed in data from one or more additional VMs

--- a/examples/imagenet/README.md
+++ b/examples/imagenet/README.md
@@ -11,7 +11,7 @@ This example uses linear learning rate warmup and cosine learning rate schedule.
 You can run this code and even modify it directly in Google Colab, no
 installation required:
 
-https://colab.research.google.com/github/google/flax/blob/master/examples/imagenet/imagenet.ipynb
+https://colab.research.google.com/github/google/flax/blob/main/examples/imagenet/imagenet.ipynb
 
 The Colab also demonstrates how to load pretrained checkpoints from Cloud
 storage at

--- a/examples/imagenet/imagenet.ipynb
+++ b/examples/imagenet/imagenet.ipynb
@@ -1742,10 +1742,10 @@
       "source": [
         "# Flax Imagenet Example\n",
         "\n",
-        "<a href=\"https://colab.research.google.com/github/google/flax/blob/master/examples/imagenet/imagenet.ipynb\" ><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n",
+        "<a href=\"https://colab.research.google.com/github/google/flax/blob/main/examples/imagenet/imagenet.ipynb\" ><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n",
         "\n",
         "Demonstration notebook for\n",
-        "https://github.com/google/flax/tree/master/examples/imagenet\n"
+        "https://github.com/google/flax/tree/main/examples/imagenet\n"
       ]
     },
     {

--- a/examples/mnist/README.md
+++ b/examples/mnist/README.md
@@ -5,7 +5,7 @@ Trains a simple convolutional network on the MNIST dataset.
 You can run this code and even modify it directly in Google Colab, no
 installation required:
 
-https://colab.research.google.com/github/google/flax/blob/master/examples/mnist/mnist.ipynb
+https://colab.research.google.com/github/google/flax/blob/main/examples/mnist/mnist.ipynb
 
 ### Requirements
 * TensorFlow dataset `mnist` will be downloaded and prepared automatically, if necessary

--- a/examples/mnist/mnist.ipynb
+++ b/examples/mnist/mnist.ipynb
@@ -275,13 +275,13 @@
       "source": [
         "# Flax MNIST Example\n",
         "\n",
-        "<a href=\"https://colab.research.google.com/github/google/flax/blob/master/examples/mnist/mnist.ipynb\" ><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n",
+        "<a href=\"https://colab.research.google.com/github/google/flax/blob/main/examples/mnist/mnist.ipynb\" ><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n",
         "\n",
         "Demonstration notebook for\n",
-        "https://github.com/google/flax/tree/master/examples/mnist\n",
+        "https://github.com/google/flax/tree/main/examples/mnist\n",
         "\n",
         "If you're looking for an **annotated** version of Flax MNIST\n",
-        "https://colab.research.google.com/github/google/flax/blob/master/docs/notebooks/annotated_mnist_example._ipynb"
+        "https://colab.research.google.com/github/google/flax/blob/main/docs/notebooks/annotated_mnist_example._ipynb"
       ]
     },
     {
@@ -766,7 +766,7 @@
         "# We don't use TPUs in this Colab because we do not distribute our\n",
         "# training using pmap() - if you're looking for an example using TPUs\n",
         "# checkout below Colab:\n",
-        "# https://colab.research.google.com/github/google/flax/blob/master/examples/imagenet/imagenet.ipynb\n",
+        "# https://colab.research.google.com/github/google/flax/blob/main/examples/imagenet/imagenet.ipynb\n",
         "\n",
         "config.num_epochs = 3\n",
         "models = {}\n",

--- a/examples/ppo/README.md
+++ b/examples/ppo/README.md
@@ -40,7 +40,7 @@ Unit tests can be run using `python ppo_lib_test.py`.
 ## How to run on Google Cloud TPU
 
 It is also possible to run this code on Google Cloud TPU. For detailed
-instructions on the required setup, please refer to the [WMT example readme](https://github.com/google/flax/tree/master/examples/wmt).
+instructions on the required setup, please refer to the [WMT example readme](https://github.com/google/flax/tree/main/examples/wmt).
 
 ## Owners
 

--- a/examples/seq2seq/README.md
+++ b/examples/seq2seq/README.md
@@ -5,7 +5,7 @@ an encoder-decoder architecture. The data is generated on the fly.
 
 Colab lets you edit the source files and interact with the model:
 
-https://colab.research.google.com/github/google/flax/blob/master/examples/seq2seq/seq2seq.ipynb
+https://colab.research.google.com/github/google/flax/blob/main/examples/seq2seq/seq2seq.ipynb
 
 ### Example output
 

--- a/examples/seq2seq/seq2seq.ipynb
+++ b/examples/seq2seq/seq2seq.ipynb
@@ -27,10 +27,10 @@
       "source": [
         "# Flax seq2seq Example\n",
         "\n",
-        "<a href=\"https://colab.research.google.com/github/google/flax/blob/master/examples/seq2seq/seq2seq.ipynb\" ><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n",
+        "<a href=\"https://colab.research.google.com/github/google/flax/blob/main/examples/seq2seq/seq2seq.ipynb\" ><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n",
         "\n",
         "Demonstration notebook for\n",
-        "https://github.com/google/flax/tree/master/examples/seq2seq\n"
+        "https://github.com/google/flax/tree/main/examples/seq2seq\n"
       ]
     },
     {

--- a/examples/sst2/README.md
+++ b/examples/sst2/README.md
@@ -5,7 +5,7 @@ Trains a simple text classifier on the SST-2 sentiment classification dataset.
 You can run this code and even modify it directly in Google Colab, no
 installation required:
 
-https://colab.research.google.com/github/google/flax/blob/master/examples/sst2/sst2.ipynb
+https://colab.research.google.com/github/google/flax/blob/main/examples/sst2/sst2.ipynb
 
 ### Requirements
 * TensorFlow dataset `glue/sst2` will be downloaded and prepared automatically, if necessary.

--- a/examples/sst2/sst2.ipynb
+++ b/examples/sst2/sst2.ipynb
@@ -24,10 +24,10 @@
       "source": [
         "# Flax SST-2 Example\n",
         "\n",
-        "<a href=\"https://colab.research.google.com/github/google/flax/blob/master/examples/sst2/sst2.ipynb\" ><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n",
+        "<a href=\"https://colab.research.google.com/github/google/flax/blob/main/examples/sst2/sst2.ipynb\" ><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n",
         "\n",
         "Demonstration notebook for\n",
-        "https://github.com/google/flax/tree/master/examples/sst2"
+        "https://github.com/google/flax/tree/main/examples/sst2"
       ]
     },
     {

--- a/flax/core/scope.py
+++ b/flax/core/scope.py
@@ -283,7 +283,7 @@ class Scope:
   usually generally do not interact with ``Scopes`` directly.
 
   See `core design tests
-  <https://github.com/google/flax/tree/master/tests/core/design>`_
+  <https://github.com/google/flax/tree/main/tests/core/design>`_
   for a number of examples using ``Scopes``.
   """
 

--- a/flax/core/tracers.py
+++ b/flax/core/tracers.py
@@ -22,10 +22,10 @@ def current_trace():
   return jax.core.find_top_trace(())
 
 
-def trace_level(master):
+def trace_level(main):
   """Returns the level of the trace of -infinity if it is None."""
-  if master:
-    return master.level
+  if main:
+    return main.level
   return float('-inf')
 
 

--- a/flax/linen/README.md
+++ b/flax/linen/README.md
@@ -13,8 +13,8 @@ Please open a [discussion](https://github.com/google/flax/discussions) if you ha
 
 * 2-page intro to the [Linen Design Principles](https://docs.google.com/document/d/1ZlL_4bXCw5Xl0WstQw1GpnZqfb9JFOeUGAPcBVk-kn8)
 * [Slides from a talk to the JAX core team](https://docs.google.com/presentation/d/1ngKWUwsSqAwPRvATG8sAxMzu9ujv4N__cKsUofdNno0)
-* [Brief Intro to Linen](https://colab.research.google.com/github/google/flax/blob/master/docs/notebooks/linen_intro.ipynb) in Colab
+* [Brief Intro to Linen](https://colab.research.google.com/github/google/flax/blob/main/docs/notebooks/linen_intro.ipynb) in Colab
 * An [upgrade guide](https://docs.google.com/document/d/1hYavTVPaKVVe9Be8pCB7yW7r6dDv3RALVNit8NZca4c) + some additional questions we're considering
-* Ported [examples](https://github.com/google/flax/tree/master/examples)
-* "Design tests" used to ensure that our "functional core" supports [various advanced use-cases](https://github.com/google/flax/tree/master/tests/core/design), and that the mostly-syntactic-sugar Module abstraction
-  [doesn't get in the way](https://github.com/google/flax/tree/master/examples/linen_design_test)
+* Ported [examples](https://github.com/google/flax/tree/main/examples)
+* "Design tests" used to ensure that our "functional core" supports [various advanced use-cases](https://github.com/google/flax/tree/main/tests/core/design), and that the mostly-syntactic-sugar Module abstraction
+  [doesn't get in the way](https://github.com/google/flax/tree/main/examples/linen_design_test)

--- a/flax/nn/attention.py
+++ b/flax/nn/attention.py
@@ -48,7 +48,7 @@ def dot_product_attention(query,
   """DEPRECATION WARNING:
  "The `flax.nn` module is Deprecated, use `flax.linen` instead. 
   Learn more and find an upgrade guide at 
-  https://github.com/google/flax/blob/master/flax/linen/README.md"
+  https://github.com/google/flax/blob/main/flax/linen/README.md"
   Computes dot-product attention given query, key, and value.
 
   This is the core function for applying attention based on
@@ -172,7 +172,7 @@ def scan_in_dim(*args, **kwargs):
 class Cache(Collection):
   """The `flax.nn` module is Deprecated, use `flax.linen` instead. 
   Learn more and find an upgrade guide at 
-  https://github.com/google/flax/blob/master/flax/linen/README.md"
+  https://github.com/google/flax/blob/main/flax/linen/README.md"
   Collect intermediate activations for efficient autoregressive decoding."""
 
   def initialize_cache(self, shape, dtype=None):
@@ -206,7 +206,7 @@ jax.tree_util.register_pytree_node(
 class MultiHeadDotProductAttention(Module):
   """The `flax.nn` module is Deprecated, use `flax.linen` instead. 
   Learn more and find an upgrade guide at 
-  https://github.com/google/flax/blob/master/flax/linen/README.md"
+  https://github.com/google/flax/blob/main/flax/linen/README.md"
   Multi-head dot-product attention."""
 
   def apply(self,
@@ -449,7 +449,7 @@ def make_padding_mask(padding_mask_query,
                       segmentation_mask=False):
   """The `flax.nn` module is Deprecated, use `flax.linen` instead. 
   Learn more and find an upgrade guide at 
-  https://github.com/google/flax/blob/master/flax/linen/README.md"
+  https://github.com/google/flax/blob/main/flax/linen/README.md"
   Makes padding mask for attention weights.
 
   In case of 1d inputs (i.e., `[bs, len, features]`, the attention weights will
@@ -501,7 +501,7 @@ def make_padding_mask(padding_mask_query,
 def _make_causal_mask(key, attention_axis=None, self_mask=False):
   """The `flax.nn` module is Deprecated, use `flax.linen` instead. 
   Learn more and find an upgrade guide at 
-  https://github.com/google/flax/blob/master/flax/linen/README.md"
+  https://github.com/google/flax/blob/main/flax/linen/README.md"
   Makes a causal mask, to be used for masking out the future for attention.
 
   In case of 1d inputs (i.e., `[bs, len, features]`, the attention weights will

--- a/flax/nn/base.py
+++ b/flax/nn/base.py
@@ -15,7 +15,7 @@
 """DEPRECATION WARNING:
   The `flax.nn` module is Deprecated, use `flax.linen` instead. 
   Learn more and find an upgrade guide at 
-  https://github.com/google/flax/blob/master/flax/linen/README.md"
+  https://github.com/google/flax/blob/main/flax/linen/README.md"
   NN base modules for JAX."""
 
 from typing import Type
@@ -54,7 +54,7 @@ class _ModuleFrame:
   """DEPRECATION WARNING:
   The `flax.nn` module is Deprecated, use `flax.linen` instead. 
   Learn more and find an upgrade guide at 
-  https://github.com/google/flax/blob/master/flax/linen/README.md"
+  https://github.com/google/flax/blob/main/flax/linen/README.md"
   A ModuleFrame the context needed to initialize (init) or apply a Module.
 
   In particular, `self.params` is a dictionary where parameters are
@@ -142,7 +142,7 @@ def module_method(fn):
   """DEPRECATION WARNING:
   The `flax.nn` module is Deprecated, use `flax.linen` instead. 
   Learn more and find an upgrade guide at 
-  https://github.com/google/flax/blob/master/flax/linen/README.md"
+  https://github.com/google/flax/blob/main/flax/linen/README.md"
   Decorates a function as a module method.
 
   The `module_method` allows modules to have multiple methods that make use of
@@ -213,7 +213,7 @@ class _ModuleMeta(abc.ABCMeta):
   """DEPRECATION WARNING:
   The `flax.nn` module is Deprecated, use `flax.linen` instead. 
   Learn more and find an upgrade guide at 
-  https://github.com/google/flax/blob/master/flax/linen/README.md"
+  https://github.com/google/flax/blob/main/flax/linen/README.md"
   A meta class for automatically setting the doc of Modules."""
 
   def __init__(cls, name, bases, attrs):
@@ -266,11 +266,11 @@ class Module(metaclass=_ModuleMeta):
   """DEPRECATION WARNING:
   The `flax.nn` module is Deprecated, use `flax.linen` instead. 
   Learn more and find an upgrade guide at 
-  https://github.com/google/flax/blob/master/flax/linen/README.md"
+  https://github.com/google/flax/blob/main/flax/linen/README.md"
   Functional modules."""
 
   def __new__(cls, *args, name=None, **kwargs):
-    warnings.warn("The `flax.nn` module is Deprecated, use `flax.linen` instead. Learn more and find an upgrade guide at https://github.com/google/flax/blob/master/flax/linen/README.md", DeprecationWarning)
+    warnings.warn("The `flax.nn` module is Deprecated, use `flax.linen` instead. Learn more and find an upgrade guide at https://github.com/google/flax/blob/main/flax/linen/README.md", DeprecationWarning)
     # DO NOT REMOVE - Marker for internal logging.
     if not _module_stack:
       raise ValueError('A Module should only be instantiated directly inside'
@@ -718,7 +718,7 @@ def module(fun):
   """DEPRECATION WARNING:
   The `flax.nn` module is Deprecated, use `flax.linen` instead. 
   Learn more and find an upgrade guide at 
-  https://github.com/google/flax/blob/master/flax/linen/README.md"
+  https://github.com/google/flax/blob/main/flax/linen/README.md"
   Convert a function into the apply method of a new Module.
 
   This is convenient shortcut for writing higher level modules that don't need
@@ -757,7 +757,7 @@ class TransparentModule(Module):
   """DEPRECATION WARNING:
   The `flax.nn` module is Deprecated, use `flax.linen` instead. 
   Learn more and find an upgrade guide at 
-  https://github.com/google/flax/blob/master/flax/linen/README.md"
+  https://github.com/google/flax/blob/main/flax/linen/README.md"
   A transparent module.
 
   A transparent module can only have one parameter named '0'.
@@ -786,7 +786,7 @@ class TruncatedModule(TransparentModule):
   """DEPRECATION WARNING:
   The `flax.nn` module is Deprecated, use `flax.linen` instead. 
   Learn more and find an upgrade guide at 
-  https://github.com/google/flax/blob/master/flax/linen/README.md"
+  https://github.com/google/flax/blob/main/flax/linen/README.md"
   Wraps a Module and returns the requested intermediate outputs instead.
 
   Check `Model.truncate_at` for a simple API to get the intermediate outputs of
@@ -822,7 +822,7 @@ def capture_module_outputs():
   """DEPRECATION WARNING:
   The `flax.nn` module is Deprecated, use `flax.linen` instead. 
   Learn more and find an upgrade guide at 
-  https://github.com/google/flax/blob/master/flax/linen/README.md"
+  https://github.com/google/flax/blob/main/flax/linen/README.md"
   A context manager that captures all model outputs.
 
   Yields:
@@ -837,7 +837,7 @@ class ModuleState():
   """DEPRECATION WARNING:
   The `flax.nn` module is Deprecated, use `flax.linen` instead. 
   Learn more and find an upgrade guide at 
-  https://github.com/google/flax/blob/master/flax/linen/README.md"
+  https://github.com/google/flax/blob/main/flax/linen/README.md"
   Tracks a state variable.
 
   ModuleState instances should not be created directly. See `Module.state` on
@@ -876,7 +876,7 @@ def stateful(state=None, mutable=True):
   """DEPRECATION WARNING:
   The `flax.nn` module is Deprecated, use `flax.linen` instead. 
   Learn more and find an upgrade guide at 
-  https://github.com/google/flax/blob/master/flax/linen/README.md"
+  https://github.com/google/flax/blob/main/flax/linen/README.md"
   A context manager for stateful computations.
 
   Module's that use the `Module.state` by default store state inside the
@@ -931,7 +931,7 @@ def is_stateful():
   """DEPRECATION WARNING:
   The `flax.nn` module is Deprecated, use `flax.linen` instead. 
   Learn more and find an upgrade guide at 
-  https://github.com/google/flax/blob/master/flax/linen/README.md"
+  https://github.com/google/flax/blob/main/flax/linen/README.md"
   Returns true if a stateful scope is currently active (see `flax.nn.stateful`)."""
   return bool(_state_stack)
 
@@ -955,7 +955,7 @@ class Model:
   """DEPRECATION WARNING:
   The `flax.nn` module is Deprecated, use `flax.linen` instead. 
   Learn more and find an upgrade guide at 
-  https://github.com/google/flax/blob/master/flax/linen/README.md
+  https://github.com/google/flax/blob/main/flax/linen/README.md
 
   A Model contains the model parameters, state and definition."""
 
@@ -1000,7 +1000,7 @@ class Collection:
   """DEPRECATION WARNING:
   The `flax.nn` module is Deprecated, use `flax.linen` instead. 
   Learn more and find an upgrade guide at 
-  https://github.com/google/flax/blob/master/flax/linen/README.md"
+  https://github.com/google/flax/blob/main/flax/linen/README.md"
   A collection of tensors useful for tracking state.
 
   A Collection can be used to associate data with the application of a Module.
@@ -1021,7 +1021,7 @@ class Collection:
     self._anchor = _module_stack[-1] if _module_stack else None
 
     self._mutable = False
-    self._master_level = None
+    self._main_level = None
     self._root = None
 
   def as_dict(self):
@@ -1040,7 +1040,7 @@ class Collection:
     # pylint: disable=protected-access
     new_col = jax.tree_map(lambda x: x, self)  # clone the collection
     new_col._mutable = True
-    new_col._master_level = utils._trace_level(utils._current_trace())
+    new_col._main_level = utils._trace_level(utils._current_trace())
     try:
       yield new_col
     finally:
@@ -1074,14 +1074,14 @@ class Collection:
     if not self._mutable:
       raise ValueError('Collection is not mutable. Use the `mutate` method to'
                        ' create a mutable copy.')
-    # Use the Jax TraceMaster to determine if a Collection is modified from
+    # Use the Jax TraceMain to determine if a Collection is modified from
     # inside a nested jax transformation.
     # In this case, we throw an error because transforming a stateful function
     # is ill-defined (eg. what does vmap of BatchNorm do?).
     # TODO(jheek): Add doc guide on combining jax transforms and state.
     # TODO(jheek): Should some transformations be exempt from this error?
     value_level = utils._level_of_value(value)
-    if value_level > self._master_level:
+    if value_level > self._main_level:
       raise ValueError('Stateful operations are not allowed when the Collection'
                        ' is created outside of the current Jax transformation')
 

--- a/flax/nn/linear.py
+++ b/flax/nn/linear.py
@@ -15,7 +15,7 @@
 """DEPRECATION WARNING:
   The `flax.nn` module is Deprecated, use `flax.linen` instead. 
   Learn more and find an upgrade guide at 
-  https://github.com/google/flax/blob/master/flax/linen/README.md"
+  https://github.com/google/flax/blob/main/flax/linen/README.md"
   Linear modules."""
 
 from collections.abc import Iterable  # pylint: disable=g-importing-member
@@ -41,7 +41,7 @@ class DenseGeneral(base.Module):
   """DEPRECATION WARNING:
   The `flax.nn` module is Deprecated, use `flax.linen` instead. 
   Learn more and find an upgrade guide at 
-  https://github.com/google/flax/blob/master/flax/linen/README.md"
+  https://github.com/google/flax/blob/main/flax/linen/README.md"
   A linear transformation with flexible axes."""
 
   def apply(self,
@@ -135,7 +135,7 @@ class Dense(base.Module):
   """DEPRECATION WARNING:
   The `flax.nn` module is Deprecated, use `flax.linen` instead. 
   Learn more and find an upgrade guide at 
-  https://github.com/google/flax/blob/master/flax/linen/README.md"
+  https://github.com/google/flax/blob/main/flax/linen/README.md"
   A linear transformation applied over the last dimension of the input."""
 
   def apply(self,
@@ -177,7 +177,7 @@ def _conv_dimension_numbers(input_shape):
   """DEPRECATION WARNING:
   The `flax.nn` module is Deprecated, use `flax.linen` instead. 
   Learn more and find an upgrade guide at 
-  https://github.com/google/flax/blob/master/flax/linen/README.md"
+  https://github.com/google/flax/blob/main/flax/linen/README.md"
   Computes the dimension numbers based on the input shape."""
   ndim = len(input_shape)
   lhs_spec = (0, ndim - 1) + tuple(range(1, ndim - 1))
@@ -190,7 +190,7 @@ class Conv(base.Module):
   """DEPRECATION WARNING:
   The `flax.nn` module is Deprecated, use `flax.linen` instead. 
   Learn more and find an upgrade guide at 
-  https://github.com/google/flax/blob/master/flax/linen/README.md"
+  https://github.com/google/flax/blob/main/flax/linen/README.md"
   Convolution Module wrapping lax.conv_general_dilated."""
 
   def apply(self,
@@ -283,7 +283,7 @@ class ConvTranspose(base.Module):
   """DEPRECATION WARNING:
   The `flax.nn` module is Deprecated, use `flax.linen` instead. 
   Learn more and find an upgrade guide at 
-  https://github.com/google/flax/blob/master/flax/linen/README.md"
+  https://github.com/google/flax/blob/main/flax/linen/README.md"
   Transposed convolution Module wrapping lax.conv_transpose."""
 
   def apply(self,
@@ -361,7 +361,7 @@ class Embed(base.Module):
   """DEPRECATION WARNING:
   The `flax.nn` module is Deprecated, use `flax.linen` instead. 
   Learn more and find an upgrade guide at 
-  https://github.com/google/flax/blob/master/flax/linen/README.md"
+  https://github.com/google/flax/blob/main/flax/linen/README.md"
   Embedding Module.
 
   A parameterized function from integers [0, n) to d-dimensional vectors.

--- a/flax/nn/normalization.py
+++ b/flax/nn/normalization.py
@@ -32,7 +32,7 @@ class BatchNorm(base.Module):
   """DEPRECATION WARNING:
   The `flax.nn` module is Deprecated, use `flax.linen` instead. 
   Learn more and find an upgrade guide at 
-  https://github.com/google/flax/blob/master/flax/linen/README.md"
+  https://github.com/google/flax/blob/main/flax/linen/README.md"
   BatchNorm Module."""
 
   def apply(self,
@@ -130,7 +130,7 @@ class LayerNorm(base.Module):
   """DEPRECATION WARNING:
   The `flax.nn` module is Deprecated, use `flax.linen` instead. 
   Learn more and find an upgrade guide at 
-  https://github.com/google/flax/blob/master/flax/linen/README.md"
+  https://github.com/google/flax/blob/main/flax/linen/README.md"
   Layer normalization (https://arxiv.org/abs/1607.06450).
 
   Operates on the last axis of the input data.
@@ -185,7 +185,7 @@ class GroupNorm(base.Module):
   """DEPRECATION WARNING:
   The `flax.nn` module is Deprecated, use `flax.linen` instead. 
   Learn more and find an upgrade guide at 
-  https://github.com/google/flax/blob/master/flax/linen/README.md"
+  https://github.com/google/flax/blob/main/flax/linen/README.md"
   Group normalization (arxiv.org/abs/1803.08494)."""
 
   def apply(self,

--- a/flax/nn/pooling.py
+++ b/flax/nn/pooling.py
@@ -24,7 +24,7 @@ def pool(inputs, init, reduce_fn, window_shape, strides, padding):
   """DEPRECATION WARNING:
   The `flax.nn` module is Deprecated, use `flax.linen` instead. 
   Learn more and find an upgrade guide at 
-  https://github.com/google/flax/blob/master/flax/linen/README.md"
+  https://github.com/google/flax/blob/main/flax/linen/README.md"
   Helper function to define pooling functions.
 
   Pooling functions are implemented using the ReduceWindow XLA op.
@@ -63,7 +63,7 @@ def avg_pool(inputs, window_shape, strides=None, padding="VALID"):
   """DEPRECATION WARNING:
   The `flax.nn` module is Deprecated, use `flax.linen` instead. 
   Learn more and find an upgrade guide at 
-  https://github.com/google/flax/blob/master/flax/linen/README.md"
+  https://github.com/google/flax/blob/main/flax/linen/README.md"
   Pools the input by taking the average over a window.
 
   Args:
@@ -86,7 +86,7 @@ def max_pool(inputs, window_shape, strides=None, padding="VALID"):
   """DEPRECATION WARNING:
   The `flax.nn` module is Deprecated, use `flax.linen` instead. 
   Learn more and find an upgrade guide at 
-  https://github.com/google/flax/blob/master/flax/linen/README.md"
+  https://github.com/google/flax/blob/main/flax/linen/README.md"
   Pools the input by taking the maximum of a window slice.
 
   Args:

--- a/flax/nn/recurrent.py
+++ b/flax/nn/recurrent.py
@@ -15,7 +15,7 @@
 """DEPRECATION WARNING:
   The `flax.nn` module is Deprecated, use `flax.linen` instead. 
   Learn more and find an upgrade guide at 
-  https://github.com/google/flax/blob/master/flax/linen/README.md"
+  https://github.com/google/flax/blob/main/flax/linen/README.md"
   Recurrent neural network modules.
 
 THe RNNCell modules are designed to fit in with the scan function in JAX::
@@ -44,7 +44,7 @@ class RNNCellBase(base.Module):
   """DEPRECATION WARNING:
   The `flax.nn` module is Deprecated, use `flax.linen` instead. 
   Learn more and find an upgrade guide at 
-  https://github.com/google/flax/blob/master/flax/linen/README.md"
+  https://github.com/google/flax/blob/main/flax/linen/README.md"
   RNN cell base class."""
 
   @staticmethod
@@ -67,7 +67,7 @@ class LSTMCell(RNNCellBase):
   """DEPRECATION WARNING:
   The `flax.nn` module is Deprecated, use `flax.linen` instead. 
   Learn more and find an upgrade guide at 
-  https://github.com/google/flax/blob/master/flax/linen/README.md"
+  https://github.com/google/flax/blob/main/flax/linen/README.md"
   LSTM cell."""
 
   def apply(self, carry, inputs,
@@ -144,7 +144,7 @@ class OptimizedLSTMCell(RNNCellBase):
   """DEPRECATION WARNING:
   The `flax.nn` module is Deprecated, use `flax.linen` instead. 
   Learn more and find an upgrade guide at 
-  https://github.com/google/flax/blob/master/flax/linen/README.md"
+  https://github.com/google/flax/blob/main/flax/linen/README.md"
   More efficient LSTM Cell that concatenates state components before matmul.
 
   Parameters are compatible with `flax.nn.LSTMCell`.
@@ -268,7 +268,7 @@ class GRUCell(RNNCellBase):
   """DEPRECATION WARNING:
   The `flax.nn` module is Deprecated, use `flax.linen` instead. 
   Learn more and find an upgrade guide at 
-  https://github.com/google/flax/blob/master/flax/linen/README.md"
+  https://github.com/google/flax/blob/main/flax/linen/README.md"
   GRU cell."""
 
   def apply(self, carry, inputs,
@@ -340,7 +340,7 @@ class ConvLSTM(RNNCellBase):
   r"""DEPRECATION WARNING:
   The `flax.nn` module is Deprecated, use `flax.linen` instead. 
   Learn more and find an upgrade guide at 
-  https://github.com/google/flax/blob/master/flax/linen/README.md"
+  https://github.com/google/flax/blob/main/flax/linen/README.md"
   A convolutional LSTM cell.
 
   The implementation is based on xingjian2015convolutional.

--- a/flax/nn/stochastic.py
+++ b/flax/nn/stochastic.py
@@ -30,7 +30,7 @@ class _PRNGFrame:
   """DEPRECATION WARNING:
   The `flax.nn` module is Deprecated, use `flax.linen` instead. 
   Learn more and find an upgrade guide at 
-  https://github.com/google/flax/blob/master/flax/linen/README.md"
+  https://github.com/google/flax/blob/main/flax/linen/README.md"
   Random Number generator scope responsible for generation prngs in a stochastic context."""
 
   def __init__(self, rng):
@@ -56,7 +56,7 @@ def stochastic(rng):
   """DEPRECATION WARNING:
   The `flax.nn` module is Deprecated, use `flax.linen` instead. 
   Learn more and find an upgrade guide at 
-  https://github.com/google/flax/blob/master/flax/linen/README.md"
+  https://github.com/google/flax/blob/main/flax/linen/README.md"
   A context manager for stochastic computations.
 
   Args:
@@ -72,7 +72,7 @@ def is_stochastic():
   """DEPRECATION WARNING:
   The `flax.nn` module is Deprecated, use `flax.linen` instead. 
   Learn more and find an upgrade guide at 
-  https://github.com/google/flax/blob/master/flax/linen/README.md"
+  https://github.com/google/flax/blob/main/flax/linen/README.md"
   Returns true if a stochastic scope is currently active."""
   return bool(_prng_stack)
 
@@ -81,7 +81,7 @@ def make_rng():
   """DEPRECATION WARNING:
   The `flax.nn` module is Deprecated, use `flax.linen` instead. 
   Learn more and find an upgrade guide at 
-  https://github.com/google/flax/blob/master/flax/linen/README.md"
+  https://github.com/google/flax/blob/main/flax/linen/README.md"
   Create a new unique random number generator in a stochastic scope.
 
   In combination with `nn.stochastic()` this function is used to generate random
@@ -106,7 +106,7 @@ def dropout(inputs, rate, deterministic=False, rng=None):
   """DEPRECATION WARNING:
   The `flax.nn` module is Deprecated, use `flax.linen` instead. 
   Learn more and find an upgrade guide at 
-  https://github.com/google/flax/blob/master/flax/linen/README.md"
+  https://github.com/google/flax/blob/main/flax/linen/README.md"
   Applies a random dropout mask to the input.
 
   Args:

--- a/flax/nn/utils.py
+++ b/flax/nn/utils.py
@@ -15,7 +15,7 @@
 """DEPRECATION WARNING:
   The `flax.nn` module is Deprecated, use `flax.linen` instead. 
   Learn more and find an upgrade guide at 
-  https://github.com/google/flax/blob/master/flax/linen/README.md"
+  https://github.com/google/flax/blob/main/flax/linen/README.md"
   NN base modules for JAX."""
 
 import contextlib
@@ -27,7 +27,7 @@ class CallStack(object):
   """DEPRECATION WARNING:
   The `flax.nn` module is Deprecated, use `flax.linen` instead. 
   Learn more and find an upgrade guide at 
-  https://github.com/google/flax/blob/master/flax/linen/README.md"
+  https://github.com/google/flax/blob/main/flax/linen/README.md"
   Utility for tracking data across a call stack."""
 
   def __init__(self):
@@ -63,7 +63,7 @@ def classproperty(f):
   """DEPRECATION WARNING:
   The `flax.nn` module is Deprecated, use `flax.linen` instead. 
   Learn more and find an upgrade guide at 
-  https://github.com/google/flax/blob/master/flax/linen/README.md"
+  https://github.com/google/flax/blob/main/flax/linen/README.md"
   decorator that registers a function as a read-only property of the class."""
 
   class _ClassProperty:
@@ -76,25 +76,25 @@ def classproperty(f):
   return _ClassProperty()
 
 
-def _masters():
+def _mains():
   """DEPRECATION WARNING:
   The `flax.nn` module is Deprecated, use `flax.linen` instead. 
   Learn more and find an upgrade guide at 
-  https://github.com/google/flax/blob/master/flax/linen/README.md"
+  https://github.com/google/flax/blob/main/flax/linen/README.md"
   Returns a list of currently active Jax tracers."""
   # TODO(jheek): consider re-introducing the tracer check
   # for now we pretent there are never any tracers
   return ()
 
 
-def _trace_level(master):
+def _trace_level(main):
   """DEPRECATION WARNING:
  The `flax.nn` module is Deprecated, use `flax.linen` instead. 
   Learn more and find an upgrade guide at 
-  https://github.com/google/flax/blob/master/flax/linen/README.md"
+  https://github.com/google/flax/blob/main/flax/linen/README.md"
   Returns the level of the trace of -infinity if it is None."""
-  if master:
-    return master.level
+  if main:
+    return main.level
   return float('-inf')
 
 
@@ -102,9 +102,9 @@ def _current_trace():
   """DEPRECATION WARNING:
   The `flax.nn` module is Deprecated, use `flax.linen` instead. 
   Learn more and find an upgrade guide at 
-  https://github.com/google/flax/blob/master/flax/linen/README.md"
+  https://github.com/google/flax/blob/main/flax/linen/README.md"
   Returns the innermost Jax tracer."""
-  tracers = _masters()
+  tracers = _mains()
   if tracers:
     return tracers[-1]
   return None
@@ -114,13 +114,13 @@ def _level_of_value(xs):
   """DEPRECATION WARNING:
   The `flax.nn` module is Deprecated, use `flax.linen` instead. 
   Learn more and find an upgrade guide at 
-  https://github.com/google/flax/blob/master/flax/linen/README.md"
+  https://github.com/google/flax/blob/main/flax/linen/README.md"
   Returns the tracer level associated with a value if any."""
   xs = jax.tree_leaves(xs)
   max_level = float('-inf')
   # TODO(jheek): consider re-introducing the tracer check
   # for x in xs:
   #   if hasattr(x, '_trace'):
-  #     level = _trace_level(x._trace.master)
+  #     level = _trace_level(x._trace.main)
   #     max_level = max(level, max_level)
   return max_level

--- a/flax/optim/__init__.py
+++ b/flax/optim/__init__.py
@@ -20,7 +20,7 @@ deprecated** in favor of Optax_ optimizers. There is no feature parity yet (e.g.
 supported, and Optax is actively being developed and new features and
 optimizers are being added continuously.
 
-.. _FLIP #1009: https://github.com/google/flax/blob/master/docs/flip/1009-optimizer-api.md
+.. _FLIP #1009: https://github.com/google/flax/blob/main/docs/flip/1009-optimizer-api.md
 .. _Optax: https://github.com/deepmind/optax
 """
 

--- a/flax/training/lr_schedule.py
+++ b/flax/training/lr_schedule.py
@@ -18,7 +18,7 @@ Note that with `FLIP #1009`_ learning rate schedules in ``flax.training`` are
 **effectively deprecated** in favor of Optax_ schedules. Please refer to
 `Optimizer Schedules`_ for more information. 
 
-.. _FLIP #1009: https://github.com/google/flax/blob/master/docs/flip/1009-optimizer-api.md
+.. _FLIP #1009: https://github.com/google/flax/blob/main/docs/flip/1009-optimizer-api.md
 .. _Optax: https://github.com/deepmind/optax
 .. _Optimizer Schedules: https://optax.readthedocs.io/en/latest/api.html#optimizer-schedules
 """


### PR DESCRIPTION
Rename master to main.

Most of the changes are in urls to GitHub.
I have sampled a few external urls that contain "master" and found that they do not work work with "main".

 A small number of changes are in code.