### PR TITLE
Add param_dtype argument to linen Modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ vNext
 - 
 - 
 - 
-- 
+- Add `param_dtype` attribute to standard Linen Modules for specifying parameter dtypes.
 - 
 
 

--- a/tests/linen/linen_module_test.py
+++ b/tests/linen/linen_module_test.py
@@ -658,6 +658,7 @@ class ModuleTest(absltest.TestCase):
         features = 3
         use_bias = True
         dtype = float32
+        param_dtype = float32
         precision = None
         kernel_init = init
         bias_init = zeros
@@ -667,6 +668,7 @@ class ModuleTest(absltest.TestCase):
         features = 2
         use_bias = True
         dtype = float32
+        param_dtype = float32
         precision = None
         kernel_init = init
         bias_init = zeros


### PR DESCRIPTION
Introduce param_dtype attribute to standard linen layers.
This allows for parameters to be initialized to another dtype than float32.