### PR TITLE
Removes deprecated filterwarning from pytest.ini

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -12,8 +12,6 @@ filterwarnings =
     ignore:can't resolve package from.*:ImportWarning
 # Jax imports flatbuffers which imports imp in a compat file.
     ignore:the imp module is deprecated.*:DeprecationWarning
-# We still want to test deprecated library until deleted.
-    ignore:The `flax.nn` module is Deprecated, use `flax.linen` instead.*:DeprecationWarning
 # TODO(#2037): Remove this once Optax releases a new version.
     ignore:jax.tree_util.tree_multimap\(\) is deprecated.*:FutureWarning
 


### PR DESCRIPTION
Since we removed the deprecated API this filter warning can be removed as well.