### PR TITLE
Adds HOWTO "Convert PyTorch Models to Flax" to docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,26 +3,15 @@ Changelog
 
 vNext
 ------
-- linen_examples/ directory is removed.
--
--
--
--
--
--
--
--
--
--
--
--
--
--
--
--
--
--
--
+(Add your change to a random empty line to avoid merge conflicts)
+- 
+- 
+- 
+- 
+- 
+- 
+- Added Optax update guide and deprecated `flax.optim`.
+- Added `sep` argument to `flax.traverse_util.flatten_dict()`.
 -
 -
 -

--- a/README.md
+++ b/README.md
@@ -52,8 +52,6 @@ comes with everything you need to start your research, including:
 
 * **Neural network API** (`flax.linen`): Dense, Conv, {Batch|Layer|Group} Norm, Attention, Pooling, {LSTM|GRU} Cell, Dropout
 
-* **Optimizers** (`flax.optim`): SGD, Momentum, Adam, LARS, Adagrad, LAMB, RMSprop
-
 * **Utilities and patterns**: replicated training, serialization and checkpointing, metrics, prefetching on device
 
 * **Educational examples** that work out of the box: MNIST, LSTM seq2seq, Graph Neural Networks, Sequence Tagging

--- a/docs/howtos/convert_pytorch_to_flax.rst
+++ b/docs/howtos/convert_pytorch_to_flax.rst
@@ -1,0 +1,284 @@
+Convert PyTorch Models to Flax
+==============================
+
+.. testsetup::
+
+  import numpy as np
+  import jax
+  from jax import random, numpy as jnp
+  import flax
+
+  from flax import linen as nn
+  from flax.core import freeze
+
+  import torch
+
+We will show how to convert PyTorch models to Flax. We will cover convolutions, fc layers, batch norm, and average pooling.
+
+
+FC Layers
+--------------------------------
+
+Let's start with fc layers. The only thing to be aware of here is that the PyTorch kernel has shape [outC, inC]
+and the Flax kernel has shape [inC, outC]. Transposing the kernel will do the trick.
+
+.. testcode::
+
+  t_fc = torch.nn.Linear(in_features=3, out_features=4)
+  
+  kernel = t_fc.weight.detach().cpu().numpy()
+  bias = t_fc.bias.detach().cpu().numpy()
+  
+  # [outC, inC] -> [inC, outC]
+  kernel = jnp.transpose(kernel, (1, 0))
+  
+  key = random.PRNGKey(0)
+  x = random.normal(key, (1, 3))
+  
+  params = freeze({'params': {'kernel': kernel, 'bias': bias}})
+  j_fc = nn.Dense(features=4)
+  j_out = j_fc.apply(params, x)
+  
+  t_x = torch.from_numpy(np.array(x))
+  t_out = t_fc(t_x)
+  t_out = t_out.detach().cpu().numpy()
+  
+  assert np.all(np.abs(j_out - t_out) < 1e-06)
+
+
+.. testoutput::
+
+
+Convolutions
+--------------------------------
+
+Let's now look at 2D convolutions. PyTorch uses the NCHW format and Flax uses NHWC.
+Consequently, the kernels will have different shapes. The kernel in PyTorch has shape [outC, inC, kH, kW]
+and the Flax kernel has shape [kH, kW, inC, outC]. Transposing the kernel will do the trick.
+
+.. testcode::
+
+  t_conv = torch.nn.Conv2d(in_channels=3, out_channels=4, kernel_size=2, padding='valid')
+  
+  kernel = t_conv.weight.detach().cpu().numpy()
+  bias = t_conv.bias.detach().cpu().numpy()
+  
+  # [outC, inC, kH, kW] -> [kH, kW, inC, outC]
+  kernel = jnp.transpose(kernel, (2, 3, 1, 0))
+  
+  key = random.PRNGKey(0)
+  x = random.normal(key, (1, 6, 6, 3))
+  
+  params = freeze({'params': {'kernel': kernel, 'bias': bias}})
+  j_conv = nn.Conv(features=4, kernel_size=(2, 2), padding='valid')
+  j_out = j_conv.apply(params, x)
+  
+  # [N, H, W, C] -> [N, C, H, W]
+  t_x = torch.from_numpy(np.transpose(np.array(x), (0, 3, 1, 2)))
+  t_out = t_conv(t_x)
+  # [N, C, H, W] -> [N, H, W, C]
+  t_out = np.transpose(t_out.detach().cpu().numpy(), (0, 2, 3, 1))
+  
+  assert np.all(np.abs(j_out - t_out) < 1e-06)
+
+.. testoutput::
+
+
+   
+Convolutions and FC Layers
+--------------------------------
+
+We have to be careful, when we have a model that uses convolutions followed by fc layers (ResNet, VGG, etc).
+In PyTorch, the activations will have shape [N, C, H, W] after the convolutions and are then
+reshaped to [N, C * H * W] before being fed to the fc layers.
+When we port our weights from PyToch to Flax, the activations after the convolutions will be of shape [N, H, W, C] in Flax.
+Before we reshape the activations for the fc layers, we have to transpose them to [N, C, H, W].
+
+Consider this PyTorch model:
+
+.. testcode::
+
+  class TModel(torch.nn.Module):
+
+    def __init__(self):
+      super(TModel, self).__init__()
+      self.conv = torch.nn.Conv2d(in_channels=3, out_channels=4, kernel_size=2, padding='valid')
+      self.fc = torch.nn.Linear(in_features=100, out_features=2)
+
+    def forward(self, x):
+      x = self.conv(x)
+      x = x.view(x.shape[0], -1)
+      x = self.fc(x)
+      return x
+
+
+  t_model = TModel()
+
+.. testoutput::
+
+
+Now, if you want to use the weights from this model in Flax, the corresponding Flax model has to look like this:
+
+
+.. testcode::
+
+  class JModel(nn.Module):
+      
+    @nn.compact
+    def __call__(self, x):
+      x = nn.Conv(features=4, kernel_size=(2, 2), padding='valid', name='conv')(x)
+      # [N, H, W, C] -> [N, C, H, W]
+      x = jnp.transpose(x, (0, 3, 1, 2))
+      x = jnp.reshape(x, (x.shape[0], -1))
+      x = nn.Dense(features=2, name='fc')(x)
+      return x
+
+
+  j_model = JModel()
+
+.. testoutput::
+
+
+The model looks very similar to the PyTorch model, except that we included a transpose operation before
+reshaping our activations for the fc layer.
+We can omit the transpose operation if we apply pooling before reshaping such that the spatial dimensions are 1x1.
+
+Other than the transpose operation before reshaping, we can convert the weights the same way as we did before:
+
+
+.. testcode::
+
+  conv_kernel = t_model.state_dict()['conv.weight'].detach().cpu().numpy()
+  conv_bias = t_model.state_dict()['conv.bias'].detach().cpu().numpy()
+  fc_kernel = t_model.state_dict()['fc.weight'].detach().cpu().numpy()
+  fc_bias = t_model.state_dict()['fc.bias'].detach().cpu().numpy()
+
+  # [outC, inC, kH, kW] -> [kH, kW, inC, outC]
+  conv_kernel = jnp.transpose(conv_kernel, (2, 3, 1, 0))
+  
+  # [outC, inC] -> [inC, outC]
+  fc_kernel = jnp.transpose(fc_kernel, (1, 0))
+  
+  params = freeze({'params': {'conv': {'kernel': conv_kernel, 'bias': conv_bias},
+                              'fc': {'kernel': fc_kernel, 'bias': fc_bias}}})
+
+  key = random.PRNGKey(0)
+  x = random.normal(key, (1, 6, 6, 3))
+
+  j_out = j_model.apply(params, x)
+  
+  # [N, H, W, C] -> [N, C, H, W]
+  t_x = torch.from_numpy(np.transpose(np.array(x), (0, 3, 1, 2)))
+  t_out = t_model(t_x)
+  t_out = t_out.detach().cpu().numpy()
+  
+  assert np.all(np.abs(j_out - t_out) < 1e-06)
+
+.. testoutput::
+
+
+Batch Norm
+--------------------------------
+
+``torch.nn.BatchNorm2d`` uses ``0.1`` as the default value for the momentum parameter while
+|flax.linen.BatchNorm|_ uses ``0.9``. However, this corresponds to the same computation, because PyTorch multiplies
+the estimated statistic with ``(1 − momentum)`` and the new observed value with ``momentum``,
+while Flax multiplies the estimated statistic with momentum and the new observed value with ``(1 − momentum)``.
+
+.. |flax.linen.BatchNorm| replace:: ``flax.linen.BatchNorm``
+.. _flax.linen.BatchNorm: https://flax.readthedocs.io/en/latest/_autosummary/flax.linen.BatchNorm.html
+
+.. testcode::
+
+  t_bn = torch.nn.BatchNorm2d(num_features=3, momentum=0.1)
+  t_bn.eval()
+  
+  scale = t_bn.weight.detach().cpu().numpy()
+  bias = t_bn.bias.detach().cpu().numpy()
+  mean = t_bn.running_mean.detach().cpu().numpy()
+  var = t_bn.running_var.detach().cpu().numpy()
+  
+  params = freeze({'params': {'scale': scale, 'bias': bias},
+                   'batch_stats': {'mean': mean, 'var': var}})
+  
+  key = random.PRNGKey(0)
+  x = random.normal(key, (1, 6, 6, 3))
+  
+  j_bn = nn.BatchNorm(momentum=0.9, use_running_average=True)
+  
+  j_out = j_bn.apply(params, x)
+  
+  # [N, H, W, C] -> [N, C, H, W]
+  t_x = torch.from_numpy(np.transpose(np.array(x), (0, 3, 1, 2)))
+  t_out = t_bn(t_x)
+  # [N, C, H, W] -> [N, H, W, C]
+  t_out = np.transpose(t_out.detach().cpu().numpy(), (0, 2, 3, 1))
+  
+  assert np.all(np.abs(j_out - t_out) < 1e-06)
+
+.. testoutput::
+
+
+Average Pooling
+--------------------------------
+
+``torch.nn.AvgPool2d`` and |flax.linen.avg_pool()|_ are compatible when using default parameters.
+However, ``torch.nn.AvgPool2d`` has a parameter ``count_include_pad``. When ``count_include_pad=False``,
+the zero-padding will not be considered for the average calculation. There does not exist a similar
+parameter for |flax.linen.avg_pool()|_. However, we can easily implement a wrapper around the pooling
+operation.
+
+.. |flax.linen.avg_pool()| replace:: ``flax.linen.avg_pool()``
+.. _flax.linen.avg_pool(): https://flax.readthedocs.io/en/latest/_autosummary/flax.linen.avg_pool.html
+
+.. testcode::
+
+   def avg_pool(inputs, window_shape, strides=None, padding='VALID'):
+     """
+     Pools the input by taking the average over a window.
+     In comparison to flax.linen.avg_pool, this pooling operation does not
+     consider the padded zero's for the average computation.
+     Args:
+       inputs: input data with dimensions (batch, window dims..., features).
+       window_shape: a shape tuple defining the window to reduce over.
+       strides: a sequence of `n` integers, representing the inter-window
+           strides (default: `(1, ..., 1)`).
+       padding: either the string `'SAME'`, the string `'VALID'`, or a sequence
+         of `n` `(low, high)` integer pairs that give the padding to apply before
+         and after each spatial dimension (default: `'VALID'`).
+     Returns:
+       The average for each window slice.
+     """
+     assert inputs.ndim == 4
+     assert len(window_shape) == 2
+     
+     # from https://github.com/google/flax/blob/main/flax/linen/pooling.py
+     y = pool(inputs, 0., jax.lax.add, window_shape, strides, padding)
+
+     ones = jnp.ones(shape=(1, inputs.shape[1], inputs.shape[2], 1)).astype(inputs.dtype)
+     counts = jax.lax.conv_general_dilated(ones,
+                                           jnp.expand_dims(jnp.ones(window_shape).astype(inputs.dtype), axis=(-2, -1)),
+                                           window_strides=(1, 1),
+                                           padding=((1, 1), (1, 1)),
+                                           dimension_numbers=nn.linear._conv_dimension_numbers(ones.shape),
+                                           feature_group_count=1)
+     y = y / counts 
+     return y
+
+
+.. testoutput::
+
+
+Transposed Convolutions
+--------------------------------
+
+``torch.nn.ConvTranspose2d`` and |flax.linen.ConvTranspose|_ are not compatible.
+|flax.linen.ConvTranspose|_ is a wrapper around |jax.lax.conv_transpose|_ which computes a fractionally strided convolution,
+while ``torch.nn.ConvTranspose2d`` computes a gradient based transposed convolution.
+
+
+.. |flax.linen.ConvTranspose| replace:: ``flax.linen.ConvTranspose``
+.. _flax.linen.ConvTranspose: https://flax.readthedocs.io/en/latest/_autosummary/flax.linen.ConvTranspose.html
+
+.. |jax.lax.conv_transpose| replace:: ``jax.lax.conv_transpose``
+.. _jax.lax.conv_transpose: https://jax.readthedocs.io/en/latest/_autosummary/jax.lax.conv_transpose.html

--- a/docs/howtos/model_surgery.rst
+++ b/docs/howtos/model_surgery.rst
@@ -4,14 +4,14 @@ Model Surgery
 .. testsetup::
 
   import functools
-  import numpy as np
-  import jax
-  from jax import lax, random, numpy as jnp
-  import flax
-  from flax import optim, traverse_util
 
+  import jax
+  import jax.numpy as jnp
+  from flax import traverse_util
   from flax import linen as nn
-  from flax.core import unfreeze, freeze
+  from flax.core import freeze
+  import jax
+  import optax
 
 We will show how to get a flat dict of all the tensors, and then go back to a 
 nested, frozen dict. This will be demonstrated for both Flax modules and optimizers.
@@ -44,7 +44,7 @@ Let's create a small convolutional neural network model for our demo.
     initial_params = CNN().init(rng, init_shape)['params']
     return initial_params
 
-  key = random.PRNGKey(0)
+  key = jax.random.PRNGKey(0)
   params = get_initial_params(key)
 
   print(jax.tree_map(jnp.shape, params))
@@ -75,10 +75,8 @@ Next, get a flat dict for doing model surgery as follows:
 
 .. testcode::
 
-  # Unfreeze params to normal dict.
-  params = unfreeze(params)
   # Get flattened-key: value list.
-  flat_params = {'/'.join(k): v for k, v in traverse_util.flatten_dict(params).items()}
+  flat_params = traverse_util.flatten_dict(params, sep='/')
   print(jax.tree_map(jnp.shape, flat_params))
 
 .. testoutput::
@@ -98,7 +96,7 @@ After doing whatever you want, unflatten back:
 .. testcode::
 
   # Unflatten.
-  unflat_params = traverse_util.unflatten_dict({tuple(k.split('/')): v for k, v in flat_params.items()})
+  unflat_params = traverse_util.unflatten_dict(flat_params, sep='/')
   # Refreeze.
   unflat_params = freeze(unflat_params)
   print(jax.tree_map(jnp.shape, unflat_params))
@@ -128,105 +126,64 @@ After doing whatever you want, unflatten back:
 Surgery with Optimizers
 --------------------------------
 
-If you're loading from a flax optimizer, all of the variables that should be
-optimized live in ``optimizer.target``.
+When using `Optax` as an optimizer, the ``opt_state`` is actually a nested tuple
+of the states of individual gradient transformations that compose the optimizer.
+These states contain pytrees that mirror the parameter tree, and can be modified
+the same way: flattening, modifying, unflattening, and then recreating a new
+optimizer state that mirrors the original state.
 
 .. testcode::
 
-  opt_def = optim.Adam(1.0)
-  opt = opt_def.create(params)
+  tx = optax.adam(1.0)
+  opt_state = tx.init(params)
 
-  # Get optimizer state and target vars by:
-  opt_state = opt.state_dict()
+  # The optimizer state is a tuple of gradient transformation states.
   print(jax.tree_map(jnp.shape, opt_state))
 
 .. testoutput::
   :options: +NORMALIZE_WHITESPACE
+
+  (ScaleByAdamState(count=(), mu=FrozenDict({
+      Conv_0: { bias: (32,), kernel: (3, 3, 1, 32), },
+      Conv_1: { bias: (64,), kernel: (3, 3, 32, 64), },
+      Dense_0: { bias: (256,), kernel: (3136, 256), },
+      Dense_1: { bias: (10,), kernel: (256, 10), },
+  }), nu=FrozenDict({
+      Conv_0: { bias: (32,), kernel: (3, 3, 1, 32), },
+      Conv_1: { bias: (64,), kernel: (3, 3, 32, 64), },
+      Dense_0: { bias: (256,), kernel: (3136, 256), },
+      Dense_1: { bias: (10,), kernel: (256, 10), },
+  })), EmptyState())
   
-  {'state': {'param_states': {'Conv_0': {'bias': {'grad_ema': (32,),
-      'grad_sq_ema': (32,)},
-      'kernel': {'grad_ema': (3, 3, 1, 32), 'grad_sq_ema': (3, 3, 1, 32)}},
-    'Conv_1': {'bias': {'grad_ema': (64,), 'grad_sq_ema': (64,)},
-      'kernel': {'grad_ema': (3, 3, 32, 64), 'grad_sq_ema': (3, 3, 32, 64)}},
-    'Dense_0': {'bias': {'grad_ema': (256,), 'grad_sq_ema': (256,)},
-      'kernel': {'grad_ema': (3136, 256), 'grad_sq_ema': (3136, 256)}},
-    'Dense_1': {'bias': {'grad_ema': (10,), 'grad_sq_ema': (10,)},
-      'kernel': {'grad_ema': (256, 10), 'grad_sq_ema': (256, 10)}}},
-    'step': ()},
-  'target': {'Conv_0': {'bias': (32,), 'kernel': (3, 3, 1, 32)},
-    'Conv_1': {'bias': (64,), 'kernel': (3, 3, 32, 64)},
-    'Dense_0': {'bias': (256,), 'kernel': (3136, 256)},
-    'Dense_1': {'bias': (10,), 'kernel': (256, 10)}}}
+The pytrees inside the optimizer state follow the same structure as the
+parameters and can be flattened / modified exactly the same way
 
 .. testcode::
 
-  # Get flattened-key:: value list.
-  flat_opt_state = {'/'.join(k): v for k, v in traverse_util.flatten_dict(opt_state).items()}
-  print(jax.tree_map(jnp.shape, flat_opt_state))
+  flat_mu = traverse_util.flatten_dict(opt_state[0].mu, sep='/')
+  flat_nu = traverse_util.flatten_dict(opt_state[0].nu, sep='/')
+
+  print(jax.tree_map(jnp.shape, flat_mu))
 
 .. testoutput::
   :options: +NORMALIZE_WHITESPACE
   
-  {'state/param_states/Conv_0/bias/grad_ema': (32,),
-  'state/param_states/Conv_0/bias/grad_sq_ema': (32,),
-  'state/param_states/Conv_0/kernel/grad_ema': (3, 3, 1, 32),
-  'state/param_states/Conv_0/kernel/grad_sq_ema': (3, 3, 1, 32),
-  'state/param_states/Conv_1/bias/grad_ema': (64,),
-  'state/param_states/Conv_1/bias/grad_sq_ema': (64,),
-  'state/param_states/Conv_1/kernel/grad_ema': (3, 3, 32, 64),
-  'state/param_states/Conv_1/kernel/grad_sq_ema': (3, 3, 32, 64),
-  'state/param_states/Dense_0/bias/grad_ema': (256,),
-  'state/param_states/Dense_0/bias/grad_sq_ema': (256,),
-  'state/param_states/Dense_0/kernel/grad_ema': (3136, 256),
-  'state/param_states/Dense_0/kernel/grad_sq_ema': (3136, 256),
-  'state/param_states/Dense_1/bias/grad_ema': (10,),
-  'state/param_states/Dense_1/bias/grad_sq_ema': (10,),
-  'state/param_states/Dense_1/kernel/grad_ema': (256, 10),
-  'state/param_states/Dense_1/kernel/grad_sq_ema': (256, 10),
-  'state/step': (),
-  'target/Conv_0/bias': (32,),
-  'target/Conv_0/kernel': (3, 3, 1, 32),
-  'target/Conv_1/bias': (64,),
-  'target/Conv_1/kernel': (3, 3, 32, 64),
-  'target/Dense_0/bias': (256,),
-  'target/Dense_0/kernel': (3136, 256),
-  'target/Dense_1/bias': (10,),
-  'target/Dense_1/kernel': (256, 10)}
+  {'Conv_0/bias': (32,),
+   'Conv_0/kernel': (3, 3, 1, 32),
+   'Conv_1/bias': (64,),
+   'Conv_1/kernel': (3, 3, 32, 64),
+   'Dense_0/bias': (256,),
+   'Dense_0/kernel': (3136, 256),
+   'Dense_1/bias': (10,),
+   'Dense_1/kernel': (256, 10)}
+
+After modification, re-create optimizer state:
 
 .. testcode::
 
-    # Unflatten
-    unflat_opt_state = traverse_util.unflatten_dict({tuple(k.split('/')): v for k, v in flat_opt_state.items()})
-    print(jax.tree_map(jnp.shape, unflat_opt_state))
-
-.. testoutput::
-  :options: +NORMALIZE_WHITESPACE
-  
-  {'state': {'param_states': {'Conv_0': {'bias': {'grad_ema': (32,),
-      'grad_sq_ema': (32,)},
-      'kernel': {'grad_ema': (3, 3, 1, 32), 'grad_sq_ema': (3, 3, 1, 32)}},
-    'Conv_1': {'bias': {'grad_ema': (64,), 'grad_sq_ema': (64,)},
-      'kernel': {'grad_ema': (3, 3, 32, 64), 'grad_sq_ema': (3, 3, 32, 64)}},
-    'Dense_0': {'bias': {'grad_ema': (256,), 'grad_sq_ema': (256,)},
-      'kernel': {'grad_ema': (3136, 256), 'grad_sq_ema': (3136, 256)}},
-    'Dense_1': {'bias': {'grad_ema': (10,), 'grad_sq_ema': (10,)},
-      'kernel': {'grad_ema': (256, 10), 'grad_sq_ema': (256, 10)}}},
-    'step': ()},
-  'target': {'Conv_0': {'bias': (32,), 'kernel': (3, 3, 1, 32)},
-    'Conv_1': {'bias': (64,), 'kernel': (3, 3, 32, 64)},
-    'Dense_0': {'bias': (256,), 'kernel': (3136, 256)},
-    'Dense_1': {'bias': (10,), 'kernel': (256, 10)}}}
-
-We can restore the optimizer object from the nested-dict state. The restored 
-state must agree with the shape of the existing object as a sort of "structural
-unit test".
-
-.. testcode::
-
-  restored_opt = opt.restore_state(unflat_opt_state)
-  print(jax.tree_map(jnp.shape, restored_opt))
-
-.. testoutput::
-  :options: +NORMALIZE_WHITESPACE, +ELLIPSIS
-
-  Optimizer(optimizer_def=<flax.optim.adam.Adam object at ...>, state=OptimizerState(step=(), param_states={'Conv_0': {'bias': _AdamParamState(grad_ema=(32,), grad_sq_ema=(32,)), 'kernel': _AdamParamState(grad_ema=(3, 3, 1, 32), grad_sq_ema=(3, 3, 1, 32))}, 'Conv_1': {'bias': _AdamParamState(grad_ema=(64,), grad_sq_ema=(64,)), 'kernel': _AdamParamState(grad_ema=(3, 3, 32, 64), grad_sq_ema=(3, 3, 32, 64))}, 'Dense_0': {'bias': _AdamParamState(grad_ema=(256,), grad_sq_ema=(256,)), 'kernel': _AdamParamState(grad_ema=(3136, 256), grad_sq_ema=(3136, 256))}, 'Dense_1': {'bias': _AdamParamState(grad_ema=(10,), grad_sq_ema=(10,)), 'kernel': _AdamParamState(grad_ema=(256, 10), grad_sq_ema=(256, 10))}}), target={'Conv_0': {'bias': (32,), 'kernel': (3, 3, 1, 32)}, 'Conv_1': {'bias': (64,), 'kernel': (3, 3, 32, 64)}, 'Dense_0': {'bias': (256,), 'kernel': (3136, 256)}, 'Dense_1': {'bias': (10,), 'kernel': (256, 10)}})
+  opt_state = (
+      opt_state[0]._replace(
+          mu=traverse_util.unflatten_dict(flat_mu, sep='/'),
+          nu=traverse_util.unflatten_dict(flat_nu, sep='/'),
+      ),
+  ) + opt_state[1:]

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -64,7 +64,6 @@ For a quick introduction and short example snippets, see our `README
    :caption: API reference
 
    flax.linen
-   flax.optim
    flax.serialization
    flax.core.frozen_dict
    flax.struct

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -29,8 +29,6 @@ comes with everything you need to start your research, including:
 
 * **Neural network API** (`flax.linen`): Dense, Conv, {Batch|Layer|Group} Norm, Attention, Pooling, {LSTM|GRU} Cell, Dropout
 
-* **Optimizers** (`flax.optim`): SGD, Momentum, Adam, LARS, Adagrad, LAMB, RMSprop
-
 * **Utilities and patterns**: replicated training, serialization and checkpointing, metrics, prefetching on device
 
 * **Educational examples** that work out of the box: MNIST, LSTM seq2seq, Graph Neural Networks, Sequence Tagging

--- a/flax/traverse_util.py
+++ b/flax/traverse_util.py
@@ -58,7 +58,7 @@ class _EmptyNode:
 empty_node = _EmptyNode()
 
 
-def flatten_dict(xs, keep_empty_nodes=False, is_leaf=None):
+def flatten_dict(xs, keep_empty_nodes=False, is_leaf=None, sep=None):
   """Flatten a nested dictionary.
 
   The nested keys are flattened to a tuple.
@@ -88,14 +88,23 @@ def flatten_dict(xs, keep_empty_nodes=False, is_leaf=None):
       next nested dictionary and nested keys and
       returns True if the nested dictionary is a
       leaf (i.e., should not be flattened further).
+    sep: if specified, then the keys of the returned
+      dictionary will be `sep`-joined strings (if
+      `None`, then keys will be tuples).
   Returns:
     The flattened dictionary.
   """
-  assert isinstance(xs, dict), 'input is not a dict'
+  assert isinstance(xs, (flax.core.FrozenDict, dict)), 'expected (frozen)dict'
+
+  def _key(path):
+    if sep is None:
+      return path
+    return sep.join(path)
 
   def _flatten(xs, prefix):
-    if not isinstance(xs, dict) or (is_leaf and is_leaf(prefix, xs)):
-      return {prefix: xs}
+    if not isinstance(xs, (flax.core.FrozenDict, dict)) or (
+        is_leaf and is_leaf(prefix, xs)):
+      return {_key(prefix): xs}
     result = {}
     is_empty = True
     for key, value in xs.items():
@@ -103,12 +112,12 @@ def flatten_dict(xs, keep_empty_nodes=False, is_leaf=None):
       path = prefix + (key,)
       result.update(_flatten(value, path))
     if keep_empty_nodes and is_empty:
-      return {prefix: empty_node}
+      return {_key(prefix): empty_node}
     return result
   return _flatten(xs, ())
 
 
-def unflatten_dict(xs):
+def unflatten_dict(xs, sep=None):
   """Unflatten a dictionary.
 
   See `flatten_dict`
@@ -128,12 +137,15 @@ def unflatten_dict(xs):
 
   Args:
     xs: a flattened dictionary
+    sep: separator (same as used with `flatten_dict()`).
   Returns:
     The nested dictionary.
   """
   assert isinstance(xs, dict), 'input is not a dict'
   result = {}
   for path, value in xs.items():
+    if sep is not None:
+      path = path.split(sep)
     if value is empty_node:
       value = {}
     cursor = result

--- a/tests/traverse_util_test.py
+++ b/tests/traverse_util_test.py
@@ -18,6 +18,7 @@
 import collections
 from absl.testing import absltest
 import flax
+from flax.core import freeze
 from flax import traverse_util
 import jax
 
@@ -150,14 +151,32 @@ class TraversalTest(absltest.TestCase):
         ('foo',): 1,
         ('bar', 'a'): 2,
     })
+    flat_xs = traverse_util.flatten_dict(freeze(xs))
+    self.assertEqual(flat_xs, {
+      ('foo',): 1,
+      ('bar', 'a'): 2,
+    })
+    flat_xs = traverse_util.flatten_dict(xs, sep='/')
+    self.assertEqual(flat_xs, {
+      'foo': 1,
+      'bar/a': 2,
+    })
 
   def test_unflatten_dict(self):
-    flat_xs = {
-        ('foo',): 1,
-        ('bar', 'a'): 2,
+    expected_xs = {
+      'foo': 1,
+      'bar': {'a': 2}
     }
-    xs = traverse_util.unflatten_dict(flat_xs)
-    self.assertEqual(xs, {'foo': 1, 'bar': {'a': 2}})
+    xs = traverse_util.unflatten_dict({
+      ('foo',): 1,
+      ('bar', 'a'): 2,
+    })
+    self.assertEqual(xs, expected_xs)
+    xs = traverse_util.unflatten_dict({
+      'foo': 1,
+      'bar/a': 2,
+    }, sep='/')
+    self.assertEqual(xs, expected_xs)
 
   def test_flatten_dict_keep_empty(self):
     xs = {'foo': 1, 'bar': {'a': 2, 'b': {}}}


### PR DESCRIPTION
This HOWTO shows how to convert PyTorch models to Flax.
The idea for this HOWTO originated in #1770, specifically [this](https://github.com/google/flax/discussions/1770#discussioncomment-1942875) comment by @marcvanzee.
