### PR TITLE
Add __getattribute__ with lazy setup trigger.

### DIFF
--- a/flax/linen/module.py
+++ b/flax/linen/module.py
@@ -714,6 +714,17 @@ class Module:
       raise AttributeError(
           f'"{self.__class__.__name__}" object has no attribute "{name}"')
 
+  def __getattribute__(self, name):
+    """Call setup() before accessing any submodule attributes."""
+    # NB: all code here is very "hot" and will be run very frequently.
+    if name in object.__getattribute__(self, '__dataclass_fields__'):
+      if (name != 'parent' and
+          object.__getattribute__(self, '__dataclass_fields__')[name].init and
+          isinstance(object.__getattribute__(self, name), Module)):
+        object.__getattribute__(self, '_try_setup')()
+    # always run original python __getattribute__
+    return object.__getattribute__(self, name)
+
   def __dir__(self) -> Iterable[str]:
     """Call setup() before listing attributes."""
     self._try_setup()


### PR DESCRIPTION
Currently there's a dumb difference in behavior when accessing submodules defined in setup() vs submodules passed in as dataclass attributes - the former will work in more situations as `getattr` triggers `setup` but the latter won't as `getattribute` does not currently trigger `setup`.  This PR fixes that discrepancy.