### PR TITLE
Bumps flax/jax versions in examples/imagenet.

### DIFF
--- a/examples/imagenet/requirements.txt
+++ b/examples/imagenet/requirements.txt
@@ -1,9 +1,9 @@
 absl-py==1.0.0
 clu==0.0.6
-flax==0.3.6
-jax==0.2.21
+flax==0.4.1
+jax==0.3.4
 --find-links https://storage.googleapis.com/jax-releases/jax_releases.html
-jaxlib==0.1.70+cuda110  # Make sure CUDA version matches the base image.
+jaxlib==0.3.2+cuda11.cudnn82  # Make sure CUDA version matches the base image.
 ml-collections==0.1.0
 numpy==1.21.4
 optax==0.1.0


### PR DESCRIPTION
Tested that training starts with TPU pod commands from

https://github.com/google/flax/blob/main/examples/imagenet/README.md