### PR TITLE
Simplify MNIST example.

### DIFF
--- a/examples/mnist/train.py
+++ b/examples/mnist/train.py
@@ -53,7 +53,7 @@ class CNN(nn.Module):
 
 @jax.jit
 def apply_model(state, images, labels):
-  """Compute gradientsh loss and accuracy for a single batch."""
+  """Computes gradients, loss and accuracy for a single batch."""
   def loss_fn(params):
     logits = CNN().apply({'params': params}, images)
     one_hot = jax.nn.one_hot(labels, 10)


### PR DESCRIPTION
# What does this PR do?
This PR aims to simplify the code and make it more readable.
It is aimed at making it more attractive to ML beginners.

- Remove a duplicate cross entropy calculation in `compute_metrics`.
- Use the same code for train set and test set
- Expose the one liner `update_model`.
- Replace fairly hard to read dictionaries and dictionary comprehensions with variables.
- Remove `jax.device_get` calls.
- Replace `logging.info` with `print` for the main log.
  This improves train log visibility and removes the need for `googlelog.Capture()`.
- Make the training log one line per epoch with constant with numbers making it easy to compare them.
- Make naming uniform (`test`, `eval` into `test`), in line with [PyTorch example](https://github.com/pytorch/examples/blob/master/mnist/main.py).