### PR TITLE
Forward experimental checkpoint policy option in lift.remat

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6]
+        python-version: [3.7]
     steps:
     - name: Cancel previous
       uses: styfle/cancel-workflow-action@0.8.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ vNext
 - 
 - 
 - 
-- 
+- Add experimental checkpoint policy argument. See `flax.linen.checkpoint`
 - 
 - 
 - 

--- a/docs/flax.linen.rst
+++ b/docs/flax.linen.rst
@@ -49,6 +49,7 @@ Transformations
     scan
     jit
     remat
+    remat_scan
 
 
 Linear modules

--- a/flax/linen/__init__.py
+++ b/flax/linen/__init__.py
@@ -32,7 +32,7 @@ from .normalization import BatchNorm, GroupNorm, LayerNorm
 from .pooling import avg_pool, max_pool
 from .recurrent import GRUCell, LSTMCell, ConvLSTM, OptimizedLSTMCell
 from .stochastic import Dropout
-from .transforms import jit, named_call, remat, scan, vmap
+from .transforms import jit, named_call, checkpoint, remat, remat_scan, scan, vmap
 from .initializers import zeros, ones
 
 # pylint: enable=g-multiple-import

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ except IOError:
 
 install_requires = [
     "numpy>=1.12",
-    "jax>=0.2.13",
+    "jax>=0.2.20",
     "matplotlib",  # only needed for tensorboard export
     "dataclasses;python_version<'3.7'", # will only install on py3.6
     "msgpack",

--- a/tests/core/design/core_big_resnets_test.py
+++ b/tests/core/design/core_big_resnets_test.py
@@ -50,9 +50,10 @@ def big_resnet(scope: Scope, x, blocks=(10, 5), dtype=jnp.float32,
     return residual_block(scope, x, conv, norm, act, features=x.shape[-1])
 
   return lift.remat_scan(
-      body_fn, scope, x, lengths=blocks,
+      body_fn, lengths=blocks,
       variable_axes={'params': 0, 'batch_stats': 0},
-      split_rngs={'params': True})
+      split_rngs={'params': True},
+      policy=None)(scope, x)
 
 
 class BigResnetTest(absltest.TestCase):
@@ -65,7 +66,6 @@ class BigResnetTest(absltest.TestCase):
         jax.tree_map(jnp.shape, variables['params']))
     batch_stats_shapes = unfreeze(
         jax.tree_map(jnp.shape, variables['batch_stats']))
-    print(param_shapes)
     self.assertEqual(param_shapes, {
         'conv_1': {'kernel': (10, 5, 3, 3, 8, 8)},
         'conv_2': {'kernel': (10, 5, 3, 3, 8, 8)},


### PR DESCRIPTION
- The latest versions of JAX require python 3.7. Updating testing environment accordingly