### PR TITLE
Map variables for linen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ vNext
 - 
 - 
 - 
-- 
+- Add lifted transformation for mapping variables. See `flax.linen.map_variables`.
 - 
 - 
 - 

--- a/docs/flax.linen.rst
+++ b/docs/flax.linen.rst
@@ -50,6 +50,7 @@ Transformations
     jit
     remat
     remat_scan
+    map_variables
 
 
 Linear modules

--- a/flax/core/scope.py
+++ b/flax/core/scope.py
@@ -91,6 +91,20 @@ def _fold_in_str(rng: PRNGKey, data: str) -> PRNGKey:
   return random.fold_in(rng, jnp.uint32(hash_int))
 
 
+def is_filter_empty(filter_like: Filter) -> bool:
+  if isinstance(filter_like, str):
+    return False
+  if isinstance(filter_like, Container):
+    return len(filter_like) == 0
+  if isinstance(filter_like, bool):
+    return not filter_like
+  if isinstance(filter_like, DenyList):
+    # if any arbitrary collection is in the denylist it matches.
+    # everything so the filter is empty. This is checked with a stub.
+    return in_filter(filter_like.deny, "__flax_internal_stub__")
+  raise errors.InvalidFilterError(filter_like)
+
+
 def in_filter(filter_like: Filter, col: str) -> bool:
   """Checks whether a filter can be applied to a collection.
 

--- a/flax/linen/__init__.py
+++ b/flax/linen/__init__.py
@@ -32,7 +32,7 @@ from .normalization import BatchNorm, GroupNorm, LayerNorm
 from .pooling import avg_pool, max_pool
 from .recurrent import GRUCell, LSTMCell, ConvLSTM, OptimizedLSTMCell
 from .stochastic import Dropout
-from .transforms import jit, named_call, checkpoint, remat, remat_scan, scan, vmap
+from .transforms import jit, named_call, checkpoint, remat, remat_scan, scan, vmap, map_variables
 from .initializers import zeros, ones
 
 # pylint: enable=g-multiple-import

--- a/flax/linen/transforms.py
+++ b/flax/linen/transforms.py
@@ -641,6 +641,49 @@ def scan(target: Target,
       methods=methods)
 
 
+def map_variables(
+    target: Target,
+    mapped_collections: lift.CollectionFilter,
+    trans_in_fn: Callable[..., Any] = lift.id_fn,
+    trans_out_fn: Callable[..., Any] = lift.id_fn,
+    init: bool = False, mutable: bool = False,
+    rngs: lift.PRNGSequenceFilter = True,
+    variables: lift.CollectionFilter = True) -> Target:
+  """Map Variables inside a module.
+
+  Example::
+
+    class OneBitDense(nn.Module):
+      @nn.compact
+      def __call__(self, x):
+        def sign(x):
+          return jax.tree_map(jnp.sign, x)
+        MapDense = nn.map_variables(nn.Dense, "params", sign, init=True)
+        return MapDense(4)(x)
+
+  Args:
+    fn: the function to be transformed.
+    mapped_collections: the collection(s) to be transformed.
+    map_in_fn: creates a view of the target variables.
+    map_out_fn: transforms the updated variables in the view after mutation.
+    init: If True, variables are initialized before transformation.
+    mutable: If True, the mapped variable collections will be mutable.
+    rngs: PRNGSequences added to the transformed scope (default: all).
+    variables: Additional Variable collections added to the transformed scope.
+      Besides those specified by `target` (default: all).
+  Returns:
+    a wrapped version of ``target`` that will map the specificied collections.
+  """
+
+  return lift_transform(
+      lift.map_variables, target,
+      mapped_collections,
+      trans_in_fn, trans_out_fn,
+      init, mutable,
+      rngs, variables
+  )
+
+
 # Special case of decorator_lift_transform to handle named calls for profiling.
 def named_call(class_fn, force=True):
   """Labels a method for labelled traces in profiles.

--- a/tests/core/design/core_tied_autoencoder_test.py
+++ b/tests/core/design/core_tied_autoencoder_test.py
@@ -25,12 +25,11 @@ from flax.core import init, unfreeze, lift, nn
 
 def transpose(fn):
   def trans(variables):
-    params = variables['params']
-    params['kernel'] = params['kernel'].T
-    return variables
+    return jax.tree_map(lambda x: x.T, variables)
 
-  return lift.transform_module(
-      fn, trans_in_fn=trans, trans_out_fn=trans)
+  return lift.map_variables(
+      fn, "params", map_in_fn=trans, map_out_fn=trans,
+      mutable=True)
 
 
 @dataclass

--- a/tests/core/design/core_weight_std_test.py
+++ b/tests/core/design/core_weight_std_test.py
@@ -34,12 +34,12 @@ def weight_std(fn, kernel_name='kernel', eps=1e-8):
     params[kernel_name] = std_kernel
     return variables
 
-  # transform handles a few of nasty edge cases here...
+  # map_variables handles a few of nasty edge cases here...
   # the transformed kind will be immutable inside fn
   # this way we avoid lost mutations to param
-  # transform also avoids accidental reuse of rngs
+  # map_variables also avoids accidental reuse of rngs
   # and it makes sure that other state is updated correctly (not twice during init!)
-  return lift.transform_module(fn, trans_in_fn=std)
+  return lift.map_variables(fn, "params", std, init=True)
 
 def mlp(scope: Scope, x: Array,
         sizes: Sequence[int] = (8, 1)):


### PR DESCRIPTION
- refactor old transform and transform_module to map_variables
- add map_variables to linen
- add tied autoencoder test to linen transforms
