### PR TITLE
Update checkpoints.py to add a `pool_size` param to  `checkpoints.restore_checkpoint`

### DIFF
--- a/flax/training/checkpoints.py
+++ b/flax/training/checkpoints.py
@@ -203,7 +203,8 @@ def restore_checkpoint(ckpt_dir: Union[str, os.PathLike],
                        target: Optional[PyTree],
                        step: Optional[int] = None,
                        prefix: str = 'checkpoint_',
-                       parallel: bool = True) -> PyTree:
+                       parallel: bool = True,
+                       pool_size:Optional[int]=32) -> PyTree:
   """Restore last/best checkpoint from checkpoints in path.
 
   Sorts the checkpoint files naturally, returning the highest-valued
@@ -223,6 +224,7 @@ def restore_checkpoint(ckpt_dir: Union[str, os.PathLike],
       ckpt_dir must be a directory.
     prefix: str: name prefix of checkpoint files.
     parallel: bool: whether to load seekable checkpoints in parallel, for speed.
+    pool_size: int: number of parallel threads to use.
 
   Returns:
     Restored `target` updated from checkpoint file, or if no step specified and
@@ -268,7 +270,7 @@ def restore_checkpoint(ckpt_dir: Union[str, os.PathLike],
             checkpoint_contents[i * buf_size:i * buf_size + len(buf)] = buf
           return len(buf) / buf_size
 
-      pool_size = 32
+
       pool = thread.ThreadPoolExecutor(pool_size)
       results = pool.map(read_chunk, range(int(num_bufs) + 1))
       results = list(results)


### PR DESCRIPTION
# What does this PR do?
added pool_size as an optional param to restore_checkpoint. This gives control to the user on the number of threads being used (this is helpful in the GCS use case, specially with the new TPU-VMs).
```python
cpus=multiprocessing.cpu_count()
pool_size=int(cpus*0.2) # on a 96 core TPU-VM that ends up being 19 threads
cProfile.run('state=checkpoints.restore_checkpoint(gcs_path,state,parallel=True,pool_size=pool_size)')
```
yields:
```
Parallel GCS with pool 19 ==============================
         5363 function calls (4608 primitive calls) in 0.563 seconds
```
and
```python
cpus=multiprocessing.cpu_count()
pool_size=int(cpus*0.5) # on a 96 core TPU-VM that ends up being 48 threads
cProfile.run('state=checkpoints.restore_checkpoint(gcs_path,state,parallel=True,pool_size=pool_size)')
```
yields:
```
Parallel GCS with pool 48 ==============================
         5363 function calls (4608 primitive calls) in 0.574 seconds
```
and
```python
cpus=multiprocessing.cpu_count()
pool_size=cpus # on a 96 core TPU-VM that ends up being 96 threads
cProfile.run('state=checkpoints.restore_checkpoint(gcs_path,state,parallel=True,pool_size=pool_size)')
```
yields: 
```
Parallel GCS with pool 96 ==============================
         8625 function calls (6460 primitive calls) in 0.651 seconds
```
While 
```python
cProfile.run('state=checkpoints.restore_checkpoint(gcs_path,state,parallel=True)')

```
yields:
```
Parallel GCS with pool 32 ==============================
         8625 function calls (6460 primitive calls) in 0.734 seconds
```



## Checklist
- [ ] This PR fixes a minor issue (e.g.: typo or small bug) or improves the docs (you can dismiss the other
      checks if that's the case).
- [ ] This change is discussed in a Github issue/
      [discussion](https://github.com/google/flax/discussions) (please add a
      link).
- [ ] The documentation and docstrings adhere to the
      [documentation guidelines](https://github.com/google/flax/blob/main/docs/README.md#how-to-write-code-documentation).
- [x] This change includes necessary high-coverage tests.
      (No quality testing = no merge!)
