### PR TITLE
Lifted cond

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ vNext
 -
 -
 -
--
+- Added lifted conditional `nn.cond`
 -
 -
 -

--- a/docs/flax.linen.rst
+++ b/docs/flax.linen.rst
@@ -76,6 +76,7 @@ Transformations
     vjp
     custom_vjp
     while_loop
+    cond
 
 
 Linear modules

--- a/flax/core/scope.py
+++ b/flax/core/scope.py
@@ -672,7 +672,8 @@ class Scope:
     variables = self._mutable_collection(col)
     variables[name] = value
 
-  def variable(self, col: str, name: str, init_fn: Callable[..., T],
+  def variable(self, col: str, name: str,
+               init_fn: Optional[Callable[..., T]] = None,
                *init_args) -> Variable[T]:
     """Creates a variable if it doesn't exist yet in this scope and returns it.
 
@@ -680,7 +681,8 @@ class Scope:
       col: the collection of the variable.
       name: the name of the variable.
       init_fn: a function taking a PRNGKey plus any other number of positional
-        arguments.
+        arguments. If None, the variable must already be initialized otherwise
+        an error is raised.
       *init_args: the arguments to evaluate init_fn on lazily.
 
     Returns:
@@ -688,7 +690,7 @@ class Scope:
     """
     self.reserve(name)
     if not self.has_variable(col, name):
-      if not self.is_mutable_collection(col):
+      if not self.is_mutable_collection(col) or init_fn is None:
         if self.is_collection_empty(col):
           raise errors.ScopeCollectionNotFound(col, name, self.path_text)
         raise errors.ScopeVariableNotFoundError(name, col, self.path_text)

--- a/flax/linen/__init__.py
+++ b/flax/linen/__init__.py
@@ -37,6 +37,6 @@ from .recurrent import ConvLSTM, GRUCell, LSTMCell, OptimizedLSTMCell
 from .stochastic import Dropout
 from .transforms import (checkpoint, custom_vjp, jit, jvp, map_variables,
                          named_call, remat, remat_scan, scan, vjp, vmap,
-                         while_loop)
+                         while_loop, cond)
 
 # pylint: enable=g-multiple-import

--- a/flax/linen/module.py
+++ b/flax/linen/module.py
@@ -906,7 +906,9 @@ class Module:
     attrs.update(parent=parent, **updates)
     return self.__class__(**attrs)
 
-  def variable(self, col: str, name: str, init_fn, *init_args) -> Variable:
+  def variable(self, col: str, name: str,
+               init_fn: Optional[Callable[..., Any]] = None,
+               *init_args) -> Variable:
     """Declares and returns a variable in this Module.
 
     See :mod:`flax.core.variables` for more information. See also :meth:`param`
@@ -928,7 +930,8 @@ class Module:
       name: The variable name.
       init_fn: The function that will be called to compute the initial value
         of this variable. This function will only be called the first time
-        this variable is used in this module.
+        this variable is used in this module. If None, the variable must
+        already be initialized otherwise an error is raised.
       *init_args: The arguments to pass to init_fn.
 
     Returns:

--- a/tests/core/core_scope_test.py
+++ b/tests/core/core_scope_test.py
@@ -199,6 +199,16 @@ class ScopeTest(absltest.TestCase):
     root = Scope({'state': {}})
     with self.assertRaises(errors.ScopeCollectionNotFound):
       root.variable('state', 'test', jnp.zeros, ())
+  
+  def test_variable_no_init(self):
+    root = Scope({}, mutable='state')
+    with self.assertRaises(errors.ScopeCollectionNotFound):
+      root.variable('state', 'test')
+    root = Scope({'state': {'abc': 1}}, mutable='state')
+    abc = root.variable('state', 'abc')
+    self.assertEqual(abc.value, 1)
+    with self.assertRaises(errors.ScopeVariableNotFoundError):
+      root.variable('state', 'test')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Implemented a lifted versio of lax.cond

For convenience I have also made the init_fn argument to `.variable` optional. This is nice when redefining a variable inside a lifted context. The init_fn is already ignored when the variable is defined so it was redundant but this change adds optionality to the signature and recognizes the case in error checking.