### PR TITLE
Add a method for detecting the use of "init" functions.

### DIFF
--- a/docs/flax.linen.rst
+++ b/docs/flax.linen.rst
@@ -12,7 +12,7 @@ Module
 ------------------------
 
 .. autoclass:: Module
-   :members: setup, variable, param, bind, apply, init, init_with_output, make_rng, sow, variables, Variable, __setattr__, tabulate
+   :members: setup, variable, param, bind, apply, init, init_with_output, make_rng, sow, variables, Variable, __setattr__, tabulate, is_initializing
 
 Init/Apply
 ------------------------

--- a/flax/core/lift.py
+++ b/flax/core/lift.py
@@ -181,7 +181,7 @@ def pack(fn: Callable[..., Any],
         inner_scope = Scope(
             variables, name=scope.name, rngs=rngs,
             mutable=scope_mutable, parent=None,
-            path=new_path)
+            path=new_path, flags=scope.flags)
         inner_scope.rng_counters = rng_counters
         inner_scopes.append(inner_scope)
       inner_scopes = _dup_scopes(scopes, inner_scopes, paths)

--- a/tests/linen/linen_module_test.py
+++ b/tests/linen/linen_module_test.py
@@ -1517,5 +1517,14 @@ class ModuleTest(absltest.TestCase):
     self.assertTrue(foo.apply({}, rngs={'bar': k}))
     self.assertFalse(foo.apply({}, rngs={'baz': k}))
 
+  def test_is_initializing(self):
+    class Foo(nn.Module):
+      def __call__(self):
+        return self.is_initializing()
+    foo = Foo()
+    k = random.PRNGKey(0)
+    self.assertTrue(foo.init_with_output(k)[0])
+    self.assertFalse(foo.apply({}))
+
 if __name__ == '__main__':
   absltest.main()


### PR DESCRIPTION
We add an optional frozen-dict-valued `flags` field to Scope objects that are copied onwards, and use
it solely to implement a flag to indicate the use of top-level "init" functions.

