### PR TITLE
[remove-units] avoid calling unit-generating trace_to_jaxpr

### DIFF
--- a/flax/jax_utils.py
+++ b/flax/jax_utils.py
@@ -94,7 +94,7 @@ def partial_eval_by_shape(fn, input_spec, *args, **kwargs):
   f_flat, out_tree = jax.api_util.flatten_fun_nokwargs(lu.wrap_init(f), in_tree)
   in_pvals = [pe.PartialVal.unknown(jax.ShapedArray(x.shape, x.dtype))
               for x in inputs_flat]
-  _, out_pvals, _ = pe.trace_to_jaxpr(f_flat, in_pvals)
+  _, out_pvals, _ = pe.trace_to_jaxpr_nounits(f_flat, in_pvals)
   out_flat = [const if pv is None else jax.ShapeDtypeStruct(pv.shape, pv.dtype)
               for pv, const in out_pvals]
   return jax.tree_unflatten(out_tree(), out_flat)


### PR DESCRIPTION
Since the caller here was dropping units anyway (plugging in ShapeDtypeStruct instances in their stead), trace_to_jaxpr_nounits was a drop-in replacement!