### PR TITLE
Fix `get_type_hints()` for linen modules

### DIFF
--- a/flax/linen/module.py
+++ b/flax/linen/module.py
@@ -530,8 +530,8 @@ class Module(metaclass=ModuleMeta):
     """Handles final optional dataclass attributes: `parent` and `name`."""
     # Use cls.__dict__ to get annotations of cls itself (no parent class).
     annotations = dict(cls.__dict__.get('__annotations__', {}))
-    parent_annotation = Union[Type["Module"], Type["Scope"],
-                              Type["_Sentinel"], None]
+    parent_annotation = Union[Type[Module], Type[Scope],
+                              Type[_Sentinel], None]
     if ('parent' in annotations
         and annotations['parent'] != parent_annotation):
       raise errors.ReservedModuleAttributeError(annotations)


### PR DESCRIPTION
# What does this PR do?

<!--

Great, you are contributing to Flax! 

But... please read the following carefully so we can make sure your PR is merged
easily.

Replace this text block with a description of the change and which issue it
fixes (if applicable). Please also include relevant motivation/context.

Once you're done, someone in the Flax team will review your PR shortly. They may
suggest changes to make the code even better. If no one reviewed your PR after a
week has passed, don't hesitate to post a new comment @-mentioning the same
persons (sometimes notifications get lost).
-->

Fixes #1947 

I removed some unnecessary forward references in `nn.Module`, which were preventing the types of the module's `parent` field from being resolved correctly. Happy to add tests if it's desired/appropriate.

## Checklist
- [x] This PR fixes a minor issue (e.g.: typo or small bug) or improves the docs (you can dismiss the other
      checks if that's the case).
- [x] This change is discussed in a Github issue/
      [discussion](https://github.com/google/flax/discussions) #1947 
- [ ] The documentation and docstrings adhere to the
      [documentation guidelines](https://github.com/google/flax/blob/main/docs/README.md#how-to-write-code-documentation).
- [ ] This change includes necessary high-coverage tests.
      (No quality testing = no merge!)
