### PR TITLE
Two tiny fixes in the examples

### DIFF
--- a/examples/sst2/models.py
+++ b/examples/sst2/models.py
@@ -147,7 +147,9 @@ class Embedder(nn.Module):
     deterministic = nn.module.merge_param(
         'deterministic', self.deterministic, deterministic)
     inputs = self.word_dropout_layer(inputs, deterministic=deterministic)
-    embedded_inputs = self.embedding[inputs]
+    # Use take because fancy indexing numpy arrays with JAX indices does not
+    # work correctly.
+    embedded_inputs = jnp.take(self.embedding, inputs, axis=0)
 
     # Keep the embeddings fixed at initial (e.g. pretrained) values.
     if self.frozen:

--- a/examples/vae/train.py
+++ b/examples/vae/train.py
@@ -24,7 +24,7 @@ import optax
 import tensorflow as tf
 import tensorflow_datasets as tfds
 
-import utils as vae_utils
+from . import utils as vae_utils
 
 
 FLAGS = flags.FLAGS


### PR DESCRIPTION
- SST2 was using the old version of embeddings, which doesn't work when combining JAX and np arrays.
- VAE isn't using relative imports, which means you can't import the Module from another place.