### PR TITLE
Improves seq2seq example

### DIFF
--- a/examples/seq2seq/README.md
+++ b/examples/seq2seq/README.md
@@ -12,15 +12,15 @@ https://colab.research.google.com/github/google/flax/blob/main/examples/seq2seq/
 From Colab run that also generated [tfhub.dev]
 
 ```
-INFO:absl:[1900] accuracy=0.992188, loss=0.009365
-INFO:absl:DECODE: 48+57 = 105 (CORRECT)
-INFO:absl:DECODE: 13+59 = 72 (CORRECT)
-INFO:absl:DECODE: 83+948 = 1031 (CORRECT)
-INFO:absl:DECODE: 91+280 = 371 (CORRECT)
-INFO:absl:DECODE: 65+270 = 335 (CORRECT)
+INFO:absl:[1800] accuracy=1.0, loss=0.0020284138154238462
+INFO:absl:DECODE: 14+381 = 395 (CORRECT)
+INFO:absl:DECODE: 68+91 = 159 (CORRECT)
+INFO:absl:DECODE: 0+807 = 707 (INCORRECT) correct=807
+INFO:absl:DECODE: 95+532 = 627 (CORRECT)
+INFO:absl:DECODE: 6+600 = 606 (CORRECT)
 ```
 
-[tfhub.dev]: https://tensorboard.dev/experiment/h81jpOlgS5iBJv4MVdznRQ/#scalars&_smoothingWeight=0
+[tfhub.dev]: https://tensorboard.dev/experiment/TwvKVBqzTaKWgEbyebillw/#scalars&_smoothingWeight=0
 
 ### How to run
 

--- a/examples/seq2seq/input_pipeline.py
+++ b/examples/seq2seq/input_pipeline.py
@@ -14,17 +14,17 @@
 
 """Input pipeline for seq2seq addition example."""
 
-import numpy as np
 import random
 
 import jax
 import jax.numpy as jnp
+import numpy as np
 
 
-class CharacterTable(object):
-  """Encode/decodes between strings and integer representations."""
+class CharacterTable:
+  """Encodes/decodes between strings and integer representations."""
 
-  def __init__(self, chars, max_len_query_digit = 3):
+  def __init__(self, chars, max_len_query_digit=3):
     self._chars = sorted(set(chars))
     self._char_indices = dict(
         (ch, idx + 2) for idx, ch in enumerate(self._chars))
@@ -66,12 +66,12 @@ class CharacterTable(object):
     return (1, self.max_output_len, self.vocab_size)
 
   def encode(self, inputs):
-    """Encode from string to list of integers."""
+    """Encodes from string to list of integers."""
     return np.array(
         [self._char_indices[char] for char in inputs] + [self.eos_id])
 
   def decode(self, inputs):
-    """Decode from list of integers to string."""
+    """Decodes from list of integers to string."""
     chars = []
     for elem in inputs.tolist():
       if elem == self.eos_id:
@@ -80,7 +80,7 @@ class CharacterTable(object):
     return ''.join(chars)
 
   def encode_onehot(self, batch_inputs, max_len=None):
-    """One-hot encode a string input."""
+    """One-hot encodes a string input."""
 
     if max_len is None:
       max_len = self.max_input_len
@@ -96,12 +96,12 @@ class CharacterTable(object):
     return np.array([encode_str(inp) for inp in batch_inputs])
 
   def decode_onehot(self, batch_inputs):
-    """Decode a batch of one-hot encoding to strings."""
+    """Decodes a batch of one-hot encoding to strings."""
     decode_inputs = lambda inputs: self.decode(inputs.argmax(axis=-1))
     return np.array(list(map(decode_inputs, batch_inputs)))
 
   def generate_examples(self, num_examples):
-    """Returns @num_examples examples."""
+    """Yields `num_examples` examples."""
     for _ in range(num_examples):
       max_digit = pow(10, self._max_len_query_digit) - 1
       # TODO(marcvanzee): Use jax.random here.
@@ -121,7 +121,7 @@ class CharacterTable(object):
 
 
 def mask_sequences(sequence_batch, lengths):
-  """Set positions beyond the length of each sequence to 0."""
+  """Sets positions beyond the length of each sequence to 0."""
   return sequence_batch * (
       lengths[:, np.newaxis] > np.arange(sequence_batch.shape[1])[np.newaxis])
 

--- a/examples/seq2seq/input_pipeline.py
+++ b/examples/seq2seq/input_pipeline.py
@@ -1,0 +1,139 @@
+# Copyright 2022 The Flax Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Input pipeline for seq2seq addition example."""
+
+import numpy as np
+import random
+
+import jax
+import jax.numpy as jnp
+
+
+class CharacterTable(object):
+  """Encode/decodes between strings and integer representations."""
+
+  def __init__(self, chars, max_len_query_digit = 3):
+    self._chars = sorted(set(chars))
+    self._char_indices = dict(
+        (ch, idx + 2) for idx, ch in enumerate(self._chars))
+    self._indices_char = dict(
+        (idx + 2, ch) for idx, ch in enumerate(self._chars))
+    self._indices_char[self.pad_id] = '_'
+    # Maximum length of a single input digit
+    self._max_len_query_digit = max_len_query_digit
+
+  @property
+  def pad_id(self):
+    return 0
+
+  @property
+  def eos_id(self):
+    return 1
+
+  @property
+  def vocab_size(self):
+    return len(self._chars) + 2
+
+  @property
+  def max_input_len(self):
+    """Returns the max length of an input sequence."""
+    return self._max_len_query_digit * 2 + 2  # includes EOS
+
+  @property
+  def max_output_len(self):
+    """Returns the max length of an output sequence."""
+    return self._max_len_query_digit + 3  # includes start token '=' and EOS.
+
+  @property
+  def encoder_input_shape(self):
+    max_input_len = self._max_len_query_digit * 2 + 2  # includes EOS
+    return (1, max_input_len, self.vocab_size)
+
+  @property
+  def decoder_input_shape(self):
+    return (1, self.max_output_len, self.vocab_size)
+
+  def encode(self, inputs):
+    """Encode from string to list of integers."""
+    return np.array(
+        [self._char_indices[char] for char in inputs] + [self.eos_id])
+
+  def decode(self, inputs):
+    """Decode from list of integers to string."""
+    chars = []
+    for elem in inputs.tolist():
+      if elem == self.eos_id:
+        break
+      chars.append(self._indices_char[elem])
+    return ''.join(chars)
+
+  def encode_onehot(self, batch_inputs, max_len=None):
+    """One-hot encode a string input."""
+
+    if max_len is None:
+      max_len = self.max_input_len
+
+    def encode_str(s):
+      tokens = self.encode(s)
+      unpadded_len = len(tokens)
+      if unpadded_len > max_len:
+        raise ValueError(f'Sequence too long ({len(tokens)}>{max_len}): \'{s}\'')
+      tokens = np.pad(tokens, [(0, max_len-len(tokens))], mode='constant')
+      return jax.nn.one_hot(tokens, self.vocab_size, dtype=jnp.float32)
+
+    return np.array([encode_str(inp) for inp in batch_inputs])
+
+  def decode_onehot(self, batch_inputs):
+    """Decode a batch of one-hot encoding to strings."""
+    decode_inputs = lambda inputs: self.decode(inputs.argmax(axis=-1))
+    return np.array(list(map(decode_inputs, batch_inputs)))
+
+  def generate_examples(self, num_examples):
+    """Returns @num_examples examples."""
+    for _ in range(num_examples):
+      max_digit = pow(10, self._max_len_query_digit) - 1
+      # TODO(marcvanzee): Use jax.random here.
+      key = tuple(sorted((random.randint(0, 99), random.randint(0, max_digit))))
+      inputs = '{}+{}'.format(key[0], key[1])
+      # Preprend output by the decoder's start token.
+      outputs = '=' + str(key[0] + key[1])
+      yield (inputs, outputs)
+
+  def get_batch(self, batch_size):
+    """Returns a batch of example of size @batch_size."""
+    inputs, outputs = zip(*self.generate_examples(batch_size))
+    return {
+        'query': self.encode_onehot(inputs),
+        'answer': self.encode_onehot(outputs),
+    }
+
+
+def mask_sequences(sequence_batch, lengths):
+  """Set positions beyond the length of each sequence to 0."""
+  return sequence_batch * (
+      lengths[:, np.newaxis] > np.arange(sequence_batch.shape[1])[np.newaxis])
+
+
+def get_sequence_lengths(sequence_batch, eos_id):
+  """Returns the length of each one-hot sequence, including the EOS token."""
+  # sequence_batch.shape = (batch_size, seq_length, vocab_size)
+  eos_row = sequence_batch[:, :, eos_id]
+  eos_idx = jnp.argmax(eos_row, axis=-1)  # returns first occurrence
+  # `eos_idx` is 0 if EOS is not present, so we use full length in that case.
+  return jnp.where(
+      eos_row[jnp.arange(eos_row.shape[0]), eos_idx],
+      eos_idx + 1,
+      sequence_batch.shape[1]  # if there is no EOS, use full length
+  )

--- a/examples/seq2seq/models.py
+++ b/examples/seq2seq/models.py
@@ -56,7 +56,7 @@ class EncoderLSTM(nn.Module):
 
   @staticmethod
   def initialize_carry(batch_size, hidden_size):
-    # use dummy key since default state init fn is just zeros.
+    # Use a dummy key since the default state init fn is just zeros.
     return nn.LSTMCell.initialize_carry(
         jax.random.PRNGKey(0), (batch_size,), hidden_size)
 

--- a/examples/seq2seq/models.py
+++ b/examples/seq2seq/models.py
@@ -25,10 +25,6 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 
-PRNGKey = Any
-Shape = Tuple[int]
-Dtype = Any
-Array = Any
 
 class EncoderLSTM(nn.Module):
   eos_id: int
@@ -62,7 +58,7 @@ class EncoderLSTM(nn.Module):
 
 
 class Encoder(nn.Module):
-  """LSTM encoder, returning state after EOS is input."""
+  """LSTM encoder, returning state after finding the EOS token in the input."""
   hidden_size: int
   eos_id: int
 
@@ -136,7 +132,7 @@ class Seq2seq(nn.Module):
 
   @nn.compact
   def __call__(self, encoder_inputs, decoder_inputs):
-    """Run the seq2seq model.
+    """Runs the seq2seq model.
 
     Args:
       encoder_inputs: padded batch of input sequences to encode, shaped

--- a/examples/seq2seq/models.py
+++ b/examples/seq2seq/models.py
@@ -1,0 +1,163 @@
+# Copyright 2022 The Flax Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""seq2seq example: Mode code."""
+
+# See issue #620.
+# pytype: disable=wrong-keyword-args
+
+import functools
+from typing import Any, Tuple
+
+from flax import linen as nn
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+PRNGKey = Any
+Shape = Tuple[int]
+Dtype = Any
+Array = Any
+
+class EncoderLSTM(nn.Module):
+  eos_id: int
+
+  @functools.partial(
+      nn.scan,
+      variable_broadcast='params',
+      in_axes=1,
+      out_axes=1,
+      split_rngs={'params': False})
+  @nn.compact
+  def __call__(self, carry, x):
+    lstm_state, is_eos = carry
+    new_lstm_state, y = nn.LSTMCell()(lstm_state, x)
+    # Pass forward the previous state if EOS has already been reached.
+    def select_carried_state(new_state, old_state):
+      return jnp.where(is_eos[:, np.newaxis], old_state, new_state)
+    # LSTM state is a tuple (c, h).
+    carried_lstm_state = tuple(
+        select_carried_state(*s) for s in zip(new_lstm_state, lstm_state))
+    # Update `is_eos`.
+    is_eos = jnp.logical_or(is_eos, x[:, self.eos_id])
+    return (carried_lstm_state, is_eos), y
+
+
+  @staticmethod
+  def initialize_carry(batch_size, hidden_size):
+    # use dummy key since default state init fn is just zeros.
+    return nn.LSTMCell.initialize_carry(
+        jax.random.PRNGKey(0), (batch_size,), hidden_size)
+
+
+class Encoder(nn.Module):
+  """LSTM encoder, returning state after EOS is input."""
+  hidden_size: int
+  eos_id: int
+
+  @nn.compact
+  def __call__(self, inputs):
+    # inputs.shape = (batch_size, seq_length, vocab_size).
+    batch_size = inputs.shape[0]
+    lstm = EncoderLSTM(name='encoder_lstm', eos_id=self.eos_id)
+    init_lstm_state = lstm.initialize_carry(batch_size, self.hidden_size)
+    init_is_eos = jnp.zeros(batch_size, dtype=bool)
+    init_carry = (init_lstm_state, init_is_eos)
+    (final_state, _), _ = lstm(init_carry, inputs)
+    return final_state
+
+
+class DecoderLSTM(nn.Module):
+  teacher_force: bool
+  vocab_size: int
+
+  @functools.partial(
+      nn.scan,
+      variable_broadcast='params',
+      in_axes=1,
+      out_axes=1,
+      split_rngs={'params': False})
+  @nn.compact
+  def __call__(self, carry, x):
+    rng, lstm_state, last_prediction = carry
+    carry_rng, categorical_rng = jax.random.split(rng, 2)
+    if not self.teacher_force:
+      x = last_prediction
+    lstm_state, y = nn.LSTMCell()(lstm_state, x)
+    logits = nn.Dense(features=self.vocab_size)(y)
+    predicted_token = jax.random.categorical(categorical_rng, logits)
+    prediction = jax.nn.one_hot(
+        predicted_token, self.vocab_size, dtype=jnp.float32)
+
+    return (carry_rng, lstm_state, prediction), (logits, prediction)
+
+
+class Decoder(nn.Module):
+  """LSTM decoder."""
+  init_state: Tuple[Any]
+  teacher_force: bool
+  vocab_size: int
+
+  @nn.compact
+  def __call__(self, inputs):
+    # inputs.shape = (seq_length, vocab_size).
+    lstm = DecoderLSTM(teacher_force=self.teacher_force,
+                       vocab_size=self.vocab_size)
+    init_carry = (self.make_rng('lstm'), self.init_state, inputs[:, 0])
+    _, (logits, predictions) = lstm(init_carry, inputs)
+    return logits, predictions
+
+
+class Seq2seq(nn.Module):
+  """Sequence-to-sequence class using encoder/decoder architecture.
+
+  Attributes:
+    teacher_force: bool, whether to use `decoder_inputs` as input to the
+        decoder at every step. If False, only the first input is used, followed
+        by samples taken from the previous output logits.
+    hidden_size: int, the number of hidden dimensions in the encoder and
+      decoder LSTMs.
+  """
+  teacher_force: bool
+  hidden_size: int
+  vocab_size: int
+  eos_id: int = 1
+
+  @nn.compact
+  def __call__(self, encoder_inputs, decoder_inputs):
+    """Run the seq2seq model.
+
+    Args:
+      encoder_inputs: padded batch of input sequences to encode, shaped
+        `[batch_size, max(encoder_input_lengths), vocab_size]`.
+      decoder_inputs: padded batch of expected decoded sequences for teacher
+        forcing, shaped `[batch_size, max(decoder_inputs_length), vocab_size]`.
+        When sampling (i.e., `teacher_force = False`), the initial time step is
+        forced into the model and samples are used for the following inputs. The
+        second dimension of this tensor determines how many steps will be
+        decoded, regardless of the value of `teacher_force`.
+
+    Returns:
+      Array of decoded logits.
+    """
+    # Encode inputs.
+    init_decoder_state = Encoder(
+        hidden_size=self.hidden_size, eos_id=self.eos_id)(encoder_inputs)
+    # Decode outputs.
+    logits, predictions = Decoder(
+        init_state=init_decoder_state, 
+        teacher_force=self.teacher_force,
+        vocab_size=self.vocab_size)(decoder_inputs[:, :-1])
+
+    return logits, predictions

--- a/examples/seq2seq/train.py
+++ b/examples/seq2seq/train.py
@@ -18,8 +18,7 @@
 # pytype: disable=wrong-keyword-args
 
 import functools
-import random
-from typing import Any, Tuple
+from typing import Any
 
 from absl import app
 from absl import flags
@@ -29,8 +28,12 @@ from flax import linen as nn
 from flax.training import train_state
 import jax
 import jax.numpy as jnp
-import numpy as np
 import optax
+
+from input_pipeline import mask_sequences, get_sequence_lengths
+from input_pipeline import CharacterTable as CTable
+
+import models
 
 
 FLAGS = flags.FLAGS
@@ -61,259 +64,31 @@ flags.DEFINE_integer(
     default=3,
     help=('Maximum length of a single input digit.'))
 
-PRNGKey = Any
-Shape = Tuple[int]
-Dtype = Any
-Array = Any
+
+def get_model(ctable, *, teacher_force: bool = False):
+  return models.Seq2seq(teacher_force=teacher_force,
+                        hidden_size=FLAGS.hidden_size, eos_id=ctable.eos_id,
+                        vocab_size=ctable.vocab_size)
 
 
-class CharacterTable(object):
-  """Encode/decodes between strings and integer representations."""
-
-  @property
-  def pad_id(self):
-    return 0
-
-  @property
-  def eos_id(self):
-    return 1
-
-  @property
-  def vocab_size(self):
-    return len(self._chars) + 2
-
-  def __init__(self, chars):
-    self._chars = sorted(set(chars))
-    self._char_indices = dict(
-        (ch, idx + 2) for idx, ch in enumerate(self._chars))
-    self._indices_char = dict(
-        (idx + 2, ch) for idx, ch in enumerate(self._chars))
-    self._indices_char[self.pad_id] = '_'
-
-  def encode(self, inputs):
-    """Encode from string to list of integers."""
-    return np.array(
-        [self._char_indices[char] for char in inputs] + [self.eos_id])
-
-  def decode(self, inputs):
-    """Decode from list of integers to string."""
-    chars = []
-    for elem in inputs.tolist():
-      if elem == self.eos_id:
-        break
-      chars.append(self._indices_char[elem])
-    return ''.join(chars)
-
-
-# We use a global CharacterTable so we don't have pass it around everywhere.
-CTABLE = CharacterTable('0123456789+= ')
-
-
-def get_max_input_len():
-  """Returns the max length of an input sequence."""
-  return FLAGS.max_len_query_digit * 2 + 2  # includes EOS
-
-
-def get_max_output_len():
-  """Returns the max length of an output sequence."""
-  return FLAGS.max_len_query_digit + 3  # includes start token '=' and EOS.
-
-
-def encode_onehot(batch_inputs, max_len=None):
-  """One-hot encode a string input."""
-
-  if max_len is None:
-    max_len = get_max_input_len()
-
-  def encode_str(s):
-    tokens = CTABLE.encode(s)
-    unpadded_len = len(tokens)
-    if unpadded_len > max_len:
-      raise ValueError(f'Sequence too long ({len(tokens)}>{max_len}): \'{s}\'')
-    tokens = np.pad(tokens, [(0, max_len-len(tokens))], mode='constant')
-    return jax.nn.one_hot(tokens, CTABLE.vocab_size, dtype=jnp.float32)
-
-  return np.array([encode_str(inp) for inp in batch_inputs])
-
-
-def decode_onehot(batch_inputs):
-  """Decode a batch of one-hot encoding to strings."""
-  decode_inputs = lambda inputs: CTABLE.decode(inputs.argmax(axis=-1))
-  return np.array(list(map(decode_inputs, batch_inputs)))
-
-
-def get_sequence_lengths(sequence_batch, eos_id=CTABLE.eos_id):
-  """Returns the length of each one-hot sequence, including the EOS token."""
-  # sequence_batch.shape = (batch_size, seq_length, vocab_size)
-  eos_row = sequence_batch[:, :, eos_id]
-  eos_idx = jnp.argmax(eos_row, axis=-1)  # returns first occurrence
-  # `eos_idx` is 0 if EOS is not present, so we use full length in that case.
-  return jnp.where(
-      eos_row[jnp.arange(eos_row.shape[0]), eos_idx],
-      eos_idx + 1,
-      sequence_batch.shape[1]  # if there is no EOS, use full length
+def get_initial_params(model, rng, ctable):
+  """Get the initial parameters of a seq2seq model."""
+  rng1, rng2 = jax.random.split(rng)
+  variables = model.init(
+      {'params': rng1, 'lstm': rng2},
+      jnp.ones(ctable.encoder_input_shape, jnp.float32),
+      jnp.ones(ctable.decoder_input_shape, jnp.float32)
   )
+  return variables['params']
 
 
-def mask_sequences(sequence_batch, lengths):
-  """Set positions beyond the length of each sequence to 0."""
-  return sequence_batch * (
-      lengths[:, np.newaxis] > np.arange(sequence_batch.shape[1])[np.newaxis])
-
-
-class EncoderLSTM(nn.Module):
-
-  @functools.partial(
-      nn.scan,
-      variable_broadcast='params',
-      in_axes=1,
-      out_axes=1,
-      split_rngs={'params': False})
-  @nn.compact
-  def __call__(self, carry, x):
-    lstm_state, is_eos = carry
-    new_lstm_state, y = nn.LSTMCell()(lstm_state, x)
-    # Pass forward the previous state if EOS has already been reached.
-    def select_carried_state(new_state, old_state):
-      return jnp.where(is_eos[:, np.newaxis], old_state, new_state)
-    # LSTM state is a tuple (c, h).
-    carried_lstm_state = tuple(
-        select_carried_state(*s) for s in zip(new_lstm_state, lstm_state))
-    # Update `is_eos`.
-    is_eos = jnp.logical_or(is_eos, x[:, CTABLE.eos_id])
-    return (carried_lstm_state, is_eos), y
-
-
-  @staticmethod
-  def initialize_carry(batch_size, hidden_size):
-    # use dummy key since default state init fn is just zeros.
-    return nn.LSTMCell.initialize_carry(
-        jax.random.PRNGKey(0), (batch_size,), hidden_size)
-
-
-class Encoder(nn.Module):
-  """LSTM encoder, returning state after EOS is input."""
-  hidden_size: int
-
-  @nn.compact
-  def __call__(self, inputs):
-    # inputs.shape = (batch_size, seq_length, vocab_size).
-    batch_size = inputs.shape[0]
-    lstm = EncoderLSTM(name='encoder_lstm')
-    init_lstm_state = lstm.initialize_carry(batch_size, self.hidden_size)
-    init_is_eos = jnp.zeros(batch_size, dtype=bool)
-    init_carry = (init_lstm_state, init_is_eos)
-    (final_state, _), _ = lstm(init_carry, inputs)
-    return final_state
-
-
-class DecoderLSTM(nn.Module):
-  teacher_force: bool
-
-  @functools.partial(
-      nn.scan,
-      variable_broadcast='params',
-      in_axes=1,
-      out_axes=1,
-      split_rngs={'params': False})
-  @nn.compact
-  def __call__(self, carry, x):
-    rng, lstm_state, last_prediction = carry
-    carry_rng, categorical_rng = jax.random.split(rng, 2)
-    if not self.teacher_force:
-      x = last_prediction
-    lstm_state, y = nn.LSTMCell()(lstm_state, x)
-    logits = nn.Dense(features=CTABLE.vocab_size)(y)
-    predicted_token = jax.random.categorical(categorical_rng, logits)
-    prediction = jax.nn.one_hot(
-        predicted_token, CTABLE.vocab_size, dtype=jnp.float32)
-
-    return (carry_rng, lstm_state, prediction), (logits, prediction)
-
-
-class Decoder(nn.Module):
-  """LSTM decoder."""
-  init_state: Tuple[Any]
-  teacher_force: bool
-
-  @nn.compact
-  def __call__(self, inputs):
-    # inputs.shape = (seq_length, vocab_size).
-    lstm = DecoderLSTM(teacher_force=self.teacher_force)
-    init_carry = (self.make_rng('lstm'), self.init_state, inputs[:, 0])
-    _, (logits, predictions) = lstm(init_carry, inputs)
-    return logits, predictions
-
-
-class Seq2seq(nn.Module):
-  """Sequence-to-sequence class using encoder/decoder architecture.
-
-  Attributes:
-    teacher_force: bool, whether to use `decoder_inputs` as input to the
-        decoder at every step. If False, only the first input is used, followed
-        by samples taken from the previous output logits.
-    hidden_size: int, the number of hidden dimensions in the encoder and
-      decoder LSTMs.
-  """
-  teacher_force: bool
-  hidden_size: int
-
-  @nn.compact
-  def __call__(self, encoder_inputs, decoder_inputs):
-    """Run the seq2seq model.
-
-    Args:
-      encoder_inputs: padded batch of input sequences to encode, shaped
-        `[batch_size, max(encoder_input_lengths), vocab_size]`.
-      decoder_inputs: padded batch of expected decoded sequences for teacher
-        forcing, shaped `[batch_size, max(decoder_inputs_length), vocab_size]`.
-        When sampling (i.e., `teacher_force = False`), the initial time step is
-        forced into the model and samples are used for the following inputs. The
-        second dimension of this tensor determines how many steps will be
-        decoded, regardless of the value of `teacher_force`.
-
-    Returns:
-      Array of decoded logits.
-    """
-    # Encode inputs.
-    init_decoder_state = Encoder(hidden_size=self.hidden_size)(encoder_inputs)
-    # Decode outputs.
-    logits, predictions = Decoder(
-        init_state=init_decoder_state, teacher_force=self.teacher_force)(
-            decoder_inputs[:, :-1])
-
-    return logits, predictions
-
-
-def get_initial_params(model, key):
-  """Creates a seq2seq model."""
-  vocab_size = CTABLE.vocab_size
-  encoder_shape = jnp.ones((1, get_max_input_len(), vocab_size), jnp.float32)
-  decoder_shape = jnp.ones((1, get_max_output_len(), vocab_size), jnp.float32)
-  return model.init({
-      'params': key,
-      'lstm': key
-  }, encoder_shape, decoder_shape)['params']
-
-
-def get_examples(num_examples):
-  """Returns @num_examples examples."""
-  for _ in range(num_examples):
-    max_digit = pow(10, FLAGS.max_len_query_digit) - 1
-    key = tuple(sorted((random.randint(0, 99), random.randint(0, max_digit))))
-    inputs = '{}+{}'.format(key[0], key[1])
-    # Preprend output by the decoder's start token.
-    outputs = '=' + str(key[0] + key[1])
-    yield (inputs, outputs)
-
-
-def get_batch(batch_size):
-  """Returns a batch of example of size @batch_size."""
-  inputs, outputs = zip(*get_examples(batch_size))
-  return {
-      'query': encode_onehot(inputs),
-      'answer': encode_onehot(outputs),
-  }
+def get_train_state(rng, ctable):
+  model = get_model(ctable)
+  params = get_initial_params(model, rng, ctable)
+  tx = optax.adam(FLAGS.learning_rate)
+  state = train_state.TrainState.create(
+      apply_fn=model.apply, params=params, tx=tx)
+  return state
 
 
 def cross_entropy_loss(logits, labels, lengths):
@@ -323,9 +98,9 @@ def cross_entropy_loss(logits, labels, lengths):
   return -masked_xe
 
 
-def compute_metrics(logits, labels):
+def compute_metrics(logits, labels, eos_id):
   """Computes metrics and returns them."""
-  lengths = get_sequence_lengths(labels)
+  lengths = get_sequence_lengths(labels, eos_id)
   loss = cross_entropy_loss(logits, labels, lengths)
   # Computes sequence accuracy, which is the same as the accuracy during
   # inference, since teacher forcing is irrelevant when all output are correct.
@@ -342,22 +117,24 @@ def compute_metrics(logits, labels):
 
 
 @jax.jit
-def train_step(state, batch, lstm_key):
+def train_step(state, batch, lstm_rng, eos_id):
   """Train one step."""
   labels = batch['answer'][:, 1:]
+  lstm_key = jax.random.fold_in(lstm_rng, state.step)
 
   def loss_fn(params):
     logits, _ = state.apply_fn({'params': params},
                                batch['query'],
                                batch['answer'],
                                rngs={'lstm': lstm_key})
-    loss = cross_entropy_loss(logits, labels, get_sequence_lengths(labels))
+    loss = cross_entropy_loss(
+        logits, labels, get_sequence_lengths(labels, eos_id))
     return loss, logits
 
   grad_fn = jax.value_and_grad(loss_fn, has_aux=True)
   (_, logits), grads = grad_fn(state.params)
   state = state.apply_gradients(grads=grads)
-  metrics = compute_metrics(logits, labels)
+  metrics = compute_metrics(logits, labels, eos_id)
 
   return state, metrics
 
@@ -369,61 +146,56 @@ def log_decode(question, inferred, golden):
   logging.info('DECODE: %s = %s %s', question, inferred, suffix)
 
 
-@jax.jit
-def decode(params, inputs, key):
+@functools.partial(jax.jit, static_argnums=3)
+def decode(params, inputs, decode_rng, ctable):
   """Decode inputs."""
   init_decoder_input = jax.nn.one_hot(
-      CTABLE.encode('=')[0:1], CTABLE.vocab_size, dtype=jnp.float32)
+      ctable.encode('=')[0:1], ctable.vocab_size, dtype=jnp.float32)
   init_decoder_inputs = jnp.tile(init_decoder_input,
-                                 (inputs.shape[0], get_max_output_len(), 1))
-  model = Seq2seq(teacher_force=False, hidden_size=FLAGS.hidden_size)
+                                 (inputs.shape[0], ctable.max_output_len, 1))
+  model = get_model(ctable, teacher_force=False)
   _, predictions = model.apply({'params': params},
                                inputs,
                                init_decoder_inputs,
-                               rngs={'lstm': key})
+                               rngs={'lstm': decode_rng})
   return predictions
 
 
-def decode_batch(params, batch, key):
+def decode_batch(state, batch, decode_rng, ctable):
   """Decode and log results for a batch."""
   inputs, outputs = batch['query'], batch['answer'][:, 1:]
-  inferred = decode(params, inputs, key)
-  questions = decode_onehot(inputs)
-  infers = decode_onehot(inferred)
-  goldens = decode_onehot(outputs)
+  decode_rng = jax.random.fold_in(decode_rng, state.step)
+  inferred = decode(state.params, inputs, decode_rng, ctable)
+  questions = ctable.decode_onehot(inputs)
+  infers = ctable.decode_onehot(inferred)
+  goldens = ctable.decode_onehot(outputs)
 
   for question, inferred, golden in zip(questions, infers, goldens):
     log_decode(question, inferred, golden)
 
 
-def train_model(workdir):
+def train_and_evaluate(workdir):
   """Train for a fixed number of steps and decode during training."""
 
-  key = jax.random.PRNGKey(0)
-
-  key, init_key = jax.random.split(key)
-  model = Seq2seq(teacher_force=False, hidden_size=FLAGS.hidden_size)
-  params = get_initial_params(model, init_key)
-  tx = optax.adam(FLAGS.learning_rate)
-  state = train_state.TrainState.create(
-      apply_fn=model.apply, params=params, tx=tx)
+  # TODO(marcvanzee): Integrate ctable with train_state.
+  ctable = CTable('0123456789+= ', FLAGS.max_len_query_digit)
+  rng = jax.random.PRNGKey(0)
+  state = get_train_state(rng, ctable)
 
   writer = metric_writers.create_default_writer(workdir)
   for step in range(FLAGS.num_train_steps):
-    key, lstm_key = jax.random.split(key)
-    batch = get_batch(FLAGS.batch_size)
-    state, metrics = train_step(state, batch, lstm_key)
-    if step % FLAGS.decode_frequency == 0:
+    batch = ctable.get_batch(FLAGS.batch_size)
+    state, metrics = train_step(state, batch, rng, ctable.eos_id)
+    if step and step % FLAGS.decode_frequency == 0:
       writer.write_scalars(step, metrics)
-      key, lstm_key = jax.random.split(key)
-      batch = get_batch(5)
-      decode_batch(state.params, batch, lstm_key)
+      batch = ctable.get_batch(5)
+      decode_batch(state, batch, rng, ctable)
 
   return state
 
 
 def main(_):
-  _ = train_model(FLAGS.workdir)
+  _ = train_and_evaluate(FLAGS.workdir)
 
 
 if __name__ == '__main__':

--- a/examples/seq2seq/train_test.py
+++ b/examples/seq2seq/train_test.py
@@ -24,32 +24,40 @@ from jax import random
 import numpy as np
 import optax
 
+import input_pipeline
 import train
+import models
 
 jax.config.parse_flags_with_absl()
 
+def create_ctable(chars = '0123456789+= '):
+  return input_pipeline.CharacterTable(chars)
 
-def create_test_state():
-  model = train.Seq2seq(teacher_force=False, hidden_size=train.FLAGS.hidden_size)
-  params = train.get_initial_params(model, jax.random.PRNGKey(0))
+
+def create_train_state(ctable):
+  model = models.Seq2seq(teacher_force=False, 
+      hidden_size=train.FLAGS.hidden_size, vocab_size=ctable.vocab_size)
+  params = train.get_initial_params(model, jax.random.PRNGKey(0), ctable)
   tx = optax.adam(train.FLAGS.learning_rate)
-  return train_state.TrainState.create(
+  state = train_state.TrainState.create(
       apply_fn=model.apply, params=params, tx=tx)
+  return state
 
 
 class TrainTest(absltest.TestCase):
 
   def test_character_table(self):
+    ctable = create_ctable()
     text = '410+19'
-    enc_text = train.CTABLE.encode(text)
-    dec_text = train.CTABLE.decode(enc_text)
+    enc_text = ctable.encode(text)
+    dec_text = ctable.decode(enc_text)
     # The text is possibly padded with whitespace, but the trimmed output should
     # be equal to the input.
     self.assertEqual(text, dec_text.strip())
 
   def test_mask_sequences(self):
     np.testing.assert_equal(
-        train.mask_sequences(
+        input_pipeline.mask_sequences(
             np.arange(1, 13).reshape((4, 3)),
             np.array([3, 2, 1, 0])
         ),
@@ -66,33 +74,35 @@ class TrainTest(absltest.TestCase):
         functools.partial(jax.nn.one_hot, num_classes=4))(
             np.array([[0, 1, 0], [1, 0, 2], [1, 2, 0], [1, 2, 3]]))
     np.testing.assert_equal(
-        train.get_sequence_lengths(oh_sequence_batch, eos_id=0),
+        input_pipeline.get_sequence_lengths(oh_sequence_batch, eos_id=0),
         np.array([1, 2, 3, 3], np.int32)
     )
     np.testing.assert_equal(
-        train.get_sequence_lengths(oh_sequence_batch, eos_id=1),
+        input_pipeline.get_sequence_lengths(oh_sequence_batch, eos_id=1),
         np.array([2, 1, 1, 1], np.int32)
     )
     np.testing.assert_equal(
-        train.get_sequence_lengths(oh_sequence_batch, eos_id=2),
+        input_pipeline.get_sequence_lengths(oh_sequence_batch, eos_id=2),
         np.array([3, 3, 2, 2], np.int32)
     )
 
   def test_train_one_step(self):
-    batch = train.get_batch(128)
+    ctable = create_ctable()
+    batch = ctable.get_batch(128)
 
-    state = create_test_state()
+    state = create_train_state(ctable)
     key = random.PRNGKey(0)
-    _, train_metrics = train.train_step(state, batch, key)
+    _, train_metrics = train.train_step(state, batch, key, ctable.eos_id)
 
     self.assertLessEqual(train_metrics['loss'], 5)
     self.assertGreaterEqual(train_metrics['accuracy'], 0)
 
   def test_decode_batch(self):
+    ctable = create_ctable()
+    batch = ctable.get_batch(5)
     key = random.PRNGKey(0)
-    state = create_test_state()
-    batch = train.get_batch(5)
-    train.decode_batch(state.params, batch, key)
+    state = create_train_state(ctable)
+    train.decode_batch(state, batch, key, ctable)
 
 if __name__ == '__main__':
   absltest.main()


### PR DESCRIPTION
Makes the following improvements:

- Factors out model and input pipeline code into separate files. Before it was a single file, but it was actually too much code so it made it hard to navigate around
- Splits rngs inside jitted function
- No longer use a global CharacterTable, but pass around a local one instead.
- Fixes tests with new setup

Further follow-up improvements:

- Update Colab
- Put relevant stuff of CharacterTable inside a train_state so we only have to pass around that (and it can also be passed to jitted functions)
- Add type annotations everywhere