### PR TITLE
Enable traceback filtering of flax internal frames.

### DIFF
--- a/docs/flax.config.rst
+++ b/docs/flax.config.rst
@@ -1,0 +1,7 @@
+
+flax.config package
+====================
+
+Flax has the following global config options.
+
+.. automodule:: flax.config

--- a/docs/flax.traceback_util.rst
+++ b/docs/flax.traceback_util.rst
@@ -1,0 +1,14 @@
+flax.traceback_util package
+============================
+
+.. currentmodule:: flax.traceback_util
+
+.. automodule:: flax.traceback_util
+
+
+Traceback filtering utils
+--------------------------
+
+.. autofunction:: hide_flax_in_tracebacks
+
+.. autofunction:: show_flax_in_tracebacks

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -68,8 +68,10 @@ For a quick introduction and short example snippets, see our `README
    flax.core.frozen_dict
    flax.struct
    flax.jax_utils
+   flax.traceback_util
    flax.traverse_util
    flax.training
+   flax.config
    flax.errors
 
 .. toctree::

--- a/flax/config.py
+++ b/flax/config.py
@@ -1,0 +1,58 @@
+# Copyright 2021 The Flax Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Global configuration options for Flax.
+
+.. data:: flax_filter_frames
+
+    Whether to hide flax-internal stack frames from tracebacks.  Set by the
+    FLAX_FILTER_FRAMES environment variable.  Defaults to True.
+
+.. data:: flax_profile
+
+    Whether to automatically wrap Module methods with named_call for profiles.
+    Set by the FLAX_PROFILE environment variable.  Defaults to False.
+"""
+
+import os
+
+# Config parsing utils
+
+def bool_env(varname: str, default: bool) -> bool:
+  """Read an environment variable and interpret it as a boolean.
+  True values are (case insensitive): 'y', 'yes', 't', 'true', 'on', and '1';
+  false values are 'n', 'no', 'f', 'false', 'off', and '0'.
+  Args:
+    varname: the name of the variable
+    default: the default boolean value
+  Raises: ValueError if the environment variable is anything else.
+  """
+  val = os.getenv(varname, str(default))
+  val = val.lower()
+  if val in ('y', 'yes', 't', 'true', 'on', '1'):
+    return True
+  elif val in ('n', 'no', 'f', 'false', 'off', '0'):
+    return False
+  else:
+    raise ValueError(
+        "invalid truth value %r for environment %r" % (val, varname))
+
+
+# Flax Global Configuration Variables:
+
+# Whether to hide flax-internal stack frames from tracebacks.
+flax_filter_frames = bool_env('FLAX_FILTER_FRAMES', True)
+
+# Whether to automatically wrap Module methods with named_call for profiles.
+flax_profile = bool_env('FLAX_PROFILE', False)

--- a/flax/core/lift.py
+++ b/flax/core/lift.py
@@ -20,6 +20,7 @@ import functools
 import warnings
 
 
+from flax import traceback_util
 import jax
 from jax import random
 
@@ -33,6 +34,7 @@ from .scope import Scope, DenyList, CollectionFilter, PRNGSequenceFilter, in_fil
 
 from . import axes_scan
 
+traceback_util.register_exclusion(__file__)
 
 T = TypeVar('T')
 

--- a/flax/core/scope.py
+++ b/flax/core/scope.py
@@ -22,12 +22,15 @@ from typing import Any, Callable, Container, Dict, Generic, Iterable, Mapping, O
 
 from . import tracers
 from flax import errors
+from flax import traceback_util
 from .frozen_dict import freeze
 from .frozen_dict import FrozenDict
 from .frozen_dict import unfreeze
 import jax
 from jax import numpy as jnp
 from jax import random
+
+traceback_util.register_exclusion(__file__)
 
 T = TypeVar('T')
 

--- a/flax/jax_utils.py
+++ b/flax/jax_utils.py
@@ -12,19 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Copyright 2021 The Flax Authors.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 """Utilities we could consider upstreaming to Jax.
 """
 

--- a/flax/linen/transforms.py
+++ b/flax/linen/transforms.py
@@ -28,6 +28,7 @@ import dataclasses
 import functools
 import inspect
 from flax import errors
+from flax import traceback_util
 from flax.core import lift, Scope
 from flax.linen.module import Module
 from flax.linen.module import Variable
@@ -35,6 +36,8 @@ from flax.linen.module import wrap_method_once
 from flax.linen import module as linen_module
 from flax import struct
 import jax
+
+traceback_util.register_exclusion(__file__)
 
 # Utils
 # -----------------------------------------------------------------------------
@@ -315,6 +318,7 @@ def lift_transform(transform, target, *trafo_args, methods=None, **trafo_kwargs)
 TransformTarget = Union[Type[Module], Callable[..., Any]]
 
 Target = TypeVar('Target', bound=TransformTarget)
+
 
 def vmap(target: Target,
          variable_axes: Mapping[lift.CollectionFilter, lift.InOutAxis],

--- a/flax/traceback_util.py
+++ b/flax/traceback_util.py
@@ -1,0 +1,57 @@
+# Copyright 2021 The Flax Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Flax specific traceback_util functions."""
+
+from jax._src import traceback_util as jax_traceback_util
+from flax import config
+
+# pylint: disable=protected-access
+
+# Globals:
+# Whether to filter flax frames from traceback.
+_flax_filter_tracebacks = config.flax_filter_frames
+# Flax specific set of paths to exclude from tracebacks.
+_flax_exclusions = set()
+
+
+# re-import JAX symbol for convenience.
+api_boundary = jax_traceback_util.api_boundary
+
+
+def register_exclusion(path):
+  """Marks a Flax source file for exclusion."""
+  global _flax_exclusions, _flax_filter_tracebacks
+  # Record flax exclusions so we can dynamically add and remove them.
+  _flax_exclusions.add(path)
+  if _flax_filter_tracebacks:
+    jax_traceback_util.register_exclusion(path)
+
+
+def hide_flax_in_tracebacks():
+  """Hides Flax internal stack frames in tracebacks."""
+  global _flax_exclusions, _flax_filter_tracebacks
+  _flax_filter_tracebacks = True
+  for exclusion in _flax_exclusions:
+    if exclusion not in jax_traceback_util._exclude_paths:
+      jax_traceback_util._exclude_paths.append(exclusion)
+
+
+def show_flax_in_tracebacks():
+  """Shows Flax internal stack frames in tracebacks."""
+  global _flax_exclusions, _flax_filter_tracebacks
+  _flax_filter_tracebacks = False
+  for exclusion in _flax_exclusions:
+    if exclusion in jax_traceback_util._exclude_paths:
+      jax_traceback_util._exclude_paths.remove(exclusion)

--- a/tests/traceback_util_test.py
+++ b/tests/traceback_util_test.py
@@ -1,0 +1,193 @@
+# Copyright 2021 The Flax Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for flax.traceback_util."""
+
+import traceback
+import sys
+from absl.testing import absltest
+import jax
+from jax import numpy as jnp
+from jax import random
+from jax._src import traceback_util as jax_traceback_util
+from flax import linen as nn
+from flax import traceback_util
+
+
+# pylint: disable=arguments-differ,protected-access
+
+# __tracebackhide__ is a python >=3.7 feature.
+TRACEBACKHIDE_SUPPORTED = tuple(sys.version_info)[:3] >= (3,7,0)
+
+class TracebackTest(absltest.TestCase):
+
+  def test_exclusion_list(self):
+    traceback_util.show_flax_in_tracebacks()
+    exclusion_len_wo_flax = len(jax_traceback_util._exclude_paths)
+    traceback_util.hide_flax_in_tracebacks()
+    exclusion_len_w_flax = len(jax_traceback_util._exclude_paths)
+    self.assertEqual(
+      exclusion_len_w_flax-exclusion_len_wo_flax,
+      len(traceback_util._flax_exclusions))
+
+  def test_simple_exclusion_tracebackhide(self):
+    if not TRACEBACKHIDE_SUPPORTED:
+      return
+    class Test1(nn.Module):
+      @nn.remat
+      @nn.compact
+      def __call__(self, x):
+        return Test2()(x)
+    class Test2(nn.Module):
+      @nn.jit
+      @nn.compact
+      def __call__(self, x):
+        raise ValueError('error here.')
+        return x  # pylint: disable=unreachable
+
+    traceback_util.hide_flax_in_tracebacks()
+    jax.config.update('jax_traceback_filtering', 'tracebackhide')
+
+    key = random.PRNGKey(0)
+    try:
+      nn.jit(Test1)().init(key, jnp.ones((5,3)))
+    except ValueError as e:
+      tb = e.__traceback__
+
+    filtered_frames = 0
+    unfiltered_frames = 0
+    for f, _ in traceback.walk_tb(tb):
+      if '__tracebackhide__' not in f.f_locals:
+        self.assertEqual(f.f_code.co_filename, __file__)
+        filtered_frames += 1
+      unfiltered_frames += 1
+
+    self.assertEqual(filtered_frames, 3)
+    self.assertGreater(unfiltered_frames, filtered_frames)
+
+
+  def test_simple_exclusion_remove_frames(self):
+    class Test1(nn.Module):
+      @nn.remat
+      @nn.compact
+      def __call__(self, x):
+        return Test2()(x)
+    class Test2(nn.Module):
+      @nn.jit
+      @nn.compact
+      def __call__(self, x):
+        raise ValueError('error here.')
+        return x  # pylint: disable=unreachable
+
+    traceback_util.hide_flax_in_tracebacks()
+    jax.config.update('jax_traceback_filtering', 'remove_frames')
+
+    key = random.PRNGKey(0)
+    try:
+      nn.jit(Test1)().init(key, jnp.ones((5,3)))
+    except ValueError as e:
+      tb_filtered = e.__traceback__
+      tb_unfiltered = e.__cause__.__traceback__
+      e_cause = e.__cause__
+
+    self.assertIsInstance(e_cause, jax_traceback_util.UnfilteredStackTrace)
+
+    filtered_frames = 0
+    for f, _ in traceback.walk_tb(tb_filtered):
+      filtered_frames += 1
+
+    unfiltered_frames = 0
+    for f, _ in traceback.walk_tb(tb_unfiltered):
+      unfiltered_frames += 1
+
+    self.assertEqual(filtered_frames, 3)
+    self.assertGreater(unfiltered_frames, filtered_frames)
+
+
+  def test_dynamic_exclusion(self):
+
+    if not TRACEBACKHIDE_SUPPORTED:
+      return
+
+    class Test1(nn.Module):
+      @nn.remat
+      @nn.compact
+      def __call__(self, x):
+        return Test2()(x)
+    class Test2(nn.Module):
+      @nn.jit
+      @nn.compact
+      def __call__(self, x):
+        raise ValueError('error here.')
+        return x  # pylint: disable=unreachable
+
+    key = random.PRNGKey(0)
+
+    traceback_util.show_flax_in_tracebacks()
+    jax.config.update('jax_traceback_filtering', 'off')
+    try:
+      nn.jit(Test1)().init(key, jnp.ones((5,3)))
+    except ValueError as e:
+      tb_all = e.__traceback__
+
+    traceback_util.hide_flax_in_tracebacks()
+    jax.config.update('jax_traceback_filtering', 'tracebackhide')
+    try:
+      nn.jit(Test1)().init(key, jnp.ones((5,3)))
+    except ValueError as e:
+      tb_no_flax = e.__traceback__
+
+    traceback_util.show_flax_in_tracebacks()
+    jax.config.update('jax_traceback_filtering', 'tracebackhide')
+    try:
+      nn.jit(Test1)().init(key, jnp.ones((5,3)))
+    except ValueError as e:
+      tb_w_flax = e.__traceback__
+
+    filtered_frames_all = 0
+    unfiltered_frames_all = 0
+    for f, _ in traceback.walk_tb(tb_all):
+      if '__tracebackhide__' not in f.f_locals:
+        unfiltered_frames_all += 1
+      else:
+        filtered_frames_all += 1
+
+    filtered_frames_no_flax = 0
+    unfiltered_frames_no_flax = 0
+    for f, _ in traceback.walk_tb(tb_no_flax):
+      if '__tracebackhide__' not in f.f_locals:
+        self.assertEqual(f.f_code.co_filename, __file__)
+        unfiltered_frames_no_flax += 1
+      else:
+        filtered_frames_no_flax += 1
+
+    filtered_frames_w_flax = 0
+    unfiltered_frames_w_flax = 0
+    for f, _ in traceback.walk_tb(tb_w_flax):
+      if '__tracebackhide__' not in f.f_locals:
+        unfiltered_frames_w_flax += 1
+      else:
+        filtered_frames_w_flax += 1
+
+    self.assertEqual(unfiltered_frames_all + filtered_frames_all,
+                     unfiltered_frames_w_flax + filtered_frames_w_flax)
+    self.assertEqual(unfiltered_frames_all + filtered_frames_all,
+                     unfiltered_frames_no_flax + filtered_frames_no_flax)
+    self.assertEqual(unfiltered_frames_no_flax, 3)
+    self.assertGreater(unfiltered_frames_all, unfiltered_frames_w_flax)
+    self.assertGreater(unfiltered_frames_w_flax, unfiltered_frames_no_flax)
+
+
+if __name__ == '__main__':
+  absltest.main()


### PR DESCRIPTION
Add an option to remove Flax internal frames from tracebacks
for more parseable exception stack traces.  Allow users to
enable/disable flax filtering by environment variable or dynamically
with simple function calls.
