### PR TITLE
Check for attribute-variable correspondence

### DIFF
--- a/tests/linen/linen_module_test.py
+++ b/tests/linen/linen_module_test.py
@@ -1562,7 +1562,7 @@ class ModuleTest(absltest.TestCase):
     self.assertIn("bar", variables["params"])
     self.assertIn("submod_0", variables["params"])
 
-  def test_correspondance_counter_example(self):
+  def test_correspondance_allow_repeated_values_from_fields(self):
     class Foo(nn.Module):
       def setup(self):
         self.bar = self.param("bar", lambda key: jnp.array(1))
@@ -1575,8 +1575,7 @@ class ModuleTest(absltest.TestCase):
 
     module = Foo(parent=None)
 
-    with self.assertRaises(RuntimeError):
-      variables = module.init(jax.random.PRNGKey(0))
+    variables = module.init(jax.random.PRNGKey(0))
   
 
 if __name__ == '__main__':

--- a/tests/linen/linen_module_test.py
+++ b/tests/linen/linen_module_test.py
@@ -1566,9 +1566,7 @@ class ModuleTest(absltest.TestCase):
     class Foo(nn.Module):
       def setup(self):
         self.bar = self.param("bar", lambda key: jnp.array(1))
-        # this will fail because assigned value is found but
-        # no 'baz' variable exists
-        self.baz = self.bar
+        self.baz = self.bar # this is OK
 
       def __call__(self):
         pass


### PR DESCRIPTION
Fixes #2100, see discussion.

# Changes
This PR tries to prevent users from assigning fields during `setup` to variables created with different names e.g:

```python
class Foo(nn.Module):
  def setup(self):
    # this would error as value from 'baz' was found for field 'bar'
    self.bar = self.param("baz", lambda key: jnp.array(1))
```
However there are edge cases. The following will yield an error but its not clear it should:

```python
class Foo(nn.Module):
  def setup(self):
    self.bar = self.param("bar", lambda key: jnp.array(1))
    self.baz = self.bar # error: value found but 'baz' key was not found
```
The correspondence can also be broken while being undetectable:
```python
class Foo(nn.Module):
  def setup(self):
    self.bar = self.param("bar", lambda key: jnp.array(1)) + 3
```
In this example no error arises because its value was not found in `variables`. 

