### PR TITLE
Adding "count_include_pad" argument to flax.linen.pooling.avg_pool

### DIFF
--- a/flax/linen/pooling.py
+++ b/flax/linen/pooling.py
@@ -89,7 +89,9 @@ def avg_pool(inputs, window_shape, strides=None, padding="VALID", count_include_
   if count_include_pad:
     y = y / np.prod(window_shape)
   else:
-    div_shape = (1,) + inputs.shape[1:-1] + (1,)
+    div_shape = inputs.shape[:-1] + (1,)
+    if len(div_shape) - 2 == len(window_shape):
+        div_shape = (1,) + div_shape[1:]
     y = y / pool(jnp.ones(div_shape), 0., lax.add, window_shape, strides, padding)
   return y
 

--- a/flax/linen/pooling.py
+++ b/flax/linen/pooling.py
@@ -80,7 +80,8 @@ def avg_pool(inputs, window_shape, strides=None, padding="VALID", count_include_
     padding: either the string `'SAME'`, the string `'VALID'`, or a sequence
       of `n` `(low, high)` integer pairs that give the padding to apply before
       and after each spatial dimension (default: `'VALID'`).
-    count_include_pad: ...
+    count_include_pad: a boolean whether to include padded tokens
+      in the average calculation (default: `True`).
   Returns:
     The average for each window slice.
   """

--- a/flax/linen/pooling.py
+++ b/flax/linen/pooling.py
@@ -69,7 +69,7 @@ def pool(inputs, init, reduce_fn, window_shape, strides, padding):
   return y
 
 
-def avg_pool(inputs, window_shape, strides=None, padding="VALID"):
+def avg_pool(inputs, window_shape, strides=None, padding="VALID", count_include_pad=True):
   """Pools the input by taking the average over a window.
 
   Args:
@@ -80,11 +80,16 @@ def avg_pool(inputs, window_shape, strides=None, padding="VALID"):
     padding: either the string `'SAME'`, the string `'VALID'`, or a sequence
       of `n` `(low, high)` integer pairs that give the padding to apply before
       and after each spatial dimension (default: `'VALID'`).
+    count_include_pad: ...
   Returns:
     The average for each window slice.
   """
   y = pool(inputs, 0., lax.add, window_shape, strides, padding)
-  y = y / np.prod(window_shape)
+  if count_include_pad:
+    y = y / np.prod(window_shape)
+  else:
+    div_shape = (1,) + inputs.shape[1:-1] + (1,)
+    y = y / pool(jnp.ones(div_shape), 0., lax.add, window_shape, strides, padding)
   return y
 
 

--- a/tests/linen/linen_test.py
+++ b/tests/linen/linen_test.py
@@ -34,60 +34,86 @@ jax.config.parse_flags_with_absl()
 
 class PoolTest(parameterized.TestCase):
 
-    def test_pool_custom_reduce(self):
-        x = jnp.full((1, 3, 3, 1), 2.)
-        mul_reduce = lambda x, y: x * y
-        y = nn.pooling.pool(x, 1., mul_reduce, (2, 2), (1, 1), 'VALID')
-        np.testing.assert_allclose(y, np.full((1, 2, 2, 1), 2. ** 4))
+  def test_pool_custom_reduce(self):
+    x = jnp.full((1, 3, 3, 1), 2.)
+    mul_reduce = lambda x, y: x * y
+    y = nn.pooling.pool(x, 1., mul_reduce, (2, 2), (1, 1), 'VALID')
+    np.testing.assert_allclose(y, np.full((1, 2, 2, 1), 2. ** 4))
 
-    @parameterized.parameters(
-        {'count_include_pad': True},
-        {'count_include_pad': False})
-    def test_avg_pool(self, count_include_pad):
-        x = jnp.full((1, 3, 3, 1), 2.)
-        pool = lambda x: nn.avg_pool(x, (2, 2), count_include_pad=count_include_pad)
-        y = pool(x)
-        np.testing.assert_allclose(y, np.full((1, 2, 2, 1), 2.))
-        y_grad = jax.grad(lambda x: pool(x).sum())(x)
-        expected_grad = jnp.array([
-            [0.25, 0.5, 0.25],
-            [0.5, 1., 0.5],
-            [0.25, 0.5, 0.25],
-        ]).reshape((1, 3, 3, 1))
-        np.testing.assert_allclose(y_grad, expected_grad)
+  @parameterized.parameters(
+      {'count_include_pad': True},
+      {'count_include_pad': False})
+  def test_avg_pool(self, count_include_pad):
+    x = jnp.full((1, 3, 3, 1), 2.)
+    pool = lambda x: nn.avg_pool(x, (2, 2), count_include_pad=count_include_pad)
+    y = pool(x)
+    np.testing.assert_allclose(y, np.full((1, 2, 2, 1), 2.))
+    y_grad = jax.grad(lambda x: pool(x).sum())(x)
+    expected_grad = jnp.array([
+        [0.25, 0.5, 0.25],
+        [0.5, 1., 0.5],
+        [0.25, 0.5, 0.25],
+    ]).reshape((1, 3, 3, 1))
+    np.testing.assert_allclose(y_grad, expected_grad)
 
-    @parameterized.parameters(
-        {'count_include_pad': True},
-        {'count_include_pad': False})
-    def test_avg_pool_no_batch(self, count_include_pad):
-        x = jnp.full((3, 3, 1), 2.)
-        pool = lambda x: nn.avg_pool(x, (2, 2), count_include_pad=count_include_pad)
-        y = pool(x)
-        np.testing.assert_allclose(y, np.full((2, 2, 1), 2.))
-        y_grad = jax.grad(lambda x: pool(x).sum())(x)
-        expected_grad = jnp.array([
-            [0.25, 0.5, 0.25],
-            [0.5, 1., 0.5],
-            [0.25, 0.5, 0.25],
-        ]).reshape((3, 3, 1))
-        np.testing.assert_allclose(y_grad, expected_grad)
+  @parameterized.parameters(
+      {'count_include_pad': True},
+      {'count_include_pad': False})
+  def test_avg_pool_no_batch(self, count_include_pad):
+    x = jnp.full((3, 3, 1), 2.)
+    pool = lambda x: nn.avg_pool(x, (2, 2), count_include_pad=count_include_pad)
+    y = pool(x)
+    np.testing.assert_allclose(y, np.full((2, 2, 1), 2.))
+    y_grad = jax.grad(lambda x: pool(x).sum())(x)
+    expected_grad = jnp.array([
+        [0.25, 0.5, 0.25],
+        [0.5, 1., 0.5],
+        [0.25, 0.5, 0.25],
+    ]).reshape((3, 3, 1))
+    np.testing.assert_allclose(y_grad, expected_grad)
 
-    def test_max_pool(self):
-        x = jnp.arange(9).reshape((1, 3, 3, 1)).astype(jnp.float32)
-        pool = lambda x: nn.max_pool(x, (2, 2))
-        expected_y = jnp.array([
-            [4., 5.],
-            [7., 8.],
-        ]).reshape((1, 2, 2, 1))
-        y = pool(x)
-        np.testing.assert_allclose(y, expected_y)
-        y_grad = jax.grad(lambda x: pool(x).sum())(x)
-        expected_grad = jnp.array([
-            [0., 0., 0.],
-            [0., 1., 1.],
-            [0., 1., 1.],
-        ]).reshape((1, 3, 3, 1))
-        np.testing.assert_allclose(y_grad, expected_grad)
+  @parameterized.parameters(
+      {'count_include_pad': True},
+      {'count_include_pad': False})
+  def test_avg_pool_padding_same(self, count_include_pad):
+    x = jnp.array([1.0, 2.0, 3.0, 4.0]).reshape((1, 2, 2, 1))
+    pool = lambda x: nn.avg_pool(x, (2, 2), padding="SAME", count_include_pad=count_include_pad)
+    y = pool(x)
+    if count_include_pad:
+        expected_y = jnp.array([10.0 / 4, 6.0 / 4, 7.0 / 4, 4.0 / 4]).reshape((1, 2, 2, 1))
+    else:
+        expected_y = jnp.array([10.0 / 4, 6.0 / 2, 7.0 / 2, 4.0 / 1]).reshape((1, 2, 2, 1))
+    np.testing.assert_allclose(y, expected_y)
+
+  def test_max_pool(self):
+    x = jnp.arange(9).reshape((1, 3, 3, 1)).astype(jnp.float32)
+    pool = lambda x: nn.max_pool(x, (2, 2))
+    expected_y = jnp.array([
+        [4., 5.],
+        [7., 8.],
+    ]).reshape((1, 2, 2, 1))
+    y = pool(x)
+    np.testing.assert_allclose(y, expected_y)
+    y_grad = jax.grad(lambda x: pool(x).sum())(x)
+    expected_grad = jnp.array([
+        [0., 0., 0.],
+        [0., 1., 1.],
+        [0., 1., 1.],
+    ]).reshape((1, 3, 3, 1))
+    np.testing.assert_allclose(y_grad, expected_grad)
+
+  @parameterized.parameters(
+      {'count_include_pad': True},
+      {'count_include_pad': False})
+  def test_avg_pool_padding_same(self, count_include_pad):
+    x = jnp.array([1.0, 2.0, 3.0, 4.0]).reshape((1, 2, 2, 1))
+    pool = lambda x: nn.avg_pool(x, (2, 2), padding="SAME", count_include_pad=count_include_pad)
+    y = pool(x)
+    if count_include_pad:
+        expected_y = jnp.array([10.0 / 4, 6.0 / 4, 7.0 / 4, 4.0 / 4]).reshape((1, 2, 2, 1))
+    else:
+        expected_y = jnp.array([10.0 / 4, 6.0 / 2, 7.0 / 2, 4.0 / 1]).reshape((1, 2, 2, 1))
+    np.testing.assert_allclose(y, expected_y)
 
 
 class NormalizationTest(parameterized.TestCase):

--- a/tests/linen/linen_test.py
+++ b/tests/linen/linen_test.py
@@ -32,57 +32,62 @@ import numpy as np
 jax.config.parse_flags_with_absl()
 
 
-class PoolTest(absltest.TestCase):
+class PoolTest(parameterized.TestCase):
 
-  def test_pool_custom_reduce(self):
-    x = jnp.full((1, 3, 3, 1), 2.)
-    mul_reduce = lambda x, y: x * y
-    y = nn.pooling.pool(x, 1., mul_reduce, (2, 2), (1, 1), 'VALID')
-    np.testing.assert_allclose(y, np.full((1, 2, 2, 1), 2. ** 4))
+    def test_pool_custom_reduce(self):
+        x = jnp.full((1, 3, 3, 1), 2.)
+        mul_reduce = lambda x, y: x * y
+        y = nn.pooling.pool(x, 1., mul_reduce, (2, 2), (1, 1), 'VALID')
+        np.testing.assert_allclose(y, np.full((1, 2, 2, 1), 2. ** 4))
 
-  def test_avg_pool(self):
-    x = jnp.full((1, 3, 3, 1), 2.)
-    pool = lambda x: nn.avg_pool(x, (2, 2))
-    y = pool(x)
-    np.testing.assert_allclose(y, np.full((1, 2, 2, 1), 2.))
-    y_grad = jax.grad(lambda x: pool(x).sum())(x)
-    expected_grad = jnp.array([
-        [0.25, 0.5, 0.25],
-        [0.5, 1., 0.5],
-        [0.25, 0.5, 0.25],
-    ]).reshape((1, 3, 3, 1))
-    np.testing.assert_allclose(y_grad, expected_grad)
+    @parameterized.parameters(
+        {'count_include_pad': True},
+        {'count_include_pad': False})
+    def test_avg_pool(self, count_include_pad):
+        x = jnp.full((1, 3, 3, 1), 2.)
+        pool = lambda x: nn.avg_pool(x, (2, 2), count_include_pad=count_include_pad)
+        y = pool(x)
+        np.testing.assert_allclose(y, np.full((1, 2, 2, 1), 2.))
+        y_grad = jax.grad(lambda x: pool(x).sum())(x)
+        expected_grad = jnp.array([
+            [0.25, 0.5, 0.25],
+            [0.5, 1., 0.5],
+            [0.25, 0.5, 0.25],
+        ]).reshape((1, 3, 3, 1))
+        np.testing.assert_allclose(y_grad, expected_grad)
 
-  def test_avg_pool_no_batch(self):
-    x = jnp.full((3, 3, 1), 2.)
-    pool = lambda x: nn.avg_pool(x, (2, 2))
-    y = pool(x)
-    np.testing.assert_allclose(y, np.full((2, 2, 1), 2.))
-    y_grad = jax.grad(lambda x: pool(x).sum())(x)
-    expected_grad = jnp.array([
-        [0.25, 0.5, 0.25],
-        [0.5, 1., 0.5],
-        [0.25, 0.5, 0.25],
-    ]).reshape((3, 3, 1))
-    np.testing.assert_allclose(y_grad, expected_grad)
+    @parameterized.parameters(
+        {'count_include_pad': True},
+        {'count_include_pad': False})
+    def test_avg_pool_no_batch(self, count_include_pad):
+        x = jnp.full((3, 3, 1), 2.)
+        pool = lambda x: nn.avg_pool(x, (2, 2), count_include_pad=count_include_pad)
+        y = pool(x)
+        np.testing.assert_allclose(y, np.full((2, 2, 1), 2.))
+        y_grad = jax.grad(lambda x: pool(x).sum())(x)
+        expected_grad = jnp.array([
+            [0.25, 0.5, 0.25],
+            [0.5, 1., 0.5],
+            [0.25, 0.5, 0.25],
+        ]).reshape((3, 3, 1))
+        np.testing.assert_allclose(y_grad, expected_grad)
 
-  def test_max_pool(self):
-    x = jnp.arange(9).reshape((1, 3, 3, 1)).astype(jnp.float32)
-    pool = lambda x: nn.max_pool(x, (2, 2))
-    expected_y = jnp.array([
-        [4., 5.],
-        [7., 8.],
-    ]).reshape((1, 2, 2, 1))
-    y = pool(x)
-    np.testing.assert_allclose(y, expected_y)
-    y_grad = jax.grad(lambda x: pool(x).sum())(x)
-    expected_grad = jnp.array([
-        [0., 0., 0.],
-        [0., 1., 1.],
-        [0., 1., 1.],
-    ]).reshape((1, 3, 3, 1))
-    np.testing.assert_allclose(y_grad, expected_grad)
-
+    def test_max_pool(self):
+        x = jnp.arange(9).reshape((1, 3, 3, 1)).astype(jnp.float32)
+        pool = lambda x: nn.max_pool(x, (2, 2))
+        expected_y = jnp.array([
+            [4., 5.],
+            [7., 8.],
+        ]).reshape((1, 2, 2, 1))
+        y = pool(x)
+        np.testing.assert_allclose(y, expected_y)
+        y_grad = jax.grad(lambda x: pool(x).sum())(x)
+        expected_grad = jnp.array([
+            [0., 0., 0.],
+            [0., 1., 1.],
+            [0., 1., 1.],
+        ]).reshape((1, 3, 3, 1))
+        np.testing.assert_allclose(y_grad, expected_grad)
 
 
 class NormalizationTest(parameterized.TestCase):


### PR DESCRIPTION
# What does this PR do?

Now version's flax.linen.pooling.avg_pool average window_sum result include padded tokens. I add argument whether to include padded tokens or not

## Checklist
- [x] This change is discussed in a Github issue/
      [issues](https://github.com/google/flax/issues/2448)
- [x] The documentation and docstrings adhere to the
      [documentation guidelines](https://github.com/google/flax/blob/main/docs/README.md#how-to-write-code-documentation).
- [x] This change includes necessary high-coverage tests.
      (No quality testing = no merge!)
