### PR TITLE
Fix type for user-facing precision arguments.

### DIFF
--- a/examples/linen_design_test/attention_simple.py
+++ b/examples/linen_design_test/attention_simple.py
@@ -19,6 +19,7 @@ from flax.core import Scope
 from flax.core.frozen_dict import freeze, unfreeze
 from flax.linen import initializers
 from flax.linen import Module, compact, vmap
+from flax.linen.linear import PrecisionLike
 import jax
 from jax import lax, numpy as jnp, random
 import numpy as np
@@ -31,7 +32,7 @@ class Dense(Module):
   kernel_init: Callable = initializers.lecun_normal()
   bias_init: Callable = initializers.zeros
   dtype: Any = jnp.float32
-  precision: Optional[lax.Precision] = None
+  precision: PrecisionLike = None
 
   @compact
   def __call__(self, inputs):

--- a/flax/linen/attention.py
+++ b/flax/linen/attention.py
@@ -25,6 +25,7 @@ import numpy as np
 
 from flax.linen.linear import default_kernel_init
 from flax.linen.linear import DenseGeneral
+from flax.linen.linear import PrecisionLike
 from flax.linen.module import Module, compact, merge_param
 from flax.linen.initializers import zeros
 
@@ -43,7 +44,7 @@ def dot_product_attention_weights(query: Array,
                                   dropout_rate: float = 0.,
                                   deterministic: bool = False,
                                   dtype: Dtype = jnp.float32,
-                                  precision: Optional[lax.Precision] = None):
+                                  precision: PrecisionLike = None):
   """Computes dot-product attention weights given query and key.
 
   Used by :func:`dot_product_attention`, which is what you'll most likely use.
@@ -126,7 +127,7 @@ def dot_product_attention(query: Array,
                           dropout_rate: float = 0.,
                           deterministic: bool = False,
                           dtype: Dtype = jnp.float32,
-                          precision: Optional[lax.Precision] = None):
+                          precision: PrecisionLike = None):
   """Computes dot-product attention given query, key, and value.
 
   This is the core function for applying attention based on
@@ -212,7 +213,7 @@ class MultiHeadDotProductAttention(Module):
   broadcast_dropout: bool = True
   dropout_rate: float = 0.
   deterministic: Optional[bool] = None
-  precision: Optional[lax.Precision] = None
+  precision: PrecisionLike = None
   kernel_init: Callable[[PRNGKey, Shape, Dtype], Array] = default_kernel_init
   bias_init: Callable[[PRNGKey, Shape, Dtype], Array] = zeros
   use_bias: bool = True

--- a/flax/linen/experimental/layers_with_named_axes.py
+++ b/flax/linen/experimental/layers_with_named_axes.py
@@ -21,6 +21,7 @@ from flax.linen.initializers import lecun_normal
 from flax.linen.initializers import ones
 from flax.linen.initializers import variance_scaling
 from flax.linen.initializers import zeros
+from flax.linen.linear import PrecisionLike
 from flax.linen.partitioning import param_with_axes
 from flax.linen.partitioning import with_sharding_constraint
 from jax import lax
@@ -63,7 +64,7 @@ class Dense(nn.Module):
   use_bias: bool = True
   dtype: Any = jnp.float32
   param_dtype: DType = jnp.float32
-  precision: Optional[lax.Precision] = None
+  precision: PrecisionLike = None
   kernel_init: Callable[[PRNGKey, Shape, DType], Array] = default_kernel_init
   bias_init: Callable[[PRNGKey, Shape, DType], Array] = zeros
   kernel_axes: Tuple[str, ...] = ()

--- a/flax/linen/linear.py
+++ b/flax/linen/linear.py
@@ -34,7 +34,8 @@ PRNGKey = Any
 Shape = Tuple[int, ...]
 Dtype = Any  # this could be a real type?
 Array = Any
-
+PrecisionLike = Union[None, str, lax.Precision, Tuple[str, str],
+                      Tuple[lax.Precision, lax.Precision]]
 
 default_kernel_init = lecun_normal()
 
@@ -75,7 +76,7 @@ class DenseGeneral(Module):
   param_dtype: Dtype = jnp.float32
   kernel_init: Callable[[PRNGKey, Shape, Dtype], Array] = default_kernel_init
   bias_init: Callable[[PRNGKey, Shape, Dtype], Array] = zeros
-  precision: Optional[lax.Precision] = None
+  precision: PrecisionLike = None
 
   @compact
   def __call__(self, inputs: Array) -> Array:
@@ -163,7 +164,7 @@ class Dense(Module):
   use_bias: bool = True
   dtype: Dtype = jnp.float32
   param_dtype: Dtype = jnp.float32
-  precision: Optional[lax.Precision] = None
+  precision: PrecisionLike = None
   kernel_init: Callable[[PRNGKey, Shape, Dtype], Array] = default_kernel_init
   bias_init: Callable[[PRNGKey, Shape, Dtype], Array] = zeros
 
@@ -245,7 +246,7 @@ class _Conv(Module):
   use_bias: bool = True
   dtype: Dtype = jnp.float32
   param_dtype: Dtype = jnp.float32
-  precision: Optional[lax.Precision] = None
+  precision: PrecisionLike = None
   kernel_init: Callable[[PRNGKey, Shape, Dtype], Array] = default_kernel_init
   bias_init: Callable[[PRNGKey, Shape, Dtype], Array] = zeros
 
@@ -445,7 +446,7 @@ class ConvTranspose(Module):
   use_bias: bool = True
   dtype: Dtype = jnp.float32
   param_dtype: Dtype = jnp.float32
-  precision: Optional[lax.Precision] = None
+  precision: PrecisionLike = None
   kernel_init: Callable[[PRNGKey, Shape, Dtype], Array] = default_kernel_init
   bias_init: Callable[[PRNGKey, Shape, Dtype], Array] = zeros
 

--- a/flax/linen/recurrent.py
+++ b/flax/linen/recurrent.py
@@ -31,7 +31,7 @@ from typing import (Any, Callable, Iterable, Mapping, Optional, Sequence, Tuple,
 from flax.linen.module import Module, compact
 from flax.linen.activation import sigmoid, tanh
 from flax.linen.initializers import orthogonal, zeros
-from flax.linen.linear import Conv, Dense, default_kernel_init
+from flax.linen.linear import Conv, Dense, default_kernel_init, PrecisionLike
 
 from jax import numpy as jnp
 from jax import lax
@@ -163,7 +163,7 @@ class DenseParams(Module):
   use_bias: bool = True
   dtype: Dtype = jnp.float32
   param_dtype: Dtype = jnp.float32
-  precision: Optional[lax.Precision] = None
+  precision: PrecisionLike = None
   kernel_init: Callable[[PRNGKey, Shape, Dtype], Array] = default_kernel_init
   bias_init: Callable[[PRNGKey, Shape, Dtype], Array] = zeros
 


### PR DESCRIPTION
The type for lax precision arguments was too narrow, this
adjusts the type to cover all possible cases.
