### PR TITLE
Added glorot and he initializers

### DIFF
--- a/flax/linen/initializers.py
+++ b/flax/linen/initializers.py
@@ -17,6 +17,10 @@
 
 # pylint: disable=unused-import
 # re-export initializer functions from jax.nn
+from jax.nn.initializers import glorot_normal
+from jax.nn.initializers import glorot_uniform
+from jax.nn.initializers import he_normal
+from jax.nn.initializers import he_uniform
 from jax.nn.initializers import kaiming_normal
 from jax.nn.initializers import kaiming_uniform
 from jax.nn.initializers import lecun_normal


### PR DESCRIPTION
# What does this PR do?

Added missing initializers from https://jax.readthedocs.io/en/latest/jax.nn.initializers.html into linen/initializers - `he` and `glorot`

Fixes # (issue)

## Checklist
- [x] This PR fixes a minor issue (e.g.: typo or small bug) or improves the docs (you can dismiss the other
      checks if that's the case).
- [ ] This change is discussed in a Github issue/
      [discussion](https://github.com/google/flax/discussions) (please add a
      link).
- [x] The documentation and docstrings adhere to the
      [documentation guidelines](https://github.com/google/flax/blob/main/docs/README.md#how-to-write-code-documentation).
- [ ] This change includes necessary high-coverage tests.
      (No quality testing = no merge!)
