### PR TITLE
Remove sep argument from Model Surgery HOWTO

### DIFF
--- a/docs/howtos/model_surgery.rst
+++ b/docs/howtos/model_surgery.rst
@@ -76,27 +76,27 @@ Next, get a flat dict for doing model surgery as follows:
 .. testcode::
 
   # Get flattened-key: value list.
-  flat_params = traverse_util.flatten_dict(params, sep='/')
+  flat_params = traverse_util.flatten_dict(params)
   print(jax.tree_map(jnp.shape, flat_params))
 
 .. testoutput::
   :options: +NORMALIZE_WHITESPACE
 
-  {'Conv_0/bias': (32,),
-   'Conv_0/kernel': (3, 3, 1, 32),
-   'Conv_1/bias': (64,),
-   'Conv_1/kernel': (3, 3, 32, 64),
-   'Dense_0/bias': (256,),
-   'Dense_0/kernel': (3136, 256),
-   'Dense_1/bias': (10,),
-   'Dense_1/kernel': (256, 10)}
+  {('Conv_0', 'bias'): (32,),
+   ('Conv_0', 'kernel'): (3, 3, 1, 32),
+   ('Conv_1', 'bias'): (64,),
+   ('Conv_1', 'kernel'): (3, 3, 32, 64),
+   ('Dense_0', 'bias'): (256,),
+   ('Dense_0', 'kernel'): (3136, 256),
+   ('Dense_1', 'bias'): (10,),
+   ('Dense_1', 'kernel'): (256, 10)}
 
 After doing whatever you want, unflatten back:
 
 .. testcode::
 
   # Unflatten.
-  unflat_params = traverse_util.unflatten_dict(flat_params, sep='/')
+  unflat_params = traverse_util.unflatten_dict(flat_params)
   # Refreeze.
   unflat_params = freeze(unflat_params)
   print(jax.tree_map(jnp.shape, unflat_params))
@@ -160,22 +160,22 @@ parameters and can be flattened / modified exactly the same way
 
 .. testcode::
 
-  flat_mu = traverse_util.flatten_dict(opt_state[0].mu, sep='/')
-  flat_nu = traverse_util.flatten_dict(opt_state[0].nu, sep='/')
+  flat_mu = traverse_util.flatten_dict(opt_state[0].mu)
+  flat_nu = traverse_util.flatten_dict(opt_state[0].nu)
 
   print(jax.tree_map(jnp.shape, flat_mu))
 
 .. testoutput::
   :options: +NORMALIZE_WHITESPACE
   
-  {'Conv_0/bias': (32,),
-   'Conv_0/kernel': (3, 3, 1, 32),
-   'Conv_1/bias': (64,),
-   'Conv_1/kernel': (3, 3, 32, 64),
-   'Dense_0/bias': (256,),
-   'Dense_0/kernel': (3136, 256),
-   'Dense_1/bias': (10,),
-   'Dense_1/kernel': (256, 10)}
+  {('Conv_0', 'bias'): (32,),
+   ('Conv_0', 'kernel'): (3, 3, 1, 32),
+   ('Conv_1', 'bias'): (64,),
+   ('Conv_1', 'kernel'): (3, 3, 32, 64),
+   ('Dense_0', 'bias'): (256,),
+   ('Dense_0', 'kernel'): (3136, 256),
+   ('Dense_1', 'bias'): (10,),
+   ('Dense_1', 'kernel'): (256, 10)}
 
 After modification, re-create optimizer state:
 
@@ -183,7 +183,7 @@ After modification, re-create optimizer state:
 
   opt_state = (
       opt_state[0]._replace(
-          mu=traverse_util.unflatten_dict(flat_mu, sep='/'),
-          nu=traverse_util.unflatten_dict(flat_nu, sep='/'),
+          mu=traverse_util.unflatten_dict(flat_mu),
+          nu=traverse_util.unflatten_dict(flat_nu),
       ),
   ) + opt_state[1:]


### PR DESCRIPTION
## What does this PR do?
- Fixes #1849 
- This change removes the `sep` argument from the Model Surgery HOWTO, as this is not required and may imply to readers that `params` keys must be strings, and updates the test outputs accordingly.

## Testing
Relevant `doctest` output:

```
Document: howtos/model_surgery
------------------------------
1 items passed all tests:
   6 tests in default
6 tests in 1 items.
6 passed and 0 failed.
Test passed.

Doctest summary
===============
   33 tests
    0 failures in tests
    0 failures in setup code
    0 failures in cleanup code
```

## Checklist
- [x] This PR fixes a minor issue (e.g.: typo or small bug) or improves the docs (you can dismiss the other
      checks if that's the case).
- [x] This change is discussed in a Github issue/
      [discussion](https://github.com/google/flax/discussions) (please add a
      link).
- [x] The documentation and docstrings adhere to the
      [documentation guidelines](https://github.com/google/flax/blob/main/docs/README.md#how-to-write-code-documentation).
- [x] This change includes necessary high-coverage tests.
      (No quality testing = no merge!)
