### PR TITLE
improve jax pytree error messages with flax struct

### DIFF
--- a/flax/struct.py
+++ b/flax/struct.py
@@ -138,6 +138,11 @@ def dataclass(clz: _T) -> _T:
                                      iterate_clz,
                                      clz_from_iterable)
 
+  if tuple(map(int, jax.version.__version__.split('.'))) >= (0, 3, 1):
+    def keypaths(_):
+      return [jax.tree_util.AttributeKeyPathEntry(name) for name in data_fields]
+    jax.tree_util.register_keypaths(data_clz, keypaths)
+
   def to_state_dict(x):
     state_dict = {name: serialization.to_state_dict(getattr(x, name))
                   for name in data_fields}


### PR DESCRIPTION
This is a follow-up on JAX's google/jax#9493 to improve pjit error messages. It registers flax.struct with the optional "key paths for error messages" jax.tree_util API, introduced in google/jax#9372. (This change will also improve vmap, pmap, and other error messages, once the necessary improvements are made in JAX.)