### PR TITLE
Allow nn.cond, nn.while to act on bound methods.

### DIFF
--- a/flax/linen/module.py
+++ b/flax/linen/module.py
@@ -384,7 +384,8 @@ def _get_unbound_fn(method_or_fn: Callable[..., Any]) -> Callable[..., Any]:
   Returns:
     An unbound version of input function.
   """
-  if inspect.ismethod(method_or_fn):
+  if (inspect.ismethod(method_or_fn) and
+      isinstance(method_or_fn.__self__, Module)):  # pytype: disable=attribute-error
     method_or_fn = method_or_fn.__func__  # pytype: disable=attribute-error
 
   # The method should be callable, and it should have at least one argument


### PR DESCRIPTION
Currently when using e.g.
`nn.cond(pred, true_fn, false_fn, module, *args)`
true_fn can't be self.some_method, but has to be passed in as
class.some_method which has been an unexpected stumbling block for our users.
This PR allows the control flow transforms to take bound methods by
automatically using the unbound function in this case.
