### PR TITLE
0.5.3 update version & changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,20 @@ vNext
 -
 -
 
+0.5.3
+-----
+New features:
+- Added `nn.switch` as a lifted version of `jax.lax.switch`.
+- Added a method for detecting the use of "init" functions.
+- Added checkpointing support for `jax.experimental.GlobalDeviceArray`, a useful array type for multiprocess/multihost computing.
+- Added async option to `save_checkpoints()` on single-process scenario.
+- Improved documentation pages.
+
+Bug fixes: 
+- Fixed variable aliasing in put_variable
+- Fixed missing passthrough of nn.scan unroll arg
+- Fixed the MNIST example
+
 0.5.2
 -----
 - Fixes missing PyYAML dependecy.

--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ To cite this repository:
   author = {Jonathan Heek and Anselm Levskaya and Avital Oliver and Marvin Ritter and Bertrand Rondepierre and Andreas Steiner and Marc van {Z}ee},
   title = {{F}lax: A neural network library and ecosystem for {JAX}},
   url = {http://github.com/google/flax},
-  version = {0.5.2},
+  version = {0.5.3},
   year = {2020},
 }
 ```

--- a/flax/version.py
+++ b/flax/version.py
@@ -13,5 +13,5 @@
 # limitations under the License.
 
 """Current Flax version at head on Github."""
-__version__ = "0.5.2"
+__version__ = "0.5.3"
 


### PR DESCRIPTION
Doing a 0.5.3 release. 

0.5.3
-----
New features:
- Added `nn.switch` as a lifted version of `jax.lax.switch`.
- Added a method for detecting the use of "init" functions.
- Added checkpointing support for `jax.experimental.GlobalDeviceArray`, a useful array type for multiprocess/multihost computing.
- Added async option to `save_checkpoints()` on single-process scenario.
- Improved documentation pages.

Bug fixes: 
- Fixed variable aliasing in put_variable
- Fixed missing passthrough of nn.scan unroll arg
- Fixed the MNIST example
