### PR TITLE
remove remaining uses of deprecated host_id

### DIFF
--- a/examples/imagenet/train.py
+++ b/examples/imagenet/train.py
@@ -263,7 +263,7 @@ def train_and_evaluate(config: ml_collections.ConfigDict,
   """
 
   writer = metric_writers.create_default_writer(
-      logdir=workdir, just_logging=jax.host_id() != 0)
+      logdir=workdir, just_logging=jax.process_index() != 0)
 
   rng = random.PRNGKey(0)
 

--- a/examples/lm1b/train.py
+++ b/examples/lm1b/train.py
@@ -273,7 +273,7 @@ def per_host_sum_pmap(in_tree):
   """Execute psum on in_tree"s leaves over one device per host."""
   host2devices = collections.defaultdict(list)
   for d in jax.devices():
-    host2devices[d.host_id].append(d)
+    host2devices[d.process_index].append(d)
   devices = [host2devices[k][0] for k in host2devices]
   host_psum = jax.pmap(lambda x: jax.lax.psum(x, "i"), "i", devices=devices)
 

--- a/examples/wmt/train.py
+++ b/examples/wmt/train.py
@@ -297,7 +297,7 @@ def per_host_sum_pmap(in_tree):
   """Execute psum on in_tree"s leaves over one device per host."""
   host2devices = collections.defaultdict(list)
   for d in jax.devices():
-    host2devices[d.host_id].append(d)
+    host2devices[d.process_index].append(d)
   devices = [host2devices[k][0] for k in host2devices]
   host_psum = jax.pmap(lambda x: jax.lax.psum(x, "i"), "i", devices=devices)
 


### PR DESCRIPTION
replace jax.host_id() with jax.process_index() and jax_device.host_id with jax_device.process_index