### PR TITLE
Replace use of id() with global counter-based id.

### DIFF
--- a/flax/core/scope.py
+++ b/flax/core/scope.py
@@ -22,7 +22,7 @@ import typing
 from typing import (Any, Callable, Dict, Generic, Iterable, Mapping, Optional,
                     Sequence, Set, Tuple, TypeVar, Union)
 
-from . import tracers
+from flax.ids import uuid
 from flax import config
 from flax import errors
 from flax import struct
@@ -30,6 +30,7 @@ from flax import traceback_util
 from .frozen_dict import freeze
 from .frozen_dict import FrozenDict
 from .frozen_dict import unfreeze
+from . import tracers
 import jax
 from jax import config as jax_config
 from jax import numpy as jnp
@@ -50,7 +51,6 @@ Filter = Union[bool, str, typing.Collection[str], 'DenyList']
 
 # When conditioning on filters we require explicit boolean comparisons.
 # pylint: disable=g-bool-id-comparison
-
 
 @dataclasses.dataclass(frozen=True, eq=True)
 class DenyList:
@@ -343,6 +343,7 @@ class Variable(Generic[T]):
       collection: The collection of the variable (e.g., "params").
       name: The name of the variable (e.g., "dense").
     """
+    self._id = uuid()
     self.scope = scope
     self.collection = collection
     self.name = name

--- a/flax/ids.py
+++ b/flax/ids.py
@@ -1,0 +1,57 @@
+# Copyright 2022 The Flax Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""UUIDs for Flax internals."""
+
+import threading
+
+
+class UUIDManager:
+  """Globally unique counter-based id manager.
+
+  We need globally unique key ids for Module and Variable object instances
+  to preserve and recreate sharing-by-reference relationship when lifting
+  transforms and adopting outside Modules.
+  - Use of id() is unacceptable because these identifiers are literally
+    pointers which can be recycled, so we rely on a globally unique counter id
+    instead.
+  - We need to handle copy/deepcopy uniqueness via a wrapped type.
+  """
+  def __init__(self):
+    self._lock = threading.Lock()
+    self._id = 0
+
+  def __call__(self):
+    with self._lock:
+      self._id += 1
+      return FlaxId(self._id)
+
+uuid = UUIDManager()
+
+
+class FlaxId:
+  """Hashable wrapper for ids that handles uniqueness of copies."""
+  def __init__(self, rawid):
+    self.id = rawid
+  def __eq__(self, other):
+    return isinstance(other, FlaxId) and other.id == self.id
+  def __hash__(self):
+    return hash(self.id)
+  def __repr__(self):
+    return f"FlaxId({self.id})"
+  def __deepcopy__(self, memo):
+    del memo
+    return uuid()
+  def __copy__(self):
+    return uuid()

--- a/tests/linen/linen_test.py
+++ b/tests/linen/linen_test.py
@@ -14,8 +14,10 @@
 
 """Tests for flax.linen."""
 
+import copy
 from absl.testing import absltest, parameterized
 
+from flax import ids
 from flax import linen as nn
 
 import jax
@@ -359,6 +361,20 @@ class RecurrentTest(absltest.TestCase):
 
     np.testing.assert_allclose(y, y_opt, rtol=1e-6)
     jtu.check_eq(lstm_params, lstm_opt_params)
+
+
+class IdsTest(absltest.TestCase):
+
+  def test_hashable(self):
+    id1 = ids.uuid()
+    id2 = ids.uuid()
+    self.assertEqual(id1, id1)
+    self.assertNotEqual(id1, id2)
+    self.assertNotEqual(hash(id1), hash(id2))
+    id1c = copy.copy(id1)
+    id1dc = copy.deepcopy(id1)
+    self.assertNotEqual(hash(id1), hash(id1c))
+    self.assertNotEqual(hash(id1), hash(id1dc))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Historically we key'd on id() to record sharing relationships during
lifting and outer module adoption.  This was dumb, and after recently
fixing one bad bug arising from id reuse, we should use something
sound instead.