### PR TITLE
Improve tabulate

### DIFF
--- a/flax/linen/module.py
+++ b/flax/linen/module.py
@@ -1362,7 +1362,7 @@ class Module:
     method: Optional[Callable[..., Any]] = None,
     mutable: CollectionFilter = True,
     depth: Optional[int] = None,
-    output_methods: Optional[Union[Sequence[str], Set[str]]] = None,
+    exclude_methods: Sequence[str] = (),
     **kwargs) -> str:
     """Creates a summary of the Module represented as a table.
 
@@ -1432,16 +1432,19 @@ class Module:
         depth limit, its parameter count and bytes will be added to the row of 
         its first shown ancestor such that the sum of all rows always adds up to 
         the total number of parameters of the Module.
-      output_methods: Method names in the `intermediates` collection that should be
-        included as outputs in the summary. The `'__call__'` method is always included.
+      exclude_methods: A sequence of strings that specifies which methods should
+        be ignored. In case a module calls a helper method from its main method,
+        use this argument to exclude the helper method from the summary to avoid
+        ambiguity.
       **kwargs: keyword arguments to pass to the forward computation.
 
     Returns:
       A string summarizing the Module.
     """
 
-    tabulate_fn = summary.tabulate(self, rngs, method=method, mutable=mutable, 
-                           depth=depth, output_methods=output_methods)
+    tabulate_fn = summary.tabulate(self, rngs, method=method, 
+                                   mutable=mutable, depth=depth,
+                                   exclude_methods=exclude_methods)
     return tabulate_fn(*args, **kwargs)
     
 


### PR DESCRIPTION
# What does this PR do?
Adds various small improvements to `tabulate` including:
* Removes `output_methods` argument, it is no longer necessary since now internally `capture_intermediates` is set to a function that collects them automatically (inspired by [this comment](https://github.com/google/flax/pull/1844#issuecomment-1140321111), thanks @trvs2cool!). Also solves the issue of intermediates for methods other than `__call__` not being captured.
* Adds the `exclude_methods` argument which lets you exclude certain methods, `setup` is excluded by default.
* Adds a test for modules with methods
* Sets `summary.tabulate`'s `mutable` argument to `True` by default to be consistent with `Module.tabulate`'s signature.
* Fixes `None`s being rendered as `null`.
* Removes argument default values from `_get_module_table` to avoid potential errors.

