### PR TITLE
Updates examples/{imagenet,wmt} requirements.

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ To cite this repository:
   author = {Jonathan Heek and Anselm Levskaya and Avital Oliver and Marvin Ritter and Bertrand Rondepierre and Andreas Steiner and Marc van {Z}ee},
   title = {{F}lax: A neural network library and ecosystem for {JAX}},
   url = {http://github.com/google/flax},
-  version = {0.5.3},
+  version = {0.6.0},
   year = {2020},
 }
 ```

--- a/examples/imagenet/requirements.txt
+++ b/examples/imagenet/requirements.txt
@@ -1,11 +1,11 @@
 absl-py==1.0.0
 clu==0.0.6
-flax==0.4.1
-jax==0.3.4
---find-links https://storage.googleapis.com/jax-releases/jax_releases.html
-jaxlib==0.3.2+cuda11.cudnn82  # Make sure CUDA version matches the base image.
+flax==0.6.0
+-f https://storage.googleapis.com/jax-releases/libtpu_releases.html
+-f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
+jax[gpu]==0.3.16  # change to jax[tpu] if running on tpus
 ml-collections==0.1.0
 numpy==1.22.0
-optax==0.1.0
+optax==0.1.3
 tensorflow==2.8.1
 tensorflow-datasets==4.4.0

--- a/examples/wmt/requirements.txt
+++ b/examples/wmt/requirements.txt
@@ -1,9 +1,9 @@
 absl-py==1.0.0
 clu==0.0.6
-flax==0.4.1
-jax==0.3.4
---find-links https://storage.googleapis.com/jax-releases/jax_releases.html
-jaxlib==0.3.2+cuda11.cudnn82  # Make sure CUDA version matches the base image.
+flax==0.6.0
+-f https://storage.googleapis.com/jax-releases/libtpu_releases.html
+-f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
+jax[gpu]==0.3.16  # change to jax[tpu] if running on tpus
 ml-collections==0.1.0
 numpy==1.22.0
 optax==0.1.0


### PR DESCRIPTION
These examples use dynamic_scale which was recently moved from `optim
to`training`.

This should fix #2403.

