### PR TITLE
Split build into multiple jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -112,7 +112,7 @@ jobs:
         pip install -r docs/requirements.txt
     - name: Test with pytest and generate coverage report
       run: |
-        tests/run_all_tests.sh --with-cov
+        tests/run_all_tests.sh --with-cov --no-doctest
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v1
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,24 +29,15 @@ jobs:
         with:
           python-version: 3.7
       - uses: pre-commit/action@v2.0.3
-  build:
+  commit-count:
+    name: Check commit count
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: [3.7]
     steps:
     - name: Cancel previous
       uses: styfle/cancel-workflow-action@0.8.0
       with:
         access_token: ${{ github.token }}          
-    - name: Install native dependencies
-      run: |
-        sudo apt-get -y install pandoc
     - uses: actions/checkout@v2
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
-      with:
-        python-version: ${{ matrix.python-version }}
     # We allow at most 5 commits in a branch to ensure our CI doesn't break.
     - name: Check commit count in PR
       if: always()
@@ -68,6 +59,25 @@ jobs:
           echo "See $url for help on how to resolve this."
           exit 1
         fi
+  test-docs:
+    name: Test documentation
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.7]
+    steps:
+    - name: Cancel previous
+      uses: styfle/cancel-workflow-action@0.8.0
+      with:
+        access_token: ${{ github.token }}          
+    - name: Install native dependencies
+      run: |
+        sudo apt-get -y install pandoc
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
         pip install .
@@ -79,6 +89,26 @@ jobs:
     - name: Build documentation
       run: |
         sphinx-build -M html docs docs/_build
+  run-tests:
+    name: Run tests
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.7]
+    steps:
+    - name: Cancel previous
+      uses: styfle/cancel-workflow-action@0.8.0
+      with:
+        access_token: ${{ github.token }}          
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        pip install .
+        pip install .[testing]
     - name: Test with pytest and generate coverage report
       run: |
         tests/run_all_tests.sh --with-cov
@@ -104,7 +134,6 @@ jobs:
            "description": "'$status'",
            "context": "github-actions/Build"
            }'
-
   test-import:
     name: Test import standalone
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -109,6 +109,7 @@ jobs:
       run: |
         pip install .
         pip install .[testing]
+        pip install -r docs/requirements.txt
     - name: Test with pytest and generate coverage report
       run: |
         tests/run_all_tests.sh --with-cov

--- a/tests/run_all_tests.sh
+++ b/tests/run_all_tests.sh
@@ -39,9 +39,6 @@ handle_errors () {
     fi
 }
 
-# Run embedded tests inside docs
-sphinx-build -M doctest docs docs/_build
-
 # Run battery of core FLAX API tests.
 pytest -n auto tests $PYTEST_OPTS
 

--- a/tests/run_all_tests.sh
+++ b/tests/run_all_tests.sh
@@ -5,6 +5,7 @@ export FLAX_PROFILE=1
 export FLAX_LAZY_RNG=1
 
 PYTEST_OPTS=
+RUN_DOCTEST=true
 for flag in "$@"; do
 case $flag in
   --with-cov)
@@ -14,6 +15,9 @@ case $flag in
   echo "Usage:"
   echo "  --with-cov: Also generate pytest coverage."
   exit
+  ;;
+  --no-doctest)
+  RUN_DOCTEST=false
   ;;
   *)
   echo "Unknown flag: $flag"
@@ -38,6 +42,11 @@ handle_errors () {
       exit 1
     fi
 }
+
+# Run embedded tests inside docs
+if $RUN_DOCTEST; then
+  sphinx-build -M doctest docs docs/_build
+fi
 
 # Run battery of core FLAX API tests.
 pytest -n auto tests $PYTEST_OPTS


### PR DESCRIPTION
# What does this PR do?

Splits the `build` job into multiple jobs. This has two main benefits:
* Isolates the `pytest` tests from the `notebooks` which often try to install additional dependencies.
* Speed: some tasks are independent and can be ran in parallel.