### PR TITLE
Exclude pseudo-fields of dataclass

### DIFF
--- a/flax/struct.py
+++ b/flax/struct.py
@@ -95,16 +95,15 @@ def dataclass(clz: _T) -> _T:
   Returns:
     The new class.
   """
-  # workaround for pytype not recognizing __dataclass_fields__
-  data_clz: Any = dataclasses.dataclass(frozen=True)(clz)
+  data_clz = dataclasses.dataclass(frozen=True)(clz)
   meta_fields = []
   data_fields = []
-  for name, field_info in data_clz.__dataclass_fields__.items():
+  for field_info in dataclasses.fields(data_clz):
     is_pytree_node = field_info.metadata.get('pytree_node', True)
     if is_pytree_node:
-      data_fields.append(name)
+      data_fields.append(field_info.name)
     else:
-      meta_fields.append(name)
+      meta_fields.append(field_info.name)
 
   def replace(self, **updates):
     """"Returns a new object replacing the specified fields with new values."""


### PR DESCRIPTION
pseudo-fields inlclude ClassVar's and InitVar's:
ClassVar is shared by all instances of the class by design, i.e. it is a class attribute. 
InitVar is not regarded as an attribute of an instance, it will be passed to `__post_init__ `hook only.
They shouldn't be data or meta-data of pytree.
This change will also make flax don't depend on dataclasses' internal implementation "`__dataclass_fields__`".
possible problem: There is not a runtime promise that ClassVar/InitVar can not be used as a normal instance attribute, i.e. user can read and mutate them freely. This problem might be not important, since flax use `frozen=True` and mutation is not allowed.

## Checklist
- [x] This PR fixes a minor issue (e.g.: typo or small bug) or improves the docs (you can dismiss the other
      checks if that's the case).
