### PR TITLE
Updates LR schedule HOWTO for optax

### DIFF
--- a/docs/howtos/lr_schedule.rst
+++ b/docs/howtos/lr_schedule.rst
@@ -19,7 +19,10 @@ We will show you how to...
 .. testsetup::
 
   import jax
+  import jax.numpy as jnp
+  from flax.training import train_state
   import optax
+  import functools
 
 .. testcode::
   


### PR DESCRIPTION
This PR addresses #1577.

Note that I replaced the triangular scheduler with the cosine scheduler from the [imagenet example](https://github.com/google/flax/blob/cb5ebcd3b9ab8db10c79e88fcdb2dc67ce2668e2/examples/imagenet/train.py#L88) because the triangular scheduler did not play well with ``jit``. I think ``jit`` cannot trace the ``create_triangular_schedule`` function because of the if else that depends on the input.