### PR TITLE
Updates run_all_tests.sh

### DIFF
--- a/tests/run_all_tests.sh
+++ b/tests/run_all_tests.sh
@@ -12,7 +12,6 @@ case $flag in
   ;;
   --help)
   echo "Usage:"
-  echo "  --all: Also run tests for deprecated examples."
   echo "  --with-cov: Also generate pytest coverage."
   exit
   ;;


### PR DESCRIPTION
The `all` flag is no longer used since we don't have deprecated examples anymore.