### PR TITLE
Replace all jax.tree_* calls with jax.tree_util.tree_*

### DIFF
--- a/docs/advanced_topics/lift.md
+++ b/docs/advanced_topics/lift.md
@@ -86,7 +86,7 @@ class ManualVmapMLP(nn.Module):
 
 xs = jnp.ones((3, 4))
 variables = ManualVmapMLP().init(random.PRNGKey(0), xs)
-print(jax.tree_map(jnp.shape, variables['params']))
+print(jax.tree_util.tree_map(jnp.shape, variables['params']))
 """==>
 {
     mlp: {
@@ -257,7 +257,7 @@ def lift_transpose(fn, target='params', variables=True, rngs=True):
       if x.ndim == 2:
         return x.T
       return x
-    target = jax.tree_map(trans, target)
+    target = jax.tree_util.tree_map(trans, target)
     variable_groups = (target, rest)
     scope = scope_fn(variable_groups, rng_groups)
     y = fn(scope, *args)
@@ -307,7 +307,7 @@ class LinenVmapMLP(nn.Module):
     return VmapMLP(name='mlp')(xs)
 
 variables = LinenVmapMLP().init(random.PRNGKey(0), xs)
-print(jax.tree_map(jnp.shape, variables['params']))
+print(jax.tree_util.tree_map(jnp.shape, variables['params']))
 """==>
 {
     mlp: {

--- a/docs/advanced_topics/optax_update_guide.rst
+++ b/docs/advanced_topics/optax_update_guide.rst
@@ -167,10 +167,10 @@ becomes just another gradient transformation |optax.clip_by_global_norm()|_.
 
   def train_step(optimizer, batch):
     grads = jax.grad(loss)(optimizer.target, batch)
-    grads_flat, _ = jax.tree_flatten(grads)
+    grads_flat, _ = jax.tree_util.tree_flatten(grads)
     global_l2 = jnp.sqrt(sum([jnp.vdot(p, p) for p in grads_flat]))
     g_factor = jnp.minimum(1.0, grad_clip_norm / global_l2)
-    grads = jax.tree_map(lambda g: g * g_factor, grads)
+    grads = jax.tree_util.tree_map(lambda g: g * g_factor, grads)
     return optimizer.apply_gradient(grads)
 
   ---
@@ -268,7 +268,7 @@ that is not readily available outside the outer mask).
   kernels = flax.traverse_util.ModelParamTraversal(lambda p, _: 'kernel' in p)
   biases = flax.traverse_util.ModelParamTraversal(lambda p, _: 'bias' in p)
 
-  all_false = jax.tree_map(lambda _: False, params)
+  all_false = jax.tree_util.tree_map(lambda _: False, params)
   kernels_mask = kernels.update(lambda _: True, all_false)
   biases_mask = biases.update(lambda _: True, all_false)
 

--- a/docs/flip/1009-optimizer-api.md
+++ b/docs/flip/1009-optimizer-api.md
@@ -349,7 +349,7 @@ Remarks:
   `OptimizerDef`).
 - The functions `init_param_state()` and `apply_param_gradient()` are called
   for every leaf in the params/grads pytree. This makes it possible to write the
-  calculations directly without `jax.tree_map()`.
+  calculations directly without `jax.tree_util.tree_map()`.
 - The interface was defined in pre-Linen without the distinction of `params` vs.
   other collections in `variables` in mind. The original API was elegant because
   one only needed to pass around the optimizer, which included the parameters,
@@ -500,5 +500,5 @@ rng = jax.random.PRNGKey(0)
 ds = tfds.load('mnist')['train'].take(160).map(pp).batch(16)
 batch = next(iter(ds))
 variables = model.init(rng, jnp.array(batch['image'][:1]))
-jax.tree_map(jnp.shape, variables)
+jax.tree_util.tree_map(jnp.shape, variables)
 ```

--- a/docs/flip/1777-default-dtype.md
+++ b/docs/flip/1777-default-dtype.md
@@ -47,8 +47,8 @@ A simplified example implementation:
 ```python
 def promote_arrays(*xs, dtype):
  if dtype is None:
-   dtype = jnp.result_type(*jax.tree_leaves(xs))
- return jax.tree_map(lambda x: jnp.asarray(x, dtype), xs)
+   dtype = jnp.result_type(*jax.tree_util.tree_leaves(xs))
+ return jax.tree_util.tree_map(lambda x: jnp.asarray(x, dtype), xs)
 
 Dtype = Any
 class Dense(nn.Module):

--- a/docs/getting_started.ipynb
+++ b/docs/getting_started.ipynb
@@ -420,7 +420,7 @@
     "def eval_model(params, test_ds):\n",
     "  metrics = eval_step(params, test_ds)\n",
     "  metrics = jax.device_get(metrics)\n",
-    "  summary = jax.tree_map(lambda x: x.item(), metrics)\n",
+    "  summary = jax.tree_util.tree_map(lambda x: x.item(), metrics)\n",
     "  return summary['loss'], summary['accuracy']"
    ]
   },

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -306,7 +306,7 @@ Create a model evaluation function that:
 def eval_model(params, test_ds):
   metrics = eval_step(params, test_ds)
   metrics = jax.device_get(metrics)
-  summary = jax.tree_map(lambda x: x.item(), metrics)
+  summary = jax.tree_util.tree_map(lambda x: x.item(), metrics)
   return summary['loss'], summary['accuracy']
 ```
 

--- a/docs/guides/extracting_intermediates.rst
+++ b/docs/guides/extracting_intermediates.rst
@@ -198,12 +198,12 @@ In the following code example we check if any intermediate activations are non-f
   def predict(variables, x):
     y, state = CNN().apply(variables, x, capture_intermediates=True, mutable=["intermediates"])
     intermediates = state['intermediates']
-    fin = jax.tree_map(lambda xs: jnp.all(jnp.isfinite(xs)), intermediates)
+    fin = jax.tree_util.tree_map(lambda xs: jnp.all(jnp.isfinite(xs)), intermediates)
     return y, fin
 
   variables = init(jax.random.PRNGKey(0), batch)
   y, is_finite = predict(variables, batch)
-  all_finite = all(jax.tree_leaves(is_finite))
+  all_finite = all(jax.tree_util.tree_leaves(is_finite))
   assert all_finite, "non finite intermediate detected!"
 
 By default only the intermediates of ``__call__`` methods are collected.

--- a/docs/guides/flax_basics.ipynb
+++ b/docs/guides/flax_basics.ipynb
@@ -156,7 +156,7 @@
     "key1, key2 = random.split(random.PRNGKey(0))\n",
     "x = random.normal(key1, (10,)) # Dummy input\n",
     "params = model.init(key2, x) # Initialization call\n",
-    "jax.tree_map(lambda x: x.shape, params) # Checking output shapes"
+    "jax.tree_util.tree_map(lambda x: x.shape, params) # Checking output shapes"
    ]
   },
   {
@@ -375,7 +375,7 @@
     "\n",
     "@jax.jit\n",
     "def update_params(params, learning_rate, grads):\n",
-    "  params = jax.tree_map(\n",
+    "  params = jax.tree_util.tree_map(\n",
     "      lambda p, g: p - learning_rate * g, params, grads)\n",
     "  return params\n",
     "\n",
@@ -665,7 +665,7 @@
     "params = model.init(key2, x)\n",
     "y = model.apply(params, x)\n",
     "\n",
-    "print('initialized parameter shapes:\\n', jax.tree_map(jnp.shape, unfreeze(params)))\n",
+    "print('initialized parameter shapes:\\n', jax.tree_util.tree_map(jnp.shape, unfreeze(params)))\n",
     "print('output:\\n', y)"
    ]
   },
@@ -773,7 +773,7 @@
     "params = model.init(key2, x)\n",
     "y = model.apply(params, x)\n",
     "\n",
-    "print('initialized parameter shapes:\\n', jax.tree_map(jnp.shape, unfreeze(params)))\n",
+    "print('initialized parameter shapes:\\n', jax.tree_util.tree_map(jnp.shape, unfreeze(params)))\n",
     "print('output:\\n', y)"
    ]
   },

--- a/docs/guides/flax_basics.md
+++ b/docs/guides/flax_basics.md
@@ -91,7 +91,7 @@ outputId: 06feb9d2-db50-4f41-c169-6df4336f43a5
 key1, key2 = random.split(random.PRNGKey(0))
 x = random.normal(key1, (10,)) # Dummy input
 params = model.init(key2, x) # Initialization call
-jax.tree_map(lambda x: x.shape, params) # Checking output shapes
+jax.tree_util.tree_map(lambda x: x.shape, params) # Checking output shapes
 ```
 
 +++ {"id": "NH7Y9xMEewmO"}
@@ -207,7 +207,7 @@ loss_grad_fn = jax.value_and_grad(mse)
 
 @jax.jit
 def update_params(params, learning_rate, grads):
-  params = jax.tree_map(
+  params = jax.tree_util.tree_map(
       lambda p, g: p - learning_rate * g, params, grads)
   return params
 
@@ -352,7 +352,7 @@ model = ExplicitMLP(features=[3,4,5])
 params = model.init(key2, x)
 y = model.apply(params, x)
 
-print('initialized parameter shapes:\n', jax.tree_map(jnp.shape, unfreeze(params)))
+print('initialized parameter shapes:\n', jax.tree_util.tree_map(jnp.shape, unfreeze(params)))
 print('output:\n', y)
 ```
 
@@ -414,7 +414,7 @@ model = SimpleMLP(features=[3,4,5])
 params = model.init(key2, x)
 y = model.apply(params, x)
 
-print('initialized parameter shapes:\n', jax.tree_map(jnp.shape, unfreeze(params)))
+print('initialized parameter shapes:\n', jax.tree_util.tree_map(jnp.shape, unfreeze(params)))
 print('output:\n', y)
 ```
 

--- a/docs/guides/jax_for_the_impatient.ipynb
+++ b/docs/guides/jax_for_the_impatient.ipynb
@@ -1117,7 +1117,7 @@
     "id": "nW1IKnjqXFdN"
    },
    "source": [
-    "Now using our tree of params, we can write the gradient descent in a simpler way using `jax.tree_map`:"
+    "Now using our tree of params, we can write the gradient descent in a simpler way using `jax.tree_util.tree_map`:"
    ]
   },
   {
@@ -1164,7 +1164,7 @@
     "# Always remember to jit!\n",
     "@jax.jit\n",
     "def update_params_pytree(params, learning_rate, x_samples, y_samples):\n",
-    "  params = jax.tree_map(\n",
+    "  params = jax.tree_util.tree_map(\n",
     "        lambda p, g: p - learning_rate * g, params,\n",
     "        jax.grad(mse_pytree)(params, x_samples, y_samples))\n",
     "  return params\n",
@@ -1202,7 +1202,7 @@
     "for i in range(101):\n",
     "  # Note that here the loss is computed before the param update.\n",
     "    loss_val, grads = loss_grad_fn(params, x_samples, y_samples)\n",
-    "    params = jax.tree_map(\n",
+    "    params = jax.tree_util.tree_map(\n",
     "        lambda p, g: p - learning_rate * g, params, grads)\n",
     "    if (i % 5 == 0):\n",
     "        print(f\"Loss step {i}: \", loss_val)"

--- a/docs/guides/jax_for_the_impatient.md
+++ b/docs/guides/jax_for_the_impatient.md
@@ -576,7 +576,7 @@ jax.grad(mse_pytree)(params, x_samples, y_samples)
 
 +++ {"id": "nW1IKnjqXFdN"}
 
-Now using our tree of params, we can write the gradient descent in a simpler way using `jax.tree_map`:
+Now using our tree of params, we can write the gradient descent in a simpler way using `jax.tree_util.tree_map`:
 
 ```{code-cell}
 ---
@@ -588,7 +588,7 @@ outputId: f309aff7-2aad-453f-ad88-019d967d4289
 # Always remember to jit!
 @jax.jit
 def update_params_pytree(params, learning_rate, x_samples, y_samples):
-  params = jax.tree_map(
+  params = jax.tree_util.tree_map(
         lambda p, g: p - learning_rate * g, params,
         jax.grad(mse_pytree)(params, x_samples, y_samples))
   return params
@@ -616,7 +616,7 @@ loss_grad_fn = jax.value_and_grad(mse_pytree)
 for i in range(101):
   # Note that here the loss is computed before the param update.
     loss_val, grads = loss_grad_fn(params, x_samples, y_samples)
-    params = jax.tree_map(
+    params = jax.tree_util.tree_map(
         lambda p, g: p - learning_rate * g, params, grads)
     if (i % 5 == 0):
         print(f"Loss step {i}: ", loss_val)

--- a/docs/guides/model_surgery.rst
+++ b/docs/guides/model_surgery.rst
@@ -47,7 +47,7 @@ Let's create a small convolutional neural network model for our demo.
   key = jax.random.PRNGKey(0)
   params = get_initial_params(key)
 
-  print(jax.tree_map(jnp.shape, params))
+  print(jax.tree_util.tree_map(jnp.shape, params))
 
 .. testoutput::
 
@@ -77,7 +77,7 @@ Next, get a flat dict for doing model surgery as follows:
 
   # Get flattened-key: value list.
   flat_params = traverse_util.flatten_dict(params)
-  print(jax.tree_map(jnp.shape, flat_params))
+  print(jax.tree_util.tree_map(jnp.shape, flat_params))
 
 .. testoutput::
   :options: +NORMALIZE_WHITESPACE
@@ -99,7 +99,7 @@ After doing whatever you want, unflatten back:
   unflat_params = traverse_util.unflatten_dict(flat_params)
   # Refreeze.
   unflat_params = freeze(unflat_params)
-  print(jax.tree_map(jnp.shape, unflat_params))
+  print(jax.tree_util.tree_map(jnp.shape, unflat_params))
 
 .. testoutput::
   :options: +NORMALIZE_WHITESPACE
@@ -138,7 +138,7 @@ optimizer state that mirrors the original state.
   opt_state = tx.init(params)
 
   # The optimizer state is a tuple of gradient transformation states.
-  print(jax.tree_map(jnp.shape, opt_state))
+  print(jax.tree_util.tree_map(jnp.shape, opt_state))
 
 .. testoutput::
   :options: +NORMALIZE_WHITESPACE
@@ -163,7 +163,7 @@ parameters and can be flattened / modified exactly the same way
   flat_mu = traverse_util.flatten_dict(opt_state[0].mu)
   flat_nu = traverse_util.flatten_dict(opt_state[0].nu)
 
-  print(jax.tree_map(jnp.shape, flat_mu))
+  print(jax.tree_util.tree_map(jnp.shape, flat_mu))
 
 .. testoutput::
   :options: +NORMALIZE_WHITESPACE

--- a/docs/notebooks/linen_intro.ipynb
+++ b/docs/notebooks/linen_intro.ipynb
@@ -304,7 +304,7 @@
     "init_variables = model.init(key2, x)\n",
     "y = model.apply(init_variables, x)\n",
     "\n",
-    "print('initialized parameter shapes:\\n', jax.tree_map(jnp.shape, unfreeze(init_variables)))\n",
+    "print('initialized parameter shapes:\\n', jax.tree_util.tree_map(jnp.shape, unfreeze(init_variables)))\n",
     "print('output:\\n', y)"
    ]
   },
@@ -370,7 +370,7 @@
     "init_variables = model.init(key2, x)\n",
     "y = model.apply(init_variables, x)\n",
     "\n",
-    "print('initialized parameter shapes:\\n', jax.tree_map(jnp.shape, unfreeze(init_variables)))\n",
+    "print('initialized parameter shapes:\\n', jax.tree_util.tree_map(jnp.shape, unfreeze(init_variables)))\n",
     "print('output:\\n', y)"
    ]
   },
@@ -762,7 +762,7 @@
     "\n",
     "print('updated variables:\\n', updated_variables)\n",
     "print('initialized variable shapes:\\n', \n",
-    "      jax.tree_map(jnp.shape, init_variables))\n",
+    "      jax.tree_util.tree_map(jnp.shape, init_variables))\n",
     "print('output:\\n', y)\n",
     "\n",
     "# Let's run these model variables during \"evaluation\":\n",
@@ -847,7 +847,7 @@
     "init_variables = model.init(key2, x)\n",
     "y = model.apply(init_variables, x)\n",
     "\n",
-    "print('initialized parameter shapes:\\n', jax.tree_map(jnp.shape, unfreeze(init_variables)))\n",
+    "print('initialized parameter shapes:\\n', jax.tree_util.tree_map(jnp.shape, unfreeze(init_variables)))\n",
     "print('output:\\n', y)"
    ]
   },
@@ -919,7 +919,7 @@
     "init_variables = model.init(key2, x)\n",
     "y = model.apply(init_variables, x)\n",
     "\n",
-    "print('initialized parameter shapes:\\n', jax.tree_map(jnp.shape, unfreeze(init_variables)))\n",
+    "print('initialized parameter shapes:\\n', jax.tree_util.tree_map(jnp.shape, unfreeze(init_variables)))\n",
     "print('output:\\n', y)"
    ]
   },
@@ -1076,7 +1076,7 @@
     "  batch_axes=(0,))\n",
     "\n",
     "init_variables = model(train=False).init({'params': key2}, x, x)\n",
-    "print('initialized parameter shapes:\\n', jax.tree_map(jnp.shape, unfreeze(init_variables)))\n",
+    "print('initialized parameter shapes:\\n', jax.tree_util.tree_map(jnp.shape, unfreeze(init_variables)))\n",
     "\n",
     "y = model(train=True).apply(init_variables, x, x, rngs={'dropout': key4})\n",
     "print('output:\\n', y.shape)"
@@ -1153,7 +1153,7 @@
     "model = SimpleScan()\n",
     "init_variables = model.init(key2, xs)\n",
     "\n",
-    "print('initialized parameter shapes:\\n', jax.tree_map(jnp.shape, unfreeze(init_variables)))\n",
+    "print('initialized parameter shapes:\\n', jax.tree_util.tree_map(jnp.shape, unfreeze(init_variables)))\n",
     "\n",
     "y = model.apply(init_variables, xs)\n",
     "print('output:\\n', y)"

--- a/docs/notebooks/linen_intro.md
+++ b/docs/notebooks/linen_intro.md
@@ -167,7 +167,7 @@ model = ExplicitMLP(features=[3,4,5])
 init_variables = model.init(key2, x)
 y = model.apply(init_variables, x)
 
-print('initialized parameter shapes:\n', jax.tree_map(jnp.shape, unfreeze(init_variables)))
+print('initialized parameter shapes:\n', jax.tree_util.tree_map(jnp.shape, unfreeze(init_variables)))
 print('output:\n', y)
 ```
 
@@ -205,7 +205,7 @@ model = SimpleMLP(features=[3,4,5])
 init_variables = model.init(key2, x)
 y = model.apply(init_variables, x)
 
-print('initialized parameter shapes:\n', jax.tree_map(jnp.shape, unfreeze(init_variables)))
+print('initialized parameter shapes:\n', jax.tree_util.tree_map(jnp.shape, unfreeze(init_variables)))
 print('output:\n', y)
 ```
 
@@ -399,7 +399,7 @@ updated_variables = freeze(dict(params=init_params,
 
 print('updated variables:\n', updated_variables)
 print('initialized variable shapes:\n', 
-      jax.tree_map(jnp.shape, init_variables))
+      jax.tree_util.tree_map(jnp.shape, init_variables))
 print('output:\n', y)
 
 # Let's run these model variables during "evaluation":
@@ -450,7 +450,7 @@ model = MLP(features=[3,4,5])
 init_variables = model.init(key2, x)
 y = model.apply(init_variables, x)
 
-print('initialized parameter shapes:\n', jax.tree_map(jnp.shape, unfreeze(init_variables)))
+print('initialized parameter shapes:\n', jax.tree_util.tree_map(jnp.shape, unfreeze(init_variables)))
 print('output:\n', y)
 ```
 
@@ -493,7 +493,7 @@ model = RematMLP(features=[3,4,5])
 init_variables = model.init(key2, x)
 y = model.apply(init_variables, x)
 
-print('initialized parameter shapes:\n', jax.tree_map(jnp.shape, unfreeze(init_variables)))
+print('initialized parameter shapes:\n', jax.tree_util.tree_map(jnp.shape, unfreeze(init_variables)))
 print('output:\n', y)
 ```
 
@@ -624,7 +624,7 @@ model = functools.partial(
   batch_axes=(0,))
 
 init_variables = model(train=False).init({'params': key2}, x, x)
-print('initialized parameter shapes:\n', jax.tree_map(jnp.shape, unfreeze(init_variables)))
+print('initialized parameter shapes:\n', jax.tree_util.tree_map(jnp.shape, unfreeze(init_variables)))
 
 y = model(train=True).apply(init_variables, x, x, rngs={'dropout': key4})
 print('output:\n', y.shape)
@@ -671,7 +671,7 @@ xs = random.uniform(key1, (1, 5, 2))
 model = SimpleScan()
 init_variables = model.init(key2, xs)
 
-print('initialized parameter shapes:\n', jax.tree_map(jnp.shape, unfreeze(init_variables)))
+print('initialized parameter shapes:\n', jax.tree_util.tree_map(jnp.shape, unfreeze(init_variables)))
 
 y = model.apply(init_variables, xs)
 print('output:\n', y)

--- a/docs/notebooks/optax_update_guide.ipynb
+++ b/docs/notebooks/optax_update_guide.ipynb
@@ -131,7 +131,7 @@
     "model = Perceptron([50, 10])\n",
     "variables = model.init(jax.random.PRNGKey(0), batch['image'])\n",
     "\n",
-    "jax.tree_map(jnp.shape, variables)"
+    "jax.tree_util.tree_map(jnp.shape, variables)"
    ]
   },
   {
@@ -170,12 +170,12 @@
     "\n",
     "builder = tfds.builder('mnist')\n",
     "builder.download_and_prepare()\n",
-    "ds_test = jax.tree_map(jnp.array, builder.as_dataset('test', batch_size=-1))\n",
+    "ds_test = jax.tree_util.tree_map(jnp.array, builder.as_dataset('test', batch_size=-1))\n",
     "get_ds_train = lambda: (\n",
-    "    jax.tree_map(jnp.array, x)\n",
+    "    jax.tree_util.tree_map(jnp.array, x)\n",
     "    for x in builder.as_dataset('train').batch(128))\n",
     "batch = next(get_ds_train())\n",
-    "jax.tree_map(jnp.shape, batch)"
+    "jax.tree_util.tree_map(jnp.shape, batch)"
    ]
   },
   {
@@ -547,10 +547,10 @@
     "@jax.jit\n",
     "def train_step(optimizer, batch):\n",
     "  grads = jax.grad(loss)(optimizer.target, batch)\n",
-    "  grads_flat, _ = jax.tree_flatten(grads)\n",
+    "  grads_flat, _ = jax.tree_util.tree_flatten(grads)\n",
     "  global_l2 = jnp.sqrt(sum([jnp.vdot(p, p) for p in grads_flat]))\n",
     "  g_factor = jnp.minimum(1.0, grad_clip_norm / global_l2)\n",
-    "  grads = jax.tree_map(lambda g: g * g_factor, grads)\n",
+    "  grads = jax.tree_util.tree_map(lambda g: g * g_factor, grads)\n",
     "  return optimizer.apply_gradient(grads)\n",
     "\n",
     "optimizer = flax.optim.Momentum(learning_rate, momentum).create(\n",
@@ -790,7 +790,7 @@
     "kernels = flax.traverse_util.ModelParamTraversal(lambda p, _: 'kernel' in p)\n",
     "biases = flax.traverse_util.ModelParamTraversal(lambda p, _: 'bias' in p)\n",
     "\n",
-    "all_false = jax.tree_map(lambda _: False, params)\n",
+    "all_false = jax.tree_util.tree_map(lambda _: False, params)\n",
     "kernels_mask = kernels.update(lambda _: True, all_false)\n",
     "biases_mask = biases.update(lambda _: True, all_false)\n",
     "\n",
@@ -841,7 +841,7 @@
     "kernels = flax.traverse_util.ModelParamTraversal(lambda p, _: 'kernel' in p)\n",
     "biases = flax.traverse_util.ModelParamTraversal(lambda p, _: 'bias' in p)\n",
     "\n",
-    "all_false = jax.tree_map(lambda _: False, params)\n",
+    "all_false = jax.tree_util.tree_map(lambda _: False, params)\n",
     "kernels_mask = kernels.update(lambda _: True, all_false)\n",
     "biases_mask = biases.update(lambda _: True, all_false)\n",
     "\n",

--- a/docs/notebooks/optax_update_guide.md
+++ b/docs/notebooks/optax_update_guide.md
@@ -80,7 +80,7 @@ def loss(params, batch):
 model = Perceptron([50, 10])
 variables = model.init(jax.random.PRNGKey(0), batch['image'])
 
-jax.tree_map(jnp.shape, variables)
+jax.tree_util.tree_map(jnp.shape, variables)
 ```
 
 ```{code-cell}
@@ -94,12 +94,12 @@ import tensorflow_datasets as tfds
 
 builder = tfds.builder('mnist')
 builder.download_and_prepare()
-ds_test = jax.tree_map(jnp.array, builder.as_dataset('test', batch_size=-1))
+ds_test = jax.tree_util.tree_map(jnp.array, builder.as_dataset('test', batch_size=-1))
 get_ds_train = lambda: (
-    jax.tree_map(jnp.array, x)
+    jax.tree_util.tree_map(jnp.array, x)
     for x in builder.as_dataset('train').batch(128))
 batch = next(get_ds_train())
-jax.tree_map(jnp.shape, batch)
+jax.tree_util.tree_map(jnp.shape, batch)
 ```
 
 ```{code-cell}
@@ -308,10 +308,10 @@ outputId: aae283d2-623e-4a43-c001-3e62b11483ae
 @jax.jit
 def train_step(optimizer, batch):
   grads = jax.grad(loss)(optimizer.target, batch)
-  grads_flat, _ = jax.tree_flatten(grads)
+  grads_flat, _ = jax.tree_util.tree_flatten(grads)
   global_l2 = jnp.sqrt(sum([jnp.vdot(p, p) for p in grads_flat]))
   g_factor = jnp.minimum(1.0, grad_clip_norm / global_l2)
-  grads = jax.tree_map(lambda g: g * g_factor, grads)
+  grads = jax.tree_util.tree_map(lambda g: g * g_factor, grads)
   return optimizer.apply_gradient(grads)
 
 optimizer = flax.optim.Momentum(learning_rate, momentum).create(
@@ -456,7 +456,7 @@ def train_step(params, opt_state, batch):
 kernels = flax.traverse_util.ModelParamTraversal(lambda p, _: 'kernel' in p)
 biases = flax.traverse_util.ModelParamTraversal(lambda p, _: 'bias' in p)
 
-all_false = jax.tree_map(lambda _: False, params)
+all_false = jax.tree_util.tree_map(lambda _: False, params)
 kernels_mask = kernels.update(lambda _: True, all_false)
 biases_mask = biases.update(lambda _: True, all_false)
 
@@ -491,7 +491,7 @@ def train_step(params, opt_state, batch):
 kernels = flax.traverse_util.ModelParamTraversal(lambda p, _: 'kernel' in p)
 biases = flax.traverse_util.ModelParamTraversal(lambda p, _: 'bias' in p)
 
-all_false = jax.tree_map(lambda _: False, params)
+all_false = jax.tree_util.tree_map(lambda _: False, params)
 kernels_mask = kernels.update(lambda _: True, all_false)
 biases_mask = biases.update(lambda _: True, all_false)
 

--- a/examples/imagenet/train.py
+++ b/examples/imagenet/train.py
@@ -112,7 +112,7 @@ def train_step(state, batch, learning_rate_fn):
         batch['image'],
         mutable=['batch_stats'])
     loss = cross_entropy_loss(logits, batch['label'])
-    weight_penalty_params = jax.tree_leaves(params)
+    weight_penalty_params = jax.tree_util.tree_leaves(params)
     weight_decay = 0.0001
     weight_l2 = sum(jnp.sum(x ** 2)
                      for x in weight_penalty_params
@@ -145,11 +145,11 @@ def train_step(state, batch, learning_rate_fn):
     # if is_fin == False the gradients contain Inf/NaNs and optimizer state and
     # params should be restored (= skip this step).
     new_state = new_state.replace(
-        opt_state=jax.tree_map(
+        opt_state=jax.tree_util.tree_map(
             functools.partial(jnp.where, is_fin),
             new_state.opt_state,
             state.opt_state),
-        params=jax.tree_map(
+        params=jax.tree_util.tree_map(
             functools.partial(jnp.where, is_fin),
             new_state.params,
             state.params),
@@ -177,7 +177,7 @@ def prepare_tf_data(xs):
     # (local_devices, device_batch_size, height, width, 3)
     return x.reshape((local_device_count, -1) + x.shape[1:])
 
-  return jax.tree_map(_prepare, xs)
+  return jax.tree_util.tree_map(_prepare, xs)
 
 
 def create_input_iter(dataset_builder, batch_size, image_size, dtype, train,
@@ -202,7 +202,7 @@ def restore_checkpoint(state, workdir):
 def save_checkpoint(state, workdir):
   if jax.process_index() == 0:
     # get train state from the first replica
-    state = jax.device_get(jax.tree_map(lambda x: x[0], state))
+    state = jax.device_get(jax.tree_util.tree_map(lambda x: x[0], state))
     step = int(state.step)
     checkpoints.save_checkpoint(workdir, state, step, keep=3)
 
@@ -342,7 +342,7 @@ def train_and_evaluate(config: ml_collections.ConfigDict,
         train_metrics = common_utils.get_metrics(train_metrics)
         summary = {
             f'train_{k}': v
-            for k, v in jax.tree_map(lambda x: x.mean(), train_metrics).items()
+            for k, v in jax.tree_util.tree_map(lambda x: x.mean(), train_metrics).items()
         }
         summary['steps_per_second'] = config.log_every_steps / (
             time.time() - train_metrics_last_t)
@@ -361,7 +361,7 @@ def train_and_evaluate(config: ml_collections.ConfigDict,
         metrics = p_eval_step(state, eval_batch)
         eval_metrics.append(metrics)
       eval_metrics = common_utils.get_metrics(eval_metrics)
-      summary = jax.tree_map(lambda x: x.mean(), eval_metrics)
+      summary = jax.tree_util.tree_map(lambda x: x.mean(), eval_metrics)
       logging.info('eval epoch: %d, loss: %.4f, accuracy: %.2f',
                    epoch, summary['loss'], summary['accuracy'] * 100)
       writer.write_scalars(

--- a/examples/linen_design_test/attention_simple.py
+++ b/examples/linen_design_test/attention_simple.py
@@ -201,5 +201,5 @@ if __name__ == '__main__':
 
   print('input shape: ', inputs.shape)
   print('parameter shapes:')
-  pprint(jax.tree_map(jnp.shape, unfreeze(params)))
+  pprint(jax.tree_util.tree_map(jnp.shape, unfreeze(params)))
   print('output shape: ', y.shape)

--- a/examples/linen_design_test/autoencoder.py
+++ b/examples/linen_design_test/autoencoder.py
@@ -81,7 +81,7 @@ print("encoder", jnp.shape(ae.apply(params, jnp.ones((1, 28, 28, 1)), method=ae.
 
 # `ae.variables` is a frozen dict that looks like
 # {'params': {"decoder": {"Dense_0": {"bias": ..., "kernel": ...}, ...}}
-print("var shapes", jax.tree_map(jnp.shape, params))
+print("var shapes", jax.tree_util.tree_map(jnp.shape, params))
 
 
 # TODO(avital, levskaya): resurrect this example once interactive api is restored.
@@ -90,10 +90,10 @@ print("var shapes", jax.tree_map(jnp.shape, params))
 # You can access submodules defined in setup(), they are just references on
 # the autoencoder instance
 # encoder = ae.encoder
-# print("encoder var shapes", jax.tree_map(jnp.shape, encoder.variables))
+# print("encoder var shapes", jax.tree_util.tree_map(jnp.shape, encoder.variables))
 
 
 # # You can also access submodules that were defined in-line.
 # # (We may add syntactic sugar here, e.g. to allow `ae.encoder.Dense_0`)
 # encoder_dense0 = ae.encoder.children['Dense_0']
-# print("encoder dense0 var shapes", jax.tree_map(jnp.shape, encoder_dense0.variables))
+# print("encoder dense0 var shapes", jax.tree_util.tree_map(jnp.shape, encoder_dense0.variables))

--- a/examples/linen_design_test/linear_regression.py
+++ b/examples/linen_design_test/linear_regression.py
@@ -45,4 +45,4 @@ for i in range(50):
   loss, grad = jax.value_and_grad(loss_fn)(params)
   print(i, "loss = ", loss, "Yhat = ", predict(params))
   lr = 0.03
-  params = jax.tree_map(lambda x, d: x - lr * d, params, grad)
+  params = jax.tree_util.tree_map(lambda x, d: x - lr * d, params, grad)

--- a/examples/linen_design_test/tied_autoencoder.py
+++ b/examples/linen_design_test/tied_autoencoder.py
@@ -42,4 +42,4 @@ from dense import Dense
 #   {'params': random.PRNGKey(42)},
 #   jnp.ones((1, 16)))
 # print("reconstruct", jnp.shape(tae(jnp.ones((1, 16)))))
-# print("var shapes", jax.tree_map(jnp.shape, tae.variables))
+# print("var shapes", jax.tree_util.tree_map(jnp.shape, tae.variables))

--- a/examples/lm1b/train.py
+++ b/examples/lm1b/train.py
@@ -277,10 +277,10 @@ def per_host_sum_pmap(in_tree):
   host_psum = jax.pmap(lambda x: jax.lax.psum(x, "i"), "i", devices=devices)
 
   def pre_pmap(xs):
-    return jax.tree_map(lambda x: jnp.broadcast_to(x, (1,) + x.shape), xs)
+    return jax.tree_util.tree_map(lambda x: jnp.broadcast_to(x, (1,) + x.shape), xs)
 
   def post_pmap(xs):
-    return jax.tree_map(lambda x: x[0], xs)
+    return jax.tree_util.tree_map(lambda x: x[0], xs)
 
   return post_pmap(host_psum(pre_pmap(in_tree)))
 
@@ -298,14 +298,14 @@ def evaluate(*, p_eval_step, params, eval_ds: tf.data.Dataset,
   eval_metrics = []
   eval_iter = iter(eval_ds)  # pytype: disable=wrong-arg-types
   for _, eval_batch in zip(range(num_eval_steps), eval_iter):
-    eval_batch = jax.tree_map(lambda x: x._numpy(), eval_batch)  # pylint: disable=protected-access
+    eval_batch = jax.tree_util.tree_map(lambda x: x._numpy(), eval_batch)  # pylint: disable=protected-access
     eval_batch = common_utils.shard(eval_batch)
     metrics = p_eval_step(params, eval_batch)
     eval_metrics.append(metrics)
   eval_metrics = common_utils.get_metrics(eval_metrics)
-  eval_metrics_sums = jax.tree_map(jnp.sum, eval_metrics)
+  eval_metrics_sums = jax.tree_util.tree_map(jnp.sum, eval_metrics)
   eval_denominator = eval_metrics_sums.pop("denominator")
-  eval_summary = jax.tree_map(
+  eval_summary = jax.tree_util.tree_map(
       lambda x: x / eval_denominator,  # pylint: disable=cell-var-from-loop
       eval_metrics_sums)
   return eval_summary
@@ -329,7 +329,7 @@ def generate_prediction(*, p_pred_step, params,
     if cur_pred_batch_size % n_devices:
       padded_size = int(
           np.ceil(cur_pred_batch_size / n_devices) * n_devices)
-      pred_batch = jax.tree_map(
+      pred_batch = jax.tree_util.tree_map(
           lambda x: pad_examples(x, padded_size), pred_batch)  # pylint: disable=cell-var-from-loop
     pred_batch = common_utils.shard(pred_batch)
     inference_rng, sub_rng = random.split(inference_rng)
@@ -501,7 +501,7 @@ def train_and_evaluate(config: ml_collections.ConfigDict, workdir: str):
 
       # Shard data to devices and do a training step.
       with jax.profiler.StepTraceAnnotation("train", step_num=step):
-        batch = common_utils.shard(jax.tree_map(np.asarray, next(train_iter)))
+        batch = common_utils.shard(jax.tree_util.tree_map(np.asarray, next(train_iter)))
         state, metrics = p_train_step(
             state, batch, dropout_rng=dropout_rngs)
         train_metrics.append(metrics)
@@ -517,9 +517,9 @@ def train_and_evaluate(config: ml_collections.ConfigDict, workdir: str):
           logging.info("Gathering training metrics.")
           train_metrics = common_utils.get_metrics(train_metrics)
           lr = train_metrics.pop("learning_rate").mean()
-          metrics_sums = jax.tree_map(jnp.sum, train_metrics)
+          metrics_sums = jax.tree_util.tree_map(jnp.sum, train_metrics)
           denominator = metrics_sums.pop("denominator")
-          summary = jax.tree_map(lambda x: x / denominator, metrics_sums)  # pylint: disable=cell-var-from-loop
+          summary = jax.tree_util.tree_map(lambda x: x / denominator, metrics_sums)  # pylint: disable=cell-var-from-loop
           summary["learning_rate"] = lr
           summary["perplexity"] = jnp.clip(
               jnp.exp(summary["loss"]), a_max=1.0e4)

--- a/examples/mnist/train_test.py
+++ b/examples/mnist/train_test.py
@@ -48,7 +48,7 @@ class TrainTest(absltest.TestCase):
     self.assertEqual((1, 10), output.shape)
     self.assertEqual(
         CNN_PARAMS,
-        sum(np.prod(arr.shape) for arr in jax.tree_leaves(variables["params"])))
+        sum(np.prod(arr.shape) for arr in jax.tree_util.tree_leaves(variables["params"])))
 
   def test_train_and_evaluate(self):
     """Tests training and evaluation code by running a single step."""

--- a/examples/ogbg_molpcba/train.py
+++ b/examples/ogbg_molpcba/train.py
@@ -349,7 +349,7 @@ def train_and_evaluate(config: ml_collections.ConfigDict,
 
     # Perform one step of training.
     with jax.profiler.StepTraceAnnotation('train', step_num=step):
-      graphs = jax.tree_map(np.asarray, next(train_iter))
+      graphs = jax.tree_util.tree_map(np.asarray, next(train_iter))
       state, metrics_update = train_step(
           state, graphs, rngs={'dropout': dropout_rng})
 

--- a/examples/ppo/ppo_lib.py
+++ b/examples/ppo/ppo_lib.py
@@ -157,7 +157,7 @@ def train_step(
     loss: loss summed over training steps
   """
   iterations = trajectories[0].shape[0] // batch_size
-  trajectories = jax.tree_map(
+  trajectories = jax.tree_util.tree_map(
       lambda x: x.reshape((iterations, batch_size) + x.shape[1:]), trajectories)
   loss = 0.
   for batch in zip(*trajectories):

--- a/examples/sst2/train.py
+++ b/examples/sst2/train.py
@@ -157,7 +157,7 @@ def batch_to_numpy(batch: Dict[str, tf.Tensor]) -> Dict[str, Array]:
   """Converts a batch with TF tensors to a batch of NumPy arrays."""
   # _numpy() reuses memory, does not make a copy.
   # pylint: disable=protected-access
-  return jax.tree_map(lambda x: x._numpy(), batch)
+  return jax.tree_util.tree_map(lambda x: x._numpy(), batch)
 
 
 def evaluate_model(

--- a/examples/sst2/train_test.py
+++ b/examples/sst2/train_test.py
@@ -47,8 +47,8 @@ class TrainTest(parameterized.TestCase):
     new_state, metrics = train_step_fn(state, batch, rngs)
     self.assertIsInstance(new_state, train.TrainState)
     self.assertIsInstance(metrics, train.Metrics)
-    old_param_values = jax.tree_leaves(state.params)
-    new_param_values = jax.tree_leaves(new_state.params)
+    old_param_values = jax.tree_util.tree_leaves(state.params)
+    new_param_values = jax.tree_util.tree_leaves(new_state.params)
     for old_array, new_array in zip(old_param_values, new_param_values):
       # Make sure parameters were updated.
       self.assertFalse(np.allclose(old_array, new_array))

--- a/examples/wmt/decode.py
+++ b/examples/wmt/decode.py
@@ -97,7 +97,7 @@ def gather_beams(nested, beam_indices, batch_size, new_beam_size):
       return x
     else:
       return x[batch_indices, beam_indices]
-  return jax.tree_map(gather_fn, nested)
+  return jax.tree_util.tree_map(gather_fn, nested)
 
 
 def gather_topk_beams(nested, score_or_log_prob, batch_size, new_beam_size):
@@ -153,7 +153,7 @@ def beam_init(batch_size, beam_size, max_decode_len, cache):
       (batch_size, beam_size, max_decode_len), jnp.int32)
   finished_flags0 = jnp.zeros((batch_size, beam_size), jnp.bool_)
   # add beam dimension to attention cache pytree elements
-  beam_cache0 = jax.tree_map(lambda x: add_beam_dim(x, beam_size), cache)
+  beam_cache0 = jax.tree_util.tree_map(lambda x: add_beam_dim(x, beam_size), cache)
   return BeamState(cur_index=cur_index0,
                    live_logprobs=live_logprobs0,
                    finished_scores=finished_scores0,
@@ -238,7 +238,7 @@ def beam_search(inputs,
         (batch_size, beam_size, 1)))
     # Flatten beam dimension into batch to be compatible with model.
     # {[batch, beam, ...], ...} --> {[batch * beam, ...], ...}
-    flat_cache = jax.tree_map(flatten_beam_dim, state.cache)
+    flat_cache = jax.tree_util.tree_map(flatten_beam_dim, state.cache)
 
     # Call fast-decoder model on current tokens to get next-position logits.
     # --> [batch * beam, vocab]
@@ -249,7 +249,7 @@ def beam_search(inputs,
     logits = unflatten_beam_dim(flat_logits, batch_size, beam_size)
     # Unflatten beam dimension in attention cache arrays
     # {[batch * beam, ...], ...} --> {[batch, beam, ...], ...}
-    new_cache = jax.tree_map(
+    new_cache = jax.tree_util.tree_map(
         lambda x: unflatten_beam_dim(x, batch_size, beam_size), new_flat_cache)
 
     # Gather log probabilities from logits

--- a/flax/core/axes_scan.py
+++ b/flax/core/axes_scan.py
@@ -131,7 +131,7 @@ def scan(
         xs)
     input_avals = (carry_avals, scan_avals)
 
-    in_avals, in_tree = jax.tree_flatten(input_avals)
+    in_avals, in_tree = jax.tree_util.tree_flatten(input_avals)
     f_flat, out_tree = jax.api_util.flatten_fun_nokwargs(
         lu.wrap_init(broadcast_body), in_tree)
     in_pvals = list(map(pe.PartialVal.unknown, in_avals))
@@ -143,7 +143,7 @@ def scan(
         raise ValueError(
             'broadcasted variable has a data dependency on the scan body.')
       out_flat.append(const)
-    broadcast_in, constants_out = jax.tree_unflatten(out_tree(), out_flat)
+    broadcast_in, constants_out = jax.tree_util.tree_unflatten(out_tree(), out_flat)
 
     c, ys = lax.scan(body_fn, init, xs, length=length,
                      reverse=reverse, unroll=unroll)

--- a/flax/linen/partitioning.py
+++ b/flax/linen/partitioning.py
@@ -118,8 +118,8 @@ _unassigned_axis = _UnassignedAxis()
 
 def _mesh_assignment_free(new_assignment, existing_assignments):
   """Determines if a given mesh axis has already been assigned."""
-  new = set(jax.tree_leaves(new_assignment))
-  existing = set(jax.tree_leaves(existing_assignments))
+  new = set(jax.tree_util.tree_leaves(new_assignment))
+  existing = set(jax.tree_util.tree_leaves(existing_assignments))
   if existing.intersection(new):
     return False
   return True

--- a/flax/linen/summary.py
+++ b/flax/linen/summary.py
@@ -403,7 +403,7 @@ def _size_and_bytes_repr(size: int, num_bytes: int) -> str:
 
 
 def _size_and_bytes(pytree: Any) -> Tuple[int, int]:
-  leaves = jax.tree_leaves(pytree)
+  leaves = jax.tree_util.tree_leaves(pytree)
   size = sum(x.size for x in leaves)
   num_bytes = sum(x.size * x.dtype.itemsize for x in leaves)
   return size, num_bytes

--- a/flax/linen/transforms.py
+++ b/flax/linen/transforms.py
@@ -246,7 +246,7 @@ def set_module_scopes(module, args, kwargs, scopes):
 def _test_transformed_return_values(tree, method_name):
   """Tests whether the return value contains any Modules or Variables."""
   impure = any(map(lambda x: isinstance(x, (Module, Variable)),
-                   jax.tree_leaves(tree)))
+                   jax.tree_util.tree_leaves(tree)))
   if impure:
     raise errors.TransformedMethodReturnValueError(method_name)
 

--- a/flax/optim/base.py
+++ b/flax/optim/base.py
@@ -87,15 +87,15 @@ class OptimizerDef:
       A tuple containing the new parameters and the new optimizer state.
     """
     step = state.step
-    params_flat, treedef = jax.tree_flatten(params)
+    params_flat, treedef = jax.tree_util.tree_flatten(params)
     states_flat = treedef.flatten_up_to(state.param_states)
     grads_flat = treedef.flatten_up_to(grads)
     out = [self.apply_param_gradient(step, hyper_params, param, state, grad)
            for param, state, grad in zip(params_flat, states_flat, grads_flat)]
 
     new_params_flat, new_states_flat = list(zip(*out)) if out else ((), ())
-    new_params = jax.tree_unflatten(treedef, new_params_flat)
-    new_param_states = jax.tree_unflatten(treedef, new_states_flat)
+    new_params = jax.tree_util.tree_unflatten(treedef, new_params_flat)
+    new_param_states = jax.tree_util.tree_unflatten(treedef, new_states_flat)
     new_state = OptimizerState(step + 1, new_param_states)
     return new_params, new_state
 

--- a/flax/optim/dynamic_scale.py
+++ b/flax/optim/dynamic_scale.py
@@ -126,7 +126,7 @@ class DynamicScale(struct.PyTreeNode):
         grad = lax.pmean(grad, axis_name)
 
       finite = jnp.array(True)
-      for g in jax.tree_leaves(grad):
+      for g in jax.tree_util.tree_leaves(grad):
         finite &= jnp.all(lax.is_finite(g))
 
       grow = self.fin_steps == self.growth_interval

--- a/flax/optim/weight_norm.py
+++ b/flax/optim/weight_norm.py
@@ -88,7 +88,7 @@ class WeightNorm(OptimizerDef):
       else:
         return param, ()
 
-    leaves, treedef = jax.tree_flatten(params)
+    leaves, treedef = jax.tree_util.tree_flatten(params)
     eps = self.hyper_params.wn_eps
     directions, scales = zip(*(split_param(p) for p in leaves))
     directions = treedef.unflatten(directions)
@@ -103,7 +103,7 @@ class WeightNorm(OptimizerDef):
     return state.replace(param_states=param_states)
 
   def apply_gradient(self, hyper_params, params, state, grads):
-    treedef = jax.tree_structure(params)
+    treedef = jax.tree_util.tree_structure(params)
     s_leaves = treedef.flatten_up_to(state.param_states)
     direction = treedef.unflatten(x.direction for x in s_leaves)
     scale = treedef.unflatten(x.scale for x in s_leaves)

--- a/flax/serialization.py
+++ b/flax/serialization.py
@@ -328,7 +328,7 @@ def msgpack_serialize(pytree, in_place: bool = False) -> bytes:
     msgpack-encoded bytes of pytree.
   """
   if not in_place:
-    pytree = jax.tree_map(lambda x: x, pytree)
+    pytree = jax.tree_util.tree_map(lambda x: x, pytree)
   pytree = _np_convert_in_place(pytree)
   pytree = _chunk_array_leaves_in_place(pytree)
   return msgpack.packb(pytree, default=_msgpack_ext_pack, strict_types=True)

--- a/flax/training/common_utils.py
+++ b/flax/training/common_utils.py
@@ -22,7 +22,7 @@ import numpy as np
 
 def shard(xs):
   local_device_count = jax.local_device_count()
-  return jax.tree_map(
+  return jax.tree_util.tree_map(
       lambda x: x.reshape((local_device_count, -1) + x.shape[1:]), xs)
 
 
@@ -42,12 +42,12 @@ def onehot(labels, num_classes, on_value=1.0, off_value=0.0):
 
 def stack_forest(forest):
   stack_args = lambda *args: np.stack(args)
-  return jax.tree_map(stack_args, *forest)
+  return jax.tree_util.tree_map(stack_args, *forest)
 
 
 def get_metrics(device_metrics):
   # We select the first element of x in order to get a single copy of a
   # device-replicated metric.
-  device_metrics = jax.tree_map(lambda x: x[0], device_metrics)
+  device_metrics = jax.tree_util.tree_map(lambda x: x[0], device_metrics)
   metrics_np = jax.device_get(device_metrics)
   return stack_forest(metrics_np)

--- a/flax/traverse_util.py
+++ b/flax/traverse_util.py
@@ -387,10 +387,10 @@ class TraverseTree(Traversal):
   """
 
   def update(self, fn, inputs):
-    return jax.tree_map(fn, inputs)
+    return jax.tree_util.tree_map(fn, inputs)
 
   def iterate(self, inputs):
-    yield from jax.tree_leaves(inputs)
+    yield from jax.tree_util.tree_leaves(inputs)
 
 
 def _get_params_dict(inputs):

--- a/tests/core/core_frozen_dict_test.py
+++ b/tests/core/core_frozen_dict_test.py
@@ -32,7 +32,7 @@ class FrozenDictTest(absltest.TestCase):
   def test_frozen_dict_maps(self):
     xs = {'a': 1, 'b': {'c': 2}}
     frozen = FrozenDict(xs)
-    frozen2 = jax.tree_map(lambda x: x + x, frozen)
+    frozen2 = jax.tree_util.tree_map(lambda x: x + x, frozen)
     self.assertEqual(unfreeze(frozen2), {'a': 2, 'b': {'c': 4}})
 
   def test_frozen_dict_pop(self):
@@ -42,7 +42,7 @@ class FrozenDictTest(absltest.TestCase):
     self.assertEqual(unfreeze(b), {'b': {'c': 2}})
 
   def test_frozen_dict_partially_maps(self):
-    x = jax.tree_map(
+    x = jax.tree_util.tree_map(
         lambda a, b: (a, b),
         freeze({'a': 2}), freeze({'a': {'b': 1}}))
     self.assertEqual(unfreeze(x), {'a': (2, {'b': 1})})

--- a/tests/core/core_lift_test.py
+++ b/tests/core/core_lift_test.py
@@ -102,7 +102,7 @@ class LiftTest(absltest.TestCase):
       return p * x
 
     def f(scope, x):
-      vars_t = jax.tree_map(jnp.ones_like, scope.variables().get('params', {}))
+      vars_t = jax.tree_util.tree_map(jnp.ones_like, scope.variables().get('params', {}))
       _, out_t = lift.jvp(g, scope, (x,), (jnp.zeros_like(x),), {'params': vars_t})
       return out_t
     

--- a/tests/core/design/core_attention_test.py
+++ b/tests/core/design/core_attention_test.py
@@ -146,7 +146,7 @@ class AttentionTest(absltest.TestCase):
 
     rngs = {'params': random.PRNGKey(0), 'dropout': random.PRNGKey(1)}
     y, variables = jax.jit(init(model))(rngs, inputs, inputs)
-    variable_shapes = jax.tree_map(jnp.shape, variables['params'])
+    variable_shapes = jax.tree_util.tree_map(jnp.shape, variables['params'])
     self.assertEqual(y.shape, (2, 7, 16))
     self.assertEqual(unfreeze(variable_shapes), {
         'key': {'kernel': (2, 16, 8)},

--- a/tests/core/design/core_auto_encoder_test.py
+++ b/tests/core/design/core_auto_encoder_test.py
@@ -106,7 +106,7 @@ class AutoEncoderTest(absltest.TestCase):
     x = jnp.ones((1, 4))
     x_r, variables = init(ae)(random.PRNGKey(0), x)
     self.assertEqual(x.shape, x_r.shape)
-    variable_shapes = unfreeze(jax.tree_map(jnp.shape, variables['params']))
+    variable_shapes = unfreeze(jax.tree_util.tree_map(jnp.shape, variables['params']))
     self.assertEqual(variable_shapes, {
         'encoder': {
             'hidden': {'kernel': (4, 3), 'bias': (3,)},
@@ -124,7 +124,7 @@ class AutoEncoderTest(absltest.TestCase):
 
     x_r, variables = init(ae)(random.PRNGKey(0), x)
     self.assertEqual(x.shape, x_r.shape)
-    variable_shapes = unfreeze(jax.tree_map(jnp.shape, variables['params']))
+    variable_shapes = unfreeze(jax.tree_util.tree_map(jnp.shape, variables['params']))
     self.assertEqual(variable_shapes, {
         'encode': {
             'hidden': {'kernel': (4, 3), 'bias': (3,)},
@@ -142,7 +142,7 @@ class AutoEncoderTest(absltest.TestCase):
 
     x_r, variables = init(ae)(random.PRNGKey(0), x)
     self.assertEqual(x.shape, x_r.shape)
-    variable_shapes = unfreeze(jax.tree_map(jnp.shape, variables['params']))
+    variable_shapes = unfreeze(jax.tree_util.tree_map(jnp.shape, variables['params']))
     self.assertEqual(variable_shapes, {
         'encode': {
             'hidden': {'kernel': (4, 3), 'bias': (3,)},

--- a/tests/core/design/core_big_resnets_test.py
+++ b/tests/core/design/core_big_resnets_test.py
@@ -63,9 +63,9 @@ class BigResnetTest(absltest.TestCase):
     y, variables = init(big_resnet)(random.PRNGKey(1), x)
     self.assertEqual(y.shape, (1, 8, 8, 8))
     param_shapes = unfreeze(
-        jax.tree_map(jnp.shape, variables['params']))
+        jax.tree_util.tree_map(jnp.shape, variables['params']))
     batch_stats_shapes = unfreeze(
-        jax.tree_map(jnp.shape, variables['batch_stats']))
+        jax.tree_util.tree_map(jnp.shape, variables['batch_stats']))
     self.assertEqual(param_shapes, {
         'conv_1': {'kernel': (10, 5, 3, 3, 8, 8)},
         'conv_2': {'kernel': (10, 5, 3, 3, 8, 8)},

--- a/tests/core/design/core_custom_vjp_test.py
+++ b/tests/core/design/core_custom_vjp_test.py
@@ -40,7 +40,7 @@ def mlp_custom_grad(scope: Scope, x: Array,
     del features
     vjp_fn = res
     input_t, params_t = vjp_fn(y_t)
-    params_t = jax.tree_map(jnp.sign, params_t)
+    params_t = jax.tree_util.tree_map(jnp.sign, params_t)
     return input_t, params_t
 
   dense_custom_grad = lift.custom_vjp(
@@ -61,11 +61,11 @@ class CustomVJPTest(absltest.TestCase):
     x = random.normal(random.PRNGKey(0), (1, 4))
     y, variables = init(mlp_custom_grad)(random.PRNGKey(1), x)
     param_shapes = unfreeze(
-        jax.tree_map(jnp.shape, variables['params']))
+        jax.tree_util.tree_map(jnp.shape, variables['params']))
     loss_fn = lambda p, x: jnp.mean(apply(mlp_custom_grad)(p, x) ** 2)
     grad = jax.grad(loss_fn)(variables, x)
     grad_shapes = unfreeze(
-        jax.tree_map(jnp.shape, grad['params']))
+        jax.tree_util.tree_map(jnp.shape, grad['params']))
     self.assertEqual(y.shape, (1, 1))
     expected_param_shapes = {
         'hidden_0': {'kernel': (4, 8), 'bias': (8,)},
@@ -73,7 +73,7 @@ class CustomVJPTest(absltest.TestCase):
     }
     self.assertEqual(param_shapes, expected_param_shapes)
     self.assertEqual(grad_shapes, expected_param_shapes)
-    for g in jax.tree_leaves(grad):
+    for g in jax.tree_util.tree_leaves(grad):
       self.assertTrue(np.all(g == np.sign(g)))
 
 

--- a/tests/core/design/core_dense_test.py
+++ b/tests/core/design/core_dense_test.py
@@ -101,7 +101,7 @@ class DenseTest(absltest.TestCase):
     x = jnp.ones((1, 3))
     y, variables = init(model)(random.PRNGKey(0), x)
     param_shapes = unfreeze(
-        jax.tree_map(jnp.shape, variables['params']))
+        jax.tree_util.tree_map(jnp.shape, variables['params']))
     self.assertEqual(y.shape, (1, 4))
     self.assertEqual(param_shapes, {
         'kernel': (3, 4),
@@ -112,7 +112,7 @@ class DenseTest(absltest.TestCase):
     x = jnp.ones((1, 3))
     y, variables = init(explicit_mlp)(random.PRNGKey(0), x)
     param_shapes = unfreeze(
-        jax.tree_map(jnp.shape, variables['params']))
+        jax.tree_util.tree_map(jnp.shape, variables['params']))
     self.assertEqual(y.shape, (1, 4))
     self.assertEqual(param_shapes, {
         'kernel': (3, 4),
@@ -123,7 +123,7 @@ class DenseTest(absltest.TestCase):
     x = jnp.ones((1, 4))
     y, variables = init(explicit_mlp)(random.PRNGKey(0), x)
     param_shapes = unfreeze(
-        jax.tree_map(jnp.shape, variables['params']))
+        jax.tree_util.tree_map(jnp.shape, variables['params']))
     self.assertEqual(y.shape, (1, 1))
     self.assertEqual(param_shapes, {
         'dense_0': ExplicitDense((4, 3), (3,)),
@@ -134,7 +134,7 @@ class DenseTest(absltest.TestCase):
     x = jnp.ones((1, 4))
     y, variables = init(semi_explicit_mlp)(random.PRNGKey(0), x)
     param_shapes = unfreeze(
-        jax.tree_map(jnp.shape, variables['params']))
+        jax.tree_util.tree_map(jnp.shape, variables['params']))
     self.assertEqual(y.shape, (1, 1))
     self.assertEqual(param_shapes, {
         'dense_0': {'kernel': (4, 3), 'bias': (3,)},

--- a/tests/core/design/core_flow_test.py
+++ b/tests/core/design/core_flow_test.py
@@ -71,7 +71,7 @@ class FlowTest(absltest.TestCase):
     flow = StackFlow((DenseFlow(),) * 3)
     y, variables = init(flow.forward)(random.PRNGKey(0), x)
     param_shapes = unfreeze(
-        jax.tree_map(jnp.shape, variables['params']))
+        jax.tree_util.tree_map(jnp.shape, variables['params']))
     self.assertEqual(y.shape, (1, 3))
     self.assertEqual(param_shapes, {
         '0': {'kernel': (3, 3), 'bias': (3,)},

--- a/tests/core/design/core_resnet_test.py
+++ b/tests/core/design/core_resnet_test.py
@@ -81,7 +81,7 @@ class ResNetTest(absltest.TestCase):
     x = random.normal(random.PRNGKey(0), (1, 64, 64, 3))
     y, variables = init(resnet)(random.PRNGKey(1), x, block_sizes=block_sizes, features=16)
     param_shapes = unfreeze(
-        jax.tree_map(jnp.shape, variables['params']))
+        jax.tree_util.tree_map(jnp.shape, variables['params']))
     self.assertEqual(y.shape, (1, 1000))
 
     self.assertEqual(param_shapes, {

--- a/tests/core/design/core_scan_test.py
+++ b/tests/core/design/core_scan_test.py
@@ -56,7 +56,7 @@ class ScanTest(absltest.TestCase):
     y, variables = init(mlp_scan)(random.PRNGKey(1), x, share_params=False)
 
     param_shapes = unfreeze(
-        jax.tree_map(jnp.shape, variables['params']))
+        jax.tree_util.tree_map(jnp.shape, variables['params']))
     self.assertEqual(variables['counter']['i'], 2)
     self.assertEqual(param_shapes, {
       'dense_0': {'kernel': (2, 4, 1), 'bias': (2, 1)},
@@ -72,7 +72,7 @@ class ScanTest(absltest.TestCase):
     y, variables = init(mlp_scan)(random.PRNGKey(1), x, share_params=True)
 
     param_shapes = unfreeze(
-        jax.tree_map(jnp.shape, variables['params']))
+        jax.tree_util.tree_map(jnp.shape, variables['params']))
     self.assertEqual(variables['counter']['i'], 2)
     self.assertEqual(param_shapes, {
       'dense_0': {'kernel': (4, 1), 'bias': (1,)},

--- a/tests/core/design/core_tied_autoencoder_test.py
+++ b/tests/core/design/core_tied_autoencoder_test.py
@@ -25,7 +25,7 @@ from flax.core import init, unfreeze, lift, nn
 
 def transpose(fn):
   def trans(variables):
-    return jax.tree_map(lambda x: x.T, variables)
+    return jax.tree_util.tree_map(lambda x: x.T, variables)
 
   return lift.map_variables(
       fn, "params", map_in_fn=trans, map_out_fn=trans,
@@ -58,7 +58,7 @@ class TiedAutoEncoderTest(absltest.TestCase):
     x_r, variables = init(ae)(random.PRNGKey(0), x)
 
     param_shapes = unfreeze(
-        jax.tree_map(jnp.shape, variables['params']))
+        jax.tree_util.tree_map(jnp.shape, variables['params']))
     self.assertEqual(param_shapes, {
         'kernel': (4, 2),
     })
@@ -70,7 +70,7 @@ class TiedAutoEncoderTest(absltest.TestCase):
     x_r, variables = init(ae.decode)(random.PRNGKey(0), z)
 
     param_shapes = unfreeze(
-        jax.tree_map(jnp.shape, variables['params']))
+        jax.tree_util.tree_map(jnp.shape, variables['params']))
     self.assertEqual(param_shapes, {
         'kernel': (4, 2),
     })

--- a/tests/core/design/core_vmap_test.py
+++ b/tests/core/design/core_vmap_test.py
@@ -55,7 +55,7 @@ class VMapTest(absltest.TestCase):
     y, variables = init(mlp_vmap)(random.PRNGKey(1), x, share_params=True)
 
     param_shapes = unfreeze(
-        jax.tree_map(jnp.shape, variables['params']))
+        jax.tree_util.tree_map(jnp.shape, variables['params']))
     self.assertEqual(param_shapes, {
         'hidden_0' : {'kernel': (4, 8), 'bias': (8,)},
         'out': {'kernel': (8, 1), 'bias': (1,)},
@@ -70,7 +70,7 @@ class VMapTest(absltest.TestCase):
     y, variables = init(mlp_vmap)(random.PRNGKey(1), x, share_params=False)
 
     param_shapes = unfreeze(
-        jax.tree_map(jnp.shape, variables['params']))
+        jax.tree_util.tree_map(jnp.shape, variables['params']))
     self.assertEqual(param_shapes, {
         'hidden_0': {'kernel': (2, 4, 8), 'bias': (2, 8)},
         'out': {'kernel': (2, 8, 1), 'bias': (2, 1)},

--- a/tests/core/design/core_weight_std_test.py
+++ b/tests/core/design/core_weight_std_test.py
@@ -57,7 +57,7 @@ class WeightStdTest(absltest.TestCase):
     y, variables = init(mlp)(random.PRNGKey(1), x)
 
     param_shapes = unfreeze(
-        jax.tree_map(jnp.shape, variables['params']))
+        jax.tree_util.tree_map(jnp.shape, variables['params']))
     self.assertEqual(param_shapes, {
         'hidden_0': {'kernel': (4, 8), 'bias': (8,)},
         'out': {'kernel': (8, 1), 'bias': (1,)},

--- a/tests/linen/dotgetter_test.py
+++ b/tests/linen/dotgetter_test.py
@@ -87,7 +87,7 @@ class DotGetterTest(absltest.TestCase):
     dg2 = DotGetter({'a': jnp.array([2.0]),
                      'b': {'c': jnp.array([4.0]),
                            'd': jnp.array([6.0])}})
-    self.assertEqual(jax.tree_map(lambda x: 2 * x, dg1), dg2)
+    self.assertEqual(jax.tree_util.tree_map(lambda x: 2 * x, dg1), dg2)
 
   def test_statedict(self):
     d = {'a': jnp.array([1.0]),

--- a/tests/linen/linen_linear_test.py
+++ b/tests/linen/linen_linear_test.py
@@ -919,7 +919,7 @@ class LinearTest(parameterized.TestCase):
     x = jnp.ones((2, 4, 8))
     y, variables = Foo().init_with_output(random.PRNGKey(0), x)
     self.assertEqual(
-        jax.tree_map(jnp.shape, variables['params']),
+        jax.tree_util.tree_map(jnp.shape, variables['params']),
         {'dense': {
             'kernel': (4, 6),
             'bias': (6,)
@@ -936,7 +936,7 @@ class LinearTest(parameterized.TestCase):
     x = jnp.ones((2, 4, 8))
     y, variables = Foo().init_with_output(random.PRNGKey(0), x)
     self.assertEqual(
-        jax.tree_map(jnp.shape, variables['params']),
+        jax.tree_util.tree_map(jnp.shape, variables['params']),
         {'dense': {
             'kernel': (2, 4, 6),
             'bias': (6,)

--- a/tests/linen/linen_module_test.py
+++ b/tests/linen/linen_module_test.py
@@ -38,7 +38,7 @@ jax.config.parse_flags_with_absl()
 
 
 def tree_equals(x, y):
-  return jax.tree_util.tree_all(jax.tree_map(operator.eq, x, y))
+  return jax.tree_util.tree_all(jax.tree_util.tree_map(operator.eq, x, y))
 
 
 class DummyModule(nn.Module):
@@ -103,7 +103,7 @@ class ModuleTest(absltest.TestCase):
     params = scope.variables()['params']
     y2 = MLP(parent=scope.rewound())(x)
     np.testing.assert_allclose(y, y2)
-    param_shape = jax.tree_map(jnp.shape, params)
+    param_shape = jax.tree_util.tree_map(jnp.shape, params)
     self.assertEqual(param_shape, {
         'Dense_0': {
             'kernel': (10, 3)
@@ -142,7 +142,7 @@ class ModuleTest(absltest.TestCase):
     params = scope.variables()['params']
     y2 = Top(parent=scope.rewound())(x)
     np.testing.assert_allclose(y, y2)
-    param_shape = jax.tree_map(jnp.shape, params)
+    param_shape = jax.tree_util.tree_map(jnp.shape, params)
     self.assertEqual(param_shape, {
         'MLP_0': {
             'Dense_0': {
@@ -177,7 +177,7 @@ class ModuleTest(absltest.TestCase):
     params = scope.variables()['params']
     y2 = MLP(parent=scope.rewound())(x)
     np.testing.assert_allclose(y, y2)
-    param_shape = jax.tree_map(jnp.shape, params)
+    param_shape = jax.tree_util.tree_map(jnp.shape, params)
     self.assertEqual(param_shape, {
         'lyrs1_a': {
             'kernel': (10, 3)
@@ -200,7 +200,7 @@ class ModuleTest(absltest.TestCase):
     foo = Foo()
     x = jnp.ones(shape=(1, 3))
     params = foo.init(random.PRNGKey(0), x)['params']
-    param_shape = jax.tree_map(jnp.shape, params)
+    param_shape = jax.tree_util.tree_map(jnp.shape, params)
     self.assertEqual(param_shape,
                      {'a_(1, 2)': {
                          'kernel': (3, 2),
@@ -1095,7 +1095,7 @@ class ModuleTest(absltest.TestCase):
         return self.foo(x)
 
     variables = A().init(random.PRNGKey(0), jnp.ones((1,)))
-    var_shapes = jax.tree_map(jnp.shape, variables)
+    var_shapes = jax.tree_util.tree_map(jnp.shape, variables)
     ref_var_shapes = freeze({
         'params': {
             'b': {
@@ -1120,7 +1120,7 @@ class ModuleTest(absltest.TestCase):
         return self.foo(x)
 
     variables = B().init(random.PRNGKey(0), jnp.ones((1,)))
-    var_shapes = jax.tree_map(jnp.shape, variables)
+    var_shapes = jax.tree_util.tree_map(jnp.shape, variables)
     ref_var_shapes = freeze({
         'params': {
             'foo': {
@@ -1170,7 +1170,7 @@ class ModuleTest(absltest.TestCase):
     y = model.apply(variables, x)
     self.assertEqual(y.shape, (4, 5))
 
-    var_shapes = jax.tree_map(jnp.shape, variables)
+    var_shapes = jax.tree_util.tree_map(jnp.shape, variables)
     ref_var_shapes = freeze({
         'params': {
             'dense_out': {
@@ -1227,7 +1227,7 @@ class ModuleTest(absltest.TestCase):
     })
     self.assertTrue(
         jax.tree_util.tree_all(
-            jax.tree_map(
+            jax.tree_util.tree_map(
                 lambda x, y: np.testing.assert_allclose(x, y, atol=1e-7),
                 counters, ref_counters)))
 
@@ -1261,7 +1261,7 @@ class ModuleTest(absltest.TestCase):
     b = B(a)
     c = C(a, b)
     p = c.init(key, x)
-    var_shapes = jax.tree_map(jnp.shape, p)
+    var_shapes = jax.tree_util.tree_map(jnp.shape, p)
     ref_var_shapes = freeze({
         'params': {
             'Dense_0': {
@@ -1306,7 +1306,7 @@ class ModuleTest(absltest.TestCase):
     k = jax.random.PRNGKey(0)
     x = jnp.zeros((5, 5))
     init_vars = b.init(k, x)
-    var_shapes = jax.tree_map(jnp.shape, init_vars)
+    var_shapes = jax.tree_util.tree_map(jnp.shape, init_vars)
     ref_var_shapes = freeze({
         'params': {
             'a': {
@@ -1482,7 +1482,7 @@ class ModuleTest(absltest.TestCase):
     self.assertEqual(y2, y3)
     bs_1 = new_state['batch_stats']
     bs_2 = foo_b.variables['batch_stats']
-    for x, y in zip(jax.tree_leaves(bs_1), jax.tree_leaves(bs_2)):
+    for x, y in zip(jax.tree_util.tree_leaves(bs_1), jax.tree_util.tree_leaves(bs_2)):
       np.testing.assert_allclose(x, y)
 
   def test_passing_mutable_variables(self):
@@ -1518,7 +1518,7 @@ class ModuleTest(absltest.TestCase):
     x = jnp.ones((4, 7))
 
     variables = Bar().init(k, x)
-    shapes = jax.tree_map(np.shape, variables['params'])
+    shapes = jax.tree_util.tree_map(np.shape, variables['params'])
     self.assertEqual(
         shapes, {
             'Dense_0': {

--- a/tests/linen/linen_test.py
+++ b/tests/linen/linen_test.py
@@ -276,7 +276,7 @@ class RecurrentTest(absltest.TestCase):
     self.assertEqual(carry[0].shape, (2, 4))
     self.assertEqual(carry[1].shape, (2, 4))
     np.testing.assert_allclose(y, carry[1])
-    param_shapes = jax.tree_map(np.shape, initial_params['params'])
+    param_shapes = jax.tree_util.tree_map(np.shape, initial_params['params'])
     self.assertEqual(param_shapes, {
         'ii': {'kernel': (3, 4)},
         'if': {'kernel': (3, 4)},
@@ -298,7 +298,7 @@ class RecurrentTest(absltest.TestCase):
     (carry, y), initial_params = gru.init_with_output(key2, carry0, x)
     self.assertEqual(carry.shape, (2, 4))
     np.testing.assert_allclose(y, carry)
-    param_shapes = jax.tree_map(np.shape, initial_params['params'])
+    param_shapes = jax.tree_util.tree_map(np.shape, initial_params['params'])
     self.assertEqual(param_shapes, {
         'ir': {'kernel': (3, 4), 'bias': (4,)},
         'iz': {'kernel': (3, 4), 'bias': (4,)},
@@ -331,7 +331,7 @@ class RecurrentTest(absltest.TestCase):
     self.assertEqual(carry[0].shape, (2, 4, 4, 6))
     self.assertEqual(carry[1].shape, (2, 4, 4, 6))
     np.testing.assert_allclose(y, carry[1])
-    param_shapes = jax.tree_map(np.shape, initial_params['params'])
+    param_shapes = jax.tree_util.tree_map(np.shape, initial_params['params'])
     self.assertEqual(param_shapes, {
         'hh': {'bias': (6*4,), 'kernel': (3, 3, 6, 6*4)},
         'ih': {'bias': (6*4,), 'kernel': (3, 3, 3, 6*4)},

--- a/tests/linen/partitioning_test.py
+++ b/tests/linen/partitioning_test.py
@@ -399,7 +399,7 @@ class PartitioningTest(parameterized.TestCase):
     with partitioning.axis_rules(p_rules):
       variables = Foo().init(jax.random.PRNGKey(0), jnp.array([1, 2, 3]))
     variables = unfreeze(variables)
-    variables['params'] = jax.tree_map(lambda x: x.shape, variables['params'])
+    variables['params'] = jax.tree_util.tree_map(lambda x: x.shape, variables['params'])
     self.assertDictEqual(
         variables, {
             'params': {
@@ -415,7 +415,7 @@ class PartitioningTest(parameterized.TestCase):
       variables = Vmapped().init(
           jax.random.PRNGKey(0), jnp.array([[1, 2, 3], [4, 5, 6]]))
     variables = unfreeze(variables)
-    variables['params'] = jax.tree_map(lambda x: x.shape, variables['params'])
+    variables['params'] = jax.tree_util.tree_map(lambda x: x.shape, variables['params'])
     self.assertDictEqual(
         variables, {
             'params': {

--- a/tests/linen/summary_test.py
+++ b/tests/linen/summary_test.py
@@ -30,7 +30,7 @@ from flax.linen.summary import _get_module_table
 jax.config.parse_flags_with_absl()
 
 def _get_shapes(pytree):
-  return jax.tree_map(lambda x: x.shape if hasattr(x, 'shape') else x, pytree)
+  return jax.tree_util.tree_map(lambda x: x.shape if hasattr(x, 'shape') else x, pytree)
 
 class ConvBlock(nn.Module):
   features: int

--- a/tests/struct_test.py
+++ b/tests/struct_test.py
@@ -53,9 +53,9 @@ class StructTest(absltest.TestCase):
 
   def test_pytree_nodes(self):
     p = Point(x=1, y=2, meta={'abc': True})
-    leaves = jax.tree_leaves(p)
+    leaves = jax.tree_util.tree_leaves(p)
     self.assertEqual(leaves, [1, 2])
-    new_p = jax.tree_map(lambda x: x + x, p)
+    new_p = jax.tree_util.tree_map(lambda x: x + x, p)
     self.assertEqual(new_p, Point(x=2, y=4, meta={'abc': True}))
 
   def test_keypath_error(self):


### PR DESCRIPTION
JAX has moved all tree utils methods under jax.tree_util and will require using these in the near future.

Fixes #2324 