### PR TITLE
Show repository button

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -101,7 +101,7 @@ html_static_path = ['_static']
 html_theme_options = {
     "repository_url": "https://github.com/google/flax",
     "use_repository_button": True,     # add a "link to repository" button
-    "use_issues_button": True,         # add an "Open an Issue" button
+    "use_issues_button": False,         # add an "Open an Issue" button
     "path_to_docs": "docs",            # used to compute the path to launch notebooks in colab
     "launch_buttons": {"colab_url": "https://colab.research.google.com"},
 }

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -101,9 +101,8 @@ html_static_path = ['_static']
 html_theme_options = {
     "repository_url": "https://github.com/google/flax",
     "use_repository_button": True,     # add a "link to repository" button
-    "use_issues_button": False,         # add an "Open an Issue" button
+    "use_issues_button": False,        # add an "Open an Issue" button
     "path_to_docs": "docs",            # used to compute the path to launch notebooks in colab
-    "launch_buttons": {"colab_url": "https://colab.research.google.com"},
 }
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -98,6 +98,15 @@ html_logo = './flax.png'
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static']
 
+html_theme_options = {
+    "repository_url": "https://github.com/google/flax",
+    "use_repository_button": True,     # add a "link to repository" button
+    "use_issues_button": True,         # add an "Open an Issue" button
+    "path_to_docs": "docs",            # used to compute the path to launch notebooks in colab
+    "launch_buttons": {"colab_url": "https://colab.research.google.com"},
+}
+
+
 nbsphinx_codecell_lexer = 'ipython3'
 
 nbsphinx_prolog = r"""


### PR DESCRIPTION
Adds a link to the GitHub repository in the generated documentation. I think is useful because I often end up typing "flax" on my searchbar, I end up in the documentation, but would like to get to the repository.

~Also adds a button "launch in Colab" to all notebooks.~

~The latter is just up to your taste. I find it useful so that you don't have to add the button manually, but if you prefer not to have it, I can remove it. See https://netket.readthedocs.io/en/latest/tutorials/gs-heisenberg.html for an example.~
Note: This is not compatible with your setup.