### PR TITLE
Implement LazyRNG

### DIFF
--- a/flax/config.py
+++ b/flax/config.py
@@ -58,3 +58,6 @@ flax_filter_frames = bool_env('FLAX_FILTER_FRAMES', True)
 
 # Whether to automatically wrap Module methods with named_call for profiles.
 flax_profile = bool_env('FLAX_PROFILE', False)
+
+# Whether to use the lazy rng implementation for 
+flax_lazy_rng = bool_env('FLAX_LAZY_RNG', False)

--- a/flax/core/scope.py
+++ b/flax/core/scope.py
@@ -77,7 +77,7 @@ PRNGFoldable = Union[int, str]
 
 class LazyRng(struct.PyTreeNode):
   rng: PRNGKey
-  suffix: Tuple[Any, ...] = struct.field(pytree_node=False)
+  suffix: Tuple[PRNGFoldable, ...] = struct.field(pytree_node=False)
   
   def as_jax_rng(self) -> PRNGKey:
     return _fold_in_static(self.rng, self.suffix)

--- a/tests/core/core_scope_test.py
+++ b/tests/core/core_scope_test.py
@@ -15,6 +15,7 @@
 import unittest
 from flax import errors
 from flax.core import Scope, scope, freeze, init, apply, nn
+from flax.core.scope import LazyRng
 
 import jax
 from jax import config as jax_config
@@ -33,7 +34,7 @@ class ScopeTest(absltest.TestCase):
       self.assertTrue(scope.has_rng('params'))
       self.assertFalse(scope.has_rng('dropout'))
       rng = scope.make_rng('params')
-      self.assertTrue(np.all(rng == random.fold_in(random.PRNGKey(0), 1)))
+      self.assertTrue(np.all(rng == LazyRng.create(random.PRNGKey(0), 1).as_jax_rng()))
     init(f)(random.PRNGKey(0))
 
   def test_in_filter(self):

--- a/tests/run_all_tests.sh
+++ b/tests/run_all_tests.sh
@@ -2,6 +2,7 @@
 
 export JAX_NUMPY_RANK_PROMOTION=raise
 export FLAX_PROFILE=1
+export FLAX_LAZY_RNG=1
 
 PYTEST_OPTS=
 for flag in "$@"; do


### PR DESCRIPTION
No longer fold in static components of rngs (module names and rng counters) one-by-one
instead maintain a lazy rng which has a
jax prng and a suffix of static data that is
folded in only when make_rng is called

this should lead to better performance and much less cluter in jaxpr's and HLO.