### PR TITLE
Adds deprecation warnings to `flax.optim`.

### DIFF
--- a/flax/optim/README.md
+++ b/flax/optim/README.md
@@ -1,10 +1,8 @@
 # Flax Optimizers
 
-This folder contains the optimizers implemented and maintained by the Flax core team.
+Please do not use Flax optimizers anymore. Use [Optax] instead. See our
+update guide for detailed information:
 
-You can find other optimizers, that are *not* maintained by the Flax team, in the following repositories:
+https://flax.readthedocs.io/en/latest/howtos/optax_update_guide.html
 
-* [Flax Optimizers](https://github.com/nestordemeure/flaxOptimizers), which implements several common and arcane optimizers
-* [AdaHessianJax](https://github.com/nestordemeure/AdaHessianJax), which implements the AdaHessian optimizer
-
-Do not hesitate to submit a pull request to add to this list.
+[Optax]: https://optax.readthedocs.io/

--- a/flax/optim/__init__.py
+++ b/flax/optim/__init__.py
@@ -59,3 +59,7 @@ __all__ = [
     "WeightNorm",
 ]
 # pylint: enable=g-multiple-import
+
+import warnings
+# Makes sure the user sees the warning, as deprecation warnings are silent by default
+warnings.filterwarnings("always", category=DeprecationWarning, module=__name__)

--- a/flax/optim/base.py
+++ b/flax/optim/base.py
@@ -46,6 +46,10 @@ class OptimizerDef:
 
   def __init__(self, hyper_params):
     self.hyper_params = hyper_params
+    warnings.warn(
+        'Use `optax` instead of `flax.optim`. Refer to the update guide '
+        'https://flax.readthedocs.io/en/latest/howtos/optax_update_guide.html '
+        'for detailed instructions.', DeprecationWarning)
 
   def apply_param_gradient(self, step, hyper_params, param, state, grad):
     """Apply a gradient for a single parameter.


### PR DESCRIPTION
This deprecation warning is quite noisy as it will be displayed every time a `flax.optim` instance is created.

Hopefully that will move users away from `flax.optim` in the coming months so we can remove it from Flax later this year without too much pain for external users.