### PR TITLE
Update download_dataset_metadata.sh

### DIFF
--- a/tests/download_dataset_metadata.sh
+++ b/tests/download_dataset_metadata.sh
@@ -1,22 +1,21 @@
 #!/bin/bash
 
+
 set -e
 
-# Download TFDS metadata to flax/.tdfs/metadata directory. 
+# Download TFDS metadata to flax/.tdfs/metadata directory.
 # This allows the tests to specify the `data_dir` when using tfds.testing.mock_data().
 cd "$( dirname "$0" )"
 
-if [ -d "../.tfds/metadata" ]; then 
-  echo 'TFDS metadata already exists.'; 
-else 
+if [ -d "../.tfds/metadata" ]; then
+  echo 'TFDS metadata already exists.';
+else
   echo 'TFDS metadata does not exist. Downloading...';
-  # Note: We use subversions for faster downloads of only the metadata subdirectory
-  # with no history. If this script fails for you because you don't have subversion 
-  # installed, please let us know by opening a GitHub issue.
-  # 
-  # subversion checkout to the `trunk` branch which corresponds to `tree/master`.
-  # To download from branch `foo`, replace `trunk` with `branches/foo`.
-  svn checkout \
-    https://github.com/tensorflow/datasets/trunk/tensorflow_datasets/testing/metadata \
-    "../.tfds/metadata" -q; 
+  git clone --depth 3  --filter=blob:none   --sparse   https://github.com/tensorflow/datasets/
+  cd datasets
+  git sparse-checkout set tensorflow_datasets/testing/metadata
+  mkdir ../../.tfds
+  mv tensorflow_datasets/testing/metadata/ ../../.tfds/metadata/
+  cd ..
+  rm datasets -rf
 fi

--- a/tests/download_dataset_metadata.sh
+++ b/tests/download_dataset_metadata.sh
@@ -17,5 +17,5 @@ else
   mkdir ../../.tfds
   mv tensorflow_datasets/testing/metadata/ ../../.tfds/metadata/
   cd ..
-  rm datasets -rf
+  rm -rf datasets
 fi


### PR DESCRIPTION
Use git sparse operation instead of svn.

# What does this PR do?
Removes the dependency on SVN.

Fixes # (issue)
Failed to use SVN behind enterprise firewall. With not negligible IT-skills this can probably be solved. Git on the other hand works well behind the firewall, and only requires one to define the http_proxy environment variable. 

## Checklist
- [ x] This PR fixes a minor issue (e.g.: typo or small bug) or improves the docs (you can dismiss the other
      checks if that's the case).
- [ x] This change is discussed in a Github [discussion]([link](https://github.com/google/flax/discussions/1773)).
- [ x] The documentation and docstrings adhere to the
      [documentation guidelines](https://github.com/google/flax/blob/main/docs/README.md#how-to-write-code-documentation).
- [ ] This change includes necessary high-coverage tests.  - No.  ./tests/run_all_tests.sh fails.
      (No quality testing = no merge!)
