### PR TITLE
Add support for non-float32 normalization for linen normalization layers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ vNext
 - 
 - 
 - 
-- 
+- linen Normalization layers no longer downcast double and complex floats to float32
+  when computing the mean and variance.
 - 
 - 
 - 


### PR DESCRIPTION
Previously we always casted to float32 even if
this is a downcast. For example f64 -> f32 or
complex -> float. This change maxes the
reduction dtype *at least* float32