### PR TITLE
Adds ipython_genutils to doc requirements

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -7,6 +7,7 @@ ipykernel
 nbsphinx
 recommonmark
 sphinx_markdown_tables
+ipython_genutils
 
 # Need to pin docutils to 0.16 to make bulleted lists appear correctly on
 # ReadTheDocs: https://stackoverflow.com/a/68008428


### PR DESCRIPTION
This was causing our doc builds to fail, perhaps something changed in Sphinx. 