### PR TITLE
Flax Basics docs: Add missing `@jax.jit` to `mse`

### DIFF
--- a/docs/notebooks/flax_basics.ipynb
+++ b/docs/notebooks/flax_basics.ipynb
@@ -327,7 +327,7 @@
       "outputs": [],
       "source": [
         "# Same as JAX version but using model.apply().\n",
-        "@jax.jit",
+        "@jax.jit\n",
         "def mse(params, x_batched, y_batched):\n",
         "  # Define the squared loss for a single pair (x,y)\n",
         "  def squared_error(x, y):\n",

--- a/docs/notebooks/flax_basics.ipynb
+++ b/docs/notebooks/flax_basics.ipynb
@@ -327,7 +327,7 @@
       "outputs": [],
       "source": [
         "# Same as JAX version but using model.apply().\n",
-        "@jax.jit"
+        "@jax.jit",
         "def mse(params, x_batched, y_batched):\n",
         "  # Define the squared loss for a single pair (x,y)\n",
         "  def squared_error(x, y):\n",

--- a/docs/notebooks/flax_basics.ipynb
+++ b/docs/notebooks/flax_basics.ipynb
@@ -327,6 +327,7 @@
       "outputs": [],
       "source": [
         "# Same as JAX version but using model.apply().\n",
+        "@jax.jit"
         "def mse(params, x_batched, y_batched):\n",
         "  # Define the squared loss for a single pair (x,y)\n",
         "  def squared_error(x, y):\n",


### PR DESCRIPTION
Speeds up [linear regression example](https://flax.readthedocs.io/en/latest/notebooks/flax_basics.html#Linear-regression-with-Flax) by ~10x by jitting `mse`.

# What does this PR do?

<!--

Great, you are contributing to Flax! 

But... please read the following carefully so we can make sure your PR is merged
easily.

Replace this text block with a description of the change and which issue it
fixes (if applicable). Please also include relevant motivation/context.

Once you're done, someone in the Flax team will review your PR shortly. They may
suggest changes to make the code even better. If no one reviewed your PR after a
week has passed, don't hesitate to post a new comment @-mentioning the same
persons (sometimes notifications get lost).
-->

Fixes # (issue)

## Checklist
- [ ] This PR fixes a minor issue (e.g.: typo or small bug) or improves the docs (you can dismiss the other
      checks if that's the case).
- [ ] This change is discussed in a Github issue/
      [discussion](https://github.com/google/flax/discussions) (please add a
      link).
- [ ] The documentation and docstrings adhere to the
      [documentation guidelines](https://github.com/google/flax/blob/main/docs/README.md#how-to-write-code-documentation).
- [ ] This change includes necessary high-coverage tests.
      (No quality testing = no merge!)
