### PR TITLE
Fix GroupNorm type hint for param num_groups.

### DIFF
--- a/flax/linen/normalization.py
+++ b/flax/linen/normalization.py
@@ -293,7 +293,7 @@ class GroupNorm(Module):
       bias_init: Initializer for bias, by default, zero.
       scale_init: Initializer for scale, by default, one.
   """
-  num_groups: int = 32
+  num_groups: Optional[int] = 32
   group_size: Optional[int] = None
   epsilon: float = 1e-6
   dtype: Any = jnp.float32


### PR DESCRIPTION
# What does this PR do?
In GroupNorm, `num_group` can be set to None if `group_size` is set. However, currently doing so the linter (LSP) will throw an error: "Argument of type None cannot be assigned to parameter "num_group" of type "int" ..."

This PR fix that.

## Checklist
- [x] This PR fixes a minor issue (e.g.: typo or small bug) or improves the docs