### PR TITLE
Several small docs fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ research ecosystem -- both within Alphabet and with the broader community,
 and to explore the use-cases where JAX shines. We use GitHub for almost
 all of our coordination and planning, as well as where we discuss
 upcoming design changes. We welcome feedback on any of our discussion,
-issue and pull request thread. We are in the process of moving some
+issue and pull request threads. We are in the process of moving some
 remaining internal design docs and conversation threads to GitHub
 discussions, issues and pull requests. We hope to increasingly engage
 with the needs and clarifications of the broader ecosystem. Please let

--- a/docs/design_notes/arguments.md
+++ b/docs/design_notes/arguments.md
@@ -5,7 +5,7 @@
 In Linen we can define `Module` arguments either as dataclass attributes or as arguments to methods (usually `__call__`).
 Typically the distinction is clear:
 * Completely fixed properties, such as the choice of kernel initializer or number of output features, are hyperparameters and should be defined as dataclass attributes. Typically two Module instances with different hyperparamaters cannot share in a meaningful way.
-* Dynamic properties, such as input data and top-level "mode switches" like `train=True/False` that should be passed as arguments to `__call__` or another method.
+* Dynamic properties, such as input data and top-level "mode switches" like `train=True/False`, should be passed as arguments to `__call__` or another method.
 
 Some cases are however less clear cut. Take for example the `Dropout` module.
 We have a number of clear hyperparameters:
@@ -59,7 +59,7 @@ class SomeModule(nn.Module):
     # ...
 ```
 
-But as defined above `deterministic` would be an attribute, so this doesn't work.
+But, as defined above, `deterministic` would be an attribute, so this doesn't work.
 Here it makes sense to pass `deterministic` during `__call__` because it depends on the `train` argument.
 
 ## Solution

--- a/docs/howtos/extracting_intermediates.rst
+++ b/docs/howtos/extracting_intermediates.rst
@@ -92,9 +92,8 @@ Note that, by default ``sow`` appends values every time it is called:
 * So you want to make sure that you **do not** feed intermediate values back in
   in ``variables``. Otherwise every call will increase the length of that tuple
   and trigger a recompile.
-* To override the default append behavior, specify ``init_fn`` and ``reduce_fn`` to :meth:...
-  specifying ``init_fn`` and ``reduce_fn`` - see
-  :meth:`Module.sow() <flax.linen.Module.sow>`.
+* To override the default append behavior, specify ``init_fn`` and ``reduce_fn``
+  - see :meth:`Module.sow() <flax.linen.Module.sow>`.
 
 .. testcode::
 

--- a/docs/howtos/lr_schedule.rst
+++ b/docs/howtos/lr_schedule.rst
@@ -6,7 +6,7 @@ To simplify this, one can use a so-called *cyclic learning rate*, which
 virtually eliminates the need for experimentally finding the best value and
 schedule for the global learning rate. Instead of monotonically decreasing the
 learning rate, this method lets the learning rate cyclically vary between
-reasonable boundary value.
+reasonable boundary values.
 Here we will show you how to implement a triangular learning rate scheduler,
 as described in the paper  `"Cyclical Learning Rates for Training Neural Networks" <https://arxiv.org/abs/1506.01186>`_.
 
@@ -16,7 +16,7 @@ We will show you how to...
 * train a simple model using that schedule
 
 The triangular schedule makes your learning rate vary as a triangle wave during training, so over the course of a period (``steps_per_cycle``
-training steps) the value will start at ``lr_min``, increase linearly to ``lr_max`` and then decrease again to ``lr_min``.
+training steps) the value will start at ``lr_min``, increase linearly to ``lr_max``, and then decrease again to ``lr_min``.
 
 .. testsetup::
 
@@ -36,7 +36,7 @@ training steps) the value will start at ``lr_min``, increase linearly to ``lr_ma
     return learning_rate_fn
 
 
-To use the schedule one must create a learning rate function by passing the hyperparameters to the 
+To use the schedule, one must create a learning rate function by passing the hyperparameters to the
 create_triangular_schedule function and then use that function to compute the learning rate for your updates.
 For example using this schedule on MNIST would require changing the train_step function
 

--- a/docs/howtos/state_params.rst
+++ b/docs/howtos/state_params.rst
@@ -46,9 +46,9 @@ replaced for yours):
 
 .. testcode::
 
-  def update_step(apply_fun, x, optimizer, state):
+  def update_step(apply_fn, x, optimizer, state):
     def loss(params):
-      y, updated_state = apply_fun({'params': params, **state},
+      y, updated_state = apply_fn({'params': params, **state},
                                   x, mutable=list(state.keys()))
       l = ((x - y) ** 2).sum() # Replace with your loss here.
       return l, updated_state
@@ -134,11 +134,11 @@ Secondly, we need to specify the same name when calling :code:`vmap` in our trai
 
 .. testcode::
 
-  def update_step(apply_fun, x_batch, y_batch, optimizer, state):
+  def update_step(apply_fn, x_batch, y_batch, optimizer, state):
 
     def batch_loss(params):
       def loss_fn(x, y):
-        pred, updated_state = apply_fun(
+        pred, updated_state = apply_fn(
           {'params': params, **state},
           x, mutable=list(state.keys())
         )
@@ -157,7 +157,7 @@ Secondly, we need to specify the same name when calling :code:`vmap` in our trai
     optimizer = optimizer.apply_gradient(grads)
     return optimizer, updated_state, loss
 
-Note that we also need to specify the model state does not have a batch
+Note that we also need to specify that the model state does not have a batch
 dimension. Now we are able to train the model:
 
 

--- a/docs/notebooks/annotated_mnist.ipynb
+++ b/docs/notebooks/annotated_mnist.ipynb
@@ -27,7 +27,7 @@
    "source": [
     "## 1. Imports\n",
     "\n",
-    "Import JAX, [JAX NumPy](https://jax.readthedocs.io/en/latest/jax.numpy.html)\n",
+    "Import JAX, [JAX NumPy](https://jax.readthedocs.io/en/latest/jax.numpy.html),\n",
     "Flax, ordinary NumPy, and TensorFlow Datasets (TFDS). Flax can use any\n",
     "data-loading pipeline and this example demonstrates how to utilize TFDS."
    ]
@@ -261,8 +261,8 @@
     "\n",
     "Use JAX's [`@jit`](https://jax.readthedocs.io/en/latest/jax.html#jax.jit)\n",
     "decorator to trace the entire `train_step` function and just-in-time compile\n",
-    "with [XLA](https://www.tensorflow.org/xla) into fused device operations that\n",
-    "run faster and more efficiently on hardware accelerators."
+    "it with [XLA](https://www.tensorflow.org/xla) into fused device operations\n",
+    "that run faster and more efficiently on hardware accelerators."
    ]
   },
   {

--- a/docs/notebooks/flax_basics.ipynb
+++ b/docs/notebooks/flax_basics.ipynb
@@ -634,7 +634,7 @@
         "    # we automatically know what to do with lists, dicts of submodules\n",
         "    self.layers = [nn.Dense(feat) for feat in self.features]\n",
         "    # for single submodules, we would just write:\n",
-        "    # self.layer1 = nn.Dense(self, feat1)\n",
+        "    # self.layer1 = nn.Dense(feat1)\n",
         "\n",
         "  def __call__(self, inputs):\n",
         "    x = inputs\n",
@@ -793,7 +793,7 @@
         "\n",
         "*   In `setup`, you are able to name some sublayers and keep them around for further use (e.g. encoder/decoder methods in autoencoders).\n",
         "*   If you want to have multiple methods, then you **need** to declare the module using `setup`, as the `@nn.compact` annotation only allows one method to be annotated.\n",
-        "*   The last initialization will be handled differently see these notes for more details (TODO: add notes link)\n"
+        "*   The last initialization will be handled differently. See these notes for more details (TODO: add notes link).\n"
       ]
     },
     {
@@ -874,11 +874,11 @@
         "id": "MKyhfzVpzC94"
       },
       "source": [
-        "Here, we see how both declare and assign a parameter to the model using the `self.param` method. It takes as input `(name, init_fn, *init_args)` : \n",
+        "Here, we see how to both declare and assign a parameter to the model using the `self.param` method. It takes as input `(name, init_fn, *init_args)` : \n",
         "\n",
         "*   `name` is simply the name of the parameter that will end up in the parameter structure.\n",
-        "*   `init_fun` is a function with input `(PRNGKey, *init_args)` returning an Array with `init_args` the arguments needed to call the initialisation function\n",
-        "*   `init_args` the arguments to provide to the initialization function.\n",
+        "*   `init_fn` is a function with input `(PRNGKey, *init_args)` returning an Array, with `init_args` being the arguments needed to call the initialisation function.\n",
+        "*   `init_args` are the arguments to provide to the initialization function.\n",
         "\n",
         "Such params can also be declared in the `setup` method, it won't be able to use shape inference because Flax is using lazy initialization at the first call site."
       ]
@@ -921,7 +921,7 @@
         "    ra_mean = self.variable('batch_stats', 'mean',\n",
         "                            lambda s: jnp.zeros(s),\n",
         "                            x.shape[1:])\n",
-        "    mean = ra_mean.value # This will get either the value, or trigger init\n",
+        "    mean = ra_mean.value # This will either get the value or trigger init\n",
         "    bias = self.param('bias', lambda rng, shape: jnp.zeros(shape), x.shape[1:])\n",
         "    if is_initialized:\n",
         "      ra_mean.value = self.decay * ra_mean.value + (1.0 - self.decay) * jnp.mean(x, axis=0, keepdims=True)\n",
@@ -1037,10 +1037,10 @@
         }
       },
       "source": [
-        "def update_step(tx, apply_fun, x, opt_state, params, state):\n",
+        "def update_step(tx, apply_fn, x, opt_state, params, state):\n",
         "\n",
         "  def loss(params):\n",
-        "    y, updated_state = apply_fun({'params': params, **state},\n",
+        "    y, updated_state = apply_fn({'params': params, **state},\n",
         "                                x, mutable=list(state.keys()))\n",
         "    l = ((x - y) ** 2).sum()\n",
         "    return l, updated_state\n",
@@ -1092,10 +1092,10 @@
         "id": "eWUmx5EjtWge"
       },
       "source": [
-        "Note that above function has a quite verbose signature and it would not actually\n",
+        "Note that the above function has a quite verbose signature and it would not actually\n",
         "work with `jax.jit()` because the function arguments are not \"valid JAX types\".\n",
         "\n",
-        "We provide a handy wrapper that simplifies above code, see:\n",
+        "We provide a handy wrapper that simplifies the above code, see:\n",
         "\n",
         "https://flax.readthedocs.io/en/latest/flax.training.html#train-state"
       ]

--- a/docs/notebooks/linen_intro.ipynb
+++ b/docs/notebooks/linen_intro.ipynb
@@ -278,7 +278,7 @@
         "    # we automatically know what to do with lists, dicts of submodules\n",
         "    self.layers = [nn.Dense(feat) for feat in self.features]\n",
         "    # for single submodules, we would just write:\n",
-        "    # self.layer1 = nn.Dense(self, feat1)\n",
+        "    # self.layer1 = nn.Dense(feat1)\n",
         "\n",
         "  def __call__(self, inputs):\n",
         "    x = inputs\n",

--- a/flax/linen/module.py
+++ b/flax/linen/module.py
@@ -1107,8 +1107,8 @@ class Module:
       name: The name of the variable.
       value: The value of the variable.
       reduce_fn: The function used to combine the existing value with
-        the new value the default is to append the value to a tuple.
-      init_fn: For the first value stored reduce_fn will be passed
+        the new value. The default is to append the value to a tuple.
+      init_fn: For the first value stored, `reduce_fn` will be passed
         the result of `init_fn` together with the value to be stored.
         The default is an empty tuple.
 


### PR DESCRIPTION
This PR fixes minor typos in the docs, and also recommends converting all uses of `apply_fun` in the docs to `apply_fn` for consistency reasons (`apply_fn` seems to be the preferred name used elsewhere in the docs and code).