### PR TITLE
Add nowrap decorator for module methods.

### DIFF
--- a/flax/errors.py
+++ b/flax/errors.py
@@ -528,3 +528,22 @@ class InvalidCheckpointError(FlaxError):
   """
   def __init__(self, path, step):
     super().__init__(f'Trying to save an outdated checkpoint at step: "{step}" and path: "{path}".')
+
+
+#################################################
+# transforms.py errors                          #
+#################################################
+
+class TransformedMethodReturnValueError(FlaxError):
+  """
+  Transformed Module methods cannot return other Modules or Variables.
+
+  This commonly occurs when named_call is automatically applied to helper
+  constructor methods when profiling is enabled, and can be mitigated by
+  using the @nn.nowrap decorator to prevent automatic wrapping.
+  """
+  def __init__(self, name):
+    super().__init__(
+      f'Transformed module method {name} cannot return Modules or Variables. '
+      f'For helper constructor methods use the @nn.nowrap decorator to prevent '
+      f'decoration by the automatic named_call transform.')

--- a/flax/linen/__init__.py
+++ b/flax/linen/__init__.py
@@ -25,8 +25,9 @@ from .attention import (MultiHeadDotProductAttention, SelfAttention,
                         make_causal_mask, combine_masks)
 from ..core import broadcast, DenyList
 from .linear import Conv, ConvTranspose, Dense, DenseGeneral, Embed
-from .module import (Module, compact, enable_named_call, disable_named_call,
-                     Variable, init, init_with_output, apply, merge_param)
+from .module import (Module, compact, nowrap, enable_named_call,
+                     disable_named_call, Variable, init, init_with_output,
+                     apply, merge_param)
 from .normalization import BatchNorm, GroupNorm, LayerNorm
 from .pooling import avg_pool, max_pool
 from .recurrent import GRUCell, LSTMCell, ConvLSTM, OptimizedLSTMCell


### PR DESCRIPTION
User-defined module methods are automatically wrapped with a state
management wrapper and, if profiling is enabled, with named_call.

This can interfere with constructor helper methods when they are
wrapped by named_call automatically, since "functionalized" methods
cannot return Modules or Variables.

Additionally for advanced cases of overriding e.g. the base param
method, one does not want to wrap such a method with the state
management wrapper.

So a @nn.nowrap method is introduced to prevent automatic wrapping
in those advanced use cases where it is detrimental.