### PR TITLE
add link to tutorial demonstrating Wav2Vec2 finetuning

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -102,6 +102,7 @@ official Flax example, and start from there.
 | [DCGAN] Colab                 | [@bkkaggle]        | Image Synthesis                   | https://arxiv.org/abs/1511.06434                                      |
 | [BigBird Fine-tuning]         | [@vasudevgupta7]   | Question-Answering                | https://arxiv.org/abs/2007.14062                                      |
 | [jax-resnet]                  | [@n2cholas]        | Various resnet implementations    | `torch.hub`                                                            |
+| [Wav2Vec2 finetuning]         | [@vasudevgupta7]   | Automatic Speech Recognition      | https://arxiv.org/abs/2006.11477|
 
 [matthias-wright/flaxmodels]: https://github.com/matthias-wright/flaxmodels
 [DarshanDeshpande/jax-models]: https://github.com/DarshanDeshpande/jax-models
@@ -110,6 +111,7 @@ official Flax example, and start from there.
 [DCGAN]: https://github.com/bkkaggle/jax-dcgan
 [BigBird Fine-tuning]: https://github.com/huggingface/transformers/tree/master/examples/research_projects/jax-projects/big_bird
 [jax-resnet]: https://github.com/n2cholas/jax-resnet
+[Wav2Vec2 finetuning]: https://github.com/vasudevgupta7/speech-jax
 [@matthias-wright]: https://github.com/matthias-wright
 [@DarshanDeshpande]: https://github.com/DarshanDeshpande
 [@andsteing]: https://github.com/andsteing


### PR DESCRIPTION
# What does this PR do?

adds a link to tutorial demonstrating Wav2Vec2 finetuning

Closes #2285 

## Checklist
- [x] This PR fixes a minor issue (e.g.: typo or small bug) or improves the docs (you can dismiss the other
      checks if that's the case).
- [x] This change is discussed in a Github issue/
      [discussion](https://github.com/google/flax/discussions) (please add a
      link).
- [ ] The documentation and docstrings adhere to the
      [documentation guidelines](https://github.com/google/flax/blob/main/docs/README.md#how-to-write-code-documentation).
- [ ] This change includes necessary high-coverage tests.
      (No quality testing = no merge!)
