### PR TITLE
Make it harder to accidentally pass badly structured pytree to `variables`.

### DIFF
--- a/flax/errors.py
+++ b/flax/errors.py
@@ -122,7 +122,7 @@ class InvalidRngError(FlaxError):
     super().__init__(msg)
 
 
-class ApplyScopeInvalidVariablesError(FlaxError):
+class ApplyScopeInvalidVariablesTypeError(FlaxError):
   """
   When calling :meth:`Module.apply() <flax.linen.Module.apply>`, the first
   argument should be a variable dict. For more explanation on variable dicts,
@@ -132,6 +132,18 @@ class ApplyScopeInvalidVariablesError(FlaxError):
     super().__init__('The first argument passed to an apply function should be '
                      'a dictionary of collections. Each collection should be a '
                      'dictionary with string keys.')
+
+
+class ApplyScopeInvalidVariablesStructureError(FlaxError):
+  """
+  This error is thrown when the dict passed as `variables` to apply() has an
+  extra 'params' layer, i.e. {'params': {'params': ...}}.
+  For more explanation on variable dicts, please see :mod:`flax.core.variables`.
+  """
+  def __init__(self, variables):
+    super().__init__(f'Expected the first argument passed to an apply function '
+                     'to be a dictionary containing a \'params\' key at the '
+                     'root level, but got "{variables}".')
 
 
 class ScopeParamNotFoundError(FlaxError):
@@ -176,7 +188,7 @@ class ScopeCollectionNotFound(FlaxError):
   def __init__(self, col_name, var_name, scope_path):
     super().__init__(
       f'Tried to access "{var_name}" from collection "{col_name}"" in '
-      f'"{scope_path}" but the collection is emtpy.')
+      f'"{scope_path}" but the collection is empty.')
 
 
 class ScopeParamShapeError(FlaxError):

--- a/tests/core/core_scope_test.py
+++ b/tests/core/core_scope_test.py
@@ -111,6 +111,21 @@ class ScopeTest(absltest.TestCase):
     with self.assertRaisesRegex(errors.ScopeParamShapeError, msg):
       apply(f)(freeze({'params': {'test': np.ones((2,))}}))
 
+  def test_apply_variables_bad_pytree(self):
+    def f(scope):
+      scope.param('kernel', nn.initializers.ones, (4,))
+
+    params = freeze({
+        'params': {
+            'kernel': np.ones((4,)),
+        },
+    })
+    apply(f)(params)  # Valid.
+    msg = 'dictionary containing a \'params\' key at the root level'
+    with self.assertRaisesRegex(errors.ApplyScopeInvalidVariablesStructureError,
+                                msg):
+      apply(f)({'params': params})
+      
   def test_mutate_undefined_collection(self):
     def f(scope):
       scope.put_variable('state', 'test', 123)


### PR DESCRIPTION
Try to detect if user is passing a incorrectly structured pytree to nn.Module apply() `variables` arg.
If so, print hopefully helpful error message. 

Fixes #1768

## Checklist
- [x] This PR fixes a minor issue (e.g.: typo or small bug) or improves the docs (you can dismiss the other
      checks if that's the case).
- [ ] This change is discussed in a Github issue/
      [discussion](https://github.com/google/flax/discussions) (please add a
      link).
- [ ] The documentation and docstrings adhere to the
      [documentation guidelines](https://github.com/google/flax/blob/main/docs/README.md#how-to-write-code-documentation).
- [ ] This change includes necessary high-coverage tests.
      (No quality testing = no merge!)
