### PR TITLE
Handle edge-case of rate==1.0 in Dropout layer.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ vNext
 -
 -
 - Added lifted conditional `nn.cond`
--
+- Handle rate==1.0 edgecase in Dropout.
 -
 -
 -

--- a/flax/linen/stochastic.py
+++ b/flax/linen/stochastic.py
@@ -55,6 +55,9 @@ class Dropout(Module):
         'deterministic', self.deterministic, deterministic)
     if self.rate == 0.:
       return inputs
+    # Prevent gradient NaNs in 1.0 edge-case.
+    if self.rate == 1.0:
+      return jnp.zeros_like(inputs)
     keep_prob = 1. - self.rate
     if deterministic:
       return inputs


### PR DESCRIPTION
A number of users would benefit from treating the edge-case of dropout rate==1.0 acting like complete zero-ing of the input array rather than returning NaNs from the rescaling operation.  We handle this edge-case statically here based on the rate parameter.