### PR TITLE
Fix serialization restore for named tuples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ vNext
  -
  -
  -
- -
+ - Fix the serialization of named tuples. Tuple fields are no longer stored in the state dict and the named tuple class is no longer recreated ([bug](https://github.com/google/flax/issues/1429)).
  -
  -
  -

--- a/flax/serialization.py
+++ b/flax/serialization.py
@@ -22,6 +22,7 @@ import enum
 import jax
 import msgpack
 import numpy as np
+from numpy.lib.arraysetops import isin
 
 
 _STATE_DICT_REGISTRY = {}
@@ -125,27 +126,18 @@ def _restore_dict(xs, states):
 
 
 def _namedtuple_state_dict(nt):
-  return {'name': nt.__class__.__name__,
-          'fields': {str(i): to_state_dict(x)
-                     for i, x in enumerate(nt._fields)},
-          'values': {str(i): to_state_dict(x)
-                     for i, x in enumerate(nt)}
-         }
+  return {key: to_state_dict(getattr(nt, key)) for key in nt._fields}
 
 
 def _restore_namedtuple(xs, state_dict):
   """Rebuild namedtuple from serialized dict."""
-  if len(state_dict['values']) != len(xs):
-    raise ValueError('The size of the list and the state dict do not match,'
-                     f' got {len(xs)} and {len(state_dict["values"])}.')
-  fields = [state_dict['fields'][str(i)] for i in range(len(xs))]
-  namedtuple_class = collections.namedtuple(
-      state_dict['name'], fields)
-  ys = []
-  for i in range(len(state_dict['values'])):
-    y = from_state_dict(xs[i], state_dict['values'][str(i)])
-    ys.append(y)
-  return namedtuple_class(*ys)
+  sd_keys = set(state_dict.keys())
+  nt_keys = set(xs._fields)
+  if sd_keys != nt_keys:
+    raise ValueError('The field names of the state dict and the named tuple do not match,'
+                     f' got {sd_keys} and {nt_keys}.')
+  fields = {k: from_state_dict(getattr(xs, k), v) for k, v in state_dict.items()}
+  return type(xs)(**fields)
 
 
 register_serialization_state(dict, _dict_state_dict, _restore_dict)

--- a/flax/serialization.py
+++ b/flax/serialization.py
@@ -131,8 +131,14 @@ def _namedtuple_state_dict(nt):
 
 def _restore_namedtuple(xs, state_dict):
   """Rebuild namedtuple from serialized dict."""
+  if set(state_dict.keys()) == {'name', 'fields', 'values'}:
+    # TODO(jheek): remove backward compatible named tuple restoration early 2022
+    state_dict = {state_dict['fields'][str(i)]: state_dict['values'][str(i)]
+                  for i in range(len(state_dict['fields']))}
+
   sd_keys = set(state_dict.keys())
   nt_keys = set(xs._fields)
+
   if sd_keys != nt_keys:
     raise ValueError('The field names of the state dict and the named tuple do not match,'
                      f' got {sd_keys} and {nt_keys}.')

--- a/tests/serialization_test.py
+++ b/tests/serialization_test.py
@@ -214,6 +214,19 @@ class SerializationTest(absltest.TestCase):
     restored_x1 = serialization.from_bytes(x2, x1_serialized)
     self.assertEqual(type(x1), type(restored_x1))
     self.assertEqual(x1, restored_x1)
+  
+  def test_namedtuple_restore_legacy(self):
+    foo_class = collections.namedtuple('Foo', 'a b c')
+    x1 = foo_class(a=1, b=2, c=3)
+    legacy_encoding = {
+      'name': 'Foo',
+      'fields': {'0': 'a', '1': 'b', '2': 'c'},
+      'values': {'0': 1, '1': 2, '2': 3},
+    }
+    x2 = foo_class(a=0, b=0, c=0)
+    restored_x1 = serialization.from_state_dict(x2, legacy_encoding)
+    self.assertEqual(type(x1), type(restored_x1))
+    self.assertEqual(x1, restored_x1)
 
   def test_model_serialization_to_bytes(self):
     rng = random.PRNGKey(0)

--- a/tests/serialization_test.py
+++ b/tests/serialization_test.py
@@ -212,6 +212,7 @@ class SerializationTest(absltest.TestCase):
     x1_serialized = serialization.to_bytes(x1)
     x2 = foo_class(a=0, b=0, c=0)
     restored_x1 = serialization.from_bytes(x2, x1_serialized)
+    self.assertEqual(type(x1), type(restored_x1))
     self.assertEqual(x1, restored_x1)
 
   def test_model_serialization_to_bytes(self):


### PR DESCRIPTION
Serialization was creating a new named tuple class based on the fields in the state dict.
This results in a type error when comparing to the original or when comparing the structure of PyTrees.

Fixes #1429 