### PR TITLE
Fix _is_valid_rngs for frozendict of rngs.

### DIFF
--- a/flax/core/scope.py
+++ b/flax/core/scope.py
@@ -758,7 +758,7 @@ def _is_valid_rng(rng: Array):
 
 
 def _is_valid_rngs(rngs: RNGSequences):
-  if not isinstance(rngs, dict):
+  if not isinstance(rngs, (FrozenDict, dict)):
     return False
   for key, val in rngs.items():
     if not isinstance(key, str):

--- a/tests/core/scope_test.py
+++ b/tests/core/scope_test.py
@@ -130,6 +130,12 @@ class ScopeTest(absltest.TestCase):
     _, variables = apply(f, mutable='state')({}, True)
     apply(f, mutable=False)(variables, False)
 
+  def test_rngs_check_w_frozen_dict(self):
+    def f(scope, x):
+      return x
+    _ = apply(test)(
+        {}, np.array([0.]), rngs=freeze({'a':random.PRNGKey(0)}))
+
 
 if __name__ == '__main__':
   absltest.main()

--- a/tests/core/scope_test.py
+++ b/tests/core/scope_test.py
@@ -133,7 +133,7 @@ class ScopeTest(absltest.TestCase):
   def test_rngs_check_w_frozen_dict(self):
     def f(scope, x):
       return x
-    _ = apply(test)(
+    _ = apply(f)(
         {}, np.array([0.]), rngs=freeze({'a':random.PRNGKey(0)}))
 
 


### PR DESCRIPTION
Previously passing a `FrozenDict` of rngs to e.g. `apply()` failed the flax.core runtime check which only accepted regular dicts, this PR fixes this to work with frozen dicts as well.