### PR TITLE
Remove unnecessary dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,6 @@ install_requires = [
     "numpy>=1.12",
     "jax>=0.2.21",
     "matplotlib",  # only needed for tensorboard export
-    "dataclasses;python_version<'3.7'", # will only install on py3.6
     "msgpack",
     "optax",
 ]


### PR DESCRIPTION
Jax 2.21 doesn't support Python 3.6 (https://github.com/google/jax/blob/jax-v0.2.21/setup.py), so the dependency on dataclasses never gets used anymore.

# What does this PR do?

<!--

Great, you are contributing to Flax! 

But... please read the following carefully so we can make sure your PR is merged
easily.

Replace this text block with a description of the change and which issue it
fixes (if applicable). Please also include relevant motivation/context.

Once you're done, someone in the Flax team will review your PR shortly. They may
suggest changes to make the code even better. If no one reviewed your PR after a
week has passed, don't hesitate to post a new comment @-mentioning the same
persons (sometimes notifications get lost).
-->

Fixes # (issue)

## Checklist
- [x] This PR fixes a minor issue (e.g.: typo or small bug) or improves the docs (you can dismiss the other
      checks if that's the case).
- [x] This change is discussed in a Github issue/
      [discussion](https://github.com/google/flax/discussions) (please add a
      link).
- [x] The documentation and docstrings adhere to the
      [documentation guidelines](https://github.com/google/flax/blob/main/docs/README.md#how-to-write-code-documentation).
- [x] This change includes necessary high-coverage tests.
      (No quality testing = no merge!)
