### PR TITLE
Update doc tests requirements.txt

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,8 +1,8 @@
 sphinx>=3.3.1
 sphinx_rtd_theme
 Pygments>=2.6.1
-jax>=0.1.59
-jaxlib>=0.1.41
+jax>=0.3
+jaxlib
 ipykernel
 nbsphinx
 recommonmark


### PR DESCRIPTION
We were pinning to a super old JAX version and this was beginning to cause spurious test failures when docs referenced newer symbols, etc.
