### PR TITLE
Simplify and fix setattr logic.

### DIFF
--- a/tests/linen/linen_module_test.py
+++ b/tests/linen/linen_module_test.py
@@ -1472,6 +1472,24 @@ class ModuleTest(absltest.TestCase):
     rngs = {}
     D().init(rngs)
 
+  def test_modifying_attribs_in_post_init(self):
+    class Foo(nn.Module):
+      love: int = 99
+      def __post_init__(self):
+        self.hate = 100 - self.love
+        super().__post_init__()
+    foo = Foo()
+    self.assertEqual(foo.love, 99)
+    self.assertEqual(foo.hate, 1)
+
+    class Bar(nn.Module):
+      love: int = 99
+      def __post_init__(self):
+        self.love = 101
+        super().__post_init__()
+    bar = Bar()
+    self.assertEqual(bar.love, 101)
+
 
 if __name__ == '__main__':
   absltest.main()


### PR DESCRIPTION
Simplifies setattr logic and allows users to set attributes inside `__post_init__` without spurious errors.

There was too much confusing special-casing going on inside setattr, this simplifies that logic and removes some needlessly irritating constraints on our users.  Added reference to `__post_init__` usage in our error docs.
