### PR TITLE
Expose has_rng as method on Modules.

### DIFF
--- a/flax/linen/module.py
+++ b/flax/linen/module.py
@@ -1004,6 +1004,12 @@ class Module(metaclass=ModuleMeta):
       raise ValueError("Can't check mutability on unbound modules")
     return self.scope.is_mutable_collection(col)
 
+  def has_rng(self, name: str) -> bool:
+    """Returns true if a PRNGSequence with name `name` exists."""
+    if self.scope is None:
+      raise ValueError("Can't query for RNGs on unbound modules")
+    return self.scope.has_rng(name)
+
   def make_rng(self, name: str) -> PRNGKey:
     """Returns a new RNG key from a given RNG sequence for this Module.
 

--- a/tests/linen/linen_module_test.py
+++ b/tests/linen/linen_module_test.py
@@ -1490,6 +1490,16 @@ class ModuleTest(absltest.TestCase):
     bar = Bar()
     self.assertEqual(bar.love, 101)
 
+  def test_has_rng(self):
+    class Foo(nn.Module):
+      def __call__(self):
+        return self.has_rng('bar')
+    foo = Foo()
+    with self.assertRaisesRegex(ValueError, "RNGs.*unbound module"):
+      foo()
+    k = random.PRNGKey(0)
+    self.assertTrue(foo.apply({}, rngs={'bar': k}))
+    self.assertFalse(foo.apply({}, rngs={'baz': k}))
 
 if __name__ == '__main__':
   absltest.main()


### PR DESCRIPTION
`has_rng` has been requested a few times, since it exists on `scope` objects we should just expose it.