### PR TITLE
Annotate Module fields

### DIFF
--- a/flax/linen/experimental/layers_with_named_axes.py
+++ b/flax/linen/experimental/layers_with_named_axes.py
@@ -238,18 +238,17 @@ def _normalize(mdl: nn.Module, x: Array, mean: Array, var: Array,
   y = x - mean
   mul = lax.rsqrt(var + epsilon)
   if use_scale:
-    scale = mdl.param_with_axes(
-        'scale',
-        scale_init,
-        reduced_feature_shape,
-        param_dtype,
-        axes=('embed',)).reshape(feature_shape)
+    
+    scale = param_with_axes(
+        'scale', scale_init,
+        reduced_feature_shape, param_dtype,
+        axes=('embed',), module=mdl).reshape(feature_shape)
     mul *= scale
   y *= mul
   if use_bias:
-    bias = mdl.param_with_axes(
+    bias = param_with_axes(
         'bias', bias_init, reduced_feature_shape, param_dtype,
-        axes=('embed',)).reshape(feature_shape)
+        axes=('embed',), module=mdl).reshape(feature_shape)
     y += bias
   return jnp.asarray(y, dtype)
 


### PR DESCRIPTION
# What does this PR do?

Fixes #2416. Adds a base class `_ModuleBase` which contains the annotations for `Module`'s fields, this pattern avoids a couple of pitfalls with dataclasses and makes static analysis tools happy. Thanks @Conchylicultor for proposing the solution!

The approach works but adding the `TYPE_CHECKING` check over `__getattr__` opened the lid to a barricade of `pytype` errors, question is do we want to solve all typing errors right now?
