### PR TITLE
Add marker file for PEP 561: Distributing and Packaging Type Information

### DIFF
--- a/flax/py.typed
+++ b/flax/py.typed
@@ -1,0 +1,1 @@
+# Marker file for PEP 561. The package uses inline types.

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ setup(
     author_email="flax-dev@google.com",
     url="https://github.com/google/flax",
     packages=find_packages(),
-    include_package_data=False,
+    package_data={"flax": ["py.typed"]},
     zip_safe=False,
     install_requires=install_requires,
     extras_require={


### PR DESCRIPTION
Currently, in projects that depend on Flax, mypy fails to find type annotations.
This can be easily fixed by providing a marker file required by [PEP 561](https://www.python.org/dev/peps/pep-0561/).

```bash
mypy --install-types src
src/redex_flax/layer/recurrent/lstm.py:2: error: Cannot find implementation or library stub for module named "flax"
src/redex_flax/layer/recurrent/lstm.py:2: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
```