### PR TITLE
Add `unroll` to `jax_utils.scan_in_dim`

### DIFF
--- a/flax/jax_utils.py
+++ b/flax/jax_utils.py
@@ -159,7 +159,7 @@ def prefetch_to_device(iterator, size, devices=None):
     enqueue(1)
 
 
-def _scan_nd(body_fn, init, xs, n=1):
+def _scan_nd(body_fn, init, xs, n=1, unroll=(1,)):
   """Utility for performing an n-dimensional `lax.scan`.
 
   The n-d scan is simply recursive call of 1-d scan.
@@ -172,11 +172,11 @@ def _scan_nd(body_fn, init, xs, n=1):
     A tuple of the final carry and the values returned by the body.
   """
   if n == 1:
-    return lax.scan(body_fn, init, xs)
+    return lax.scan(body_fn, init, xs, unroll=unroll[0])
   else:
     def scan_body(c, x):
-      return _scan_nd(body_fn, c, x, n=n-1)
-    return lax.scan(scan_body, init, xs)
+      return _scan_nd(body_fn, c, x, n=n-1, unroll=unroll[1:])
+    return lax.scan(scan_body, init, xs, unroll=unroll[0])
 
 
 def _invert_perm(perm):
@@ -186,7 +186,7 @@ def _invert_perm(perm):
   return tuple(perm_inv)
 
 
-def scan_in_dim(body_fn, init, xs, axis=(0,), keepdims=False):
+def scan_in_dim(body_fn, init, xs, axis=(0,), unroll=(1,), keepdims=False):
   """utility for doing a scan along arbitrary dimensions.
 
   see `lax.scan` for details on how the scan operation works.
@@ -196,11 +196,21 @@ def scan_in_dim(body_fn, init, xs, axis=(0,), keepdims=False):
     xs: a pytree of tensors to scan over.
     axis: the axis to scan over.
     keepdims: keep the dimensions that are scanned over.
+    unroll: an optional positive integer, or tuple of positive integers
+      showing how many iterations of the loop to be unroll into a single
+      iteration for each axis.
   Returns:
     A tuple of the final carry and the values returned by the body.
   """
   if not isinstance(axis, Iterable):
     axis = (axis,)
+
+  if not isinstance(unroll, Iterable):
+    unroll = (unroll,)
+
+  # Pad unroll with ones so we start unrolling from the innermost loop
+  len_diff = len(unroll) - len(axis)
+  unroll = (1,) * len_diff + unroll
 
   def transpose_in(x):
     perm = axis + tuple(np.delete(np.arange(x.ndim), axis))
@@ -220,6 +230,6 @@ def scan_in_dim(body_fn, init, xs, axis=(0,), keepdims=False):
     return c, ys
 
   xs = jax.tree_map(transpose_in, xs)
-  c, ys = _scan_nd(body_wrapper, init, xs, n=len(axis))
+  c, ys = _scan_nd(body_wrapper, init, xs, n=len(axis), unroll=unroll)
   ys = jax.tree_map(transpose_out, ys)
   return c, ys

--- a/flax/jax_utils.py
+++ b/flax/jax_utils.py
@@ -209,7 +209,7 @@ def scan_in_dim(body_fn, init, xs, axis=(0,), unroll=(1,), keepdims=False):
     unroll = (unroll,)
 
   # Pad unroll with ones so we start unrolling from the innermost loop
-  len_diff = len(unroll) - len(axis)
+  len_diff = len(axis) - len(unroll)
   unroll = (1,) * len_diff + unroll
 
   def transpose_in(x):

--- a/flax/jax_utils.py
+++ b/flax/jax_utils.py
@@ -189,7 +189,13 @@ def _invert_perm(perm):
 def scan_in_dim(body_fn, init, xs, axis=(0,), unroll=(1,), keepdims=False):
   """utility for doing a scan along arbitrary dimensions.
 
-  see `lax.scan` for details on how the scan operation works.
+  See `lax.scan` for details on how the scan operation works.
+
+  Note on `unroll`: This argument gets left padded with ones to match the size
+  of `axis`. Doing so allows unrolls to performed from the innermost loop first.
+  For example, `scan_in_dim(..., axis=(1, 2, 3), unroll=5)` is equivalent to
+  `scan_in_dim(..., axis=(1, 2, 3), unroll=(1, 1, 5))`.
+
   Args:
     body_fn: the body of the loop of type (c, x) -> (c, y).
     init: initial value for the carry.


### PR DESCRIPTION
# What does this PR do?

The `unroll` flag within `jax.lax.scan` allows one to unroll a specified
number of `scan` iterations to unroll into a single iteration of the loop.

Currently, this change allows for `unroll` to be a tuple of positive
integers, allowing for one to control the number of unrolls which can
occur with each dimension being looped over.

Fixes #1687 

## Checklist
- [x] This PR fixes a minor issue (e.g.: typo or small bug) or improves the docs (you can dismiss the other
      checks if that's the case).
- [x] This change is discussed in a Github issue/
      [discussion](https://github.com/google/flax/discussions) (#1687).
- [x] The documentation and docstrings adhere to the
      [documentation guidelines](https://github.com/google/flax/blob/main/docs/README.md#how-to-write-code-documentation).
- [ ] This change includes necessary high-coverage tests.
      (No quality testing = no merge!)
