### PR TITLE
Enabling the dollarmath extension of MyST to render correctly math expresions

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -114,6 +114,7 @@ html_theme_options = {
 nb_execution_timeout = 100
 # List of patterns, relative to source directory, that match notebook
 # files that will not be executed.
+myst_enable_extensions = ['dollarmath']
 nb_execution_excludepatterns = [
   'notebooks/annotated_mnist.ipynb', # <-- times out 
 ]


### PR DESCRIPTION
# What does this PR do?

The formulas at documentation where not properly rendered for example take a look at: [https://flax.readthedocs.io/en/latest/notebooks/flax_basics.html](https://flax.readthedocs.io/en/latest/notebooks/flax_basics.html)

Looking at sphinx config file `docs/conf.py` I saw that you aren´t enabling the MyST extension in charge of rendering those formulas: [https://myst-parser.readthedocs.io/en/latest/syntax/optional.html#dollar-delimited-math](https://myst-parser.readthedocs.io/en/latest/syntax/optional.html#dollar-delimited-math)

Fixes [#2237](https://github.com/google/flax/issues/2237)

## Checklist
- [x] This PR fixes a minor issue (e.g.: typo or small bug) or improves the docs (you can dismiss the other
      checks if that's the case).
