### PR TITLE
Try pinning docutils to 0.16 to fix docs rendering of bulleted lists

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -7,6 +7,11 @@ ipykernel
 nbsphinx
 recommonmark
 sphinx_markdown_tables
+
+# Need to pin docutils to 0.16 to make bulleted lists appear correctly on
+# ReadTheDocs: https://stackoverflow.com/a/68008428
+docutils==0.16
+
 # The next packages are for notebooks.
 matplotlib
 sklearn


### PR DESCRIPTION
Before:

![Screenshot 2021-09-28 at 13 54 42](https://user-images.githubusercontent.com/37586/135081939-809d731e-e46e-4a1d-9bf5-ce28f5a57a7e.png)


After:

![Screenshot 2021-09-28 at 13 55 18](https://user-images.githubusercontent.com/37586/135082002-bc241047-d10e-4f4c-aaa4-cc7f849e48bc.png)

