### PR TITLE
Fix lifting rng splits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ vNext
  -
  -
  -
- -
+ - `flax.linen.enable_named_call` and `flax.linen.disable_named_call` now work anywhere instead of only affecting Modules constructed after the enable/disable call. Additionally, there is now `flax.linen.override_named_call` that provided a context manager to locally disable/enable named_call.
  -
  -
  - Fix the serialization of named tuples. Tuple fields are no longer stored in the state dict and the named tuple class is no longer recreated ([bug](https://github.com/google/flax/issues/1429)).

--- a/flax/linen/__init__.py
+++ b/flax/linen/__init__.py
@@ -26,8 +26,8 @@ from .attention import (MultiHeadDotProductAttention, SelfAttention,
 from ..core import broadcast, DenyList
 from .linear import Conv, ConvTranspose, Dense, DenseGeneral, Embed
 from .module import (Module, compact, nowrap, enable_named_call,
-                     disable_named_call, Variable, init, init_with_output,
-                     apply, merge_param)
+                     disable_named_call, override_named_call, Variable, init,
+                     init_with_output, apply, merge_param)
 from .normalization import BatchNorm, GroupNorm, LayerNorm
 from .pooling import avg_pool, max_pool
 from .recurrent import GRUCell, LSTMCell, ConvLSTM, OptimizedLSTMCell

--- a/flax/linen/module.py
+++ b/flax/linen/module.py
@@ -139,6 +139,18 @@ def disable_named_call():
   _use_named_call = False
 
 
+@contextmanager
+def override_named_call(enable: bool = True):
+  """Returns a context manager that enables/disables named call wrapping."""
+  global _use_named_call
+  use_named_call_prev = _use_named_call
+  _use_named_call = enable
+  try:
+    yield
+  finally:
+    _use_named_call = use_named_call_prev
+
+
 # Utilities for pytrees of Modules defined inside setup()
 # -----------------------------------------------------------------------------
 
@@ -541,10 +553,10 @@ class Module(metaclass=ModuleMeta):
       if hasattr(method, 'nowrap'):
         continue
       wrapped_method = wrap_method_once(method)
-      if _use_named_call and key != 'setup':
+      if key != 'setup':
         # We import named_call at runtime to avoid a circular import issue.
         from flax.linen.transforms import named_call  # pylint: disable=g-import-not-at-top
-        wrapped_method = named_call(wrapped_method)
+        wrapped_method = named_call(wrapped_method, force=False)
       setattr(cls, key, wrapped_method)
     return cls
 

--- a/tests/linen/module_test.py
+++ b/tests/linen/module_test.py
@@ -19,6 +19,7 @@ import functools
 import operator
 
 from absl.testing import absltest
+from flax.linen.module import override_named_call
 
 import jax
 from jax import random
@@ -1378,6 +1379,14 @@ class ModuleTest(absltest.TestCase):
       pass
     class MyModule2(nn.Module):
       submodule: MyComponent2[jnp.ndarray]
+  
+  def test_named_call_rng_equivalance(self):
+    model = nn.Dense(1, use_bias=False)
+    with override_named_call(False):
+      param = model.init(random.PRNGKey(0), np.ones((1, 1)))["params"]["kernel"]
+    with override_named_call(True):
+      param_2 = model.init(random.PRNGKey(0), np.ones((1, 1)))["params"]["kernel"]
+    self.assertEqual(param, param_2)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fixes #1530 

- Dynamically check whether named call is enabled.
   Previously enable/disable named call only affected Module construction. This is unexpected and less flexible than checking 
   the global during calls to named_call.

- This commit also introduces override_named_call which locally overrides named_call behavior.
   This is particullary useful for tests that depend on a specific setting.

- Remove unnecessary splitting of rngs in lifting logic
  Previously we split every rng that was lifted. Now the rng_counters are shared between the lifted and unlifted scope.
  This is valid because make_rng can only be called a static number of times and lifted loops/vmap split the rngs manually 
  already