### PR TITLE
Support string annotations for module name

### DIFF
--- a/flax/linen/module.py
+++ b/flax/linen/module.py
@@ -535,7 +535,7 @@ class Module(metaclass=ModuleMeta):
     if ('parent' in annotations
         and annotations['parent'] != parent_annotation):
       raise errors.ReservedModuleAttributeError(annotations)
-    if 'name' in annotations and annotations['name'] != str:
+    if 'name' in annotations and annotations['name'] not in ('str', str):
       raise errors.ReservedModuleAttributeError(annotations)
     # Add `parent` and `name` default fields at end.
     # We temporarily modify base class __dataclass_fields__ to force desired


### PR DESCRIPTION
When a file is marked `from __future__ import annotations`, annotations are strings.  The check for the module name being str needs to check against the string 'str' in addition to the symbol str.  This behaviour will become default in Python 3.11, so it may as well be fixed now.

## Checklist
- [x] This PR fixes a minor issue (e.g.: typo or small bug) or improves the docs (you can dismiss the other
      checks if that's the case).