### PR TITLE
Update link to JAX installation page

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -4,7 +4,7 @@ You will need Python 3.6 or later.
 
 For GPU support, first install `jaxlib`; please follow the
 instructions in the [JAX
-readme](https://github.com/google/jax/blob/main/README.md).  If they
+readme](https://github.com/google/jax#installation).  If they
 are not already installed, you will need to install
 [CUDA](https://developer.nvidia.com/cuda-downloads) and
 [CuDNN](https://developer.nvidia.com/cudnn) runtimes.


### PR DESCRIPTION
The original link to the JAX installation README was broken, it resulted in a 404 page not found error, so I replaced it with the new link (https://github.com/google/jax#installation)

Fixes  #2128

## Checklist
- [x] This PR fixes a minor issue (e.g.: typo or small bug) or improves the docs (you can dismiss the other
      checks if that's the case).
- [ ] This change is discussed in a Github issue/
      [discussion](https://github.com/google/flax/discussions) (please add a
      link).
- [ ] The documentation and docstrings adhere to the
      [documentation guidelines](https://github.com/google/flax/blob/main/docs/README.md#how-to-write-code-documentation).
- [ ] This change includes necessary high-coverage tests.
      (No quality testing = no merge!)
