### PR TITLE
Use proper scikit-learn dependency

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -16,7 +16,7 @@ docutils==0.16
 
 # The next packages are for notebooks.
 matplotlib
-sklearn
+scikit-learn
 # Must install flax itself for notebook execution and autodocs to work.
 .
 # The next packages are used in testcode blocks.


### PR DESCRIPTION
Depend on `scikit-learn` instead of `sklean` in `docs/requirements.txt`. `sklearn` seems to be some form of mirror for `scikit-learn` but its not the proper dependency.