### PR TITLE
Adds optax update guide.

### DIFF
--- a/docs/howtos/lr_schedule.rst
+++ b/docs/howtos/lr_schedule.rst
@@ -1,5 +1,10 @@
 Learning Rate Scheduling
 =============================
+
+Note: See "Learning Rate Schedules" in :doc:`optax_update_guide` for
+implementing learning rate schedules using ``optax``.
+
+
 The learning rate is considered one of the most important hyperparameters for
 training deep neural networks, but choosing it can be quite hard.
 To simplify this, one can use a so-called *cyclic learning rate*, which

--- a/docs/howtos/optax_update_guide.rst
+++ b/docs/howtos/optax_update_guide.rst
@@ -1,5 +1,11 @@
-Optax Update Guide
-==================
+Upgrading my Codebase to Optax
+==============================
+
+We have proposed to replace :py:mod:`flax.optim` with `Optax
+<https://optax.readthedocs.io>`_ in 2021 with `FLIP #1009
+<https://github.com/google/flax/blob/main/docs/flip/1009-optimizer-api.md>`_ and
+the Flax optimizers are now *effectively deprecated*. This guide is targeted
+towards :py:mod:`flax.optim` users to help them update their code to Optax.
 
 Code samples below are executable in
 `Colab <https://colab.research.google.com/github/google/flax/blob/main/docs/notebooks/optax_update_guide.ipynb>`_.

--- a/docs/howtos/optax_update_guide.rst
+++ b/docs/howtos/optax_update_guide.rst
@@ -4,6 +4,23 @@ Optax Update Guide
 Code samples below are executable in
 `Colab <https://colab.research.google.com/github/google/flax/blob/main/docs/notebooks/optax_update_guide.ipynb>`_.
 
+
+.. testsetup::
+
+  import flax
+  import jax
+  import jax.numpy as jnp
+  import flax.linen as nn
+  import optax
+
+  batch = {'image': jnp.ones([1, 28, 28, 1]), 'label': jnp.array([0])}
+  ds_train = [batch]
+  get_ds_train = lambda: [batch]
+  model = nn.Dense(1)
+  variables = model.init(jax.random.PRNGKey(0), batch['image'])
+  learning_rate, momentum, weight_decay, grad_clip_norm = .1, .9, 1e-3, 1.
+  loss = lambda params, batch: jnp.array(0.)
+
 Replacing ``flax.optim`` with ``optax``
 ---------------------------------------
 
@@ -151,6 +168,8 @@ argument to a function for scaling the updates added with
 |optax.scale_by_schedule()|_. Optax also allows to specify functions to
 inject arbitrary scalar values for other gradient updates via
 |optax.inject_hyperparams()|_.
+
+Read more about learning rate schedules in the :doc:`lr_schedule` guide.
 
 .. |optax.scale_by_schedule()| replace:: ``optax.scale_by_schedule()``
 .. _optax.scale_by_schedule(): https://optax.readthedocs.io/en/latest/api.html#optax.scale_by_schedule

--- a/docs/howtos/optax_update_guide.rst
+++ b/docs/howtos/optax_update_guide.rst
@@ -203,7 +203,7 @@ learning rate schedule as a parameter for `learning_rate`.
       optax.scale_by_schedule(lambda step: -schedule(step)),
   )
 
-Multiple Optimizers
+Multiple Optimizers or only updating a subset of parameters
 -------------------
 
 In Flax, Traversals are used to specify which parameters should be updated by an optimizer. And you can combine Traversals using :py:class:`flax.optim.MultiOptimizer` to apply different optimizers on different parameters. The equivalent in Optax is `optax.masked()` and `optax.chain()`.

--- a/docs/howtos/optax_update_guide.rst
+++ b/docs/howtos/optax_update_guide.rst
@@ -1,0 +1,230 @@
+Optax Update Guide
+==================
+
+Code samples below are executable in
+`Colab <https://colab.research.google.com/github/google/flax/blob/main/docs/notebooks/optax_update_guide.ipynb>`_.
+
+Replacing ``flax.optim`` with ``optax``
+---------------------------------------
+
+Optax has drop-in replacements for all of Flax's optimizers. Refer to Optax's
+documentation `Common Optimizers <https://optax.readthedocs.io/en/latest/api.html>`_
+for API details.
+
+The usage is very similar, with the difference that ``optax`` does not keep a
+copy of the ``params``, so they need to be passed around separately. Flax
+provides the utility :py:class:`~flax.training.train_state.TrainState` to store
+optimizer state, parameters, and other associated data in a single dataclass.
+
+.. codediff::
+  :title_left: ``flax.optim``
+  :title_right: ``optax``
+
+  @jax.jit
+  def train_step(optimizer, batch):
+    grads = jax.grad(loss)(optimizer.target, batch)
+    return optimizer.apply_gradient(grads)
+
+  optimizer_def = flax.optim.Momentum(
+      learning_rate, momentum)
+  optimizer = optimizer_def.create(variables['params'])
+
+  for batch in get_ds_train():
+    optimizer = train_step(optimizer, batch)
+
+  ---
+
+  @jax.jit
+  def train_step(params, opt_state, batch):
+    grads = jax.grad(loss)(params, batch)
+    updates, opt_state = tx.update(grads, opt_state)
+    params = optax.apply_updates(params, updates)
+    return params, opt_state
+
+  tx = optax.sgd(learning_rate, momentum)
+  params = variables['params']
+  opt_state = tx.init(params)
+
+  for batch in ds_train:
+    params, opt_state = train_step(params, opt_state, batch)
+
+
+Composable Gradient Transformations
+-----------------------------------
+
+Note though that |optax.sgd()|_ is simply a wrapper for the sequential
+application of two gradient transformations. Instead of using this alias, it is
+common to use |optax.chain()|_ to combine multiple of these generic building
+blocks.
+
+.. |optax.sgd()| replace:: ``optax.sgd()``
+.. _optax.sgd(): https://optax.readthedocs.io/en/latest/api.html#optax.sgd
+.. |optax.chain()| replace:: ``optax.chain()``
+.. _optax.chain(): https://optax.readthedocs.io/en/latest/api.html#chain
+
+.. codediff::
+  :title_left: Pre-defined alias
+  :title_right: Combining transformations
+
+  # Note that the aliases follow the convention to use positive
+  # values for the learning rate by default.
+  tx = optax.sgd(learning_rate, momentum)
+
+  ---
+
+  tx = optax.chain(
+      # 1. Step: keep a trace of past updates and add to gradients. 
+      optax.trace(decay=momentum),
+      # 2. Step: multiply result from step 1 with negative learning rate.
+      # Note that `optax.apply_updates()` simply adds the final updates to the
+      # parameters, so we must make sure to flip the sign here for gradient
+      # descent.
+      optax.scale(-learning_rate),
+  )
+
+Weight Decay
+------------
+
+Some of Flax's optimizers also include a weight decay. In Optax, the weight
+decay can be added as another "gradient transformation"
+|optax.add_decayed_weights()|_ that adds an update derived from the parameters.
+
+.. |optax.add_decayed_weights()| replace:: ``optax.add_decayed_weights()``
+.. _optax.add_decayed_weights(): https://optax.readthedocs.io/en/latest/api.html#optax.add_decayed_weights
+
+.. codediff::
+  :title_left: ``flax.optim``
+  :title_right: ``optax``
+
+  optimizer_def = flax.optim.Adam(
+      learning_rate, weight_decay=weight_decay)
+  optimizer = optimizer_def.create(variables['params'])
+
+  ---
+
+  tx = optax.chain(
+      optax.scale_by_adam(),
+      optax.add_decayed_weights(weight_decay),
+      # params -= learning_rate * (adam(grads) + params * weight_decay)
+      optax.scale(-learning_rate),
+  )
+  # Note that you'll need to specify `params` when computing the udpates:
+  # tx.update(grads, opt_state, params)
+
+Gradient Clipping
+-----------------
+
+Training can be stabilized by clipping gradients to a global norm (`Pascanu et
+al, 2012 <https://arxiv.org/abs/1211.5063>`_). In Flax this is often done by
+processing the gradients before passing them to the optimizer. With Optax this
+becomes just another gradient transformation |optax.clip_by_global_norm()|_.
+
+.. |optax.clip_by_global_norm()| replace:: ``optax.clip_by_global_norm()``
+.. _optax.clip_by_global_norm(): https://optax.readthedocs.io/en/latest/api.html#optax.clip_by_global_norm
+
+.. codediff::
+  :title_left: ``flax.optim``
+  :title_right: ``optax``
+
+  def train_step(optimizer, batch):
+    grads = jax.grad(loss)(optimizer.target, batch)
+    grads_flat, _ = jax.tree_flatten(grads)
+    global_l2 = jnp.sqrt(sum([jnp.vdot(p, p) for p in grads_flat]))
+    g_factor = jnp.minimum(1.0, grad_clip_norm / global_l2)
+    grads = jax.tree_map(lambda g: g * g_factor, grads)
+    return optimizer.apply_gradient(grads)
+
+  ---
+
+  tx = optax.chain(
+      optax.clip_by_global_norm(grad_clip_norm),
+      optax.trace(decay=momentum),
+      optax.scale(-learning_rate),
+  )
+
+Learning Rate Schedules
+-----------------------
+
+For learning rate schedules, Flax allows to overwrite hyper parameters when
+applying the gradients. Optax keeps a step counter and provides this as an
+argument to a function for scaling the updates added with
+|optax.scale_by_schedule()|_. Optax also allows to specify functions to
+inject arbitrary scalar values for other gradient updates via
+|optax.inject_hyperparams()|_.
+
+.. |optax.scale_by_schedule()| replace:: ``optax.scale_by_schedule()``
+.. _optax.scale_by_schedule(): https://optax.readthedocs.io/en/latest/api.html#optax.scale_by_schedule
+.. |optax.inject_hyperparams()| replace:: ``optax.inject_hyperparams()``
+.. _optax.inject_hyperparams(): https://optax.readthedocs.io/en/latest/api.html#optax.inject_hyperparams
+
+.. codediff::
+  :title_left: ``flax.optim``
+  :title_right: ``optax``
+
+  def train_step(step, optimizer, batch):
+    grads = jax.grad(loss)(optimizer.target, batch)
+    return step + 1, optimizer.apply_gradient(grads, learning_rate=schedule(step))
+
+  ---
+
+  tx = optax.chain(
+      optax.trace(decay=momentum),
+      # Note that we still want a negative value for scaling the updates!
+      optax.scale_by_schedule(lambda step: -schedule(step)),
+  )
+
+Multiple Optimizers
+-------------------
+
+Flax's :py:class:`flax.optim.MultiOptimizer` can be used to compose multiple
+optimizers and only apply them to a part of the params pytree. Optax provides
+an efficient masking mechanism to achieve the same goal.
+
+Note that below example is using :py:mod:`flax.traverse_util` to create the
+boolean masks required by |optax.masked()|_ - alternatively you could also
+create them manually, or use |optax.multi_transform()|_ that takes a
+multivalent pytree to specify gradient transformations.
+
+Beware that |optax.masked()|_ flattens the pytree internally and the inner
+gradient transformations will only be called with that partial flattened view of
+the params/gradients. This is not a problem usually, but it makes it hard to
+nest multiple levels of masked gradient transformations (because the inner
+masks will expect the mask to be defined in terms of the partial flattened view
+that is not readily available outside the outer mask).
+
+.. |optax.masked()| replace:: ``optax.masked()``
+.. _optax.masked(): https://optax.readthedocs.io/en/latest/api.html#optax.masked
+.. |optax.multi_transform()| replace:: ``optax.multi_transform()``
+.. _optax.multi_transform(): https://optax.readthedocs.io/en/latest/api.html#optax.multi_transform
+
+.. codediff::
+  :title_left: ``flax.optim``
+  :title_right: ``optax``
+
+  kernels = flax.traverse_util.ModelParamTraversal(lambda p, _: 'kernel' in p)
+  biases = flax.traverse_util.ModelParamTraversal(lambda p, _: 'bias' in p)
+  kernel_opt = flax.optim.Momentum(learning_rate, momentum)
+  bias_opt = flax.optim.Momentum(learning_rate * 0.1, momentum)
+  optimizer = flax.optim.MultiOptimizer(
+      (kernels, kernel_opt),
+      (biases, bias_opt)
+  ).create(variables['params'])
+
+  ---
+
+  kernels = flax.traverse_util.ModelParamTraversal(lambda p, _: 'kernel' in p)
+  biases = flax.traverse_util.ModelParamTraversal(lambda p, _: 'bias' in p)
+
+  all_false = jax.tree_map(lambda _: False, params)
+  kernels_mask = kernels.update(lambda _: True, all_false)
+  biases_mask = biases.update(lambda _: True, all_false)
+
+  tx = optax.chain(
+      optax.trace(decay=momentum),
+      optax.masked(optax.scale(-learning_rate), kernels_mask),
+      optax.masked(optax.scale(-learning_rate * 0.1), biases_mask),
+  )
+
+All above patterns can of course also be mixed and Optax makes it possible to
+encapsulate all these transformations into a single place outside the main
+training loop, which makes testing much easier.

--- a/docs/howtos/optax_update_guide.rst
+++ b/docs/howtos/optax_update_guide.rst
@@ -206,7 +206,7 @@ learning rate schedule as a parameter for `learning_rate`.
 Multiple Optimizers
 -------------------
 
-Flax's :py:class:`flax.optim.MultiOptimizer` can be used to compose multiple
+In Flax, Traversals are used to specify which parameters should be updated by an optimizer. And you can combine Traversals using :py:class:`flax.optim.MultiOptimizer` to apply different optimizers on different parameters. The equivalent in Optax is `optax.masked()` and `optax.chain()`.
 optimizers and only apply them to a part of the params pytree. Optax provides
 an efficient masking mechanism to achieve the same goal.
 

--- a/docs/howtos/optax_update_guide.rst
+++ b/docs/howtos/optax_update_guide.rst
@@ -181,10 +181,10 @@ becomes just another gradient transformation |optax.clip_by_global_norm()|_.
 Learning Rate Schedules
 -----------------------
 
-For learning rate schedules, Flax allows to overwrite hyper parameters when
-applying the gradients. Optax keeps a step counter and provides this as an
+For learning rate schedules, Flax allows overwriting hyper parameters when
+applying the gradients. Optax maintains a step counter and provides this as an
 argument to a function for scaling the updates added with
-|optax.scale_by_schedule()|_. Optax also allows to specify functions to
+|optax.scale_by_schedule()|_. Optax also allows specifying a functions to
 inject arbitrary scalar values for other gradient updates via
 |optax.inject_hyperparams()|_.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -41,6 +41,7 @@ For a quick introduction and short example snippets, see our `README
    howtos/lr_schedule
    howtos/extracting_intermediates
    howtos/model_surgery
+   howtos/optax_update_guide
 
 .. toctree::
    :maxdepth: 1

--- a/docs/notebooks/optax_update_guide.ipynb
+++ b/docs/notebooks/optax_update_guide.ipynb
@@ -1,0 +1,878 @@
+{
+  "nbformat": 4,
+  "nbformat_minor": 0,
+  "metadata": {
+    "colab": {
+      "name": "Optax Update Guide",
+      "provenance": [],
+      "collapsed_sections": [],
+      "toc_visible": true
+    },
+    "kernelspec": {
+      "name": "python3",
+      "display_name": "Python 3"
+    },
+    "language_info": {
+      "name": "python"
+    }
+  },
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Colab for\n",
+        "https://flax.readthedocs.io/en/latest/howtos/optax_update_guide.html"
+      ],
+      "metadata": {
+        "id": "dHMnJTK9R5n9"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "### Setup"
+      ],
+      "metadata": {
+        "id": "fCCY-S009eHv"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "!pip install -q flax optax"
+      ],
+      "metadata": {
+        "id": "I4PiwrnnO6Fw"
+      },
+      "execution_count": 1,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "from typing import Sequence\n",
+        "\n",
+        "import flax\n",
+        "from  flax.training import train_state\n",
+        "import jax\n",
+        "import jax.numpy as jnp\n",
+        "import flax.linen as nn\n",
+        "import optax"
+      ],
+      "metadata": {
+        "id": "7hDWlLOOt4U6"
+      },
+      "execution_count": 2,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "batch = {\n",
+        "    'image': jnp.ones([1, 28, 28, 1]),\n",
+        "    'label': jnp.array([0]),\n",
+        "}"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "mb2xGRAwueSa",
+        "outputId": "30260605-6773-482d-be0e-0383e63b9fa2"
+      },
+      "execution_count": 3,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "WARNING:absl:No GPU/TPU found, falling back to CPU. (Set TF_CPP_MIN_LOG_LEVEL=0 and rerun for more info.)\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "class Perceptron(nn.Module):\n",
+        "  units: Sequence[int]\n",
+        "  @nn.compact\n",
+        "  def __call__(self, x):\n",
+        "    x = x.reshape([x.shape[0], -1]) / 255.\n",
+        "    x = nn.Dense(50)(x)\n",
+        "    x = nn.relu(x)\n",
+        "    return nn.Dense(10)(x)\n",
+        "\n",
+        "def loss(params, batch):\n",
+        "  logits = model.apply({'params': params}, batch['image'])\n",
+        "  one_hot = jax.nn.one_hot(batch['label'], 10)\n",
+        "  return jnp.mean(optax.softmax_cross_entropy(logits=logits, labels=one_hot))\n",
+        "\n",
+        "model = Perceptron([50, 10])\n",
+        "variables = model.init(jax.random.PRNGKey(0), batch['image'])\n",
+        "\n",
+        "jax.tree_map(jnp.shape, variables)"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "lf11Nzj-t32w",
+        "outputId": "c54a570b-d76a-43bb-f1ab-5cbbbfd6f584"
+      },
+      "execution_count": 4,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "FrozenDict({\n",
+              "    params: {\n",
+              "        Dense_0: {\n",
+              "            bias: (50,),\n",
+              "            kernel: (784, 50),\n",
+              "        },\n",
+              "        Dense_1: {\n",
+              "            bias: (10,),\n",
+              "            kernel: (50, 10),\n",
+              "        },\n",
+              "    },\n",
+              "})"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 4
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "xKm0nn4X57Vg",
+        "outputId": "e1794ea2-ea91-45b5-8b89-d39d2d923cc5",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        }
+      },
+      "source": [
+        "import tensorflow_datasets as tfds\n",
+        "\n",
+        "builder = tfds.builder('mnist')\n",
+        "builder.download_and_prepare()\n",
+        "ds_test = jax.tree_map(jnp.array, builder.as_dataset('test', batch_size=-1))\n",
+        "get_ds_train = lambda: (\n",
+        "    jax.tree_map(jnp.array, x)\n",
+        "    for x in builder.as_dataset('train').batch(128))\n",
+        "batch = next(get_ds_train())\n",
+        "jax.tree_map(jnp.shape, batch)"
+      ],
+      "execution_count": 5,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "WARNING:tensorflow:From /usr/local/lib/python3.7/dist-packages/tensorflow_datasets/core/dataset_builder.py:598: get_single_element (from tensorflow.python.data.experimental.ops.get_single_element) is deprecated and will be removed in a future version.\n",
+            "Instructions for updating:\n",
+            "Use `tf.data.Dataset.get_single_element()`.\n"
+          ]
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "{'image': (128, 28, 28, 1), 'label': (128,)}"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 5
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "@jax.jit\n",
+        "def eval(params):\n",
+        "  logits = model.apply({'params': params}, ds_test['image'])\n",
+        "  return (logits.argmax(axis=-1) == ds_test['label']).mean()\n",
+        "\n",
+        "eval(variables['params'])"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "eCceGZ_Kvko5",
+        "outputId": "af1f8657-b3eb-4c9b-d073-48954481166b"
+      },
+      "execution_count": 6,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "DeviceArray(0.103, dtype=float32)"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 6
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "learning_rate, momentum = 0.01, 0.9"
+      ],
+      "metadata": {
+        "id": "rqQiq3ugxKjX"
+      },
+      "execution_count": 7,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "### Replacing `flax.optim` with `optax`"
+      ],
+      "metadata": {
+        "id": "JyXnY2WW9gfR"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "@jax.jit\n",
+        "def train_step(optimizer, batch):\n",
+        "  grads = jax.grad(loss)(optimizer.target, batch)\n",
+        "  return optimizer.apply_gradient(grads)\n",
+        "\n",
+        "optimizer = flax.optim.Momentum(learning_rate, momentum).create(\n",
+        "    variables['params'])\n",
+        "for batch in get_ds_train():\n",
+        "  optimizer = train_step(optimizer, batch)\n",
+        "\n",
+        "eval(optimizer.target)"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "7mlz-P5AwBc2",
+        "outputId": "05cb4271-e407-4798-d0ea-cd8dfbd9f2a1"
+      },
+      "execution_count": 8,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "DeviceArray(0.9165, dtype=float32)"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 8
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "@jax.jit\n",
+        "def train_step(params, opt_state, batch):\n",
+        "  grads = jax.grad(loss)(params, batch)\n",
+        "  updates, opt_state = tx.update(grads, opt_state)\n",
+        "  params = optax.apply_updates(params, updates)\n",
+        "  return params, opt_state\n",
+        "\n",
+        "tx = optax.sgd(learning_rate, momentum)\n",
+        "params = variables['params']\n",
+        "opt_state = tx.init(params)\n",
+        "\n",
+        "for batch in get_ds_train():\n",
+        "  params, opt_state = train_step(params, opt_state, batch)\n",
+        "\n",
+        "eval(params)"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "n9IxglwJxD3X",
+        "outputId": "a42f9e8d-d1fe-4221-ec28-b7258174b16c"
+      },
+      "execution_count": 9,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "DeviceArray(0.9165, dtype=float32)"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 9
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "\n",
+        "@jax.jit\n",
+        "def train_step(state, batch):\n",
+        "  def loss(params):\n",
+        "    logits = state.apply_fn({'params': params}, batch['image'])\n",
+        "    one_hot = jax.nn.one_hot(batch['label'], 10)\n",
+        "    return jnp.mean(optax.softmax_cross_entropy(logits=logits, labels=one_hot))\n",
+        "  grads = jax.grad(loss)(state.params)\n",
+        "  return state.apply_gradients(grads=grads)\n",
+        "\n",
+        "tx = optax.sgd(learning_rate, momentum)\n",
+        "state = train_state.TrainState.create(\n",
+        "    apply_fn=model.apply, tx=tx, params=variables['params'],\n",
+        ")\n",
+        "opt_state = tx.init(params)\n",
+        "\n",
+        "for batch in get_ds_train():\n",
+        "  state = train_step(state, batch)\n",
+        "\n",
+        "eval(params)"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "mBcp17BEvBVs",
+        "outputId": "dd912efc-669f-42c2-86b2-e242cecc67ce"
+      },
+      "execution_count": 10,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "DeviceArray(0.9165, dtype=float32)"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 10
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "### Composable Gradient Transformations"
+      ],
+      "metadata": {
+        "id": "4ute1zBpRnaq"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "@jax.jit\n",
+        "def train_step(params, opt_state, batch):\n",
+        "  grads = jax.grad(loss)(params, batch)\n",
+        "  updates, opt_state = tx.update(grads, opt_state)\n",
+        "  params = optax.apply_updates(params, updates)\n",
+        "  return params, opt_state\n",
+        "\n",
+        "tx = optax.chain(\n",
+        "    optax.trace(decay=momentum),\n",
+        "    optax.scale(-learning_rate),\n",
+        ")\n",
+        "params = variables['params']\n",
+        "opt_state = tx.init(params)\n",
+        "\n",
+        "for batch in get_ds_train():\n",
+        "  params, opt_state = train_step(params, opt_state, batch)\n",
+        "\n",
+        "eval(params)"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "M2WjJ7HT8GMn",
+        "outputId": "7ae7117e-5d1d-44ca-abb8-65b0db2c0eb6"
+      },
+      "execution_count": 11,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "DeviceArray(0.9165, dtype=float32)"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 11
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "### Weight Decay"
+      ],
+      "metadata": {
+        "id": "vFt96TU-rSQM"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "weight_decay = 1e-5"
+      ],
+      "metadata": {
+        "id": "Qbq9vK24-omQ"
+      },
+      "execution_count": 12,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "@jax.jit\n",
+        "def train_step(optimizer, batch):\n",
+        "  grads = jax.grad(loss)(optimizer.target, batch)\n",
+        "  return optimizer.apply_gradient(grads)\n",
+        "\n",
+        "optimizer = flax.optim.Adam(learning_rate, weight_decay=weight_decay).create(\n",
+        "    variables['params'])\n",
+        "for batch in get_ds_train():\n",
+        "  optimizer = train_step(optimizer, batch)\n",
+        "\n",
+        "eval(optimizer.target)"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "cx1YCFVL9ktA",
+        "outputId": "bb6795a7-c5c2-458a-d3e9-4b769b857fed"
+      },
+      "execution_count": 13,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "DeviceArray(0.95129997, dtype=float32)"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 13
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "@jax.jit\n",
+        "def train_step(params, opt_state, batch):\n",
+        "  grads = jax.grad(loss)(params, batch)\n",
+        "  updates, opt_state = tx.update(grads, opt_state, params)\n",
+        "  params = optax.apply_updates(params, updates)\n",
+        "  return params, opt_state\n",
+        "\n",
+        "tx = optax.chain(\n",
+        "    optax.scale_by_adam(),\n",
+        "    optax.add_decayed_weights(weight_decay),\n",
+        "    optax.scale(-learning_rate),\n",
+        ")\n",
+        "params = variables['params']\n",
+        "opt_state = tx.init(params)\n",
+        "\n",
+        "for batch in get_ds_train():\n",
+        "  params, opt_state = train_step(params, opt_state, batch)\n",
+        "\n",
+        "eval(params)"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "kIWCQz33-p98",
+        "outputId": "84753c79-314b-4982-97e6-0c61a490eab1"
+      },
+      "execution_count": 14,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "DeviceArray(0.9517, dtype=float32)"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 14
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "### Gradient Clipping"
+      ],
+      "metadata": {
+        "id": "MZE97FEbCgmn"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "grad_clip_norm = 1.0"
+      ],
+      "metadata": {
+        "id": "Y_DCoogODZL6"
+      },
+      "execution_count": 15,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "@jax.jit\n",
+        "def train_step(optimizer, batch):\n",
+        "  grads = jax.grad(loss)(optimizer.target, batch)\n",
+        "  grads_flat, _ = jax.tree_flatten(grads)\n",
+        "  global_l2 = jnp.sqrt(sum([jnp.vdot(p, p) for p in grads_flat]))\n",
+        "  g_factor = jnp.minimum(1.0, grad_clip_norm / global_l2)\n",
+        "  grads = jax.tree_map(lambda g: g * g_factor, grads)\n",
+        "  return optimizer.apply_gradient(grads)\n",
+        "\n",
+        "optimizer = flax.optim.Momentum(learning_rate, momentum).create(\n",
+        "    variables['params'])\n",
+        "for batch in get_ds_train():\n",
+        "  optimizer = train_step(optimizer, batch)\n",
+        "\n",
+        "eval(optimizer.target)"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "mFnX8fb3Chwb",
+        "outputId": "aae283d2-623e-4a43-c001-3e62b11483ae"
+      },
+      "execution_count": 16,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "DeviceArray(0.91679996, dtype=float32)"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 16
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "@jax.jit\n",
+        "def train_step(params, opt_state, batch):\n",
+        "  grads = jax.grad(loss)(params, batch)\n",
+        "  updates, opt_state = tx.update(grads, opt_state)\n",
+        "  params = optax.apply_updates(params, updates)\n",
+        "  return params, opt_state\n",
+        "\n",
+        "tx = optax.chain(\n",
+        "    optax.clip_by_global_norm(grad_clip_norm),\n",
+        "    optax.trace(decay=momentum),\n",
+        "    optax.scale(-learning_rate),\n",
+        ")\n",
+        "params = variables['params']\n",
+        "opt_state = tx.init(params)\n",
+        "\n",
+        "for batch in get_ds_train():\n",
+        "  params, opt_state = train_step(params, opt_state, batch)\n",
+        "\n",
+        "eval(params)"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "aJYN2A-TDhp3",
+        "outputId": "a9563d3a-7dc6-4ecf-bb7b-49356cf9fe13"
+      },
+      "execution_count": 17,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "DeviceArray(0.91679996, dtype=float32)"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 17
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "### Learning Rate Schedules"
+      ],
+      "metadata": {
+        "id": "d9e9YmNHE-xV"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "schedule = lambda step: learning_rate * jnp.exp(step * 1e-3)"
+      ],
+      "metadata": {
+        "id": "zCqz6fDsFB5n"
+      },
+      "execution_count": 18,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "@jax.jit\n",
+        "def train_step(step, optimizer, batch):\n",
+        "  grads = jax.grad(loss)(optimizer.target, batch)\n",
+        "  return step + 1, optimizer.apply_gradient(grads, learning_rate=schedule(step))\n",
+        "\n",
+        "optimizer = flax.optim.Momentum(learning_rate, momentum).create(\n",
+        "    variables['params'])\n",
+        "step = jnp.array(0)\n",
+        "for batch in get_ds_train():\n",
+        "  step, optimizer = train_step(step, optimizer, batch)\n",
+        "\n",
+        "eval(optimizer.target)"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "NinuzivVFYb5",
+        "outputId": "c90b880e-d6f0-40fc-94b8-28d0622d8440"
+      },
+      "execution_count": 19,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "DeviceArray(0.9201, dtype=float32)"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 19
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "@jax.jit\n",
+        "def train_step(params, opt_state, batch):\n",
+        "  grads = jax.grad(loss)(params, batch)\n",
+        "  updates, opt_state = tx.update(grads, opt_state)\n",
+        "  params = optax.apply_updates(params, updates)\n",
+        "  return params, opt_state\n",
+        "\n",
+        "tx = optax.chain(\n",
+        "    optax.trace(decay=momentum),\n",
+        "    optax.scale_by_schedule(lambda step: -schedule(step)),\n",
+        ")\n",
+        "params = variables['params']\n",
+        "opt_state = tx.init(params)\n",
+        "\n",
+        "for batch in get_ds_train():\n",
+        "  params, opt_state = train_step(params, opt_state, batch)\n",
+        "\n",
+        "eval(params)"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "lzaYwXzuFp-L",
+        "outputId": "0ed7f41f-cc2d-46c6-ae9f-4be5b906fb7f"
+      },
+      "execution_count": 20,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "DeviceArray(0.9201, dtype=float32)"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 20
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "### Multiple Optimizers"
+      ],
+      "metadata": {
+        "id": "HLkQDKK0GCHH"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "@jax.jit\n",
+        "def train_step(optimizer, batch):\n",
+        "  grads = jax.grad(loss)(optimizer.target, batch)\n",
+        "  return optimizer.apply_gradient(grads)\n",
+        "\n",
+        "kernels = flax.traverse_util.ModelParamTraversal(lambda p, _: 'kernel' in p)\n",
+        "biases = flax.traverse_util.ModelParamTraversal(lambda p, _: 'bias' in p)\n",
+        "kernel_opt = flax.optim.Momentum(learning_rate, momentum)\n",
+        "bias_opt = flax.optim.Momentum(learning_rate * 0.1, momentum)\n",
+        "optimizer = flax.optim.MultiOptimizer(\n",
+        "    (kernels, kernel_opt),\n",
+        "    (biases, bias_opt)\n",
+        ").create(variables['params'])\n",
+        "\n",
+        "for batch in get_ds_train():\n",
+        "  optimizer = train_step(optimizer, batch)\n",
+        "\n",
+        "eval(optimizer.target)"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "d-2veL8lGDbV",
+        "outputId": "b006d3cc-eff6-410a-e201-ccd9464db9d7"
+      },
+      "execution_count": 21,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "DeviceArray(0.91679996, dtype=float32)"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 21
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "@jax.jit\n",
+        "def train_step(params, opt_state, batch):\n",
+        "  grads = jax.grad(loss)(params, batch)\n",
+        "  updates, opt_state = tx.update(grads, opt_state)\n",
+        "  params = optax.apply_updates(params, updates)\n",
+        "  return params, opt_state\n",
+        "\n",
+        "kernels = flax.traverse_util.ModelParamTraversal(lambda p, _: 'kernel' in p)\n",
+        "biases = flax.traverse_util.ModelParamTraversal(lambda p, _: 'bias' in p)\n",
+        "\n",
+        "all_false = jax.tree_map(lambda _: False, params)\n",
+        "kernels_mask = kernels.update(lambda _: True, all_false)\n",
+        "biases_mask = biases.update(lambda _: True, all_false)\n",
+        "\n",
+        "tx = optax.chain(\n",
+        "    optax.trace(decay=momentum),\n",
+        "    optax.masked(optax.scale(-learning_rate), kernels_mask),\n",
+        "    optax.masked(optax.scale(-learning_rate * 0.1), biases_mask),\n",
+        ")\n",
+        "params = variables['params']\n",
+        "opt_state = tx.init(params)\n",
+        "\n",
+        "for batch in get_ds_train():\n",
+        "  params, opt_state = train_step(params, opt_state, batch)\n",
+        "\n",
+        "eval(params)"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "MvQlkiCuHr41",
+        "outputId": "88b4b0dd-4b80-4c5b-c21d-803c097b8cc6"
+      },
+      "execution_count": 22,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "DeviceArray(0.91679996, dtype=float32)"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 22
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "@jax.jit\n",
+        "def train_step(params, opt_state, batch):\n",
+        "  grads = jax.grad(loss)(params, batch)\n",
+        "  updates, opt_state = tx.update(grads, opt_state)\n",
+        "  params = optax.apply_updates(params, updates)\n",
+        "  return params, opt_state\n",
+        "\n",
+        "kernels = flax.traverse_util.ModelParamTraversal(lambda p, _: 'kernel' in p)\n",
+        "biases = flax.traverse_util.ModelParamTraversal(lambda p, _: 'bias' in p)\n",
+        "\n",
+        "all_false = jax.tree_map(lambda _: False, params)\n",
+        "kernels_mask = kernels.update(lambda _: True, all_false)\n",
+        "biases_mask = biases.update(lambda _: True, all_false)\n",
+        "\n",
+        "tx = optax.chain(\n",
+        "    optax.trace(decay=momentum),\n",
+        "    optax.multi_transform({\n",
+        "      'kernels': optax.scale(-learning_rate),\n",
+        "      'biases': optax.scale(-learning_rate * 0.1),\n",
+        "  }, kernels.update(lambda _: 'kernels',\n",
+        "                    biases.update(lambda _: 'biases', params))),\n",
+        ")\n",
+        "params = variables['params']\n",
+        "opt_state = tx.init(params)\n",
+        "\n",
+        "for batch in get_ds_train():\n",
+        "  params, opt_state = train_step(params, opt_state, batch)\n",
+        "\n",
+        "eval(params)"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "v2omX108JYDo",
+        "outputId": "a9f45c8c-0db5-4b5e-b429-e6d79b22eca0"
+      },
+      "execution_count": 23,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "DeviceArray(0.91679996, dtype=float32)"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 23
+        }
+      ]
+    }
+  ]
+}

--- a/docs/notebooks/optax_update_guide.ipynb
+++ b/docs/notebooks/optax_update_guide.ipynb
@@ -1,54 +1,42 @@
 {
-  "nbformat": 4,
-  "nbformat_minor": 0,
-  "metadata": {
-    "colab": {
-      "name": "Optax Update Guide",
-      "provenance": [],
-      "collapsed_sections": [],
-      "toc_visible": true
-    },
-    "kernelspec": {
-      "name": "python3",
-      "display_name": "Python 3"
-    },
-    "language_info": {
-      "name": "python"
-    }
-  },
   "cells": [
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "dHMnJTK9R5n9"
+      },
       "source": [
         "Colab for\n",
         "https://flax.readthedocs.io/en/latest/howtos/optax_update_guide.html"
-      ],
-      "metadata": {
-        "id": "dHMnJTK9R5n9"
-      }
+      ]
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "### Setup"
-      ],
       "metadata": {
         "id": "fCCY-S009eHv"
-      }
+      },
+      "source": [
+        "### Setup"
+      ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "!pip install -q flax optax"
-      ],
+      "execution_count": 1,
       "metadata": {
         "id": "I4PiwrnnO6Fw"
       },
-      "execution_count": 1,
-      "outputs": []
+      "outputs": [],
+      "source": [
+        "!pip install -q flax optax"
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": 2,
+      "metadata": {
+        "id": "7hDWlLOOt4U6"
+      },
+      "outputs": [],
       "source": [
         "from typing import Sequence\n",
         "\n",
@@ -58,21 +46,11 @@
         "import jax.numpy as jnp\n",
         "import flax.linen as nn\n",
         "import optax"
-      ],
-      "metadata": {
-        "id": "7hDWlLOOt4U6"
-      },
-      "execution_count": 2,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "batch = {\n",
-        "    'image': jnp.ones([1, 28, 28, 1]),\n",
-        "    'label': jnp.array([0]),\n",
-        "}"
-      ],
+      "execution_count": 3,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -80,19 +58,55 @@
         "id": "mb2xGRAwueSa",
         "outputId": "30260605-6773-482d-be0e-0383e63b9fa2"
       },
-      "execution_count": 3,
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stderr",
+          "output_type": "stream",
           "text": [
             "WARNING:absl:No GPU/TPU found, falling back to CPU. (Set TF_CPP_MIN_LOG_LEVEL=0 and rerun for more info.)\n"
           ]
         }
+      ],
+      "source": [
+        "batch = {\n",
+        "    'image': jnp.ones([1, 28, 28, 1]),\n",
+        "    'label': jnp.array([0]),\n",
+        "}"
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": 4,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "lf11Nzj-t32w",
+        "outputId": "c54a570b-d76a-43bb-f1ab-5cbbbfd6f584"
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "FrozenDict({\n",
+              "    params: {\n",
+              "        Dense_0: {\n",
+              "            bias: (50,),\n",
+              "            kernel: (784, 50),\n",
+              "        },\n",
+              "        Dense_1: {\n",
+              "            bias: (10,),\n",
+              "            kernel: (50, 10),\n",
+              "        },\n",
+              "    },\n",
+              "})"
+            ]
+          },
+          "execution_count": 4,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
       "source": [
         "class Perceptron(nn.Module):\n",
         "  units: Sequence[int]\n",
@@ -112,48 +126,39 @@
         "variables = model.init(jax.random.PRNGKey(0), batch['image'])\n",
         "\n",
         "jax.tree_map(jnp.shape, variables)"
-      ],
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "lf11Nzj-t32w",
-        "outputId": "c54a570b-d76a-43bb-f1ab-5cbbbfd6f584"
-      },
-      "execution_count": 4,
-      "outputs": [
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": [
-              "FrozenDict({\n",
-              "    params: {\n",
-              "        Dense_0: {\n",
-              "            bias: (50,),\n",
-              "            kernel: (784, 50),\n",
-              "        },\n",
-              "        Dense_1: {\n",
-              "            bias: (10,),\n",
-              "            kernel: (50, 10),\n",
-              "        },\n",
-              "    },\n",
-              "})"
-            ]
-          },
-          "metadata": {},
-          "execution_count": 4
-        }
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": 5,
       "metadata": {
-        "id": "xKm0nn4X57Vg",
-        "outputId": "e1794ea2-ea91-45b5-8b89-d39d2d923cc5",
         "colab": {
           "base_uri": "https://localhost:8080/"
-        }
+        },
+        "id": "xKm0nn4X57Vg",
+        "outputId": "e1794ea2-ea91-45b5-8b89-d39d2d923cc5"
       },
+      "outputs": [
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "WARNING:tensorflow:From /usr/local/lib/python3.7/dist-packages/tensorflow_datasets/core/dataset_builder.py:598: get_single_element (from tensorflow.python.data.experimental.ops.get_single_element) is deprecated and will be removed in a future version.\n",
+            "Instructions for updating:\n",
+            "Use `tf.data.Dataset.get_single_element()`.\n"
+          ]
+        },
+        {
+          "data": {
+            "text/plain": [
+              "{'image': (128, 28, 28, 1), 'label': (128,)}"
+            ]
+          },
+          "execution_count": 5,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
       "source": [
         "import tensorflow_datasets as tfds\n",
         "\n",
@@ -165,40 +170,11 @@
         "    for x in builder.as_dataset('train').batch(128))\n",
         "batch = next(get_ds_train())\n",
         "jax.tree_map(jnp.shape, batch)"
-      ],
-      "execution_count": 5,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "WARNING:tensorflow:From /usr/local/lib/python3.7/dist-packages/tensorflow_datasets/core/dataset_builder.py:598: get_single_element (from tensorflow.python.data.experimental.ops.get_single_element) is deprecated and will be removed in a future version.\n",
-            "Instructions for updating:\n",
-            "Use `tf.data.Dataset.get_single_element()`.\n"
-          ]
-        },
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": [
-              "{'image': (128, 28, 28, 1), 'label': (128,)}"
-            ]
-          },
-          "metadata": {},
-          "execution_count": 5
-        }
       ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "@jax.jit\n",
-        "def eval(params):\n",
-        "  logits = model.apply({'params': params}, ds_test['image'])\n",
-        "  return (logits.argmax(axis=-1) == ds_test['label']).mean()\n",
-        "\n",
-        "eval(variables['params'])"
-      ],
+      "execution_count": 6,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -206,42 +182,69 @@
         "id": "eCceGZ_Kvko5",
         "outputId": "af1f8657-b3eb-4c9b-d073-48954481166b"
       },
-      "execution_count": 6,
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "DeviceArray(0.103, dtype=float32)"
             ]
           },
+          "execution_count": 6,
           "metadata": {},
-          "execution_count": 6
+          "output_type": "execute_result"
         }
+      ],
+      "source": [
+        "@jax.jit\n",
+        "def eval(params):\n",
+        "  logits = model.apply({'params': params}, ds_test['image'])\n",
+        "  return (logits.argmax(axis=-1) == ds_test['label']).mean()\n",
+        "\n",
+        "eval(variables['params'])"
       ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "learning_rate, momentum = 0.01, 0.9"
-      ],
+      "execution_count": 7,
       "metadata": {
         "id": "rqQiq3ugxKjX"
       },
-      "execution_count": 7,
-      "outputs": []
+      "outputs": [],
+      "source": [
+        "learning_rate, momentum = 0.01, 0.9"
+      ]
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "### Replacing `flax.optim` with `optax`"
-      ],
       "metadata": {
         "id": "JyXnY2WW9gfR"
-      }
+      },
+      "source": [
+        "### Replacing `flax.optim` with `optax`"
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": 8,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "7mlz-P5AwBc2",
+        "outputId": "05cb4271-e407-4798-d0ea-cd8dfbd9f2a1"
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "DeviceArray(0.9165, dtype=float32)"
+            ]
+          },
+          "execution_count": 8,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
       "source": [
         "@jax.jit\n",
         "def train_step(optimizer, batch):\n",
@@ -254,47 +257,11 @@
         "  optimizer = train_step(optimizer, batch)\n",
         "\n",
         "eval(optimizer.target)"
-      ],
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "7mlz-P5AwBc2",
-        "outputId": "05cb4271-e407-4798-d0ea-cd8dfbd9f2a1"
-      },
-      "execution_count": 8,
-      "outputs": [
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": [
-              "DeviceArray(0.9165, dtype=float32)"
-            ]
-          },
-          "metadata": {},
-          "execution_count": 8
-        }
       ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "@jax.jit\n",
-        "def train_step(params, opt_state, batch):\n",
-        "  grads = jax.grad(loss)(params, batch)\n",
-        "  updates, opt_state = tx.update(grads, opt_state)\n",
-        "  params = optax.apply_updates(params, updates)\n",
-        "  return params, opt_state\n",
-        "\n",
-        "tx = optax.sgd(learning_rate, momentum)\n",
-        "params = variables['params']\n",
-        "opt_state = tx.init(params)\n",
-        "\n",
-        "for batch in get_ds_train():\n",
-        "  params, opt_state = train_step(params, opt_state, batch)\n",
-        "\n",
-        "eval(params)"
-      ],
+      "execution_count": 9,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -302,22 +269,58 @@
         "id": "n9IxglwJxD3X",
         "outputId": "a42f9e8d-d1fe-4221-ec28-b7258174b16c"
       },
-      "execution_count": 9,
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "DeviceArray(0.9165, dtype=float32)"
             ]
           },
+          "execution_count": 9,
           "metadata": {},
-          "execution_count": 9
+          "output_type": "execute_result"
         }
+      ],
+      "source": [
+        "tx = optax.sgd(learning_rate, momentum)\n",
+        "params = variables['params']\n",
+        "opt_state = tx.init(params)\n",
+        "\n",
+        "@jax.jit\n",
+        "def train_step(params, opt_state, batch):\n",
+        "  grads = jax.grad(loss)(params, batch)\n",
+        "  updates, opt_state = tx.update(grads, opt_state)\n",
+        "  params = optax.apply_updates(params, updates)\n",
+        "  return params, opt_state\n",
+        "\n",
+        "for batch in get_ds_train():\n",
+        "  params, opt_state = train_step(params, opt_state, batch)\n",
+        "\n",
+        "eval(params)"
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": 10,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "mBcp17BEvBVs",
+        "outputId": "dd912efc-669f-42c2-86b2-e242cecc67ce"
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "DeviceArray(0.9165, dtype=float32)"
+            ]
+          },
+          "execution_count": 10,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
       "source": [
         "\n",
         "@jax.jit\n",
@@ -339,39 +342,39 @@
         "  state = train_step(state, batch)\n",
         "\n",
         "eval(params)"
-      ],
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "4ute1zBpRnaq"
+      },
+      "source": [
+        "### Composable Gradient Transformations"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 11,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "id": "mBcp17BEvBVs",
-        "outputId": "dd912efc-669f-42c2-86b2-e242cecc67ce"
+        "id": "M2WjJ7HT8GMn",
+        "outputId": "7ae7117e-5d1d-44ca-abb8-65b0db2c0eb6"
       },
-      "execution_count": 10,
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "DeviceArray(0.9165, dtype=float32)"
             ]
           },
+          "execution_count": 11,
           "metadata": {},
-          "execution_count": 10
+          "output_type": "execute_result"
         }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "### Composable Gradient Transformations"
       ],
-      "metadata": {
-        "id": "4ute1zBpRnaq"
-      }
-    },
-    {
-      "cell_type": "code",
       "source": [
         "@jax.jit\n",
         "def train_step(params, opt_state, batch):\n",
@@ -391,50 +394,50 @@
         "  params, opt_state = train_step(params, opt_state, batch)\n",
         "\n",
         "eval(params)"
-      ],
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "M2WjJ7HT8GMn",
-        "outputId": "7ae7117e-5d1d-44ca-abb8-65b0db2c0eb6"
-      },
-      "execution_count": 11,
-      "outputs": [
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": [
-              "DeviceArray(0.9165, dtype=float32)"
-            ]
-          },
-          "metadata": {},
-          "execution_count": 11
-        }
       ]
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "### Weight Decay"
-      ],
       "metadata": {
         "id": "vFt96TU-rSQM"
-      }
+      },
+      "source": [
+        "### Weight Decay"
+      ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "weight_decay = 1e-5"
-      ],
+      "execution_count": 12,
       "metadata": {
         "id": "Qbq9vK24-omQ"
       },
-      "execution_count": 12,
-      "outputs": []
+      "outputs": [],
+      "source": [
+        "weight_decay = 1e-5"
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": 13,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "cx1YCFVL9ktA",
+        "outputId": "bb6795a7-c5c2-458a-d3e9-4b769b857fed"
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "DeviceArray(0.95129997, dtype=float32)"
+            ]
+          },
+          "execution_count": 13,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
       "source": [
         "@jax.jit\n",
         "def train_step(optimizer, batch):\n",
@@ -447,30 +450,30 @@
         "  optimizer = train_step(optimizer, batch)\n",
         "\n",
         "eval(optimizer.target)"
-      ],
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "cx1YCFVL9ktA",
-        "outputId": "bb6795a7-c5c2-458a-d3e9-4b769b857fed"
-      },
-      "execution_count": 13,
-      "outputs": [
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": [
-              "DeviceArray(0.95129997, dtype=float32)"
-            ]
-          },
-          "metadata": {},
-          "execution_count": 13
-        }
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": 14,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "kIWCQz33-p98",
+        "outputId": "84753c79-314b-4982-97e6-0c61a490eab1"
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "DeviceArray(0.9517, dtype=float32)"
+            ]
+          },
+          "execution_count": 14,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
       "source": [
         "@jax.jit\n",
         "def train_step(params, opt_state, batch):\n",
@@ -491,50 +494,50 @@
         "  params, opt_state = train_step(params, opt_state, batch)\n",
         "\n",
         "eval(params)"
-      ],
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "kIWCQz33-p98",
-        "outputId": "84753c79-314b-4982-97e6-0c61a490eab1"
-      },
-      "execution_count": 14,
-      "outputs": [
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": [
-              "DeviceArray(0.9517, dtype=float32)"
-            ]
-          },
-          "metadata": {},
-          "execution_count": 14
-        }
       ]
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "### Gradient Clipping"
-      ],
       "metadata": {
         "id": "MZE97FEbCgmn"
-      }
+      },
+      "source": [
+        "### Gradient Clipping"
+      ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "grad_clip_norm = 1.0"
-      ],
+      "execution_count": 15,
       "metadata": {
         "id": "Y_DCoogODZL6"
       },
-      "execution_count": 15,
-      "outputs": []
+      "outputs": [],
+      "source": [
+        "grad_clip_norm = 1.0"
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": 16,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "mFnX8fb3Chwb",
+        "outputId": "aae283d2-623e-4a43-c001-3e62b11483ae"
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "DeviceArray(0.91679996, dtype=float32)"
+            ]
+          },
+          "execution_count": 16,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
       "source": [
         "@jax.jit\n",
         "def train_step(optimizer, batch):\n",
@@ -551,30 +554,30 @@
         "  optimizer = train_step(optimizer, batch)\n",
         "\n",
         "eval(optimizer.target)"
-      ],
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 17,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "id": "mFnX8fb3Chwb",
-        "outputId": "aae283d2-623e-4a43-c001-3e62b11483ae"
+        "id": "aJYN2A-TDhp3",
+        "outputId": "a9563d3a-7dc6-4ecf-bb7b-49356cf9fe13"
       },
-      "execution_count": 16,
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "DeviceArray(0.91679996, dtype=float32)"
             ]
           },
+          "execution_count": 17,
           "metadata": {},
-          "execution_count": 16
+          "output_type": "execute_result"
         }
-      ]
-    },
-    {
-      "cell_type": "code",
+      ],
       "source": [
         "@jax.jit\n",
         "def train_step(params, opt_state, batch):\n",
@@ -595,50 +598,50 @@
         "  params, opt_state = train_step(params, opt_state, batch)\n",
         "\n",
         "eval(params)"
-      ],
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "aJYN2A-TDhp3",
-        "outputId": "a9563d3a-7dc6-4ecf-bb7b-49356cf9fe13"
-      },
-      "execution_count": 17,
-      "outputs": [
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": [
-              "DeviceArray(0.91679996, dtype=float32)"
-            ]
-          },
-          "metadata": {},
-          "execution_count": 17
-        }
       ]
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "### Learning Rate Schedules"
-      ],
       "metadata": {
         "id": "d9e9YmNHE-xV"
-      }
+      },
+      "source": [
+        "### Learning Rate Schedules"
+      ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "schedule = lambda step: learning_rate * jnp.exp(step * 1e-3)"
-      ],
+      "execution_count": 18,
       "metadata": {
         "id": "zCqz6fDsFB5n"
       },
-      "execution_count": 18,
-      "outputs": []
+      "outputs": [],
+      "source": [
+        "schedule = lambda step: learning_rate * jnp.exp(step * 1e-3)"
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": 19,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "NinuzivVFYb5",
+        "outputId": "c90b880e-d6f0-40fc-94b8-28d0622d8440"
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "DeviceArray(0.9201, dtype=float32)"
+            ]
+          },
+          "execution_count": 19,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
       "source": [
         "@jax.jit\n",
         "def train_step(step, optimizer, batch):\n",
@@ -652,30 +655,30 @@
         "  step, optimizer = train_step(step, optimizer, batch)\n",
         "\n",
         "eval(optimizer.target)"
-      ],
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 20,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "id": "NinuzivVFYb5",
-        "outputId": "c90b880e-d6f0-40fc-94b8-28d0622d8440"
+        "id": "lzaYwXzuFp-L",
+        "outputId": "0ed7f41f-cc2d-46c6-ae9f-4be5b906fb7f"
       },
-      "execution_count": 19,
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "DeviceArray(0.9201, dtype=float32)"
             ]
           },
+          "execution_count": 20,
           "metadata": {},
-          "execution_count": 19
+          "output_type": "execute_result"
         }
-      ]
-    },
-    {
-      "cell_type": "code",
+      ],
       "source": [
         "@jax.jit\n",
         "def train_step(params, opt_state, batch):\n",
@@ -695,39 +698,39 @@
         "  params, opt_state = train_step(params, opt_state, batch)\n",
         "\n",
         "eval(params)"
-      ],
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "lzaYwXzuFp-L",
-        "outputId": "0ed7f41f-cc2d-46c6-ae9f-4be5b906fb7f"
-      },
-      "execution_count": 20,
-      "outputs": [
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": [
-              "DeviceArray(0.9201, dtype=float32)"
-            ]
-          },
-          "metadata": {},
-          "execution_count": 20
-        }
       ]
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "### Multiple Optimizers"
-      ],
       "metadata": {
         "id": "HLkQDKK0GCHH"
-      }
+      },
+      "source": [
+        "### Multiple Optimizers"
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": 21,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "d-2veL8lGDbV",
+        "outputId": "b006d3cc-eff6-410a-e201-ccd9464db9d7"
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "DeviceArray(0.91679996, dtype=float32)"
+            ]
+          },
+          "execution_count": 21,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
       "source": [
         "@jax.jit\n",
         "def train_step(optimizer, batch):\n",
@@ -747,30 +750,30 @@
         "  optimizer = train_step(optimizer, batch)\n",
         "\n",
         "eval(optimizer.target)"
-      ],
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 22,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "id": "d-2veL8lGDbV",
-        "outputId": "b006d3cc-eff6-410a-e201-ccd9464db9d7"
+        "id": "MvQlkiCuHr41",
+        "outputId": "88b4b0dd-4b80-4c5b-c21d-803c097b8cc6"
       },
-      "execution_count": 21,
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "DeviceArray(0.91679996, dtype=float32)"
             ]
           },
+          "execution_count": 22,
           "metadata": {},
-          "execution_count": 21
+          "output_type": "execute_result"
         }
-      ]
-    },
-    {
-      "cell_type": "code",
+      ],
       "source": [
         "@jax.jit\n",
         "def train_step(params, opt_state, batch):\n",
@@ -798,30 +801,30 @@
         "  params, opt_state = train_step(params, opt_state, batch)\n",
         "\n",
         "eval(params)"
-      ],
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 23,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "id": "MvQlkiCuHr41",
-        "outputId": "88b4b0dd-4b80-4c5b-c21d-803c097b8cc6"
+        "id": "v2omX108JYDo",
+        "outputId": "a9f45c8c-0db5-4b5e-b429-e6d79b22eca0"
       },
-      "execution_count": 22,
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "DeviceArray(0.91679996, dtype=float32)"
             ]
           },
+          "execution_count": 23,
           "metadata": {},
-          "execution_count": 22
+          "output_type": "execute_result"
         }
-      ]
-    },
-    {
-      "cell_type": "code",
+      ],
       "source": [
         "@jax.jit\n",
         "def train_step(params, opt_state, batch):\n",
@@ -852,27 +855,24 @@
         "  params, opt_state = train_step(params, opt_state, batch)\n",
         "\n",
         "eval(params)"
-      ],
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "v2omX108JYDo",
-        "outputId": "a9f45c8c-0db5-4b5e-b429-e6d79b22eca0"
-      },
-      "execution_count": 23,
-      "outputs": [
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": [
-              "DeviceArray(0.91679996, dtype=float32)"
-            ]
-          },
-          "metadata": {},
-          "execution_count": 23
-        }
       ]
     }
-  ]
+  ],
+  "metadata": {
+    "colab": {
+      "collapsed_sections": [],
+      "name": "Optax Update Guide",
+      "provenance": [],
+      "toc_visible": true
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 0
 }


### PR DESCRIPTION
This PR adds a detailed guide how `flax.optim` can be replaced with `optax`, including:

- simple case: switching `flax.optim` to `optax` + updating the training loop
- specifying the `optax` optimizer in terms of composable gradient updates
- weight decay
- gradient clipping
- learning rate schedules
- multiple optimizers

Additional to the RST documentation, the PR also contains a Colab that allows for execution, modification, and inspection of the code snippets.