### PR TITLE
Upgrade to modern python idioms using pyupgrade.

### DIFF
--- a/examples/imagenet/input_pipeline.py
+++ b/examples/imagenet/input_pipeline.py
@@ -190,12 +190,12 @@ def create_split(dataset_builder, batch_size, train, dtype=tf.float32,
     train_examples = dataset_builder.info.splits['train'].num_examples
     split_size = train_examples // jax.process_count()
     start = jax.process_index() * split_size
-    split = 'train[{}:{}]'.format(start, start + split_size)
+    split = f'train[{start}:{start + split_size}]'
   else:
     validate_examples = dataset_builder.info.splits['validation'].num_examples
     split_size = validate_examples // jax.process_count()
     start = jax.process_index() * split_size
-    split = 'validation[{}:{}]'.format(start, start + split_size)
+    split = f'validation[{start}:{start + split_size}]'
 
   def decode_example(example):
     if train:

--- a/examples/imagenet/train.py
+++ b/examples/imagenet/train.py
@@ -114,9 +114,9 @@ def train_step(state, batch, learning_rate_fn):
     loss = cross_entropy_loss(logits, batch['label'])
     weight_penalty_params = jax.tree_leaves(params)
     weight_decay = 0.0001
-    weight_l2 = sum([jnp.sum(x ** 2)
+    weight_l2 = sum(jnp.sum(x ** 2)
                      for x in weight_penalty_params
-                     if x.ndim > 1])
+                     if x.ndim > 1)
     weight_penalty = weight_decay * 0.5 * weight_l2
     loss = loss + weight_penalty
     return loss, (new_model_state, logits)

--- a/examples/lm1b/train.py
+++ b/examples/lm1b/train.py
@@ -172,7 +172,7 @@ def train_step(state,
   # like a normal, unpacked sequence example.
   train_keys = ["inputs", "inputs_position", "inputs_segmentation"]
   (inputs, inputs_positions, inputs_segmentation
-   ) = [batch.get(k, None) for k in train_keys]
+   ) = (batch.get(k, None) for k in train_keys)
 
   weights = jnp.where(inputs > 0, 1, 0).astype(jnp.float32)
 

--- a/examples/nlp_seq/input_pipeline.py
+++ b/examples/nlp_seq/input_pipeline.py
@@ -69,7 +69,7 @@ def create_vocabs(filename, max_num_forms=100000):
   with tf.io.gfile.GFile(filename, 'rb') as f:
     for line in codecs.getreader('utf-8')(f):
       line = line.strip()
-      split = line.split(u'\t')
+      split = line.split('\t')
       if not line.startswith('#') and split[0]:
         form_counter[split[CoNLLAttributes.FORM.value]] += 1
         xpos_counter[split[CoNLLAttributes.XPOS.value]] += 1

--- a/examples/nlp_seq/input_pipeline_test.py
+++ b/examples/nlp_seq/input_pipeline_test.py
@@ -29,7 +29,7 @@ tf.enable_v2_behavior()
 jax.config.parse_flags_with_absl()
 
 
-CONLL_DATA = u"""1\tThey\tthey\tPRON\tPRP\tCase=Nom|Number=Plur\t2\tnsubj
+CONLL_DATA = """1\tThey\tthey\tPRON\tPRP\tCase=Nom|Number=Plur\t2\tnsubj
 2\tbuy\tbuy\t VERB\tVBP\tNumber=Plur|PTense=Pres\t0\troot
 3\tbooks\tbook\tNOUN\tNNS\tNumber=Plur\t2\tobj
 4\t.\t.\tPUNCT\t.\t_\t2\tpunct
@@ -46,7 +46,7 @@ CONLL_DATA = u"""1\tThey\tthey\tPRON\tPRP\tCase=Nom|Number=Plur\t2\tnsubj
 class InputPipelineTest(absltest.TestCase):
 
   def setUp(self):
-    super(InputPipelineTest, self).setUp()
+    super().setUp()
     self.test_tmpdir = self.create_tempdir()
 
     # Write a sample corpus.

--- a/examples/nlp_seq/train.py
+++ b/examples/nlp_seq/train.py
@@ -195,7 +195,7 @@ def train_step(optimizer, batch, learning_rate_fn, model, dropout_rng=None):
   """Perform a single training step."""
 
   train_keys = ['inputs', 'targets']
-  (inputs, targets) = [batch.get(k, None) for k in train_keys]
+  (inputs, targets) = (batch.get(k, None) for k in train_keys)
 
   weights = jnp.where(targets > 0, 1, 0).astype(jnp.float32)
   dropout_rng, new_dropout_rng = random.split(dropout_rng)

--- a/examples/ppo/seed_rl_atari_preprocessing.py
+++ b/examples/ppo/seed_rl_atari_preprocessing.py
@@ -35,7 +35,7 @@ from gym.spaces.box import Box
 import numpy as np
 
 
-class AtariPreprocessing(object):
+class AtariPreprocessing:
   """A class implementing image preprocessing for Atari 2600 agents.
   Specifically, this provides the following subset from the JAIR paper
   (Bellemare et al., 2013) and Nature DQN paper (Mnih et al., 2015):

--- a/examples/seq2seq/input_pipeline.py
+++ b/examples/seq2seq/input_pipeline.py
@@ -28,10 +28,10 @@ class CharacterTable:
 
   def __init__(self, chars: str, max_len_query_digit: int = 3) -> None:
     self._chars = sorted(set(chars))
-    self._char_indices = dict(
-        (ch, idx + 2) for idx, ch in enumerate(self._chars))
-    self._indices_char = dict(
-        (idx + 2, ch) for idx, ch in enumerate(self._chars))
+    self._char_indices = {
+        ch: idx + 2 for idx, ch in enumerate(self._chars)}
+    self._indices_char = {
+        idx + 2: ch for idx, ch in enumerate(self._chars)}
     self._indices_char[self.pad_id] = '_'
     # Maximum length of a single input digit.
     self._max_len_query_digit = max_len_query_digit
@@ -121,7 +121,7 @@ class CharacterTable:
       max_digit = pow(10, self._max_len_query_digit) - 1
       # TODO(marcvanzee): Use jax.random here.
       key = tuple(sorted((random.randint(0, 99), random.randint(0, max_digit))))
-      inputs = '{}+{}'.format(key[0], key[1])
+      inputs = f'{key[0]}+{key[1]}'
       # Preprend output by the decoder's start token.
       outputs = '=' + str(key[0] + key[1])
       yield (inputs, outputs)

--- a/examples/sst2/build_vocabulary.py
+++ b/examples/sst2/build_vocabulary.py
@@ -33,8 +33,7 @@ def get_tokenized_sequences(
   dataset = dataset.map(
       lambda example: tokenizer.tokenize(example[input_key]),
       num_parallel_calls=tf.data.experimental.AUTOTUNE)
-  for sentence in tfds.as_numpy(dataset):
-    yield sentence
+  yield from tfds.as_numpy(dataset)
 
 
 if __name__ == '__main__':

--- a/examples/vae/utils.py
+++ b/examples/vae/utils.py
@@ -42,7 +42,7 @@ def save_image(ndarray, fp, nrow=8, padding=2, pad_value=0.0, format=None):
   """
     if not (isinstance(ndarray, jnp.ndarray) or
         (isinstance(ndarray, list) and all(isinstance(t, jnp.ndarray) for t in ndarray))):
-        raise TypeError('array_like of tensors expected, got {}'.format(type(ndarray)))
+        raise TypeError(f'array_like of tensors expected, got {type(ndarray)}')
 
     ndarray = jnp.asarray(ndarray)
 

--- a/examples/wmt/bleu.py
+++ b/examples/wmt/bleu.py
@@ -47,7 +47,7 @@ import numpy as np
 import six
 
 
-class UnicodeRegex(object):
+class UnicodeRegex:
   """Ad-hoc hack to recognize all punctuation and symbols."""
 
   def __init__(self):
@@ -58,9 +58,9 @@ class UnicodeRegex(object):
 
   def property_chars(self, prefix):
     return "".join(
-        six.unichr(x)
+        chr(x)
         for x in range(sys.maxunicode)
-        if unicodedata.category(six.unichr(x)).startswith(prefix))
+        if unicodedata.category(chr(x)).startswith(prefix))
 
 
 uregex = UnicodeRegex()
@@ -144,8 +144,8 @@ def compute_bleu_matches(reference_corpus,
     ref_ngram_counts = _get_ngrams(references, max_order)
     translation_ngram_counts = _get_ngrams(translations, max_order)
 
-    overlap = dict((ngram, min(count, translation_ngram_counts[ngram]))
-                   for ngram, count in ref_ngram_counts.items())
+    overlap = {ngram: min(count, translation_ngram_counts[ngram])
+                   for ngram, count in ref_ngram_counts.items()}
 
     for ngram in overlap:
       matches_by_order[len(ngram) - 1] += overlap[ngram]

--- a/examples/wmt/train.py
+++ b/examples/wmt/train.py
@@ -180,7 +180,7 @@ def train_step(state,
       "inputs_segmentation", "targets_segmentation"
   ]
   (inputs, targets, inputs_positions, targets_positions, inputs_segmentation,
-   targets_segmentation) = [batch.get(k, None) for k in train_keys]
+   targets_segmentation) = (batch.get(k, None) for k in train_keys)
 
   weights = jnp.where(targets > 0, 1, 0).astype(jnp.float32)
 

--- a/flax/config.py
+++ b/flax/config.py
@@ -48,7 +48,7 @@ def bool_env(varname: str, default: bool) -> bool:
     return False
   else:
     raise ValueError(
-        'invalid truth value %r for environment %r' % (val, varname))
+        'invalid truth value {!r} for environment {!r}'.format(val, varname))
 
 
 # Flax Global Configuration Variables:

--- a/flax/core/nn/linear.py
+++ b/flax/core/nn/linear.py
@@ -29,7 +29,7 @@ default_kernel_init = initializers.lecun_normal()
 
 def _normalize_axes(axes, ndim):
   # A tuple by convention. len(axes_tuple) then also gives the rank efficiently.
-  return tuple([ax if ax >= 0 else ndim + ax for ax in axes])
+  return tuple(ax if ax >= 0 else ndim + ax for ax in axes)
 
 
 def dense_general(
@@ -89,8 +89,8 @@ def dense_general(
                               for _ in range(size_batch_dims)], axis=0)
     return jnp.reshape(kernel, shape)
 
-  batch_shape = tuple([inputs.shape[ax] for ax in batch_dims])
-  kernel_shape = tuple([inputs.shape[ax] for ax in axis]) + features
+  batch_shape = tuple(inputs.shape[ax] for ax in batch_dims)
+  kernel_shape = tuple(inputs.shape[ax] for ax in axis) + features
   kernel = scope.param('kernel', kernel_init_wrap, batch_shape + kernel_shape)
   kernel = jnp.asarray(kernel, dtype)
 

--- a/flax/core/nn/normalization.py
+++ b/flax/core/nn/normalization.py
@@ -21,7 +21,7 @@ import jax.numpy as jnp
 
 
 def _absolute_dims(rank, dims):
-  return tuple([rank + dim if dim < 0 else dim for dim in dims])
+  return tuple(rank + dim if dim < 0 else dim for dim in dims)
 
 
 def batch_norm(scope: Scope,

--- a/flax/linen/linear.py
+++ b/flax/linen/linear.py
@@ -44,7 +44,7 @@ default_kernel_init = lecun_normal()
 
 def _normalize_axes(axes: Tuple[int, ...], ndim: int) -> Tuple[int, ...]:
   # A tuple by convention. len(axes_tuple) then also gives the rank efficiently.
-  return tuple(sorted([ax if ax >= 0 else ndim + ax for ax in axes]))
+  return tuple(sorted(ax if ax >= 0 else ndim + ax for ax in axes))
 
 
 def _canonicalize_tuple(x: Union[Sequence[int], int]) -> Tuple[int, ...]:
@@ -113,12 +113,12 @@ class DenseGeneral(Module):
                                 for _ in range(size_batch_dims)], axis=0)
       return jnp.reshape(kernel, shape)
 
-    batch_shape = tuple([inputs.shape[ax] for ax in batch_dims])
+    batch_shape = tuple(inputs.shape[ax] for ax in batch_dims)
     # batch and non-contracting dims of input with 1s for batch dims.
     expanded_batch_shape = tuple(
         inputs.shape[ax] if ax in batch_dims else 1
         for ax in range(inputs.ndim) if ax not in axis)
-    kernel_shape = tuple([inputs.shape[ax] for ax in axis]) + features
+    kernel_shape = tuple(inputs.shape[ax] for ax in axis) + features
     kernel = self.param('kernel', kernel_init_wrap, batch_shape + kernel_shape,
                         self.param_dtype)
 

--- a/flax/metrics/tensorboard.py
+++ b/flax/metrics/tensorboard.py
@@ -53,7 +53,7 @@ def _flatten_dict(input_dict, parent_key='', sep='.'):
   return dict(items)
 
 
-class SummaryWriter(object):
+class SummaryWriter:
   """Saves data in event and summary protos for tensorboard."""
 
   def __init__(self, log_dir):

--- a/flax/serialization.py
+++ b/flax/serialization.py
@@ -257,7 +257,7 @@ def _np_convert_in_place(d):
   return d
 
 
-_tuple_to_dict = lambda tpl: dict([(str(x), y) for x, y in enumerate(tpl)])
+_tuple_to_dict = lambda tpl: {str(x): y for x, y in enumerate(tpl)}
 _dict_to_tuple = lambda dct: tuple(dct[str(i)] for i in range(len(dct)))
 
 

--- a/flax/testing/benchmark.py
+++ b/flax/testing/benchmark.py
@@ -114,7 +114,7 @@ class Benchmark(absltest.TestCase):
 
   def __init__(self, *args, **kwargs):
     """Wrap test methods in a try-except decorator to delay exceptions."""
-    super(Benchmark, self).__init__(*args, **kwargs)
+    super().__init__(*args, **kwargs)
     for func_name in dir(self):
       if func_name.startswith('assert'):
         func = getattr(self, func_name)
@@ -137,7 +137,7 @@ class Benchmark(absltest.TestCase):
 
   def setUp(self):
     """Setup ran before each test."""
-    super(Benchmark, self).setUp()
+    super().setUp()
     self._reported_name = None
     self._reported_wall_time = None
     self._reported_metrics = {}
@@ -146,7 +146,7 @@ class Benchmark(absltest.TestCase):
 
   def tearDown(self):
     """Tear down after each test."""
-    super(Benchmark, self).tearDown()
+    super().tearDown()
     self._report_benchmark_results()
     for message in self._outstanding_fails:
       raise self.failureException(message)
@@ -228,7 +228,7 @@ class Benchmark(absltest.TestCase):
 
     # Prefix the name with the class name.
     class_name = type(calling_class).__name__
-    name = '%s.%s' % (class_name, name)
+    name = '{}.{}'.format(class_name, name)
     return name
 
   def _update_reported_name(self):

--- a/flax/traverse_util.py
+++ b/flax/traverse_util.py
@@ -168,7 +168,7 @@ class Traversal(abc.ABC):
         'it for `flax.optim`, use `optax` instead. Refer to the update guide '
         'https://flax.readthedocs.io/en/latest/howtos/optax_update_guide.html '
         'for detailed instructions.', DeprecationWarning)
-    return super(Traversal, cls).__new__(cls)
+    return super().__new__(cls)
 
   @abc.abstractmethod
   def update(self, fn, inputs):

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ from setuptools import setup
 here = os.path.abspath(os.path.dirname(__file__))
 try:
   README = open(os.path.join(here, "README.md"), encoding="utf-8").read()
-except IOError:
+except OSError:
   README = ""
 
 install_requires = [


### PR DESCRIPTION
I ran the command
```
pyupgrade --py37-plus --keep-runtime-typing **.py
```
across all of the flax subdirectories and inspected all changes by eye.

All the suggestions seemed good to me with the exception of the tool's
preference for python "set" literal notation (i.e. using `{...}` instead
of `set(...)`) which I think makes several bits of code less clear to readers
who aren't so familiar with python set vs dict notation.

Most of the changes are modern `super()` notation, string formatting
fixes, and modernization of tuple/iterator syntax.