### PR TITLE
Fix typos.

### DIFF
--- a/examples/imagenet/main.py
+++ b/examples/imagenet/main.py
@@ -15,7 +15,7 @@
 """Main file for running the ImageNet example.
 
 This file is intentionally kept short. The majority for logic is in libraries
-than can be easily tested and imported in Colab.
+that can be easily tested and imported in Colab.
 """
 
 from absl import app
@@ -42,7 +42,7 @@ def main(argv):
   if len(argv) > 1:
     raise app.UsageError('Too many command-line arguments.')
 
-  # Hide any GPUs form TensorFlow. Otherwise TF might reserve memory and make
+  # Hide any GPUs from TensorFlow. Otherwise TF might reserve memory and make
   # it unavailable to JAX.
   tf.config.experimental.set_visible_devices([], 'GPU')
 

--- a/examples/lm1b/main.py
+++ b/examples/lm1b/main.py
@@ -15,7 +15,7 @@
 """Main file for running the Language Modelling example with LM1B.
 
 This file is intentionally kept short. The majority for logic is in libraries
-than can be easily tested and imported in Colab.
+that can be easily tested and imported in Colab.
 """
 
 from absl import app
@@ -43,7 +43,7 @@ def main(argv):
   if len(argv) > 1:
     raise app.UsageError('Too many command-line arguments.')
 
-  # Hide any GPUs form TensorFlow. Otherwise TF might reserve memory and make
+  # Hide any GPUs from TensorFlow. Otherwise TF might reserve memory and make
   # it unavailable to JAX.
   tf.config.experimental.set_visible_devices([], 'GPU')
 

--- a/examples/ogbg_molpcba/main.py
+++ b/examples/ogbg_molpcba/main.py
@@ -15,7 +15,7 @@
 """Main file for running the ogbg-molpcba example.
 
 This file is intentionally kept short. The majority for logic is in libraries
-than can be easily tested and imported in Colab.
+that can be easily tested and imported in Colab.
 """
 
 from absl import app
@@ -42,7 +42,7 @@ def main(argv):
   if len(argv) > 1:
     raise app.UsageError('Too many command-line arguments.')
 
-  # Hide any GPUs form TensorFlow. Otherwise TF might reserve memory and make
+  # Hide any GPUs from TensorFlow. Otherwise TF might reserve memory and make
   # it unavailable to JAX.
   tf.config.experimental.set_visible_devices([], 'GPU')
 

--- a/examples/pixelcnn/main.py
+++ b/examples/pixelcnn/main.py
@@ -15,7 +15,7 @@
 """Main file for running the PixelCNN example.
 
 This file is intentionally kept short. The majority for logic is in libraries
-than can be easily tested and imported in Colab.
+that can be easily tested and imported in Colab.
 """
 
 from absl import app
@@ -45,7 +45,7 @@ def main(argv):
   if len(argv) > 1:
     raise app.UsageError('Too many command-line arguments.')
 
-  # Hide any GPUs form TensorFlow. Otherwise TF might reserve memory and make
+  # Hide any GPUs from TensorFlow. Otherwise TF might reserve memory and make
   # it unavailable to JAX.
   tf.config.experimental.set_visible_devices([], 'GPU')
 

--- a/examples/sst2/main.py
+++ b/examples/sst2/main.py
@@ -14,7 +14,7 @@
 
 """Main file for running the SST2 example.
 This file is intentionally kept short. The majority for logic is in libraries
-than can be easily tested and imported in Colab.
+that can be easily tested and imported in Colab.
 """
 
 from absl import app
@@ -42,7 +42,7 @@ def main(argv):
   if len(argv) > 1:
     raise app.UsageError('Too many command-line arguments.')
 
-  # Hide any GPUs form TensorFlow. Otherwise TF might reserve memory and make
+  # Hide any GPUs from TensorFlow. Otherwise TF might reserve memory and make
   # it unavailable to JAX.
   tf.config.experimental.set_visible_devices([], 'GPU')
 

--- a/examples/wmt/main.py
+++ b/examples/wmt/main.py
@@ -15,7 +15,7 @@
 """Main file for running the WMT example.
 
 This file is intentionally kept short. The majority for logic is in libraries
-than can be easily tested and imported in Colab.
+that can be easily tested and imported in Colab.
 """
 
 from absl import app
@@ -43,7 +43,7 @@ def main(argv):
   if len(argv) > 1:
     raise app.UsageError('Too many command-line arguments.')
 
-  # Hide any GPUs form TensorFlow. Otherwise TF might reserve memory and make
+  # Hide any GPUs from TensorFlow. Otherwise TF might reserve memory and make
   # it unavailable to JAX.
   tf.config.experimental.set_visible_devices([], 'GPU')
 


### PR DESCRIPTION
- `form TensorFlow` → `from TensorFlow`
- `libraries than can be` → `libraries that can be`

---

- [x] This PR fixes a minor issue (e.g. typo or small bug) or improves the docs (you can dismiss the other checks if that's the case).