### PR TITLE
Makes annotated_mnist use Optax's xent loss.

### DIFF
--- a/docs/notebooks/annotated_mnist.ipynb
+++ b/docs/notebooks/annotated_mnist.ipynb
@@ -1,598 +1,655 @@
 {
- "cells": [
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "9q9JZjt16AMf"
-   },
-   "source": [
-    "# Annotated MNIST\n",
-    "\n",
-    "This tutorial demonstrates how to construct a simple convolutional neural\n",
-    "network (CNN) using the [Flax](https://flax.readthedocs.io) Linen API and train\n",
-    "the network for image classification on the MNIST dataset.\n",
-    "\n",
-    "Note: This notebook is based on Flax's official\n",
-    "[MNIST Example](https://github.com/google/flax/tree/main/examples/mnist).\n",
-    "If you see any changes between the two feel free to create a\n",
-    "[pull request](https://github.com/google/flax/compare)\n",
-    "to synchronize this Colab with the actual example."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "VSaA8Mif6srP"
-   },
-   "source": [
-    "## 1. Imports\n",
-    "\n",
-    "Import JAX, [JAX NumPy](https://jax.readthedocs.io/en/latest/jax.numpy.html),\n",
-    "Flax, ordinary NumPy, and TensorFlow Datasets (TFDS). Flax can use any\n",
-    "data-loading pipeline and this example demonstrates how to utilize TFDS."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 1,
-   "metadata": {
-    "id": "inJ9bV636dRx"
-   },
-   "outputs": [],
-   "source": [
-    "!pip install -q flax"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 2,
-   "metadata": {
-    "id": "Z7MuGFB16E8m"
-   },
-   "outputs": [],
-   "source": [
-    "import jax\n",
-    "import jax.numpy as jnp                # JAX NumPy\n",
-    "\n",
-    "from flax import linen as nn           # The Linen API\n",
-    "from flax.training import train_state  # Useful dataclass to keep train state\n",
-    "\n",
-    "import numpy as np                     # Ordinary NumPy\n",
-    "import optax                           # Optimizers\n",
-    "import tensorflow_datasets as tfds     # TFDS for MNIST"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "d0FW1DHa6cfH"
-   },
-   "source": [
-    "## 2. Define network\n",
-    "\n",
-    "Create a convolutional neural network with the Linen API by subclassing\n",
-    "[Module](https://flax.readthedocs.io/en/latest/flax.linen.html#core-module-abstraction).\n",
-    "Because the architecture in this example is relatively simple—you're just\n",
-    "stacking layers—you can define the inlined submodules directly within the\n",
-    "`__call__` method and wrap it with the\n",
-    "[@compact](https://flax.readthedocs.io/en/latest/flax.linen.html#compact-methods)\n",
-    "decorator."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 3,
-   "metadata": {
-    "id": "_s1lXBBO66dc"
-   },
-   "outputs": [],
-   "source": [
-    "class CNN(nn.Module):\n",
-    "  \"\"\"A simple CNN model.\"\"\"\n",
-    "\n",
-    "  @nn.compact\n",
-    "  def __call__(self, x):\n",
-    "    x = nn.Conv(features=32, kernel_size=(3, 3))(x)\n",
-    "    x = nn.relu(x)\n",
-    "    x = nn.avg_pool(x, window_shape=(2, 2), strides=(2, 2))\n",
-    "    x = nn.Conv(features=64, kernel_size=(3, 3))(x)\n",
-    "    x = nn.relu(x)\n",
-    "    x = nn.avg_pool(x, window_shape=(2, 2), strides=(2, 2))\n",
-    "    x = x.reshape((x.shape[0], -1))  # flatten\n",
-    "    x = nn.Dense(features=256)(x)\n",
-    "    x = nn.relu(x)\n",
-    "    x = nn.Dense(features=10)(x)\n",
-    "    x = nn.log_softmax(x)\n",
-    "    return x"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "xDEoAprU6_JZ"
-   },
-   "source": [
-    "## 3. Define loss\n",
-    "\n",
-    "Define a cross-entropy loss function using just\n",
-    "[jax.numpy](https://jax.readthedocs.io/en/latest/jax.numpy.html)\n",
-    "that takes the model's logits and label vectors and returns a scalar loss. The\n",
-    "labels can be one-hot encoded with\n",
-    "[jax.nn.one_hot](https://jax.readthedocs.io/en/latest/_autosummary/jax.nn.one_hot.html),\n",
-    "as demonstrated below.\n",
-    "\n",
-    "Note that for demonstration purposes, we return `nn.log_softmax()` from\n",
-    "the model and then simply multiply these (normalized) logits with the labels. In our\n",
-    "`examples/mnist` folder we actually return non-normalized logits and then use\n",
-    "`optax.softmax_cross_entropy()` to compute the loss, which has the same result."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 4,
-   "metadata": {
-    "id": "Zcb_ebU87G7s"
-   },
-   "outputs": [],
-   "source": [
-    "def cross_entropy_loss(*, logits, labels):\n",
-    "  one_hot_labels = jax.nn.one_hot(labels, num_classes=10)\n",
-    "  return -jnp.mean(jnp.sum(one_hot_labels * logits, axis=-1))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "INZE3eM67JUr"
-   },
-   "source": [
-    "## 4. Metric computation\n",
-    "\n",
-    "For loss and accuracy metrics, create a separate function:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 5,
-   "metadata": {
-    "id": "KvuEA8Tw-MYa"
-   },
-   "outputs": [],
-   "source": [
-    "def compute_metrics(*, logits, labels):\n",
-    "  loss = cross_entropy_loss(logits=logits, labels=labels)\n",
-    "  accuracy = jnp.mean(jnp.argmax(logits, -1) == labels)\n",
-    "  metrics = {\n",
-    "      'loss': loss,\n",
-    "      'accuracy': accuracy,\n",
-    "  }\n",
-    "  return metrics"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "lYz0Emry-ele"
-   },
-   "source": [
-    "## 5. Loading data\n",
-    "\n",
-    "Define a function that loads and prepares the MNIST dataset and converts the\n",
-    "samples to floating-point numbers."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 6,
-   "metadata": {
-    "id": "IOeWiS_b-p8O"
-   },
-   "outputs": [],
-   "source": [
-    "def get_datasets():\n",
-    "  \"\"\"Load MNIST train and test datasets into memory.\"\"\"\n",
-    "  ds_builder = tfds.builder('mnist')\n",
-    "  ds_builder.download_and_prepare()\n",
-    "  train_ds = tfds.as_numpy(ds_builder.as_dataset(split='train', batch_size=-1))\n",
-    "  test_ds = tfds.as_numpy(ds_builder.as_dataset(split='test', batch_size=-1))\n",
-    "  train_ds['image'] = jnp.float32(train_ds['image']) / 255.\n",
-    "  test_ds['image'] = jnp.float32(test_ds['image']) / 255.\n",
-    "  return train_ds, test_ds"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "UMFK51rsAUX4"
-   },
-   "source": [
-    "## 6. Create train state\n",
-    "\n",
-    "A common pattern in Flax is to create a single dataclass that represents the\n",
-    "entire training state, including step number, parameters, and optimizer state.\n",
-    "\n",
-    "Also adding optimizer & model to this state has the advantage that we only need\n",
-    "to pass around a single argument to functions like `train_step()` (see below).\n",
-    "\n",
-    "Because this is such a common pattern, Flax provides the class\n",
-    "[flax.training.train_state.TrainState](https://flax.readthedocs.io/en/latest/flax.training.html#train-state)\n",
-    "that serves most basic usecases. Usually one would subclass it to add more data\n",
-    "to be tracked, but in this example we can use it without any modifications."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 7,
-   "metadata": {
-    "id": "QadyBPbWBEAT"
-   },
-   "outputs": [],
-   "source": [
-    "def create_train_state(rng, learning_rate, momentum):\n",
-    "  \"\"\"Creates initial `TrainState`.\"\"\"\n",
-    "  cnn = CNN()\n",
-    "  params = cnn.init(rng, jnp.ones([1, 28, 28, 1]))['params']\n",
-    "  tx = optax.sgd(learning_rate, momentum)\n",
-    "  return train_state.TrainState.create(\n",
-    "      apply_fn=cnn.apply, params=params, tx=tx)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "W7l-75YE-sr-"
-   },
-   "source": [
-    "## 7. Training step\n",
-    "\n",
-    "A function that:\n",
-    "\n",
-    "- Evaluates the neural network given the parameters and a batch of input images\n",
-    "  with the\n",
-    "  [Module.apply](https://flax.readthedocs.io/en/latest/flax.linen.html#flax.linen.Module.apply)\n",
-    "  method.\n",
-    "- Computes the `cross_entropy_loss` loss function.\n",
-    "- Evaluates the loss function and its gradient using\n",
-    "  [jax.value_and_grad](https://jax.readthedocs.io/en/latest/jax.html#jax.value_and_grad).\n",
-    "- Applies a\n",
-    "  [pytree](https://jax.readthedocs.io/en/latest/pytrees.html#pytrees-and-jax-functions)\n",
-    "  of gradients to the optimizer to update the model's parameters.\n",
-    "- Computes the metrics using `compute_metrics` (defined earlier).\n",
-    "\n",
-    "Use JAX's [@jit](https://jax.readthedocs.io/en/latest/jax.html#jax.jit)\n",
-    "decorator to trace the entire `train_step` function and just-in-time compile\n",
-    "it with [XLA](https://www.tensorflow.org/xla) into fused device operations\n",
-    "that run faster and more efficiently on hardware accelerators."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 8,
-   "metadata": {
-    "id": "Ng11cdMf-z0x"
-   },
-   "outputs": [],
-   "source": [
-    "@jax.jit\n",
-    "def train_step(state, batch):\n",
-    "  \"\"\"Train for a single step.\"\"\"\n",
-    "  def loss_fn(params):\n",
-    "    logits = CNN().apply({'params': params}, batch['image'])\n",
-    "    loss = cross_entropy_loss(logits=logits, labels=batch['label'])\n",
-    "    return loss, logits\n",
-    "  grad_fn = jax.value_and_grad(loss_fn, has_aux=True)\n",
-    "  (_, logits), grads = grad_fn(state.params)\n",
-    "  state = state.apply_gradients(grads=grads)\n",
-    "  metrics = compute_metrics(logits=logits, labels=batch['label'])\n",
-    "  return state, metrics"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "t-4qDNUgBryr"
-   },
-   "source": [
-    "## 8. Evaluation step\n",
-    "\n",
-    "Create a function that evaluates your model on the test set with\n",
-    "[Module.apply](https://flax.readthedocs.io/en/latest/flax.linen.html#flax.linen.Module.apply)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 9,
-   "metadata": {
-    "id": "w1J9i6alBv_u"
-   },
-   "outputs": [],
-   "source": [
-    "@jax.jit\n",
-    "def eval_step(params, batch):\n",
-    "  logits = CNN().apply({'params': params}, batch['image'])\n",
-    "  return compute_metrics(logits=logits, labels=batch['label'])"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "MBTLQPC4BxgH"
-   },
-   "source": [
-    "## 9. Train function\n",
-    "\n",
-    "Define a training function that:\n",
-    "\n",
-    "- Shuffles the training data before each epoch using\n",
-    "  [jax.random.permutation](https://jax.readthedocs.io/en/latest/_autosummary/jax.random.permutation.html)\n",
-    "  that takes a PRNGKey as a parameter (check the\n",
-    "  [JAX - the sharp bits](https://jax.readthedocs.io/en/latest/notebooks/Common_Gotchas_in_JAX.html#JAX-PRNG)).\n",
-    "- Runs an optimization step for each batch.\n",
-    "- Retrieves the training metrics from the device with `jax.device_get` and\n",
-    "  computes their mean across each batch in an epoch.\n",
-    "- Returns the optimizer with updated parameters and the training loss and\n",
-    "  accuracy metrics."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 10,
-   "metadata": {
-    "id": "7ipyJ-JGCNqP"
-   },
-   "outputs": [],
-   "source": [
-    "def train_epoch(state, train_ds, batch_size, epoch, rng):\n",
-    "  \"\"\"Train for a single epoch.\"\"\"\n",
-    "  train_ds_size = len(train_ds['image'])\n",
-    "  steps_per_epoch = train_ds_size // batch_size\n",
-    "\n",
-    "  perms = jax.random.permutation(rng, train_ds_size)\n",
-    "  perms = perms[:steps_per_epoch * batch_size]  # skip incomplete batch\n",
-    "  perms = perms.reshape((steps_per_epoch, batch_size))\n",
-    "  batch_metrics = []\n",
-    "  for perm in perms:\n",
-    "    batch = {k: v[perm, ...] for k, v in train_ds.items()}\n",
-    "    state, metrics = train_step(state, batch)\n",
-    "    batch_metrics.append(metrics)\n",
-    "\n",
-    "  # compute mean of metrics across each batch in epoch.\n",
-    "  batch_metrics_np = jax.device_get(batch_metrics)\n",
-    "  epoch_metrics_np = {\n",
-    "      k: np.mean([metrics[k] for metrics in batch_metrics_np])\n",
-    "      for k in batch_metrics_np[0]}\n",
-    "\n",
-    "  print('train epoch: %d, loss: %.4f, accuracy: %.2f' % (\n",
-    "      epoch, epoch_metrics_np['loss'], epoch_metrics_np['accuracy'] * 100))\n",
-    "\n",
-    "  return state"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "E2cHbVUfCRMv"
-   },
-   "source": [
-    "## 10. Eval function\n",
-    "\n",
-    "Create a model evaluation function that:\n",
-    "\n",
-    "- Retrieves the evaluation metrics from the device with `jax.device_get`.\n",
-    "- Copies the metrics\n",
-    "  [data stored](https://flax.readthedocs.io/en/latest/design_notes/linen_design_principles.html#how-are-parameters-represented-and-how-do-we-handle-general-differentiable-algorithms-that-update-stateful-variables)\n",
-    "  in a JAX\n",
-    "  [pytree](https://jax.readthedocs.io/en/latest/pytrees.html#pytrees-and-jax-functions)."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 11,
-   "metadata": {
-    "id": "_dKahNmMCr5q"
-   },
-   "outputs": [],
-   "source": [
-    "def eval_model(params, test_ds):\n",
-    "  metrics = eval_step(params, test_ds)\n",
-    "  metrics = jax.device_get(metrics)\n",
-    "  summary = jax.tree_map(lambda x: x.item(), metrics)\n",
-    "  return summary['loss'], summary['accuracy']"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "mHQi20yVCsSf"
-   },
-   "source": [
-    "## 11. Download data"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 12,
-   "metadata": {
-    "id": "6CLXnP3KHptR"
-   },
-   "outputs": [],
-   "source": [
-    "train_ds, test_ds = get_datasets()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "56rKPl6OHqu8"
-   },
-   "source": [
-    "## 12. Seed randomness\n",
-    "\n",
-    "- Get one\n",
-    "  [PRNGKey](https://jax.readthedocs.io/en/latest/_autosummary/jax.random.PRNGKey.html#jax.random.PRNGKey)\n",
-    "  and\n",
-    "  [split](https://jax.readthedocs.io/en/latest/_autosummary/jax.random.split.html#jax.random.split)\n",
-    "  it to get a second key that you'll use for parameter initialization. (Learn\n",
-    "  more about\n",
-    "  [PRNG chains](https://flax.readthedocs.io/en/latest/design_notes/linen_design_principles.html#how-are-parameters-represented-and-how-do-we-handle-general-differentiable-algorithms-that-update-stateful-variables)\n",
-    "  and\n",
-    "  [JAX PRNG design](https://github.com/google/jax/blob/main/design_notes/prng.md).)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 18,
-   "metadata": {
-    "id": "n53xh_B8Ht_W"
-   },
-   "outputs": [],
-   "source": [
-    "rng = jax.random.PRNGKey(0)\n",
-    "rng, init_rng = jax.random.split(rng)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "Y3iHFiAuH41s"
-   },
-   "source": [
-    "## 13. Initialize train state\n",
-    "\n",
-    "Remember that function initializes both the model parameters and the optimizer\n",
-    "and puts both into the training state dataclass that is returned."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 19,
-   "metadata": {
-    "id": "Mj6OfdEEIU-o"
-   },
-   "outputs": [],
-   "source": [
-    "learning_rate = 0.1\n",
-    "momentum = 0.9"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 20,
-   "metadata": {
-    "id": "_87fL90dH-0Z"
-   },
-   "outputs": [],
-   "source": [
-    "state = create_train_state(init_rng, learning_rate, momentum)\n",
-    "del init_rng  # Must not be used anymore."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "UqNrWu7kIC9S"
-   },
-   "source": [
-    "## 14. Train and evaluate\n",
-    "\n",
-    "Once the training and testing is done after 10 epochs, the output should show that your model was able to achieve approximately 99% accuracy."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 21,
-   "metadata": {
-    "id": "0nxgS5Z5IsT_"
-   },
-   "outputs": [],
-   "source": [
-    "num_epochs = 10\n",
-    "batch_size = 32"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 22,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
-    },
-    "id": "ugGlV3u6Iq1A",
-    "outputId": "cfe5004c-741f-4ee6-9818-7374064acbb9"
-   },
-   "outputs": [
+  "cells": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "train epoch: 1, loss: 0.1293, accuracy: 96.04\n",
-      " test epoch: 1, loss: 0.06, accuracy: 97.93\n",
-      "train epoch: 2, loss: 0.0509, accuracy: 98.43\n",
-      " test epoch: 2, loss: 0.04, accuracy: 98.88\n",
-      "train epoch: 3, loss: 0.0332, accuracy: 99.04\n",
-      " test epoch: 3, loss: 0.03, accuracy: 98.87\n",
-      "train epoch: 4, loss: 0.0230, accuracy: 99.30\n",
-      " test epoch: 4, loss: 0.04, accuracy: 98.83\n",
-      "train epoch: 5, loss: 0.0207, accuracy: 99.37\n",
-      " test epoch: 5, loss: 0.05, accuracy: 98.78\n",
-      "train epoch: 6, loss: 0.0178, accuracy: 99.44\n",
-      " test epoch: 6, loss: 0.03, accuracy: 99.11\n",
-      "train epoch: 7, loss: 0.0142, accuracy: 99.52\n",
-      " test epoch: 7, loss: 0.04, accuracy: 98.77\n",
-      "train epoch: 8, loss: 0.0137, accuracy: 99.60\n",
-      " test epoch: 8, loss: 0.04, accuracy: 98.87\n",
-      "train epoch: 9, loss: 0.0096, accuracy: 99.69\n",
-      " test epoch: 9, loss: 0.04, accuracy: 98.98\n",
-      "train epoch: 10, loss: 0.0108, accuracy: 99.67\n",
-      " test epoch: 10, loss: 0.04, accuracy: 99.01\n"
-     ]
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "9q9JZjt16AMf"
+      },
+      "source": [
+        "# Annotated MNIST\n",
+        "\n",
+        "This tutorial demonstrates how to construct a simple convolutional neural\n",
+        "network (CNN) using the [Flax](https://flax.readthedocs.io) Linen API and train\n",
+        "the network for image classification on the MNIST dataset.\n",
+        "\n",
+        "Note: This notebook is based on Flax's official\n",
+        "[MNIST Example](https://github.com/google/flax/tree/main/examples/mnist).\n",
+        "If you see any changes between the two feel free to create a\n",
+        "[pull request](https://github.com/google/flax/compare)\n",
+        "to synchronize this Colab with the actual example."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# Check GPU\n",
+        "!nvidia-smi"
+      ],
+      "metadata": {
+        "id": "FOYfP6vf2FGx",
+        "outputId": "a5c9dcc6-6972-4240-f657-2145b8661ffb",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        }
+      },
+      "execution_count": 1,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Tue Apr 26 17:11:22 2022       \n",
+            "+-----------------------------------------------------------------------------+\n",
+            "| NVIDIA-SMI 460.32.03    Driver Version: 460.32.03    CUDA Version: 11.2     |\n",
+            "|-------------------------------+----------------------+----------------------+\n",
+            "| GPU  Name        Persistence-M| Bus-Id        Disp.A | Volatile Uncorr. ECC |\n",
+            "| Fan  Temp  Perf  Pwr:Usage/Cap|         Memory-Usage | GPU-Util  Compute M. |\n",
+            "|                               |                      |               MIG M. |\n",
+            "|===============================+======================+======================|\n",
+            "|   0  Tesla T4            Off  | 00000000:00:04.0 Off |                    0 |\n",
+            "| N/A   36C    P8     9W /  70W |      0MiB / 15109MiB |      0%      Default |\n",
+            "|                               |                      |                  N/A |\n",
+            "+-------------------------------+----------------------+----------------------+\n",
+            "                                                                               \n",
+            "+-----------------------------------------------------------------------------+\n",
+            "| Processes:                                                                  |\n",
+            "|  GPU   GI   CI        PID   Type   Process name                  GPU Memory |\n",
+            "|        ID   ID                                                   Usage      |\n",
+            "|=============================================================================|\n",
+            "|  No running processes found                                                 |\n",
+            "+-----------------------------------------------------------------------------+\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "VSaA8Mif6srP"
+      },
+      "source": [
+        "## 1. Imports\n",
+        "\n",
+        "Import JAX, [JAX NumPy](https://jax.readthedocs.io/en/latest/jax.numpy.html),\n",
+        "Flax, ordinary NumPy, and TensorFlow Datasets (TFDS). Flax can use any\n",
+        "data-loading pipeline and this example demonstrates how to utilize TFDS."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 2,
+      "metadata": {
+        "id": "inJ9bV636dRx"
+      },
+      "outputs": [],
+      "source": [
+        "!pip install -q flax"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 3,
+      "metadata": {
+        "id": "Z7MuGFB16E8m"
+      },
+      "outputs": [],
+      "source": [
+        "import jax\n",
+        "import jax.numpy as jnp                # JAX NumPy\n",
+        "\n",
+        "from flax import linen as nn           # The Linen API\n",
+        "from flax.training import train_state  # Useful dataclass to keep train state\n",
+        "\n",
+        "import numpy as np                     # Ordinary NumPy\n",
+        "import optax                           # Optimizers\n",
+        "import tensorflow_datasets as tfds     # TFDS for MNIST"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "d0FW1DHa6cfH"
+      },
+      "source": [
+        "## 2. Define network\n",
+        "\n",
+        "Create a convolutional neural network with the Linen API by subclassing\n",
+        "[Module](https://flax.readthedocs.io/en/latest/flax.linen.html#core-module-abstraction).\n",
+        "Because the architecture in this example is relatively simple—you're just\n",
+        "stacking layers—you can define the inlined submodules directly within the\n",
+        "`__call__` method and wrap it with the\n",
+        "[@compact](https://flax.readthedocs.io/en/latest/flax.linen.html#compact-methods)\n",
+        "decorator."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 4,
+      "metadata": {
+        "id": "_s1lXBBO66dc"
+      },
+      "outputs": [],
+      "source": [
+        "class CNN(nn.Module):\n",
+        "  \"\"\"A simple CNN model.\"\"\"\n",
+        "\n",
+        "  @nn.compact\n",
+        "  def __call__(self, x):\n",
+        "    x = nn.Conv(features=32, kernel_size=(3, 3))(x)\n",
+        "    x = nn.relu(x)\n",
+        "    x = nn.avg_pool(x, window_shape=(2, 2), strides=(2, 2))\n",
+        "    x = nn.Conv(features=64, kernel_size=(3, 3))(x)\n",
+        "    x = nn.relu(x)\n",
+        "    x = nn.avg_pool(x, window_shape=(2, 2), strides=(2, 2))\n",
+        "    x = x.reshape((x.shape[0], -1))  # flatten\n",
+        "    x = nn.Dense(features=256)(x)\n",
+        "    x = nn.relu(x)\n",
+        "    x = nn.Dense(features=10)(x)\n",
+        "    return x"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "xDEoAprU6_JZ"
+      },
+      "source": [
+        "## 3. Define loss\n",
+        "\n",
+        "We simply use `optax.softmax_cross_entropy()`. Note that this function expects both `logits` and `labels` to have shape `[batch, num_classes]`. Since the labels will be read from TFDS as integer values, we first need to convert them to a onehot encoding.\n",
+        "\n",
+        "Our function returns a simple scalar value ready for optimization, so we first take the mean of the vector shaped `[batch]` returned by Optax's loss function."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 5,
+      "metadata": {
+        "id": "Zcb_ebU87G7s"
+      },
+      "outputs": [],
+      "source": [
+        "def cross_entropy_loss(*, logits, labels):\n",
+        "  labels_onehot = jax.nn.one_hot(labels, num_classes=10)\n",
+        "  return optax.softmax_cross_entropy(logits=logits, labels=labels_onehot).mean()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "INZE3eM67JUr"
+      },
+      "source": [
+        "## 4. Metric computation\n",
+        "\n",
+        "For loss and accuracy metrics, create a separate function:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 6,
+      "metadata": {
+        "id": "KvuEA8Tw-MYa"
+      },
+      "outputs": [],
+      "source": [
+        "def compute_metrics(*, logits, labels):\n",
+        "  loss = cross_entropy_loss(logits=logits, labels=labels)\n",
+        "  accuracy = jnp.mean(jnp.argmax(logits, -1) == labels)\n",
+        "  metrics = {\n",
+        "      'loss': loss,\n",
+        "      'accuracy': accuracy,\n",
+        "  }\n",
+        "  return metrics"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "lYz0Emry-ele"
+      },
+      "source": [
+        "## 5. Loading data\n",
+        "\n",
+        "Define a function that loads and prepares the MNIST dataset and converts the\n",
+        "samples to floating-point numbers."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 7,
+      "metadata": {
+        "id": "IOeWiS_b-p8O"
+      },
+      "outputs": [],
+      "source": [
+        "def get_datasets():\n",
+        "  \"\"\"Load MNIST train and test datasets into memory.\"\"\"\n",
+        "  ds_builder = tfds.builder('mnist')\n",
+        "  ds_builder.download_and_prepare()\n",
+        "  train_ds = tfds.as_numpy(ds_builder.as_dataset(split='train', batch_size=-1))\n",
+        "  test_ds = tfds.as_numpy(ds_builder.as_dataset(split='test', batch_size=-1))\n",
+        "  train_ds['image'] = jnp.float32(train_ds['image']) / 255.\n",
+        "  test_ds['image'] = jnp.float32(test_ds['image']) / 255.\n",
+        "  return train_ds, test_ds"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "UMFK51rsAUX4"
+      },
+      "source": [
+        "## 6. Create train state\n",
+        "\n",
+        "A common pattern in Flax is to create a single dataclass that represents the\n",
+        "entire training state, including step number, parameters, and optimizer state.\n",
+        "\n",
+        "Also adding optimizer & model to this state has the advantage that we only need\n",
+        "to pass around a single argument to functions like `train_step()` (see below).\n",
+        "\n",
+        "Because this is such a common pattern, Flax provides the class\n",
+        "[flax.training.train_state.TrainState](https://flax.readthedocs.io/en/latest/flax.training.html#train-state)\n",
+        "that serves most basic usecases. Usually one would subclass it to add more data\n",
+        "to be tracked, but in this example we can use it without any modifications."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 8,
+      "metadata": {
+        "id": "QadyBPbWBEAT"
+      },
+      "outputs": [],
+      "source": [
+        "def create_train_state(rng, learning_rate, momentum):\n",
+        "  \"\"\"Creates initial `TrainState`.\"\"\"\n",
+        "  cnn = CNN()\n",
+        "  params = cnn.init(rng, jnp.ones([1, 28, 28, 1]))['params']\n",
+        "  tx = optax.sgd(learning_rate, momentum)\n",
+        "  return train_state.TrainState.create(\n",
+        "      apply_fn=cnn.apply, params=params, tx=tx)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "W7l-75YE-sr-"
+      },
+      "source": [
+        "## 7. Training step\n",
+        "\n",
+        "A function that:\n",
+        "\n",
+        "- Evaluates the neural network given the parameters and a batch of input images\n",
+        "  with the\n",
+        "  [Module.apply](https://flax.readthedocs.io/en/latest/flax.linen.html#flax.linen.Module.apply)\n",
+        "  method.\n",
+        "- Computes the `cross_entropy_loss` loss function.\n",
+        "- Evaluates the loss function and its gradient using\n",
+        "  [jax.value_and_grad](https://jax.readthedocs.io/en/latest/jax.html#jax.value_and_grad).\n",
+        "- Applies a\n",
+        "  [pytree](https://jax.readthedocs.io/en/latest/pytrees.html#pytrees-and-jax-functions)\n",
+        "  of gradients to the optimizer to update the model's parameters.\n",
+        "- Computes the metrics using `compute_metrics` (defined earlier).\n",
+        "\n",
+        "Use JAX's [@jit](https://jax.readthedocs.io/en/latest/jax.html#jax.jit)\n",
+        "decorator to trace the entire `train_step` function and just-in-time compile\n",
+        "it with [XLA](https://www.tensorflow.org/xla) into fused device operations\n",
+        "that run faster and more efficiently on hardware accelerators."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 9,
+      "metadata": {
+        "id": "Ng11cdMf-z0x"
+      },
+      "outputs": [],
+      "source": [
+        "@jax.jit\n",
+        "def train_step(state, batch):\n",
+        "  \"\"\"Train for a single step.\"\"\"\n",
+        "  def loss_fn(params):\n",
+        "    logits = CNN().apply({'params': params}, batch['image'])\n",
+        "    loss = cross_entropy_loss(logits=logits, labels=batch['label'])\n",
+        "    return loss, logits\n",
+        "  grad_fn = jax.value_and_grad(loss_fn, has_aux=True)\n",
+        "  (_, logits), grads = grad_fn(state.params)\n",
+        "  state = state.apply_gradients(grads=grads)\n",
+        "  metrics = compute_metrics(logits=logits, labels=batch['label'])\n",
+        "  return state, metrics"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "t-4qDNUgBryr"
+      },
+      "source": [
+        "## 8. Evaluation step\n",
+        "\n",
+        "Create a function that evaluates your model on the test set with\n",
+        "[Module.apply](https://flax.readthedocs.io/en/latest/flax.linen.html#flax.linen.Module.apply)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 10,
+      "metadata": {
+        "id": "w1J9i6alBv_u"
+      },
+      "outputs": [],
+      "source": [
+        "@jax.jit\n",
+        "def eval_step(params, batch):\n",
+        "  logits = CNN().apply({'params': params}, batch['image'])\n",
+        "  return compute_metrics(logits=logits, labels=batch['label'])"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "MBTLQPC4BxgH"
+      },
+      "source": [
+        "## 9. Train function\n",
+        "\n",
+        "Define a training function that:\n",
+        "\n",
+        "- Shuffles the training data before each epoch using\n",
+        "  [jax.random.permutation](https://jax.readthedocs.io/en/latest/_autosummary/jax.random.permutation.html)\n",
+        "  that takes a PRNGKey as a parameter (check the\n",
+        "  [JAX - the sharp bits](https://jax.readthedocs.io/en/latest/notebooks/Common_Gotchas_in_JAX.html#JAX-PRNG)).\n",
+        "- Runs an optimization step for each batch.\n",
+        "- Retrieves the training metrics from the device with `jax.device_get` and\n",
+        "  computes their mean across each batch in an epoch.\n",
+        "- Returns the optimizer with updated parameters and the training loss and\n",
+        "  accuracy metrics."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 11,
+      "metadata": {
+        "id": "7ipyJ-JGCNqP"
+      },
+      "outputs": [],
+      "source": [
+        "def train_epoch(state, train_ds, batch_size, epoch, rng):\n",
+        "  \"\"\"Train for a single epoch.\"\"\"\n",
+        "  train_ds_size = len(train_ds['image'])\n",
+        "  steps_per_epoch = train_ds_size // batch_size\n",
+        "\n",
+        "  perms = jax.random.permutation(rng, train_ds_size)\n",
+        "  perms = perms[:steps_per_epoch * batch_size]  # skip incomplete batch\n",
+        "  perms = perms.reshape((steps_per_epoch, batch_size))\n",
+        "  batch_metrics = []\n",
+        "  for perm in perms:\n",
+        "    batch = {k: v[perm, ...] for k, v in train_ds.items()}\n",
+        "    state, metrics = train_step(state, batch)\n",
+        "    batch_metrics.append(metrics)\n",
+        "\n",
+        "  # compute mean of metrics across each batch in epoch.\n",
+        "  batch_metrics_np = jax.device_get(batch_metrics)\n",
+        "  epoch_metrics_np = {\n",
+        "      k: np.mean([metrics[k] for metrics in batch_metrics_np])\n",
+        "      for k in batch_metrics_np[0]}\n",
+        "\n",
+        "  print('train epoch: %d, loss: %.4f, accuracy: %.2f' % (\n",
+        "      epoch, epoch_metrics_np['loss'], epoch_metrics_np['accuracy'] * 100))\n",
+        "\n",
+        "  return state"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "E2cHbVUfCRMv"
+      },
+      "source": [
+        "## 10. Eval function\n",
+        "\n",
+        "Create a model evaluation function that:\n",
+        "\n",
+        "- Retrieves the evaluation metrics from the device with `jax.device_get`.\n",
+        "- Copies the metrics\n",
+        "  [data stored](https://flax.readthedocs.io/en/latest/design_notes/linen_design_principles.html#how-are-parameters-represented-and-how-do-we-handle-general-differentiable-algorithms-that-update-stateful-variables)\n",
+        "  in a JAX\n",
+        "  [pytree](https://jax.readthedocs.io/en/latest/pytrees.html#pytrees-and-jax-functions)."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 12,
+      "metadata": {
+        "id": "_dKahNmMCr5q"
+      },
+      "outputs": [],
+      "source": [
+        "def eval_model(params, test_ds):\n",
+        "  metrics = eval_step(params, test_ds)\n",
+        "  metrics = jax.device_get(metrics)\n",
+        "  summary = jax.tree_map(lambda x: x.item(), metrics)\n",
+        "  return summary['loss'], summary['accuracy']"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "mHQi20yVCsSf"
+      },
+      "source": [
+        "## 11. Download data"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 13,
+      "metadata": {
+        "id": "6CLXnP3KHptR",
+        "outputId": "4f019877-e87d-4862-af7b-c82334e4f12c",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        }
+      },
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "WARNING:tensorflow:From /usr/local/lib/python3.7/dist-packages/tensorflow_datasets/core/dataset_builder.py:598: get_single_element (from tensorflow.python.data.experimental.ops.get_single_element) is deprecated and will be removed in a future version.\n",
+            "Instructions for updating:\n",
+            "Use `tf.data.Dataset.get_single_element()`.\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "WARNING:tensorflow:From /usr/local/lib/python3.7/dist-packages/tensorflow_datasets/core/dataset_builder.py:598: get_single_element (from tensorflow.python.data.experimental.ops.get_single_element) is deprecated and will be removed in a future version.\n",
+            "Instructions for updating:\n",
+            "Use `tf.data.Dataset.get_single_element()`.\n"
+          ]
+        }
+      ],
+      "source": [
+        "train_ds, test_ds = get_datasets()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "56rKPl6OHqu8"
+      },
+      "source": [
+        "## 12. Seed randomness\n",
+        "\n",
+        "- Get one\n",
+        "  [PRNGKey](https://jax.readthedocs.io/en/latest/_autosummary/jax.random.PRNGKey.html#jax.random.PRNGKey)\n",
+        "  and\n",
+        "  [split](https://jax.readthedocs.io/en/latest/_autosummary/jax.random.split.html#jax.random.split)\n",
+        "  it to get a second key that you'll use for parameter initialization. (Learn\n",
+        "  more about\n",
+        "  [PRNG chains](https://flax.readthedocs.io/en/latest/design_notes/linen_design_principles.html#how-are-parameters-represented-and-how-do-we-handle-general-differentiable-algorithms-that-update-stateful-variables)\n",
+        "  and\n",
+        "  [JAX PRNG design](https://github.com/google/jax/blob/main/design_notes/prng.md).)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 14,
+      "metadata": {
+        "id": "n53xh_B8Ht_W"
+      },
+      "outputs": [],
+      "source": [
+        "rng = jax.random.PRNGKey(0)\n",
+        "rng, init_rng = jax.random.split(rng)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "Y3iHFiAuH41s"
+      },
+      "source": [
+        "## 13. Initialize train state\n",
+        "\n",
+        "Remember that function initializes both the model parameters and the optimizer\n",
+        "and puts both into the training state dataclass that is returned."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 15,
+      "metadata": {
+        "id": "Mj6OfdEEIU-o"
+      },
+      "outputs": [],
+      "source": [
+        "learning_rate = 0.1\n",
+        "momentum = 0.9"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 16,
+      "metadata": {
+        "id": "_87fL90dH-0Z"
+      },
+      "outputs": [],
+      "source": [
+        "state = create_train_state(init_rng, learning_rate, momentum)\n",
+        "del init_rng  # Must not be used anymore."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "UqNrWu7kIC9S"
+      },
+      "source": [
+        "## 14. Train and evaluate\n",
+        "\n",
+        "Once the training and testing is done after 10 epochs, the output should show that your model was able to achieve approximately 99% accuracy."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 17,
+      "metadata": {
+        "id": "0nxgS5Z5IsT_"
+      },
+      "outputs": [],
+      "source": [
+        "num_epochs = 10\n",
+        "batch_size = 32"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 18,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "ugGlV3u6Iq1A",
+        "outputId": "d0944ddb-8d5d-4e9f-9727-040789ef3f17"
+      },
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "train epoch: 1, loss: 0.1398, accuracy: 95.77\n",
+            " test epoch: 1, loss: 0.05, accuracy: 98.59\n",
+            "train epoch: 2, loss: 0.0488, accuracy: 98.50\n",
+            " test epoch: 2, loss: 0.05, accuracy: 98.41\n",
+            "train epoch: 3, loss: 0.0347, accuracy: 98.96\n",
+            " test epoch: 3, loss: 0.04, accuracy: 98.79\n",
+            "train epoch: 4, loss: 0.0242, accuracy: 99.26\n",
+            " test epoch: 4, loss: 0.04, accuracy: 99.04\n",
+            "train epoch: 5, loss: 0.0212, accuracy: 99.37\n",
+            " test epoch: 5, loss: 0.03, accuracy: 99.00\n",
+            "train epoch: 6, loss: 0.0170, accuracy: 99.49\n",
+            " test epoch: 6, loss: 0.03, accuracy: 99.09\n",
+            "train epoch: 7, loss: 0.0114, accuracy: 99.63\n",
+            " test epoch: 7, loss: 0.03, accuracy: 99.08\n",
+            "train epoch: 8, loss: 0.0093, accuracy: 99.71\n",
+            " test epoch: 8, loss: 0.03, accuracy: 99.11\n",
+            "train epoch: 9, loss: 0.0109, accuracy: 99.65\n",
+            " test epoch: 9, loss: 0.04, accuracy: 99.08\n",
+            "train epoch: 10, loss: 0.0103, accuracy: 99.68\n",
+            " test epoch: 10, loss: 0.03, accuracy: 99.01\n"
+          ]
+        }
+      ],
+      "source": [
+        "for epoch in range(1, num_epochs + 1):\n",
+        "  # Use a separate PRNG key to permute image data during shuffling\n",
+        "  rng, input_rng = jax.random.split(rng)\n",
+        "  # Run an optimization step over a training batch\n",
+        "  state = train_epoch(state, train_ds, batch_size, epoch, input_rng)\n",
+        "  # Evaluate on the test set after each training epoch \n",
+        "  test_loss, test_accuracy = eval_model(state.params, test_ds)\n",
+        "  print(' test epoch: %d, loss: %.2f, accuracy: %.2f' % (\n",
+        "      epoch, test_loss, test_accuracy * 100))"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "oKcRiQ89xQkF"
+      },
+      "source": [
+        "Congrats! You made it to the end of the annotated MNIST example. You can revisit\n",
+        "the same example, but structured differently as a couple of Python modules, test\n",
+        "modules, config files, another Colab, and documentation in Flax's Git repo:\n",
+        "\n",
+        "https://github.com/google/flax/tree/main/examples/mnist\n"
+      ]
     }
-   ],
-   "source": [
-    "for epoch in range(1, num_epochs + 1):\n",
-    "  # Use a separate PRNG key to permute image data during shuffling\n",
-    "  rng, input_rng = jax.random.split(rng)\n",
-    "  # Run an optimization step over a training batch\n",
-    "  state = train_epoch(state, train_ds, batch_size, epoch, input_rng)\n",
-    "  # Evaluate on the test set after each training epoch \n",
-    "  test_loss, test_accuracy = eval_model(state.params, test_ds)\n",
-    "  print(' test epoch: %d, loss: %.2f, accuracy: %.2f' % (\n",
-    "      epoch, test_loss, test_accuracy * 100))"
-   ]
+  ],
+  "metadata": {
+    "accelerator": "GPU",
+    "colab": {
+      "collapsed_sections": [],
+      "name": "annotated_mnist",
+      "provenance": []
+    },
+    "jupytext": {
+      "formats": "ipynb,md:myst",
+      "main_language": "python"
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python"
+    }
   },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "oKcRiQ89xQkF"
-   },
-   "source": [
-    "Congrats! You made it to the end of the annotated MNIST example. You can revisit\n",
-    "the same example, but structured differently as a couple of Python modules, test\n",
-    "modules, config files, another Colab, and documentation in Flax's Git repo:\n",
-    "\n",
-    "https://github.com/google/flax/tree/main/examples/mnist\n"
-   ]
-  }
- ],
- "metadata": {
-  "accelerator": "GPU",
-  "colab": {
-   "collapsed_sections": [],
-   "name": "annotated_mnist",
-   "provenance": []
-  },
-  "jupytext": {
-   "formats": "ipynb,md:myst",
-   "main_language": "python"
-  },
-  "kernelspec": {
-   "display_name": "Python 3",
-   "name": "python3"
-  },
-  "language_info": {
-   "name": "python"
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 0
+  "nbformat": 4,
+  "nbformat_minor": 0
 }

--- a/docs/notebooks/annotated_mnist.ipynb
+++ b/docs/notebooks/annotated_mnist.ipynb
@@ -23,11 +23,11 @@
       "cell_type": "code",
       "source": [
         "# Check GPU\n",
-        "!nvidia-smi"
+        "!nvidia-smi -L"
       ],
       "metadata": {
         "id": "FOYfP6vf2FGx",
-        "outputId": "a5c9dcc6-6972-4240-f657-2145b8661ffb",
+        "outputId": "65ba547d-59df-4fc0-9578-9faa2c14abe8",
         "colab": {
           "base_uri": "https://localhost:8080/"
         }
@@ -38,26 +38,7 @@
           "output_type": "stream",
           "name": "stdout",
           "text": [
-            "Tue Apr 26 17:11:22 2022       \n",
-            "+-----------------------------------------------------------------------------+\n",
-            "| NVIDIA-SMI 460.32.03    Driver Version: 460.32.03    CUDA Version: 11.2     |\n",
-            "|-------------------------------+----------------------+----------------------+\n",
-            "| GPU  Name        Persistence-M| Bus-Id        Disp.A | Volatile Uncorr. ECC |\n",
-            "| Fan  Temp  Perf  Pwr:Usage/Cap|         Memory-Usage | GPU-Util  Compute M. |\n",
-            "|                               |                      |               MIG M. |\n",
-            "|===============================+======================+======================|\n",
-            "|   0  Tesla T4            Off  | 00000000:00:04.0 Off |                    0 |\n",
-            "| N/A   36C    P8     9W /  70W |      0MiB / 15109MiB |      0%      Default |\n",
-            "|                               |                      |                  N/A |\n",
-            "+-------------------------------+----------------------+----------------------+\n",
-            "                                                                               \n",
-            "+-----------------------------------------------------------------------------+\n",
-            "| Processes:                                                                  |\n",
-            "|  GPU   GI   CI        PID   Type   Process name                  GPU Memory |\n",
-            "|        ID   ID                                                   Usage      |\n",
-            "|=============================================================================|\n",
-            "|  No running processes found                                                 |\n",
-            "+-----------------------------------------------------------------------------+\n"
+            "GPU 0: Tesla T4 (UUID: GPU-d0ec4f05-c4a8-7952-556f-b668f22fe9c7)\n"
           ]
         }
       ]
@@ -77,7 +58,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 2,
+      "execution_count": null,
       "metadata": {
         "id": "inJ9bV636dRx"
       },
@@ -88,7 +69,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 3,
+      "execution_count": null,
       "metadata": {
         "id": "Z7MuGFB16E8m"
       },
@@ -124,7 +105,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 4,
+      "execution_count": null,
       "metadata": {
         "id": "_s1lXBBO66dc"
       },
@@ -163,7 +144,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 5,
+      "execution_count": null,
       "metadata": {
         "id": "Zcb_ebU87G7s"
       },
@@ -187,7 +168,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 6,
+      "execution_count": null,
       "metadata": {
         "id": "KvuEA8Tw-MYa"
       },
@@ -217,7 +198,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 7,
+      "execution_count": null,
       "metadata": {
         "id": "IOeWiS_b-p8O"
       },
@@ -256,7 +237,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 8,
+      "execution_count": null,
       "metadata": {
         "id": "QadyBPbWBEAT"
       },
@@ -301,7 +282,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 9,
+      "execution_count": null,
       "metadata": {
         "id": "Ng11cdMf-z0x"
       },
@@ -335,7 +316,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 10,
+      "execution_count": null,
       "metadata": {
         "id": "w1J9i6alBv_u"
       },
@@ -370,7 +351,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 11,
+      "execution_count": null,
       "metadata": {
         "id": "7ipyJ-JGCNqP"
       },
@@ -421,7 +402,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 12,
+      "execution_count": null,
       "metadata": {
         "id": "_dKahNmMCr5q"
       },
@@ -445,7 +426,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 13,
+      "execution_count": null,
       "metadata": {
         "id": "6CLXnP3KHptR",
         "outputId": "4f019877-e87d-4862-af7b-c82334e4f12c",
@@ -498,7 +479,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 14,
+      "execution_count": null,
       "metadata": {
         "id": "n53xh_B8Ht_W"
       },
@@ -522,7 +503,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 15,
+      "execution_count": null,
       "metadata": {
         "id": "Mj6OfdEEIU-o"
       },
@@ -534,7 +515,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 16,
+      "execution_count": null,
       "metadata": {
         "id": "_87fL90dH-0Z"
       },
@@ -557,7 +538,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 17,
+      "execution_count": null,
       "metadata": {
         "id": "0nxgS5Z5IsT_"
       },
@@ -569,7 +550,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 18,
+      "execution_count": null,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -635,7 +616,7 @@
     "accelerator": "GPU",
     "colab": {
       "collapsed_sections": [],
-      "name": "annotated_mnist",
+      "name": "annotated_mnist.ipynb",
       "provenance": []
     },
     "jupytext": {


### PR DESCRIPTION
As mentioned in #2051, it is a bit confusing that we return `nn.log_softmax(x)` from the model and then define the loss as `-jnp.mean(jnp.sum(one_hot_labels * logits, axis=-1))`

This PR updates the [Annotated MNIST](https://colab.sandbox.google.com/github/google/flax/blob/main/docs/notebooks/annotated_mnist.ipynb) to use the same `optax.softmax_cross_entropy()` for loss computation that we already use in [`examples/minst/`](https://github.com/google/flax/tree/main/examples/mnist)

Note that #2051 also has some discussions about a `vmap()` based implementation and performance comparisons, but the current implementation seems to perform better on TPU and similarly on GPU.