### PR TITLE
Updates documentation `flax.optim` -> `optax`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,25 +3,14 @@ Changelog
 
 vNext
 ------
-- linen_examples/ directory is removed.
--
--
--
--
--
--
--
--
--
--
--
--
--
--
--
--
--
--
+(Add your change to a random empty line to avoid merge conflicts)
+- 
+- 
+- 
+- 
+- 
+- 
+- Added Optax update guide and deprecated `flax.optim`.
 - Added `sep` argument to `flax.traverse_util.flatten_dict()`.
 -
 -

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ vNext
 -
 -
 -
--
+- Added `sep` argument to `flax.traverse_util.flatten_dict()`.
 -
 -
 -

--- a/README.md
+++ b/README.md
@@ -52,8 +52,6 @@ comes with everything you need to start your research, including:
 
 * **Neural network API** (`flax.linen`): Dense, Conv, {Batch|Layer|Group} Norm, Attention, Pooling, {LSTM|GRU} Cell, Dropout
 
-* **Optimizers** (`flax.optim`): SGD, Momentum, Adam, LARS, Adagrad, LAMB, RMSprop
-
 * **Utilities and patterns**: replicated training, serialization and checkpointing, metrics, prefetching on device
 
 * **Educational examples** that work out of the box: MNIST, LSTM seq2seq, Graph Neural Networks, Sequence Tagging

--- a/docs/howtos/model_surgery.rst
+++ b/docs/howtos/model_surgery.rst
@@ -132,9 +132,6 @@ These states contain pytrees that mirror the parameter tree, and can be modified
 the same way: flattening, modifying, unflattening, and then recreating a new
 optimizer state that mirrors the original state.
 
-If you're loading from a flax optimizer, all of the variables that should be
-optimized live in ``optimizer.target``.
-
 .. testcode::
 
   tx = optax.adam(1.0)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -64,7 +64,6 @@ For a quick introduction and short example snippets, see our `README
    :caption: API reference
 
    flax.linen
-   flax.optim
    flax.serialization
    flax.core.frozen_dict
    flax.struct

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -29,8 +29,6 @@ comes with everything you need to start your research, including:
 
 * **Neural network API** (`flax.linen`): Dense, Conv, {Batch|Layer|Group} Norm, Attention, Pooling, {LSTM|GRU} Cell, Dropout
 
-* **Optimizers** (`flax.optim`): SGD, Momentum, Adam, LARS, Adagrad, LAMB, RMSprop
-
 * **Utilities and patterns**: replicated training, serialization and checkpointing, metrics, prefetching on device
 
 * **Educational examples** that work out of the box: MNIST, LSTM seq2seq, Graph Neural Networks, Sequence Tagging

--- a/flax/traverse_util.py
+++ b/flax/traverse_util.py
@@ -58,7 +58,7 @@ class _EmptyNode:
 empty_node = _EmptyNode()
 
 
-def flatten_dict(xs, keep_empty_nodes=False, is_leaf=None):
+def flatten_dict(xs, keep_empty_nodes=False, is_leaf=None, sep=None):
   """Flatten a nested dictionary.
 
   The nested keys are flattened to a tuple.
@@ -88,14 +88,23 @@ def flatten_dict(xs, keep_empty_nodes=False, is_leaf=None):
       next nested dictionary and nested keys and
       returns True if the nested dictionary is a
       leaf (i.e., should not be flattened further).
+    sep: if specified, then the keys of the returned
+      dictionary will be `sep`-joined strings (if
+      `None`, then keys will be tuples).
   Returns:
     The flattened dictionary.
   """
-  assert isinstance(xs, dict), 'input is not a dict'
+  assert isinstance(xs, (flax.core.FrozenDict, dict)), 'expected (frozen)dict'
+
+  def _key(path):
+    if sep is None:
+      return path
+    return sep.join(path)
 
   def _flatten(xs, prefix):
-    if not isinstance(xs, dict) or (is_leaf and is_leaf(prefix, xs)):
-      return {prefix: xs}
+    if not isinstance(xs, (flax.core.FrozenDict, dict)) or (
+        is_leaf and is_leaf(prefix, xs)):
+      return {_key(prefix): xs}
     result = {}
     is_empty = True
     for key, value in xs.items():
@@ -103,12 +112,12 @@ def flatten_dict(xs, keep_empty_nodes=False, is_leaf=None):
       path = prefix + (key,)
       result.update(_flatten(value, path))
     if keep_empty_nodes and is_empty:
-      return {prefix: empty_node}
+      return {_key(prefix): empty_node}
     return result
   return _flatten(xs, ())
 
 
-def unflatten_dict(xs):
+def unflatten_dict(xs, sep=None):
   """Unflatten a dictionary.
 
   See `flatten_dict`
@@ -128,12 +137,15 @@ def unflatten_dict(xs):
 
   Args:
     xs: a flattened dictionary
+    sep: separator (same as used with `flatten_dict()`).
   Returns:
     The nested dictionary.
   """
   assert isinstance(xs, dict), 'input is not a dict'
   result = {}
   for path, value in xs.items():
+    if sep is not None:
+      path = path.split(sep)
     if value is empty_node:
       value = {}
     cursor = result

--- a/tests/traverse_util_test.py
+++ b/tests/traverse_util_test.py
@@ -18,6 +18,7 @@
 import collections
 from absl.testing import absltest
 import flax
+from flax.core import freeze
 from flax import traverse_util
 import jax
 
@@ -150,14 +151,32 @@ class TraversalTest(absltest.TestCase):
         ('foo',): 1,
         ('bar', 'a'): 2,
     })
+    flat_xs = traverse_util.flatten_dict(freeze(xs))
+    self.assertEqual(flat_xs, {
+      ('foo',): 1,
+      ('bar', 'a'): 2,
+    })
+    flat_xs = traverse_util.flatten_dict(xs, sep='/')
+    self.assertEqual(flat_xs, {
+      'foo': 1,
+      'bar/a': 2,
+    })
 
   def test_unflatten_dict(self):
-    flat_xs = {
-        ('foo',): 1,
-        ('bar', 'a'): 2,
+    expected_xs = {
+      'foo': 1,
+      'bar': {'a': 2}
     }
-    xs = traverse_util.unflatten_dict(flat_xs)
-    self.assertEqual(xs, {'foo': 1, 'bar': {'a': 2}})
+    xs = traverse_util.unflatten_dict({
+      ('foo',): 1,
+      ('bar', 'a'): 2,
+    })
+    self.assertEqual(xs, expected_xs)
+    xs = traverse_util.unflatten_dict({
+      'foo': 1,
+      'bar/a': 2,
+    }, sep='/')
+    self.assertEqual(xs, expected_xs)
 
   def test_flatten_dict_keep_empty(self):
     xs = {'foo': 1, 'bar': {'a': 2, 'b': {}}}


### PR DESCRIPTION
Removes mentions of `flax.optim` in documentation

- `README.md`
- `docs/index.rst`
- `docs/overview.md`

Replaces `flax.otim` with `optax` equivalent in

- `docs/howtos/model_surgery.rst`
- `docs/howtos/state_params.rst`

Adds new `traverse_util.flatten_dict(sep)` argument that allows to write the `docs/howtos/model_surgery.rst` a bit more to the point.

Note that the ensembling HOWTO was rewritten in separate #1806.