### PR TITLE
Fix remaining setup aliasing conflict edgecase.

### DIFF
--- a/tests/linen/linen_transforms_test.py
+++ b/tests/linen/linen_transforms_test.py
@@ -30,11 +30,16 @@ from flax.core import freeze
 # Parse absl flags test_srcdir and test_tmpdir.
 jax.config.parse_flags_with_absl()
 
-
+# pylint: disable=attribute-defined-outside-init,unused-variable
 
 def tree_equals(x, y):
   return jax.tree_util.tree_all(
       jax.tree_multimap(operator.eq, x, y))
+
+
+def tree_allclose(x, y):
+  return jax.tree_util.tree_all(
+      jax.tree_multimap(lambda x,y: np.all(np.isclose(x,y)), x, y))
 
 
 id_fn = lambda x: x
@@ -977,7 +982,7 @@ class TransformTest(absltest.TestCase):
         return self._helper(x)
       @nn.nowrap
       def _helper(self, x):
-        if len(nn.module._context.module_stack) > 2:
+        if len(nn.module._context.module_stack) > 2:  # pylint: disable=protected-access
           raise ValueError('Module stack too deep.')
         return x
 
@@ -1035,7 +1040,6 @@ class TransformTest(absltest.TestCase):
     y, variables = bw.init_with_output(random.PRNGKey(0), x)
     y_2 = bw.apply(variables, x)
     np.testing.assert_allclose(y, y_2)
-
 
 
   def test_remat_scan(self):
@@ -1221,6 +1225,44 @@ class TransformTest(absltest.TestCase):
 
     msg = 'Duplicate use of scope name: "sub"'
     with self.assertRaisesWithLiteralMatch(ValueError, msg):
+      y = Test().init(k, x)
+
+  def test_transform_with_setup_and_methods_on_submodule_pytrees(self):
+    class Foo(nn.Module):
+      def setup(self):
+        self.inners = [nn.Dense(2), nn.Dense(2)]
+      def helper(self, x, ms):
+        return ms[0](x) + ms[1](x)
+      def __call__(self, x):
+        return self.helper(x, self.inners)
+    k = random.PRNGKey(0)
+    x = jnp.ones((2,))
+
+    with nn.module.override_named_call(False):
+      vs_0 = Foo().init(k, x)
+    with nn.module.override_named_call(True):
+      vs_1 = Foo().init(k, x)
+
+    self.assertTrue(tree_allclose(vs_0, vs_1))
+
+  def test_transform_setup_still_reserve_names_pytrees(self):
+    class Identity(nn.Module):
+      @nn.compact
+      def __call__(self, x):
+        return x
+    class Test(nn.Module):
+      def setup(self):
+        self.subs = [Identity(), Identity()]
+        self.subs = [Identity(), Identity()]
+      @nn.jit
+      def __call__(self, x):
+        return x
+
+    k = random.PRNGKey(0)
+    x = jnp.array([1.])
+
+    msg = r'Could not create submodule "subs_0".*'
+    with self.assertRaisesRegex(errors.NameInUseError, msg):
       y = Test().init(k, x)
 
   def test_scan_of_setup_parameter(self):


### PR DESCRIPTION
This resolves an incomplete fix in #1745 for handling scope/name aliasing issues for modules defined in `setup()` and passed around in transformed helper methods.