### PR TITLE
Explicit reexport initializers from jax

### DIFF
--- a/flax/linen/initializers.py
+++ b/flax/linen/initializers.py
@@ -16,22 +16,22 @@
 
 # pylint: disable=unused-import
 # re-export initializer functions from jax.nn
-from jax.nn.initializers import constant
-from jax.nn.initializers import delta_orthogonal
-from jax.nn.initializers import glorot_normal
-from jax.nn.initializers import glorot_uniform
-from jax.nn.initializers import he_normal
-from jax.nn.initializers import he_uniform
-from jax.nn.initializers import kaiming_normal
-from jax.nn.initializers import kaiming_uniform
-from jax.nn.initializers import lecun_normal
-from jax.nn.initializers import lecun_uniform
-from jax.nn.initializers import normal
-from jax.nn.initializers import ones
-from jax.nn.initializers import orthogonal
-from jax.nn.initializers import uniform
-from jax.nn.initializers import variance_scaling
-from jax.nn.initializers import xavier_normal
-from jax.nn.initializers import xavier_uniform
-from jax.nn.initializers import zeros
+from jax.nn.initializers import constant as constant
+from jax.nn.initializers import delta_orthogonal as delta_orthogonal 
+from jax.nn.initializers import glorot_normal as glorot_normal
+from jax.nn.initializers import glorot_uniform as glorot_uniform
+from jax.nn.initializers import he_normal as he_normal
+from jax.nn.initializers import he_uniform as he_uniform
+from jax.nn.initializers import kaiming_normal as kaiming_normal
+from jax.nn.initializers import kaiming_uniform as kaiming_uniform
+from jax.nn.initializers import lecun_normal as lecun_normal
+from jax.nn.initializers import lecun_uniform as lecun_uniform
+from jax.nn.initializers import normal as normal
+from jax.nn.initializers import ones as ones
+from jax.nn.initializers import orthogonal as orthogonal
+from jax.nn.initializers import uniform as uniform
+from jax.nn.initializers import variance_scaling as variance_scaling
+from jax.nn.initializers import xavier_normal as xavier_normal
+from jax.nn.initializers import xavier_uniform as xavier_uniform
+from jax.nn.initializers import zeros as zeros
 # pylint: enable=unused-import


### PR DESCRIPTION
Fix linter warning of module not export when using `nn.initializers.normal()` etc.
Similar to #1990

Fixes # (issue)

## Checklist
- [x] This PR fixes a minor issue (e.g.: typo or small bug) or improves the docs (you can dismiss the other
      checks if that's the case).
- [ ] This change is discussed in a Github issue/
      [discussion](https://github.com/google/flax/discussions) (please add a
      link).
- [ ] The documentation and docstrings adhere to the
      [documentation guidelines](https://github.com/google/flax/blob/main/docs/README.md#how-to-write-code-documentation).
- [ ] This change includes necessary high-coverage tests.
      (No quality testing = no merge!)
