### PR TITLE
Correct state variable name

### DIFF
--- a/docs/notebooks/state_params.ipynb
+++ b/docs/notebooks/state_params.ipynb
@@ -129,7 +129,7 @@
     "      loss, has_aux=True)(params)\n",
     "  updates, opt_state = tx.update(grads, opt_state)  # Defined below.\n",
     "  params = optax.apply_updates(params, updates)\n",
-    "  return opt_state, params, state"
+    "  return opt_state, params, updated_state"
    ]
   },
   {

--- a/docs/notebooks/state_params.md
+++ b/docs/notebooks/state_params.md
@@ -103,7 +103,7 @@ def update_step(apply_fn, x, opt_state, params, state):
       loss, has_aux=True)(params)
   updates, opt_state = tx.update(grads, opt_state)  # Defined below.
   params = optax.apply_updates(params, updates)
-  return opt_state, params, state
+  return opt_state, params, updated_state
 ```
 
 +++ {"id": "zM_EyHqwVlEw"}


### PR DESCRIPTION
This pr corrects the ``update_step()`` function in the Managing Parameters and State notebook, to pass the ``updated_state``, rather than passing the ``state``, as it is.

# What does this PR do?
This pull request corrects the update_step() function in the [Managing Parameters and State notebook](https://flax.readthedocs.io/en/latest/guides/state_params.html), to return the updated_state, rather than passing the state, as it is.
## Checklist
- [x] This PR fixes a minor issue (e.g.: typo or small bug) or improves the docs (you can dismiss the other
      checks if that's the case).
- [ ] This change is discussed in a Github issue/
      [discussion](https://github.com/google/flax/discussions) (please add a
      link).
- [ ] The documentation and docstrings adhere to the
      [documentation guidelines](https://github.com/google/flax/blob/main/docs/README.md#how-to-write-code-documentation).
- [ ] This change includes necessary high-coverage tests.
      (No quality testing = no merge!)
