### PR TITLE
Test docstrings with autodoc on CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -88,7 +88,6 @@ jobs:
         sphinx-build -M doctest docs docs/_build -T
         # test docstrings
         pytest -n auto flax --doctest-modules --suppress-no-test-exit-code
-          
     - name: Build documentation
       run: |
         sphinx-build -M html docs docs/_build -T

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -86,6 +86,9 @@ jobs:
     - name: Test testcode blocks in documentation
       run: |
         sphinx-build -M doctest docs docs/_build -T
+        # test docstrings
+        pytest -n auto flax --doctest-modules --suppress-no-test-exit-code
+          
     - name: Build documentation
       run: |
         sphinx-build -M html docs docs/_build -T

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,7 @@ tests_require = [
     "opencv-python",
     "pytest",
     "pytest-cov",
+    "pytest-custom_exit_code",
     "pytest-xdist==1.34.0",  # upgrading to 2.0 broke tests, need to investigate
     "pytype",
     "sentencepiece",  # WMT example.

--- a/tests/run_all_tests.sh
+++ b/tests/run_all_tests.sh
@@ -46,6 +46,8 @@ handle_errors () {
 # Run embedded tests inside docs
 if $RUN_DOCTEST; then
   sphinx-build -M doctest docs docs/_build -T
+  # test docstrings
+  pytest -n auto flax --doctest-modules --suppress-no-test-exit-code
 fi
 
 # Run some test on separate process, avoiding device configs poluting each other


### PR DESCRIPTION
# What does this PR do?

* Runs `pytest` with the `--doctest-modules` flag on CI, this runs `doctest` over the docstrings (tests code examples using `>>>`).
