### PR TITLE
skip remat test that fails with autodiff

### DIFF
--- a/tests/linen/linen_transforms_test.py
+++ b/tests/linen/linen_transforms_test.py
@@ -17,6 +17,7 @@
 from functools import partial
 from typing import Any, Tuple, Iterable, Callable, Sequence
 import operator
+import unittest
 
 from absl.testing import absltest
 import jax
@@ -128,6 +129,7 @@ class TransformTest(absltest.TestCase):
     self.assertTrue(np.all(y1 == y2))
 
   def test_remat_kwargs(self):
+    raise unittest.SkipTest("test breaks with grad")
     class ConditionalReLU(nn.Module):
       @nn.compact
       def __call__(self, input, apply_relu : bool = False):
@@ -139,6 +141,9 @@ class TransformTest(absltest.TestCase):
     y = remat_model.apply(p, x, apply_relu=True)
 
     self.assertTrue(np.all(y == jnp.zeros_like(x)))
+
+    # This next line crashes with a concretization error
+    _ = jax.grad(lambda x: remat_model.apply(p, x, apply_relu=True))(x)
 
   def test_vmap(self):
     key1, key2 = random.split(random.PRNGKey(3), 2)


### PR DESCRIPTION
The purpose of jax.checkpoint / jax.remat is to control autodiff behavior. But there is a flax test for remat, namely test_remat_kwargs, which would fail when used with autodiff. The issue is that when used with autodiff jax.remat will abstract its arguments, which doesn't happen when no autodiff is involved. (But for jax.remat to do anything, autodiff has to be involved!)

This PR skips the test and adds a line showing the failure.

We noticed this issue because the new jax.remat implementation errors sooner, namely without waiting for autodiff.

We might be able to adapt this test code. Interestingly, no Google code seems to follow the same pattern as this test: this is the only failure which crops up when switching on the new jax.remat implementation. So an updated version of this test should probably look a bit different.

Co-authored-by: Roy Frostig <frostig@google.com>