### PR TITLE
Clean up pytest.ini

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,21 +1,15 @@
 [pytest]
-# RuntimeWarning is due to scipy (or another package) that was compiled against an older numpy than is installed.
-# UserWarning is due to statement: tensorflow.compat.v2.io import gfile
-# DeprecationWarning is due to statement: tensorflow.compat.v2.io import gfile
-# inspect.getargspec() is invoked in tensorboard/backend/event_processing/event_file_loader.py:61
-# jnp.sum([]) in examples/sst2/train.py:L152 should be replaced with an ndarray.
-# tostring() is deprecated: examples/lm1b/input_pipeline.py tf constant_op warning.
-# Importing ABCs from collections is deprecated is in tensorflow/python/data/ops/iterator_ops.py
+
 filterwarnings =
+# By default error out on any warnings.
     error
-    ignore:numpy.ufunc size changed.*:RuntimeWarning
+# Jax warning when no gpu/tpu found.
     ignore:No GPU/TPU found, falling back to CPU.*:UserWarning
+# Tensorflow's fast_tensor_util.pyx cython raises:
+# ImportWarning: can't resolve package from __spec__ or __package__, falling back on __name__ and __path__
     ignore:can't resolve package from.*:ImportWarning
+# Jax imports flatbuffers which imports imp in a compat file.
     ignore:the imp module is deprecated.*:DeprecationWarning
-    ignore:inspect.getargspec() is deprecated since Python 3.0.*:DeprecationWarning
-    ignore:jax.numpy reductions won't accept lists and tuples in future versions, only scalars and ndarrays.*:FutureWarning
-    ignore:tostring() is deprecated. Use tobytes() instead.*:DeprecationWarning
-    ignore:Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated.*:DeprecationWarning
-    ignore:Explicitly requested dtype <class 'jax.numpy.lax_numpy.float64'>*:UserWarning
+# We still want to test deprecated library until deleted.
     ignore:The `flax.nn` module is Deprecated, use `flax.linen` instead.*:DeprecationWarning
-    ignore:jax.host_(id|count) has been renamed:UserWarning
+


### PR DESCRIPTION
Lots of old cruft in here, trying to remove obsolete warnings.
This much-reduced set worked on my local machine.

Resolves #210