### PR TITLE
Set field on dataclass transform decorator

### DIFF
--- a/flax/linen/module.py
+++ b/flax/linen/module.py
@@ -30,6 +30,7 @@ from typing import (Any, Callable, Sequence, Iterable, List, Optional, Tuple,
 import jax
 from jax import tree_util
 from jax._src.numpy.lax_numpy import isin
+from typing_extensions import dataclass_transform
 import numpy as np
 
 import flax
@@ -42,7 +43,6 @@ from flax import core
 from flax.core import Scope
 from flax.core.scope import CollectionFilter, DenyList, Variable, VariableDict, FrozenVariableDict, union_filters
 from flax.core.frozen_dict import FrozenDict, freeze
-from flax.struct import __dataclass_transform__
 
 # from .dotgetter import DotGetter
 traceback_util.register_exclusion(__file__)
@@ -458,17 +458,8 @@ capture_call_intermediates = lambda _, method_name: method_name == '__call__'
 # -----------------------------------------------------------------------------
 
 
-# This metaclass + decorator is used by static analysis tools recognize that
-# Module behaves as a dataclass (attributes are constructor args).
-if typing.TYPE_CHECKING:
-  @__dataclass_transform__()
-  class ModuleMeta(type):
-    pass
-else:
-  ModuleMeta = type
-
-
-class Module(metaclass=ModuleMeta):
+@dataclass_transform()
+class Module:
   """Base class for all neural network modules. Layers and models should subclass this class.
 
   All Flax Modules are Python 3.7

--- a/flax/linen/module.py
+++ b/flax/linen/module.py
@@ -30,7 +30,7 @@ from typing import (Any, Callable, Sequence, Iterable, List, Optional, Tuple,
 import jax
 from jax import tree_util
 from jax._src.numpy.lax_numpy import isin
-from typing_extensions import dataclass_transform
+from typing_extensions import dataclass_transform  # pytype: disable=import-error
 import numpy as np
 
 import flax

--- a/flax/struct.py
+++ b/flax/struct.py
@@ -43,7 +43,11 @@ def __dataclass_transform__(
   return lambda a: a
 
 
-@__dataclass_transform__()
+def field(pytree_node=True, **kwargs):
+  return dataclasses.field(metadata={'pytree_node': pytree_node}, **kwargs)
+
+
+@__dataclass_transform__(field_descriptors=(field,))
 def dataclass(clz: _T) -> _T:
   """Create a class which can be passed to functional transformations.
 
@@ -166,22 +170,11 @@ def dataclass(clz: _T) -> _T:
   return data_clz
 
 
-def field(pytree_node=True, **kwargs):
-  return dataclasses.field(metadata={'pytree_node': pytree_node}, **kwargs)
-
-
 TNode = TypeVar('TNode', bound='PyTreeNode')
 
 
-if typing.TYPE_CHECKING:
-  @__dataclass_transform__()
-  class PyTreeNodeMeta(type):
-    pass
-else:
-  PyTreeNodeMeta = type
-
-
-class PyTreeNode(metaclass=PyTreeNodeMeta):
+@__dataclass_transform__(field_descriptors=(field,))
+class PyTreeNode:
   """Base class for dataclasses that should act like a JAX pytree node.
 
   See ``flax.struct.dataclass`` for the ``jax.tree_util`` behavior.

--- a/flax/struct.py
+++ b/flax/struct.py
@@ -22,7 +22,7 @@ from typing import TypeVar, Callable, Tuple, Union, Any
 from . import serialization
 
 import jax
-from typing_extensions import dataclass_transform
+from typing_extensions import dataclass_transform  # pytype: disable=import-error
 
 
 _T = TypeVar("_T")

--- a/flax/struct.py
+++ b/flax/struct.py
@@ -15,39 +15,24 @@
 """Utilities for defining custom classes that can be used with jax transformations.
 """
 
+import dataclasses
 import typing
 from typing import TypeVar, Callable, Tuple, Union, Any
 
 from . import serialization
 
-import dataclasses
-
 import jax
+from typing_extensions import dataclass_transform
 
 
-
-# This decorator is interpreted by static analysis tools as a hint
-# that a decorator or metaclass causes dataclass-like behavior.
-# See https://github.com/microsoft/pyright/blob/main/specs/dataclass_transforms.md
-# for more information about the __dataclass_transform__ magic.
 _T = TypeVar("_T")
-def __dataclass_transform__(
-    *,
-    eq_default: bool = True,
-    order_default: bool = False,
-    kw_only_default: bool = False,
-    field_descriptors: Tuple[Union[type, Callable[..., Any]], ...] = (()),
-) -> Callable[[_T], _T]:
-  # If used within a stub file, the following implementation can be
-  # replaced with "...".
-  return lambda a: a
 
 
 def field(pytree_node=True, **kwargs):
   return dataclasses.field(metadata={'pytree_node': pytree_node}, **kwargs)
 
 
-@__dataclass_transform__(field_descriptors=(field,))
+@dataclass_transform(field_descriptors=(field,))
 def dataclass(clz: _T) -> _T:
   """Create a class which can be passed to functional transformations.
 
@@ -173,7 +158,7 @@ def dataclass(clz: _T) -> _T:
 TNode = TypeVar('TNode', bound='PyTreeNode')
 
 
-@__dataclass_transform__(field_descriptors=(field,))
+@dataclass_transform(field_descriptors=(field,))
 class PyTreeNode:
   """Base class for dataclasses that should act like a JAX pytree node.
 

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ install_requires = [
     "matplotlib",  # only needed for tensorboard export
     "msgpack",
     "optax",
+    "typing_extensions>=4.1.0",
 ]
 
 tests_require = [

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ install_requires = [
     "matplotlib",  # only needed for tensorboard export
     "msgpack",
     "optax",
-    "typing_extensions>=4.1.0",
+    "typing_extensions>=4.1.1",
 ]
 
 tests_require = [


### PR DESCRIPTION
# What does this PR do?

- Set field on dataclass transform decorator so that type checkers know about the field descriptor.
- Use the dataclass transform on the class rather than the metaclass.
- Use `typing_extensions.dataclass_transform`

Fixes # (issue)

## Checklist
- [x] This PR fixes a minor issue (e.g.: typo or small bug) or improves the docs (you can dismiss the other
      checks if that's the case).