### PR TITLE
Update flax/examples/{wmt, lm1b} parsing JAX config flags

### DIFF
--- a/examples/lm1b/main.py
+++ b/examples/lm1b/main.py
@@ -61,5 +61,5 @@ def main(argv):
 
 
 if __name__ == '__main__':
-  jax.config.parse_flags_with_absl()
+  jax.config.config_with_absl()
   app.run(main)

--- a/examples/wmt/README.md
+++ b/examples/wmt/README.md
@@ -61,7 +61,7 @@ And finally start the training:
 ```
 python3 main.py --workdir=$HOME/logs/wmt_256 \
     --config.per_device_batch_size=32 \
-    --jax_backend_target="grpc://192.168.0.2:8470"`
+    --jax_backend_target="grpc://192.168.0.2:8470"
 ```
 
 Note that you might want to set `TFDS_DATA_DIR` as explained below. You probably

--- a/examples/wmt/main.py
+++ b/examples/wmt/main.py
@@ -61,5 +61,5 @@ def main(argv):
 
 
 if __name__ == '__main__':
-  jax.config.parse_flags_with_absl()
+  jax.config.config_with_absl()
   app.run(main)


### PR DESCRIPTION


# What does this PR do?

Recommended usage is to use `jax.config.config_with_absl()` before `app.run` call.  Updates `flax/examples/wmt` and `flax/examples/lm1b`. Due to recent change in jax.config, these examples don't run as-is. 

## Checklist
- [x ] This PR fixes a minor issue (e.g.: typo or small bug) or improves the docs (you can dismiss the other
      checks if that's the case).