### PR TITLE
Fix failing lm1b tests.

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -5,6 +5,8 @@ filterwarnings =
     error
 # Jax warning when no gpu/tpu found.
     ignore:No GPU/TPU found, falling back to CPU.*:UserWarning
+# Jax warns about XLA not being able to use donated buffers.
+    ignore:Some donated buffers were not usable.*:UserWarning
 # Tensorflow's fast_tensor_util.pyx cython raises:
 # ImportWarning: can't resolve package from __spec__ or __package__, falling back on __name__ and __path__
     ignore:can't resolve package from.*:ImportWarning


### PR DESCRIPTION
Fix lm1b tests failing on a non-important JAX warning (from XLA: non usable donated buffers).