### PR TITLE
Fix Managing Parameters and State docs

### DIFF
--- a/docs/guides/state_params.rst
+++ b/docs/guides/state_params.rst
@@ -60,7 +60,7 @@ replaced for yours):
         loss, has_aux=True)(params)
     updates, opt_state = tx.update(grads, opt_state)  # Defined below.
     params = optax.apply_updates(params, updates)
-    return opt_state, params, state
+    return opt_state, params, updated_state
 
 Then we can write the actual training code.
 


### PR DESCRIPTION
# What does this PR do?

Fixes #2467. Returns `updated_state` instead of `state` in state_params.rst` example.