### PR TITLE
Increment jax requirement to fix incompatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ except IOError:
 
 install_requires = [
     "numpy>=1.12",
-    "jax>=0.2.20",
+    "jax>=0.2.21",
     "matplotlib",  # only needed for tensorboard export
     "dataclasses;python_version<'3.7'", # will only install on py3.6
     "msgpack",


### PR DESCRIPTION
# What does this PR do?

When using `jax==0.2.20` with `flax==0.3.5`, `flax.jax_utils.replicate` fails with:

`AttributeError: 'jaxlib.tpu_client_extension.PyTpuBuffer' object has no attribute 'dtype'`

Incrementing minimum `jax` version to `jax==0.2.21` fixes this problem.

Ideally this PR also results in a version bump of `flax` as `0.3.5` currently breaks colabs that use TPUs (`pip` resolves `jax==0.2.20 flax==0.3.5` by default currently).

cc @dusenberrymw @BlackHC

<!--

Great, you are contributing to Flax! 

But... please read the following carefully so we can make sure your PR is merged
easily.

Replace this text block with a description of the change and which issue it
fixes (if applicable). Please also include relevant motivation/context.

Once you're done, someone in the Flax team will review your PR shortly. They may
suggest changes to make the code even better. If no one reviewed your PR after a
week has passed, don't hesitate to post a new comment @-mentioning the same
persons (sometimes notifications get lost).
-->

Fixes # (issue) - didn't create one.

None apply of below checklist.

## Checklist
- [ ] This PR fixes a minor issue (e.g.: typo or small bug) or improves the docs (you can dismiss the other checks if that's the case).
- [ ] This change is discussed in a Github issue/[discussion](https://github.com/google/flax/discussions) (please add a link).
- [ ] The documentation and docstrings adhere to the [documentation guidelines](https://github.com/google/flax/blob/main/docs/README.md#how-to-write-code-documentation).
- [ ] This change includes necessary high-coverage tests. (No quality testing = no merge!)
