### PR TITLE
Remove Implicit rank promotion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ vNext
 (Add your change to a random empty line to avoid merge conflicts)
  -
  -
- -
+ - Flax no longer uses implicit rank broadcasting. Thus, you can now use Flax with `--jax_numpy_rank_promotion=raise`.
  -
  -
  -

--- a/examples/lm1b/temperature_sampler.py
+++ b/examples/lm1b/temperature_sampler.py
@@ -102,7 +102,7 @@ def temperature_sample(prompt_inputs,
     next_token = (next_token * out_of_prompt +
                   sequences[:, i+1] * ~out_of_prompt)
     # If end-marker reached for batch item, only emit padding tokens.
-    next_token_or_endpad = next_token * ~ended
+    next_token_or_endpad = (next_token[None] * ~ended)
     ended |= (next_token_or_endpad == end_marker)
     # Add current sampled tokens to recorded sequences.
     new_sequences = lax.dynamic_update_slice(

--- a/examples/lm1b/train_test.py
+++ b/examples/lm1b/train_test.py
@@ -38,7 +38,7 @@ class TrainTest(absltest.TestCase):
     config = default.get_config()
     config.max_corpus_chars = 1000
     config.vocab_size = 32
-    config.per_device_batch_size = 1
+    config.per_device_batch_size = 2
     config.num_train_steps = 1
     config.num_eval_steps = 1
     config.num_predict_steps = 1

--- a/examples/pixelcnn/pixelcnn.py
+++ b/examples/pixelcnn/pixelcnn.py
@@ -174,13 +174,14 @@ shift_right = partial(spatial_pad, (0, 0), (1, -1))
 def _l2_normalize(v):
   """Normalize a convolution kernel direction over the in_features and spatial
   dimensions."""
-  return v / jnp.sqrt(jnp.sum(jnp.square(v), (0, 1, 2)))
+  return v / jnp.sqrt(jnp.sum(jnp.square(v), (0, 1, 2), keepdims=True))
 
 
 def _make_kernel(direction, scale):
   """Maps weightnorm parameterization (direction, scale) to standard
   parameterization. The direction has shape (spatial..., in_features,
   out_features), scale has shape (out_features,)."""
+  scale = scale.reshape((1,) * (direction.ndim - 1) + (-1,))
   return scale * _l2_normalize(direction)
 
 
@@ -224,7 +225,9 @@ class ConvWeightNorm(nn.Module):
 
     params = self.param('weightnorm_params', initializer)
     direction, scale, bias = [params[k] for k in ('direction', 'scale', 'bias')]
-    return conv(inputs, _make_kernel(direction, scale)) + bias
+    y = conv(inputs, _make_kernel(direction, scale))
+    y += jnp.reshape(bias, (1,) * (y.ndim - 1) + (-1,))
+    return y
 
 
 ConvOneByOne = partial(ConvWeightNorm, kernel_size=(1, 1))

--- a/examples/seq2seq/train.py
+++ b/examples/seq2seq/train.py
@@ -158,7 +158,7 @@ def get_sequence_lengths(sequence_batch, eos_id=CTABLE.eos_id):
 def mask_sequences(sequence_batch, lengths):
   """Set positions beyond the length of each sequence to 0."""
   return sequence_batch * (
-      lengths[:, np.newaxis] > np.arange(sequence_batch.shape[1]))
+      lengths[:, np.newaxis] > np.arange(sequence_batch.shape[1])[np.newaxis])
 
 
 class EncoderLSTM(nn.Module):

--- a/examples/sst2/models.py
+++ b/examples/sst2/models.py
@@ -41,7 +41,7 @@ def sequence_mask(lengths: Array, max_length: int) -> Array:
     A mask with shape: <bool>[batch_size, max_length] indicating which
     positions are valid for each sequence.
   """
-  return jnp.arange(max_length) < jnp.expand_dims(lengths, 1)
+  return jnp.arange(max_length)[None] < lengths[:, None]
 
 
 @jax.vmap

--- a/flax/core/nn/linear.py
+++ b/flax/core/nn/linear.py
@@ -155,7 +155,7 @@ def dense(scope,
   if bias:
     bias = scope.param('bias', bias_init, (features,))
     bias = jnp.asarray(bias, dtype)
-    y = y + bias
+    y += jnp.reshape(bias, (1,) * (y.ndim - 1) + (-1,))
   return y
 
 
@@ -239,7 +239,7 @@ def conv(scope,
   if bias:
     bias = scope.param('bias', bias_init, (features,))
     bias = jnp.asarray(bias, dtype)
-    y = y + bias
+    y += jnp.reshape(bias, (1,) * (y.ndim - 1) + (-1,))
   return y
 
 
@@ -295,7 +295,7 @@ def conv_transpose(scope,
   if bias:
     bias = scope.param('bias', bias_init, (features,))
     bias = jnp.asarray(bias, dtype)
-    y = y + bias
+    y += jnp.reshape(bias, (1,) * (y.ndim - 1) + (-1,))
   return y
 
 

--- a/flax/linen/linear.py
+++ b/flax/linen/linear.py
@@ -178,7 +178,7 @@ class Dense(Module):
     if self.use_bias:
       bias = self.param('bias', self.bias_init, (self.features,))
       bias = jnp.asarray(bias, self.dtype)
-      y = y + bias
+      y += jnp.reshape(bias, (1,) * (y.ndim - 1) + (-1,))
     return y
 
 
@@ -295,7 +295,7 @@ class Conv(Module):
     if self.use_bias:
       bias = self.param('bias', self.bias_init, (self.features,))
       bias = jnp.asarray(bias, self.dtype)
-      y = y + bias
+      y += jnp.reshape(bias, (1,) * (y.ndim - 1) + (-1,))
     return y
 
 
@@ -376,7 +376,7 @@ class ConvTranspose(Module):
     if self.use_bias:
       bias = self.param('bias', self.bias_init, (self.features,))
       bias = jnp.asarray(bias, self.dtype)
-      y = y + bias
+      y += jnp.reshape(bias, (1,) * (y.ndim - 1) + (-1,))
     return y
 
 

--- a/flax/linen/normalization.py
+++ b/flax/linen/normalization.py
@@ -209,6 +209,7 @@ class LayerNorm(Module):
     """
     x = jnp.asarray(x, jnp.float32)
     features = x.shape[-1]
+    feature_shape = (1,) * (x.ndim - 1) + (features,)
     mean = jnp.mean(x, axis=-1, keepdims=True)
     mean2 = jnp.mean(lax.square(x), axis=-1, keepdims=True)
     var = mean2 - lax.square(mean)
@@ -216,12 +217,12 @@ class LayerNorm(Module):
     if self.use_scale:
       mul = mul * jnp.asarray(
           self.param('scale', self.scale_init, (features,)),
-          self.dtype)
+          self.dtype).reshape(feature_shape)
     y = (x - mean) * mul
     if self.use_bias:
-      y = y + jnp.asarray(
+      y += jnp.asarray(
           self.param('bias', self.bias_init, (features,)),
-          self.dtype)
+          self.dtype).reshape(feature_shape)
     return jnp.asarray(y, self.dtype)
 
 

--- a/flax/linen/normalization.py
+++ b/flax/linen/normalization.py
@@ -156,7 +156,7 @@ class BatchNorm(Module):
         ra_var.value = self.momentum * ra_var.value + (1 - self.momentum) * var
 
     y = x - mean.reshape(feature_shape)
-    mul = lax.rsqrt(var + self.epsilon)
+    mul = lax.rsqrt(var + self.epsilon).reshape(feature_shape)
     if self.use_scale:
       scale = self.param('scale',
                          self.scale_init,

--- a/flax/linen/recurrent.py
+++ b/flax/linen/recurrent.py
@@ -227,7 +227,7 @@ class OptimizedLSTMCell(RNNCellBase):
       y = jnp.dot(inputs, kernel)
       if use_bias:
         bias = jnp.asarray(jnp.concatenate(biases, axis=-1), jnp.float32)
-        y = y + bias
+        y += jnp.reshape(bias, (1,) * (y.ndim - 1) + (-1,))
 
       # Split the result back into individual (i, f, g, o) outputs.
       split_indices = np.cumsum([b.shape[0] for b in biases[:-1]])

--- a/flax/nn/linear.py
+++ b/flax/nn/linear.py
@@ -133,8 +133,8 @@ class DenseGeneral(base.Module):
 
 class Dense(base.Module):
   """DEPRECATION WARNING:
-  The `flax.nn` module is Deprecated, use `flax.linen` instead. 
-  Learn more and find an upgrade guide at 
+  The `flax.nn` module is Deprecated, use `flax.linen` instead.
+  Learn more and find an upgrade guide at
   https://github.com/google/flax/blob/main/flax/linen/README.md"
   A linear transformation applied over the last dimension of the input."""
 
@@ -169,7 +169,7 @@ class Dense(base.Module):
     if bias:
       bias = self.param('bias', (features,), bias_init)
       bias = jnp.asarray(bias, dtype)
-      y = y + bias
+      y += jnp.reshape(bias, (1,) * (y.ndim - 1) + (-1,))
     return y
 
 
@@ -275,7 +275,7 @@ class Conv(base.Module):
     if bias:
       bias = self.param('bias', (features,), bias_init)
       bias = jnp.asarray(bias, dtype)
-      y = y + bias
+      y += jnp.reshape(bias, (1,) * (y.ndim - 1) + (-1,))
     return y
 
 
@@ -349,7 +349,7 @@ class ConvTranspose(base.Module):
     if bias:
       bias = self.param('bias', (features,), bias_init)
       bias = jnp.asarray(bias, dtype)
-      y = y + bias
+      y += jnp.reshape(bias, (1,) * (y.ndim - 1) + (-1,))
     return y
 
 

--- a/flax/nn/normalization.py
+++ b/flax/nn/normalization.py
@@ -115,7 +115,7 @@ class BatchNorm(base.Module):
         ra_var.value = momentum * ra_var.value + (1 - momentum) * var
 
     y = x - mean.reshape(feature_shape)
-    mul = lax.rsqrt(var + epsilon)
+    mul = lax.rsqrt(var + epsilon).reshape(feature_shape)
     if scale:
       mul = mul * self.param(
           'scale', reduced_feature_shape, scale_init).reshape(feature_shape)

--- a/flax/nn/recurrent.py
+++ b/flax/nn/recurrent.py
@@ -214,7 +214,7 @@ class OptimizedLSTMCell(RNNCellBase):
       y = jnp.dot(inputs, kernel)
       if use_bias:
         bias = jnp.asarray(jnp.concatenate(biases, axis=-1), jnp.float32)
-        y = y + bias
+        y += jnp.reshape(bias, (1,) * (y.ndim - 1) + (-1,))
 
       # Split the result back into individual (i, f, g, o) outputs.
       split_indices = np.cumsum([b.shape[0] for b in biases[:-1]])

--- a/flax/training/common_utils.py
+++ b/flax/training/common_utils.py
@@ -35,7 +35,7 @@ def shard_prng_key(prng_key):
 
 
 def onehot(labels, num_classes, on_value=1.0, off_value=0.0):
-  x = (labels[..., None] == jnp.arange(num_classes)[None])
+  x = (labels[..., None] == jnp.arange(num_classes).reshape((1,) * labels.ndim + (-1,)))
   x = lax.select(x, jnp.full(x.shape, on_value), jnp.full(x.shape, off_value))
   return x.astype(jnp.float32)
 

--- a/tests/core/design/core_dense_test.py
+++ b/tests/core/design/core_dense_test.py
@@ -36,7 +36,8 @@ class Dense:
     kernel = scope.param('kernel', self.kernel_init, (x.shape[-1], self.features))
     y = x @ kernel
     if self.bias:
-      y += scope.param('bias', self.bias_init, (self.features,))
+      bias = scope.param('bias', self.bias_init, (self.features,))
+      y += bias.reshape((1,) * (y.ndim - 1) + (-1,))
     return y
 
 
@@ -73,7 +74,7 @@ class ExplicitDense:
   def __call__(self, x):
     y = x @ self.kernel
     if self.bias is not None:
-      y += self.bias
+      y += self.bias.reshape((1,) * (y.ndim - 1) + (-1,))
     return y
 
 def explicit_mlp(scope, x, sizes=(3, 1)):

--- a/tests/core/design/core_flow_test.py
+++ b/tests/core/design/core_flow_test.py
@@ -40,11 +40,13 @@ class DenseFlow:
 
   def forward(self, scope: Scope, x: Array):
     kernel, bias = self.params(scope, x.shape[-1])
-    return jnp.dot(x, expm(kernel)) + bias
+    return jnp.dot(
+      x, expm(kernel)) + bias.reshape((1,) * (x.ndim - 1) + (-1,))
 
   def backward(self, scope: Scope, y: Array):
     kernel, bias = self.params(scope, y.shape[-1])
-    return jnp.dot(y - bias, expm(-kernel))
+    return jnp.dot(
+      y - bias.reshape((1,) * (y.ndim - 1) + (-1,)), expm(-kernel))
 
 
 @dataclass

--- a/tests/linen/linen_transforms_test.py
+++ b/tests/linen/linen_transforms_test.py
@@ -211,10 +211,10 @@ class TransformTest(absltest.TestCase):
         return LSTM(name="lstm_cell")(c, xs)
 
     key1, key2 = random.split(random.PRNGKey(0), 2)
-    xs = random.uniform(key1, (3, 2))
+    xs = random.uniform(key1, (5, 3, 2))
     dummy_rng = random.PRNGKey(0)
     init_carry = nn.LSTMCell.initialize_carry(dummy_rng,
-                                              xs.shape[:1],
+                                              xs.shape[1:-1],
                                               xs.shape[-1])
     model = SimpleScan()
     init_variables = model.init(key2, init_carry, xs)
@@ -244,11 +244,11 @@ class TransformTest(absltest.TestCase):
         return nn.LSTMCell(name="lstm_cell")(c, xs)
 
     key1, key2 = random.split(random.PRNGKey(0), 2)
-    xs = random.uniform(key1, (3, 2))
+    xs = random.uniform(key1, (4, 3, 2))
     b = jnp.ones((4,))
     dummy_rng = random.PRNGKey(0)
     init_carry = nn.LSTMCell.initialize_carry(dummy_rng,
-                                              xs.shape[:1],
+                                              xs.shape[1:-1],
                                               xs.shape[-1])
     model = SimpleScan()
     init_variables = model.init(key2, init_carry, b, xs)

--- a/tests/run_all_tests.sh
+++ b/tests/run_all_tests.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+export JAX_NUMPY_RANK_PROMOTION=raise
 export FLAX_PROFILE=1
 
 PYTEST_OPTS=
@@ -42,7 +43,7 @@ handle_errors () {
 sphinx-build -M doctest docs docs/_build
 
 # Run battery of core FLAX API tests.
-pytest -n 4 tests $PYTEST_OPTS
+pytest -n auto tests $PYTEST_OPTS
 
 # Per-example tests.
 #


### PR DESCRIPTION
- users can now disable implicit rank promotion in JAX without Flax throwing errors.
- Tests are no run with JAX_NUMPY_RANK_PROMOTION=raise
- This change uncovered 2 faulty LSTM tests.

Fixes #1534 