### PR TITLE
Add launch section with colab button

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -107,6 +107,9 @@ html_theme_options = {
     "use_repository_button": True,     # add a "link to repository" button
     "use_issues_button": False,        # add an "Open an Issue" button
     "path_to_docs": "docs",            # used to compute the path to launch notebooks in colab
+    "launch_buttons": {
+        "colab_url": "https://colab.research.google.com/",
+    },
 }
 
 # -- Options for myst ----------------------------------------------


### PR DESCRIPTION
# What does this PR do?
Leverages `sphinx_book_theme`s `launch_buttons` option to automatically add a button to open the notebooks in colab.

![Screenshot from 2022-06-24 12-43-02](https://user-images.githubusercontent.com/5862228/175625925-0fb473b2-8c42-492f-82fe-3eace9207cfc.png)

