### PR TITLE
Fix ConvTranspose with circular padding

### DIFF
--- a/flax/linen/linear.py
+++ b/flax/linen/linear.py
@@ -603,7 +603,7 @@ class ConvTranspose(Module):
       total_pad = [
           ((size_diff + 1) // 2, size_diff // 2) for size_diff in size_diffs
       ]
-      y = np.pad(y, [(0, 0)] + total_pad + [(0, 0)])
+      y = jnp.pad(y, [(0, 0)] + total_pad + [(0, 0)])
       # Wrap the result periodically around each spatial dimension,
       # one by one.
       for i in range(1, y.ndim - 1):

--- a/tests/linen/linen_linear_test.py
+++ b/tests/linen/linen_linear_test.py
@@ -773,6 +773,21 @@ class LinearTest(parameterized.TestCase):
     )
     np.testing.assert_allclose(y, correct_ans)
 
+  def test_circular_conv_transpose_2d_with_vmap(self):
+    layer = nn.ConvTranspose(features=5, kernel_size=(3,), padding="CIRCULAR")
+
+    # this is ok
+    sample_input = jnp.ones((1, 32, 2))
+    out, vars = layer.init_with_output(jax.random.PRNGKey(0), sample_input)
+    self.assertEqual(out.shape, (1, 32, 5))
+
+    batch_input = jnp.ones((8, 32, 2))
+    batch_apply = jax.vmap(layer.apply, in_axes=(None, 0))
+
+    # this breaks with the error provided
+    batch_out = batch_apply(vars, batch_input)
+    self.assertEqual(batch_out.shape, (8, 32, 5))
+
   def test_circular_conv_transpose_1d_custom(self):
     """Test 1d transposed convolution with circular padding and a stride."""
     rng = dict(params=random.PRNGKey(0))


### PR DESCRIPTION
# What does this PR do?

Fixes  #2362.

* Removes use of `np.pad` in favor of `jnp.pad` in `ConvTranspose` for circular padding.
* Adds  test case from #2362  which exposed the behaviour (thanks @zhong1wan).