### PR TITLE
Bump `rich` dependency version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ install_requires = [
     "matplotlib",  # only needed for tensorboard export
     "msgpack",
     "optax",
-    "rich~=11.1",
+    "rich>=11.1",
     "typing_extensions>=4.1.1",
     "PyYAML>=5.4.1",
 ]


### PR DESCRIPTION
# What does this PR do?

Bumps `rich` dependency version to `rich>=11.1` (from `rich~=11.1`).

Should be trivial as `rich` seems to be only used by `flax.linen.summary`, unless there's something I overlooked.

Fixes #2406.

## Checklist
- [x] This PR fixes a minor issue (e.g.: typo or small bug) or improves the docs (you can dismiss the other
      checks if that's the case).
- [x] This change is discussed in a Github issue/
      [discussion](https://github.com/google/flax/discussions) (please add a
      link).
- [x] The documentation and docstrings adhere to the
      [documentation guidelines](https://github.com/google/flax/blob/main/docs/README.md#how-to-write-code-documentation).
- [x] This change includes necessary high-coverage tests.
      (No quality testing = no merge!)
