### PR TITLE
Fix typos in the doc of `flax.linen.Module.bind`

### DIFF
--- a/flax/linen/module.py
+++ b/flax/linen/module.py
@@ -1056,14 +1056,14 @@ class Module:
     """Creates an interactive Module instance by binding variables and RNGs.
 
     ``bind`` provides an "interactive" instance of a Module directly without
-    transforming a function with ``apply``. This is particalary useful for debugging
+    transforming a function with ``apply``. This is particularly useful for debugging
     and interactive use cases like notebooks where a function would limit the ability
-    split up code into different cells.
+    to split up code into different cells.
 
     Once the variables (and optionally RNGs) are bound to a ``Module`` it becomes a
     stateful object. Note that idiomatic JAX is functional and therefore an interactive
-    instance does not mix well well with vanilla JAX APIs. ``bind()`` should only be used
-    for interactive experimentation, and in all other cases we strongly encourage
+    instance does not mix well with vanilla JAX APIs. ``bind()`` should only be used
+    for interactive experimentation, and in all other cases we strongly encourage users
     to use ``apply()`` instead.
 
     Example::


### PR DESCRIPTION
# What does this PR do?

<!--

Great, you are contributing to Flax! 

But... please read the following carefully so we can make sure your PR is merged
easily.

Replace this text block with a description of the change and which issue it
fixes (if applicable). Please also include relevant motivation/context.

Once you're done, someone in the Flax team will review your PR shortly. They may
suggest changes to make the code even better. If no one reviewed your PR after a
week has passed, don't hesitate to post a new comment @-mentioning the same
persons (sometimes notifications get lost).
-->

Fixes several typos in the documentation for [`flax.linen.Module.bind`](https://flax.readthedocs.io/en/latest/flax.linen.html?highlight=autoencoder#flax.linen.Module.bind).

## Checklist
- [X] This PR fixes a minor issue (e.g.: typo or small bug) or improves the docs (you can dismiss the other
      checks if that's the case).
- [ ] This change is discussed in a Github issue/[discussion](https://github.com/google/flax/discussions) (please add a link).
- [X] The documentation and docstrings adhere to the
      [documentation guidelines](https://github.com/google/flax/blob/main/docs/README.md#how-to-write-code-documentation).
- [X] This change includes necessary high-coverage tests.
      (No quality testing = no merge!)
