### PR TITLE
Add error for empty scopes.

### DIFF
--- a/flax/errors.py
+++ b/flax/errors.py
@@ -182,7 +182,7 @@ class ScopeCollectionNotFound(FlaxError):
     For example, you might have used ``module.apply(params, ...)`` instead
     of ``module.apply({'params': params}, ...)``.
   2. The collection is empty because the variables need to be initialized.
-    In this case, you have should made the collection mutable during
+    In this case, you should have made the collection mutable during
     apply (e.g.: ``module.apply(variables, ..., mutable=['state'])``.
   """
   def __init__(self, col_name, var_name, scope_path):

--- a/flax/errors.py
+++ b/flax/errors.py
@@ -182,7 +182,7 @@ class ScopeCollectionNotFound(FlaxError):
     For example, you might have used ``module.apply(params, ...)`` instead
     of ``module.apply({'params': params}, ...)``.
   2. The collection is empty because the variables need to be initialized.
-    In this case, you have should make the collection mutable during
+    In this case, you have should made the collection mutable during
     apply (e.g.: ``module.apply(variables, ..., mutable=['state'])``.
   """
   def __init__(self, col_name, var_name, scope_path):

--- a/flax/errors.py
+++ b/flax/errors.py
@@ -173,6 +173,23 @@ class ScopeParamNotFoundError(FlaxError):
                      f'"{scope_path}".')
 
 
+class ScopeCollectionNotFound(FlaxError):
+  """
+  This error is thrown when trying to access a variable from an empty collection.
+
+  There are two common causes:
+  1. The collection was not passed to ``apply`` correctly.
+    For example, you might have used ``module.apply(params, ...)`` instead
+    of ``module.apply({'params': params}, ...)``.
+  2. The collection is empty because the variables need to be initialized.
+    In this case, you have should make the collection mutable during
+    apply (e.g.: ``module.apply(variables, ..., mutable=['state'])``.
+  """
+  def __init__(self, col_name, var_name, scope_path):
+    super().__init__(f'Tried to access "{var_name}" from collection "{col_name}"" in '
+                     f'"{scope_path}" but the collection is emtpy.')
+
+
 class ScopeParamShapeError(FlaxError):
   """
   This error is thrown when the shape of an existing parameter is different from

--- a/tests/core/core_lift_test.py
+++ b/tests/core/core_lift_test.py
@@ -48,8 +48,7 @@ class LiftTest(absltest.TestCase):
 
     msg = r'No parameter named "kernel" exists in "/vmap\(dense\)".'
     with self.assertRaisesRegex(errors.ScopeParamNotFoundError, msg):
-      apply(f)({})
-
+      apply(f)({'params': {'dense': {'abc': np.ones((3, 3))}}})
 
   def test_jit_cache(self):
     compiles = 0

--- a/tests/core/core_scope_test.py
+++ b/tests/core/core_scope_test.py
@@ -163,10 +163,17 @@ class ScopeTest(absltest.TestCase):
   def test_empty_col_error(self):
     root = Scope({})
     with self.assertRaises(errors.ScopeCollectionNotFound):
-      root.param('test', nn.initializers.zeros)
+      root.param('test', nn.initializers.zeros, ())
     root = Scope({'params': {}})
     with self.assertRaises(errors.ScopeCollectionNotFound):
-      root.param('test', nn.initializers.zeros)
+      root.param('test', nn.initializers.zeros, ())
+
+    root = Scope({'params': {'abc': 1}})
+    with self.assertRaises(errors.ScopeCollectionNotFound):
+      root.variable('state', 'test', jnp.zeros, ())
+    root = Scope({'state': {}})
+    with self.assertRaises(errors.ScopeCollectionNotFound):
+      root.variable('state', 'test', jnp.zeros, ())
 
 
 if __name__ == '__main__':

--- a/tests/core/core_scope_test.py
+++ b/tests/core/core_scope_test.py
@@ -123,7 +123,7 @@ class ScopeTest(absltest.TestCase):
 
     msg = r'No parameter named "kernel" exists in "/dense".'
     with self.assertRaisesRegex(errors.ScopeParamNotFoundError, msg):
-      apply(f)({})
+      apply(f)({'params': {'abc': 1}})
 
   def test_variable_is_mutable(self):
     def f(scope, should_be_mutable):
@@ -159,6 +159,15 @@ class ScopeTest(absltest.TestCase):
     root = root.rewound()
     b = root.child(f)()
     self.assertFalse(jnp.allclose(a, b))
+
+  def test_empty_col_error(self):
+    root = Scope({})
+    with self.assertRaises(errors.ScopeCollectionNotFound):
+      root.param('test', nn.initializers.zeros)
+    root = Scope({'params': {}})
+    with self.assertRaises(errors.ScopeCollectionNotFound):
+      root.param('test', nn.initializers.zeros)
+
 
 if __name__ == '__main__':
   absltest.main()


### PR DESCRIPTION
Before, a ParamNotFoundError was raised.
This specializes the error to indicate the collection doesn't exist at all.
This should be easier to debug for users.
