### PR TITLE
Use tree_map instead of deprecated tree_multimap

### DIFF
--- a/flax/core/axes_scan.py
+++ b/flax/core/axes_scan.py
@@ -102,20 +102,20 @@ def scan(
     return jax.tree_map(trans, xs)
 
   def scan_fn(broadcast_in, init, *args):
-    xs = jax.tree_multimap(transpose_to_front, in_axes, args)
+    xs = jax.tree_map(transpose_to_front, in_axes, args)
 
     def body_fn(c, xs, init_mode=False):
       # inject constants
-      xs = jax.tree_multimap(lambda ax, arg, x: (arg if ax is broadcast else x),
+      xs = jax.tree_map(lambda ax, arg, x: (arg if ax is broadcast else x),
                              in_axes, args, xs)
       broadcast_out, c, ys = fn(broadcast_in, c, *xs)
 
       if init_mode:
-        ys = jax.tree_multimap(lambda ax, y: (y if ax is broadcast else ()),
+        ys = jax.tree_map(lambda ax, y: (y if ax is broadcast else ()),
                                out_axes, ys)
         return broadcast_out, ys
       else:
-        ys = jax.tree_multimap(lambda ax, y: (() if ax is broadcast else y),
+        ys = jax.tree_map(lambda ax, y: (() if ax is broadcast else y),
                                out_axes, ys)
         return c, ys
     broadcast_body = functools.partial(body_fn, init_mode=True)
@@ -143,8 +143,8 @@ def scan(
     broadcast_in, constants_out = jax.tree_unflatten(out_tree(), out_flat)
 
     c, ys = lax.scan(body_fn, init, xs, length=length, reverse=reverse)
-    ys = jax.tree_multimap(transpose_from_front, out_axes, ys)
-    ys = jax.tree_multimap(
+    ys = jax.tree_map(transpose_from_front, out_axes, ys)
+    ys = jax.tree_map(
         lambda ax, const, y: (const if ax is broadcast else y), out_axes,
         constants_out, ys)
     return broadcast_in, c, ys

--- a/flax/core/lift.py
+++ b/flax/core/lift.py
@@ -587,7 +587,7 @@ def vmap(fn: Callable[..., Any],
       return ()
 
     # split rngs
-    axis_sizes = jax.tree_multimap(find_axis_size, (variable_in_axes, in_axes),
+    axis_sizes = jax.tree_map(find_axis_size, (variable_in_axes, in_axes),
                                    (variable_groups, args))
     axis_sizes = set(jax.tree_leaves(axis_sizes))
     if axis_size is None and len(axis_sizes) == 1:
@@ -720,7 +720,7 @@ def scan(fn: Callable[..., Any],
           return leaves[0].shape[axis]
       return ()
     # split rngs
-    lengths = jax.tree_multimap(find_length, in_axes, args)
+    lengths = jax.tree_map(find_length, in_axes, args)
     lengths = set(jax.tree_leaves(lengths))
     if length is None and len(lengths) == 1:
       d_length, = lengths

--- a/flax/optim/weight_norm.py
+++ b/flax/optim/weight_norm.py
@@ -97,7 +97,7 @@ class WeightNorm(OptimizerDef):
     state = self.wrapped_optimizer.init_state(wn_params)
     direction_state = state.param_states['direction']
     scale_state = state.param_states['scale']
-    param_states = jax.tree_multimap(
+    param_states = jax.tree_map(
         lambda _, *args: _WeightNormParamState(*args),
         params, direction_state, scale_state, directions, scales)
     return state.replace(param_states=param_states)
@@ -120,14 +120,14 @@ class WeightNorm(OptimizerDef):
         return direction * mult
       else:
         return direction
-    merge_params = lambda d, s: jax.tree_multimap(merge_param, d, s)
+    merge_params = lambda d, s: jax.tree_map(merge_param, d, s)
     _, vjp_fn = jax.vjp(merge_params, direction, scale)
     dir_grad, scale_grad = vjp_fn(grads)
     def add_decay(direction, dir_grad):
       if direction.size > direction.shape[-1]:
         return dir_grad + decay * direction
       return dir_grad
-    dir_grad = jax.tree_multimap(add_decay, direction, dir_grad)
+    dir_grad = jax.tree_map(add_decay, direction, dir_grad)
 
     wn_params = {'direction': direction, 'scale': scale}
     wn_state = {'direction': dir_state, 'scale': scale_state}
@@ -141,7 +141,7 @@ class WeightNorm(OptimizerDef):
 
     direction_state = new_state.param_states['direction']
     scale_state = new_state.param_states['scale']
-    param_states = jax.tree_multimap(
+    param_states = jax.tree_map(
         lambda _, *args: _WeightNormParamState(*args),
         params, direction_state, scale_state, direction, scale)
     return new_params, new_state.replace(param_states=param_states)

--- a/flax/training/common_utils.py
+++ b/flax/training/common_utils.py
@@ -42,7 +42,7 @@ def onehot(labels, num_classes, on_value=1.0, off_value=0.0):
 
 def stack_forest(forest):
   stack_args = lambda *args: np.stack(args)
-  return jax.tree_multimap(stack_args, *forest)
+  return jax.tree_map(stack_args, *forest)
 
 
 def get_metrics(device_metrics):

--- a/tests/linen/linen_transforms_test.py
+++ b/tests/linen/linen_transforms_test.py
@@ -34,12 +34,12 @@ jax.config.parse_flags_with_absl()
 
 def tree_equals(x, y):
   return jax.tree_util.tree_all(
-      jax.tree_multimap(operator.eq, x, y))
+      jax.tree_map(operator.eq, x, y))
 
 
 def tree_allclose(x, y):
   return jax.tree_util.tree_all(
-      jax.tree_multimap(lambda x,y: np.all(np.isclose(x,y)), x, y))
+      jax.tree_map(lambda x,y: np.all(np.isclose(x,y)), x, y))
 
 
 id_fn = lambda x: x
@@ -772,7 +772,7 @@ class TransformTest(absltest.TestCase):
         },
       })
     self.assertTrue(jax.tree_util.tree_all(
-        jax.tree_multimap(
+        jax.tree_map(
             lambda x, y: np.testing.assert_allclose(x, y, atol=1e-7),
             cntrs, ref_cntrs)
         ))


### PR DESCRIPTION
FutureWarning error by JAX breaks the tests so we have to remove the use of tree_multimap. tree_map works as a drop-in replacement