### PR TITLE
Create keyword-only name and parent Module parameters in Python 3.10

### DIFF
--- a/flax/linen/module.py
+++ b/flax/linen/module.py
@@ -468,23 +468,17 @@ if typing.TYPE_CHECKING:
     @__dataclass_transform__()
     @dataclasses.dataclass
     class ModuleBase:
-      name: str = dataclasses.field(kw_only=True, default=None)
+      name: str = dataclasses.field(kw_only=True, default="")
       parent: Union["Module", "Scope", "_Sentinel",
                     None] = dataclasses.field(kw_only=True, repr=False,
                                               default=_unspecified_parent)
-
-      def __init__(*args: Any, **kwargs: Any):
-        # this stub makes sure pytype accepts constructor arguments.
-        pass
-
-      def __call__(self, *args: Any, **kwargs: Any) -> Any:
-        # this stub allows pytype to accept Modules as Callables.
-        pass
+      # Since pytype doesn't run on Python 3.10, inserting __init__ and __call__
+      # isn't necessary, and causes problems in MyPy.
   else:
     @__dataclass_transform__()
     @dataclasses.dataclass
     class ModuleBase:
-      name: str = dataclasses.field(default=None)
+      name: str = dataclasses.field(default="")
       parent: Union["Module", "Scope", "_Sentinel",
                     None] = dataclasses.field(repr=False,
                                               default=_unspecified_parent)

--- a/flax/linen/module.py
+++ b/flax/linen/module.py
@@ -87,8 +87,9 @@ def _module_repr(module: 'Module', num_spaces: int = 4):
   cls = type(module)
   cls_name = cls.__name__
   rep = ''
+  KW_ONLY = getattr(dataclasses, 'KW_ONLY', object())
   attributes = {k: v for k, v in cls.__annotations__.items()
-                if k not in ('parent', 'name')}
+                if k not in ('parent', 'name') and v is not KW_ONLY}
   child_modules = {k: v for k, v in module._state.children.items()  # pytype: disable=attribute-error
                    if isinstance(v, Module)}
   if attributes:

--- a/tests/linen/linen_module_test.py
+++ b/tests/linen/linen_module_test.py
@@ -565,17 +565,17 @@ class ModuleTest(absltest.TestCase):
     self.assertTrue(hasattr(test4, 'name'))
     self.assertTrue(hasattr(test4, 'parent'))
     self.assertEqual(
-        list(Test.__dataclass_fields__.keys()),
-        ['bar', 'parent', 'name'])
+        set(Test.__dataclass_fields__.keys()),
+        {'bar', 'parent', 'name'})
     self.assertEqual(
-        list(Test2.__dataclass_fields__.keys()),
-        ['bar', 'baz', 'parent', 'name'])
+        set(Test2.__dataclass_fields__.keys()),
+        {'bar', 'baz', 'parent', 'name'})
     self.assertEqual(
-        list(Test3.__dataclass_fields__.keys()),
-        ['bar', 'baz', 'parent', 'name'])
+        set(Test3.__dataclass_fields__.keys()),
+        {'bar', 'baz', 'parent', 'name'})
     self.assertEqual(
-        list(Test4.__dataclass_fields__.keys()),
-        ['bar', 'baz', 'parent', 'name'])
+        set(Test4.__dataclass_fields__.keys()),
+        {'bar', 'baz', 'parent', 'name'})
 
   def test_get_suffix_value_pairs(self):
     for x in [(), [], {}, None, 0, set()]:

--- a/tests/linen/linen_transforms_test.py
+++ b/tests/linen/linen_transforms_test.py
@@ -295,8 +295,8 @@ class TransformTest(absltest.TestCase):
 
     x = jnp.ones((10, 10))
     rngs = random.PRNGKey(0)
-    init_vars = Test(None).init(rngs, x)
-    _, new_vars = Test(None).apply(init_vars, x, mutable=['counter'])
+    init_vars = Test().init(rngs, x)
+    _, new_vars = Test().apply(init_vars, x, mutable=['counter'])
     self.assertEqual(init_vars['counter']['outer']['cntr']['foo'],
                      jnp.array([2], jnp.int32))
     self.assertEqual(new_vars['counter']['outer']['cntr']['foo'],
@@ -334,8 +334,8 @@ class TransformTest(absltest.TestCase):
 
     x = jnp.ones((1, 1))
     rngs = random.PRNGKey(0)
-    init_vars = Test(None).init(rngs, x)
-    _, new_vars = Test(None).apply(init_vars, x, mutable=['counter'])
+    init_vars = Test().init(rngs, x)
+    _, new_vars = Test().apply(init_vars, x, mutable=['counter'])
     self.assertEqual(init_vars['counter']['outer']['cntr']['foo'],
                      jnp.array([2], jnp.int32))
     self.assertEqual(new_vars['counter']['outer']['cntr']['foo'],
@@ -371,8 +371,8 @@ class TransformTest(absltest.TestCase):
 
     x = jnp.ones((1, 1))
     rngs = random.PRNGKey(0)
-    init_vars = Test(None).init(rngs, x)
-    _, new_vars = Test(None).apply(init_vars, x, mutable=['counter'])
+    init_vars = Test().init(rngs, x)
+    _, new_vars = Test().apply(init_vars, x, mutable=['counter'])
     self.assertEqual(init_vars['counter']['outer1']['cntr']['foo'],
                      jnp.array([2], jnp.int32))
     self.assertEqual(new_vars['counter']['outer1']['cntr']['foo'],
@@ -415,8 +415,8 @@ class TransformTest(absltest.TestCase):
 
     x = jnp.ones((1, 1))
     rngs = random.PRNGKey(0)
-    init_vars = Test(None).init(rngs, x)
-    _, new_vars = Test(None).apply(init_vars, x, mutable=['counter'])
+    init_vars = Test().init(rngs, x)
+    _, new_vars = Test().apply(init_vars, x, mutable=['counter'])
     self.assertEqual(init_vars['counter']['outer1']['cntr']['foo'],
                      jnp.array([2], jnp.int32))
     self.assertEqual(new_vars['counter']['outer1']['cntr']['foo'],
@@ -460,8 +460,8 @@ class TransformTest(absltest.TestCase):
 
       x = jnp.ones((1, 1))
       rngs = random.PRNGKey(0)
-      init_vars = Test(None).init(rngs, x)
-      _, new_vars = Test(None).apply(init_vars, x, mutable=['counter'])
+      init_vars = Test().init(rngs, x)
+      _, new_vars = Test().apply(init_vars, x, mutable=['counter'])
       self.assertEqual(init_vars['counter']['outer']['cntr']['foo'],
                       jnp.array([2], jnp.int32))
       self.assertEqual(new_vars['counter']['outer']['cntr']['foo'],
@@ -494,8 +494,8 @@ class TransformTest(absltest.TestCase):
 
     x = jnp.ones((3, 1, 2))
     rngs = random.PRNGKey(0)
-    init_vars = Test(None).init(rngs, x)
-    y = Test(None).apply(init_vars, x)
+    init_vars = Test().init(rngs, x)
+    y = Test().apply(init_vars, x)
     self.assertEqual(
         init_vars['params']['outer']['Dense_0']['kernel'].shape,
         (3, 2, 5))


### PR DESCRIPTION
This pull request accomplishes a few things:
- It ensures that type-checkers know about the name and parent parameters,
- it makes the name and parent parameters _keyword-only_ in Python 3.10 (which prevents accidentally setting them, or accepting too many positional arguments),
- it simplifies the code in Python 3.10, which will pay off when Flax will eventually ditch Python 3.9 (next April if NEP 29 is followed as JAX has been),
- it corrects the annotation for `Module.parent` (annotating with `X` means that parameter is an instance of `X`;  annotating with `Type[X]` means that the parameter is a subclass of `X`),  and
- it removes the `KW_ONLY` sentinel from module display.

The downside to this is that you can no longer set the name positionally. However this was practically never done, and is fraught with peril given the parameter reordering.

Fixes #1816 

## Checklist
- [x] This change is discussed in a Github issue/
      [discussion](https://github.com/google/flax/discussions) (please add a
      link).
- [x] The documentation and docstrings adhere to the
      [documentation guidelines](https://github.com/google/flax/blob/main/docs/README.md#how-to-write-code-documentation).
- [x] This change includes necessary high-coverage tests.
      (No quality testing = no merge!)
