### PR TITLE
Lint the Flax basics notebook

### DIFF
--- a/docs/notebooks/flax_basics.ipynb
+++ b/docs/notebooks/flax_basics.ipynb
@@ -408,17 +408,17 @@
         "\n",
         "Basic usage of Optax is straightforward:\n",
         "\n",
-        "1.   You choose an optimization method (e.g. `optax.sgd`).\n",
+        "1.   Choose an optimization method (e.g. `optax.sgd`).\n",
         "2.   Create optimizer state from parameters.\n",
-        "3.   You compute the gradients of your loss with `jax.value_and_grad()`.\n",
-        "4.   At every iteration, call the Optax update function to update the internal\n",
+        "3.   Compute the gradients of your loss with `jax.value_and_grad()`.\n",
+        "4.   At every iteration, call the Optax `update` function to update the internal\n",
         "     optimizer state and create an update to the parameters. Then add the update\n",
-        "     to the parameters.\n",
+        "     to the parameters with Optax's `apply_updates` method.\n",
         "\n",
-        "Note that Optax can do a lot more: It's designed for composing simple gradient\n",
+        "Note that Optax can do a lot more: it's designed for composing simple gradient\n",
         "transformations into more complex transformations that allows to implement a\n",
         "wide range of optimizers. There is also support for changing optimizer\n",
-        "hyperparameters over time (\"schedules\"), applying different udpates to different\n",
+        "hyperparameters over time (\"schedules\"), applying different updates to different\n",
         "parts of the parameter tree (\"masking\") and much more. For details please refer\n",
         "to the\n",
         "[official documentation](https://optax.readthedocs.io/en/latest/)."
@@ -690,7 +690,7 @@
         "\n",
         "*Note: lists are mostly managed as you would expect (WIP), there are corner cases you should be aware of as pointed out* [here](https://github.com/google/flax/issues/524)\n",
         "\n",
-        "Since the module structure and its parameters are not tied to each other, you can't call directly `model(x)` on a given input as it will return an error. The `__call__` function is being wrapped up in the `apply` one, which is the one to call on an input:"
+        "Since the module structure and its parameters are not tied to each other, you can't directly call `model(x)` on a given input as it will return an error. The `__call__` function is being wrapped up in the `apply` one, which is the one to call on an input:"
       ]
     },
     {
@@ -880,7 +880,7 @@
         "*   `init_fn` is a function with input `(PRNGKey, *init_args)` returning an Array, with `init_args` being the arguments needed to call the initialisation function.\n",
         "*   `init_args` are the arguments to provide to the initialization function.\n",
         "\n",
-        "Such params can also be declared in the `setup` method, it won't be able to use shape inference because Flax is using lazy initialization at the first call site."
+        "Such params can also be declared in the `setup` method; it won't be able to use shape inference because Flax is using lazy initialization at the first call site."
       ]
     },
     {


### PR DESCRIPTION
Lint the Flax basics notebook:

- Add Optax's param update method name for clarity: "to the parameters with Optax's `apply_updates` method".
- Swap words -> "directly call `model(x)`".
- Fix a small typo and other minor grammar changes.

@andsteing Thanks 👍 