### PR TITLE
Speed up seq2seq example input pipeline

### DIFF
--- a/examples/seq2seq/input_pipeline.py
+++ b/examples/seq2seq/input_pipeline.py
@@ -79,6 +79,11 @@ class CharacterTable:
       chars.append(self._indices_char[elem])
     return ''.join(chars)
 
+  def one_hot(self, tokens):
+    vecs = np.zeros((tokens.size, self.vocab_size), dtype=np.float32)
+    vecs[np.arange(tokens.size), tokens] = 1
+    return vecs
+
   def encode_onehot(self, batch_inputs, max_len=None):
     """One-hot encodes a string input."""
 
@@ -91,7 +96,7 @@ class CharacterTable:
       if unpadded_len > max_len:
         raise ValueError(f'Sequence too long ({len(tokens)}>{max_len}): \'{s}\'')
       tokens = np.pad(tokens, [(0, max_len-len(tokens))], mode='constant')
-      return jax.nn.one_hot(tokens, self.vocab_size, dtype=jnp.float32)
+      return self.one_hot(tokens)
 
     return np.array([encode_str(inp) for inp in batch_inputs])
 

--- a/examples/seq2seq/train.py
+++ b/examples/seq2seq/train.py
@@ -150,8 +150,7 @@ def log_decode(question, inferred, golden):
 @functools.partial(jax.jit, static_argnums=3)
 def decode(params, inputs, decode_rng, ctable):
   """Decodes inputs."""
-  init_decoder_input = jax.nn.one_hot(
-      ctable.encode('=')[0:1], ctable.vocab_size, dtype=jnp.float32)
+  init_decoder_input = ctable.one_hot(ctable.encode('=')[0:1])
   init_decoder_inputs = jnp.tile(init_decoder_input,
                                  (inputs.shape[0], ctable.max_output_len, 1))
   model = get_model(ctable, teacher_force=False)


### PR DESCRIPTION
# What does this PR do?
Speeds up data loading in seq2seq example by replacing instances of `jax.nn.one_hot` with the same function but written in vanilla numpy. This change avoids the unnecessary (and expensive!) transfer of each example in the batch to the accelerator in the input pipeline, and there is significant performance improvements in training time/accelerator utilization as a result.

**Motivation**: this example was used in one of our research projects and we found that the accelerator utilization was unreasonably low (basically zero) due to the input pipeline blocking the GPU. We would like to prevent other users from facing similar issues in the future if they choose to use/adapt this example for their own work.

### Before change
```
(base) ubuntu@ip-172-31-11-216:~/flax/examples/seq2seq$ time python train.py --num_train_steps=1000
I0225 09:19:12.254682 139665494882112 xla_bridge.py:248] Unable to initialize backend 'tpu_driver': NOT_FOUND: Unable to find driver in registry given worker:
I0225 09:19:12.431070 139665494882112 xla_bridge.py:248] Unable to initialize backend 'tpu': INVALID_ARGUMENT: TpuPlatform is not available.
I0225 09:20:39.256777 139640199628544 logging_writer.py:35] [200] accuracy=0.0703125, loss=0.526000440120697
I0225 09:20:41.214107 139665494882112 train.py:147] DECODE: 19+790 = 808 (INCORRECT) correct=809
I0225 09:20:41.214305 139665494882112 train.py:147] DECODE: 98+663 = 745 (INCORRECT) correct=761
I0225 09:20:41.214401 139665494882112 train.py:147] DECODE: 9+909 = 920 (INCORRECT) correct=918
I0225 09:20:41.214486 139665494882112 train.py:147] DECODE: 92+860 = 932 (INCORRECT) correct=952
I0225 09:20:41.214556 139665494882112 train.py:147] DECODE: 8+82 = 93 (INCORRECT) correct=90
I0225 09:21:55.448876 139640199628544 logging_writer.py:35] [400] accuracy=0.078125, loss=0.43180277943611145
I0225 09:21:55.467354 139665494882112 train.py:147] DECODE: 10+390 = 417 (INCORRECT) correct=400
I0225 09:21:55.467529 139665494882112 train.py:147] DECODE: 78+791 = 878 (INCORRECT) correct=869
I0225 09:21:55.467669 139665494882112 train.py:147] DECODE: 77+483 = 551 (INCORRECT) correct=560
I0225 09:21:55.467794 139665494882112 train.py:147] DECODE: 54+313 = 364 (INCORRECT) correct=367
I0225 09:21:55.467914 139665494882112 train.py:147] DECODE: 38+166 = 201 (INCORRECT) correct=204
I0225 09:23:10.322728 139640199628544 logging_writer.py:35] [600] accuracy=0.109375, loss=0.4202300012111664
I0225 09:23:10.342633 139665494882112 train.py:147] DECODE: 25+70 = 91 (INCORRECT) correct=95
I0225 09:23:10.342769 139665494882112 train.py:147] DECODE: 45+978 = 1023 (CORRECT)
I0225 09:23:10.342862 139665494882112 train.py:147] DECODE: 6+475 = 488 (INCORRECT) correct=481
I0225 09:23:10.342971 139665494882112 train.py:147] DECODE: 59+72 = 120 (INCORRECT) correct=131
I0225 09:23:10.343082 139665494882112 train.py:147] DECODE: 73+152 = 228 (INCORRECT) correct=225
I0225 09:24:24.187028 139640199628544 logging_writer.py:35] [800] accuracy=0.125, loss=0.38965171575546265
I0225 09:24:24.205177 139665494882112 train.py:147] DECODE: 96+996 = 1097 (INCORRECT) correct=1092
I0225 09:24:24.205298 139665494882112 train.py:147] DECODE: 14+860 = 873 (INCORRECT) correct=874
I0225 09:24:24.205421 139665494882112 train.py:147] DECODE: 43+441 = 479 (INCORRECT) correct=484
I0225 09:24:24.205560 139665494882112 train.py:147] DECODE: 1+249 = 249 (INCORRECT) correct=250
I0225 09:24:24.205673 139665494882112 train.py:147] DECODE: 19+112 = 139 (INCORRECT) correct=131

real    6m30.268s
user    9m30.757s
sys     1m1.067s
```

### After change
```
(base) ubuntu@ip-172-31-11-216:~/flax/examples/seq2seq$ time python train.py --num_train_steps=1000
I0225 09:14:21.906851 140685131192128 xla_bridge.py:248] Unable to initialize backend 'tpu_driver': NOT_FOUND: Unable to find driver in registry given worker:
I0225 09:14:22.079653 140685131192128 xla_bridge.py:248] Unable to initialize backend 'tpu': INVALID_ARGUMENT: TpuPlatform is not available.
I0225 09:14:37.427540 140659834939136 logging_writer.py:35] [200] accuracy=0.015625, loss=0.569172739982605
I0225 09:14:39.360623 140685131192128 train.py:147] DECODE: 12+508 = 538 (INCORRECT) correct=520
I0225 09:14:39.360813 140685131192128 train.py:147] DECODE: 39+67 = 145 (INCORRECT) correct=106
I0225 09:14:39.360909 140685131192128 train.py:147] DECODE: 67+191 = 260 (INCORRECT) correct=258
I0225 09:14:39.361002 140685131192128 train.py:147] DECODE: 52+755 = 815 (INCORRECT) correct=807
I0225 09:14:39.361161 140685131192128 train.py:147] DECODE: 31+520 = 536 (INCORRECT) correct=551
I0225 09:14:42.796954 140659834939136 logging_writer.py:35] [400] accuracy=0.046875, loss=0.41661515831947327
I0225 09:14:42.801347 140685131192128 train.py:147] DECODE: 67+144 = 217 (INCORRECT) correct=211
I0225 09:14:42.801494 140685131192128 train.py:147] DECODE: 80+765 = 848 (INCORRECT) correct=845
I0225 09:14:42.801657 140685131192128 train.py:147] DECODE: 71+845 = 911 (INCORRECT) correct=916
I0225 09:14:42.801783 140685131192128 train.py:147] DECODE: 51+724 = 764 (INCORRECT) correct=775
I0225 09:14:42.801899 140685131192128 train.py:147] DECODE: 25+156 = 181 (CORRECT)
I0225 09:14:46.194238 140659834939136 logging_writer.py:35] [600] accuracy=0.078125, loss=0.3851604163646698
I0225 09:14:46.199645 140685131192128 train.py:147] DECODE: 76+706 = 783 (INCORRECT) correct=782
I0225 09:14:46.199775 140685131192128 train.py:147] DECODE: 87+354 = 443 (INCORRECT) correct=441
I0225 09:14:46.199862 140685131192128 train.py:147] DECODE: 30+972 = 1003 (INCORRECT) correct=1002
I0225 09:14:46.199941 140685131192128 train.py:147] DECODE: 37+679 = 729 (INCORRECT) correct=716
I0225 09:14:46.200005 140685131192128 train.py:147] DECODE: 60+594 = 650 (INCORRECT) correct=654
I0225 09:14:49.604724 140659834939136 logging_writer.py:35] [800] accuracy=0.078125, loss=0.37534299492836
I0225 09:14:49.609580 140685131192128 train.py:147] DECODE: 47+355 = 401 (INCORRECT) correct=402
I0225 09:14:49.609728 140685131192128 train.py:147] DECODE: 41+604 = 643 (INCORRECT) correct=645
I0225 09:14:49.609836 140685131192128 train.py:147] DECODE: 44+510 = 559 (INCORRECT) correct=554
I0225 09:14:49.609935 140685131192128 train.py:147] DECODE: 25+974 = 999 (CORRECT)
I0225 09:14:49.610035 140685131192128 train.py:147] DECODE: 3+201 = 209 (INCORRECT) correct=204

real    0m34.815s
user    0m34.195s
sys     0m2.280s
```

<!--

Great, you are contributing to Flax! 

But... please read the following carefully so we can make sure your PR is merged
easily.

Replace this text block with a description of the change and which issue it
fixes (if applicable). Please also include relevant motivation/context.

Once you're done, someone in the Flax team will review your PR shortly. They may
suggest changes to make the code even better. If no one reviewed your PR after a
week has passed, don't hesitate to post a new comment @-mentioning the same
persons (sometimes notifications get lost).
-->

## Checklist
- [x] This PR fixes a minor issue (e.g.: typo or small bug) or improves the docs (you can dismiss the other
      checks if that's the case).
- [ ] This change is discussed in a Github issue/
      [discussion](https://github.com/google/flax/discussions) (please add a
      link).
- [ ] The documentation and docstrings adhere to the
      [documentation guidelines](https://github.com/google/flax/blob/main/docs/README.md#how-to-write-code-documentation).
- [ ] This change includes necessary high-coverage tests.
      (No quality testing = no merge!)
