### PR TITLE
Add circular padding to flax.linen.Conv and flax.linen.ConvTranspose

### DIFF
--- a/flax/linen/linear.py
+++ b/flax/linen/linear.py
@@ -393,28 +393,32 @@ class ConvTranspose(Module):
                            precision=self.precision)
 
     if self.padding == "CIRCULAR":
-      # For circular padding, we need to identify the size of the final output ("period") along
-      # each spatial dimension, pad each dimension to an integer number of periods, and wrap 
-      # the array periodically around each dimension. Padding should be done in such a way that 
-      # the start of the original input data inside the padded array is located at integer number
-      # of periods - otherwise the result would be circularly shifted.
+      # For circular padding, we need to identify the size of the final output
+      # ("period") along each spatial dimension, pad each dimension to an
+      # integer number of periods, and wrap the array periodically around each
+      # dimension. Padding should be done in such a way that the start of the
+      # original input data inside the padded array is located at integer
+      # number of periods - otherwise the result would be circularly shifted.
       
-      # Compute period along each spatial dimension - it's input size scaled by the stride.
+      # Compute period along each spatial dimension - it's input size scaled
+      # by the stride.
       scaled_x_dims = [
         x_dim * stride for x_dim, stride in zip(inputs.shape[1:-1], strides)
       ]
-      # Compute difference between the current size of y and the final output size, 
-      # and complement this difference to 2 * period - that gives how much we need to pad.
+      # Compute difference between the current size of y and the final output
+      # size, and complement this difference to 2 * period - that gives how
+      # much we need to pad.
       size_diffs = [
         -(y_dim - x_dim) % (2 * x_dim)
         for y_dim, x_dim in zip(y.shape[1:-1], scaled_x_dims)
       ]
-      # Divide the padding equaly between left and right. The choice to put "+1" 
-      # on the left (and not on the right) represents a convention for aligning 
-      # even-sized kernels.
+      # Divide the padding equaly between left and right. The choice to put
+      # "+1" on the left (and not on the right) represents a convention for
+      # aligning even-sized kernels.
       total_pad = [((size_diff + 1) // 2, size_diff // 2) for size_diff in size_diffs]
       y = np.pad(y, [(0, 0)] + total_pad + [(0, 0)])
-      # Wrap the result periodically around each spatial dimension, one by one.
+      # Wrap the result periodically around each spatial dimension,
+      # one by one.
       for i in range(1, y.ndim - 1):
         y = y.reshape(y.shape[:i] + (-1, scaled_x_dims[i - 1]) + y.shape[i + 1:])
         y = y.sum(axis=i)

--- a/flax/linen/linear.py
+++ b/flax/linen/linear.py
@@ -393,18 +393,28 @@ class ConvTranspose(Module):
                            precision=self.precision)
 
     if self.padding == "CIRCULAR":
-      # Find output dimensions
+      # For circular padding, we need to identify the size of the final output ("period") along
+      # each spatial dimension, pad each dimension to an integer number of periods, and wrap 
+      # the array periodically around each dimension. Padding should be done in such a way that 
+      # the start of the original input data inside the padded array is located at integer number
+      # of periods - otherwise the result would be circularly shifted.
+      
+      # Compute period along each spatial dimension - it's input size scaled by the stride.
       scaled_x_dims = [
         x_dim * stride for x_dim, stride in zip(inputs.shape[1:-1], strides)
       ]
-      # Pad each spatial dimension to (2 * n + 1) * (output size along that dimension)
+      # Compute difference between the current size of y and the final output size, 
+      # and complement this difference to 2 * period - that gives how much we need to pad.
       size_diffs = [
         -(y_dim - x_dim) % (2 * x_dim)
         for y_dim, x_dim in zip(y.shape[1:-1], scaled_x_dims)
       ]
+      # Divide the padding equaly between left and right. The choice to put "+1" 
+      # on the left (and not on the right) represents a convention for aligning 
+      # even-sized kernels.
       total_pad = [((size_diff + 1) // 2, size_diff // 2) for size_diff in size_diffs]
       y = np.pad(y, [(0, 0)] + total_pad + [(0, 0)])
-      # Wrap the result periodically around each spatial dimension
+      # Wrap the result periodically around each spatial dimension, one by one.
       for i in range(1, y.ndim - 1):
         y = y.reshape(y.shape[:i] + (-1, scaled_x_dims[i - 1]) + y.shape[i + 1:])
         y = y.sum(axis=i)


### PR DESCRIPTION
# What does this PR do?



This PR implements a `CIRCULAR` padding option for `flax.linen.Conv` and `flax.linen.ConvTranspose`, in addition to existing `VALID` and `SAME`. This allows creating convolutional and transposed convolutional layers with periodic boundary conditions. Code added to `flax.linen.Conv` is based on the snippet from https://github.com/google/flax/issues/903#issue-789095219. Also tests are added for the new padding option

<!--

Great, you are contributing to Flax! 

But... please read the following carefully so we can make sure your PR is merged
easily.

Replace this text block with a description of the change and which issue it
fixes (if applicable). Please also include relevant motivation/context.

Once you're done, someone in the Flax team will review your PR shortly. They may
suggest changes to make the code even better. If no one reviewed your PR after a
week has passed, don't hesitate to post a new comment @-mentioning the same
persons (sometimes notifications get lost).
-->

Fixes  #971, #903 

## Checklist
- [ ] This PR fixes a minor issue (e.g.: typo or small bug) or improves the docs (you can dismiss the other
      checks if that's the case).
- [x] This change is discussed in a Github issues #971, #903 
- [x] The documentation and docstrings adhere to the
      [documentation guidelines](https://github.com/google/flax/blob/main/docs/README.md#how-to-write-code-documentation).
- [x] This change includes necessary high-coverage tests.
      (No quality testing = no merge!)

## Additional note

Please note that this implementation differs slightly from suggested in https://github.com/google/flax/issues/971#issue-798335047 in the sense that the circular padding is applied symmetrically from both sides of the input, as in https://github.com/google/flax/issues/903#issue-789095219. 

For example, on 1D data [1, 2, 3, 4, 5] with kernel size 3 and stride 3 there will be 2 filter operations: one at [5, 1, 2] and the other at [3, 4, 5] -  instead of [1, 2, 3] and [4, 5, 1], as suggested in https://github.com/google/flax/issues/971#issue-798335047. I feel that this is better aligned with how other padding options - `VALID` and `SAME` - work.

 @VolodyaCO, please let me know if that makes sense for your use case