### PR TITLE
Add typehint to Module.scope

### DIFF
--- a/flax/linen/module.py
+++ b/flax/linen/module.py
@@ -530,7 +530,7 @@ class Module:
     cls._wrap_module_methods()
     # Set empty class defaults.
     cls._state = _uninitialized_module_internal_state
-    cls.scope = None
+    cls.scope: Optional[Scope] = None
 
   @classmethod
   def _customized_dataclass_transform(cls):


### PR DESCRIPTION
# What does this PR do?
Small but useful change that adds typehint information to `Module.scope`. Currently editors and static analyzers don't provide any useful information about `self.scope`. Users should be able to better autocompletion when referencing scope now.