### PR TITLE
Unify normalization layers

### DIFF
--- a/flax/linen/normalization.py
+++ b/flax/linen/normalization.py
@@ -62,7 +62,7 @@ def _compute_stats(x: Array, axes: Axes,
             concatenated_mean,
             axis_name=axis_name,
             axis_index_groups=axis_index_groups), 2)
-  # mean2 - lax.square(mean) is not garantueed to be non-negative due
+  # mean2 - lax.square(mean) is not guaranteed to be non-negative due
   # to floating point round-off errors.
   var = jnp.maximum(0., mean2 - lax.square(mean))
   return mean, var


### PR DESCRIPTION
- Refactor normalization helpers to share code and remove subtle differences in implemenation.
- Use clipping to avoid negative variances due to fusion optimization.
