### PR TITLE
Add -e flag to pip intall

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,8 +33,8 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        pip install .
-        pip install .[testing]
+        pip install -e .
+        pip install -e .[testing]
         pip install -r docs/requirements.txt
     - name: Test testcode blocks in documentation
       run: |


### PR DESCRIPTION
Ensures changes are immediately reflected. Otherwise some tests fail in case we do a refactoring.
