### PR TITLE
Never use named_call when in dynamic in_setup context.

### DIFF
--- a/flax/linen/transforms.py
+++ b/flax/linen/transforms.py
@@ -966,7 +966,7 @@ def named_call(class_fn, force=True):
   prewrapped_fn = wrap_method_once(class_fn)
   @functools.wraps(prewrapped_fn)
   def wrapped_fn(self, *args, **kwargs):
-    if not force and not linen_module._use_named_call:
+    if (not force and not linen_module._use_named_call) or self._state.in_setup:
       return prewrapped_fn(self, *args, **kwargs)
     fn_name = class_fn.__name__
     method_suffix = f'.{fn_name}' if fn_name != '__call__' else ''

--- a/tests/linen/linen_transforms_test.py
+++ b/tests/linen/linen_transforms_test.py
@@ -1240,6 +1240,25 @@ class TransformTest(absltest.TestCase):
     vs = scanbody().init(k, x)
     y = scanbody().apply(vs, x)
 
+  def test_named_call_on_setup_helpers(self):
+    class Foo(nn.Module):
+      def setup(self):
+        self.a = nn.Dense(2)
+        self.setup_helper()
+      def setup_helper(self):
+        self.b = nn.Dense(2)
+      def __call__(self, x):
+        return self.b(self.a(x))
+    k = random.PRNGKey(0)
+    x = jnp.ones((2,2))
+    with nn.override_named_call(True):
+      vs = Foo().init(k, x)
+      y0 = Foo().apply(vs, x)
+    with nn.override_named_call(False):
+      vs = Foo().init(k, x)
+      y1 = Foo().apply(vs, x)
+    np.testing.assert_array_equal(y0, y1)
+
 
 if __name__ == '__main__':
   absltest.main()


### PR DESCRIPTION
For complicated modules some people use helper methods for
setup.  named_call wrapping of such helper methods just breaks
these methods horribly.  Since we should never call a transform
at such a time, just make named_call a passthrough when the state
flag in_setup is True.
