### PR TITLE
correct axis resolution in case of repeated axis in the logica axis r…

### DIFF
--- a/flax/linen/partitioning.py
+++ b/flax/linen/partitioning.py
@@ -160,10 +160,14 @@ def logical_to_mesh_axes(array_dim_names: Sequence[str],
     raise ValueError('Unknown axis rule specification type.')
   # We assign mesh axes using a priority based ruleset over logical axis names.
   result = [_unassigned_axis] * len(array_dim_names)
-  for rule_model_name, rule_mesh_name in rules[::-1]:
+  for rule_model_name, rule_mesh_name in rules:
     if rule_model_name in array_dim_names:
       pos = array_dim_names.index(rule_model_name)
-      result[pos] = rule_mesh_name
+      if rule_mesh_name is None or rule_mesh_name in result:
+        if result[pos] == _unassigned_axis:
+          result[pos] = None
+      else:
+        result[pos] = result[pos] or rule_mesh_name
   if _unassigned_axis in result:
     raise ValueError(f'Unassigned axis in {array_dim_names}, the mapped '
                      f'axes are {result}')

--- a/flax/linen/partitioning.py
+++ b/flax/linen/partitioning.py
@@ -160,13 +160,10 @@ def logical_to_mesh_axes(array_dim_names: Sequence[str],
     raise ValueError('Unknown axis rule specification type.')
   # We assign mesh axes using a priority based ruleset over logical axis names.
   result = [_unassigned_axis] * len(array_dim_names)
-  for rule_model_name, rule_mesh_name in rules:
+  for rule_model_name, rule_mesh_name in rules[::-1]:
     if rule_model_name in array_dim_names:
       pos = array_dim_names.index(rule_model_name)
-      if rule_mesh_name is None or rule_mesh_name in result:
-        result[pos] = None
-      else:
-        result[pos] = result[pos] or rule_mesh_name
+      result[pos] = rule_mesh_name
   if _unassigned_axis in result:
     raise ValueError(f'Unassigned axis in {array_dim_names}, the mapped '
                      f'axes are {result}')

--- a/tests/linen/partitioning_test.py
+++ b/tests/linen/partitioning_test.py
@@ -72,6 +72,16 @@ class PartitioningTest(absltest.TestCase):
     with partitioning.axis_rules(AXIS_RULES_1):
       with self.assertRaises(ValueError):
         partitioning.logical_to_mesh_axes(('foo', 'foo', 'baz'))
+  def test_logical_to_mesh_axes_overrides(self):
+    p_rules = (
+        ('baz', 'data'),
+        ('bar', None),
+        ('foo', 'model'),
+        ('foo', 'data'))
+    with partitioning.axis_rules(p_rules):
+      self.assertEqual(
+          partitioning.logical_to_mesh_axes(('baz', 'bar', 'foo')),
+          ('data', None, 'model'))
 
   def test_logical_to_mesh_axes_priorities(self):
     p_rules = (


### PR DESCRIPTION
# What does this PR do?
Fixes  #1702
correct axis resolution in case of repeated axis in the logical axis rules. e.g. (('batch', 'data'),('length', None),('embed', 'model'),('embed', 'data')) should map sharding constraint ('batch', 'length', 'embed') to ('data', None, 'model')
## Checklist
- [ x] This PR fixes a minor issue (e.g.: typo or small bug) or improves the docs (you can dismiss the other
      checks if that's the case).
- [x ] This change is discussed in a Github issue/
      [discussion](https://github.com/google/flax/discussions) (please add a
      link).
- [ ] The documentation and docstrings adhere to the
      [documentation guidelines](https://github.com/google/flax/blob/main/docs/README.md#how-to-write-code-documentation).
- [ ] This change includes necessary high-coverage tests.
      (No quality testing = no merge!)
