### PR TITLE
test against python 3.8 and 3.9

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,8 +64,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7]
+        python-version: [3.7, 3.8, 3.9]
         test-type: [doctest, pytest, pytype]
+        exclude:
+          - test-type: pytype
+            python-version: 3.7
+          - test-type: pytype
+            python-version: 3.8
     steps:
     - name: Cancel previous
       uses: styfle/cancel-workflow-action@0.8.0
@@ -121,7 +126,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7]
+        python-version: [3.7, 3.8, 3.9]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/examples/ogbg_molpcba/train.py
+++ b/examples/ogbg_molpcba/train.py
@@ -134,8 +134,8 @@ class MeanAveragePrecision(
     for task in range(num_tasks):
       # AP is only defined when there is at least one negative data
       # and at least one positive data.
-      if np.sum(labels[:, task] == 0) > 0 and np.sum(labels[:, task] == 1) > 0:
-        is_labeled = mask[:, task]
+      is_labeled = mask[:, task]
+      if len(np.unique(labels[is_labeled, task])) >= 2:
         average_precisions[task] = sklearn.metrics.average_precision_score(
             labels[is_labeled, task], probs[is_labeled, task])
 

--- a/examples/ogbg_molpcba/train_test.py
+++ b/examples/ogbg_molpcba/train_test.py
@@ -29,6 +29,7 @@ from jax import numpy as jnp
 import jraph
 import tensorflow as tf
 import tensorflow_datasets as tfds
+import numpy as np
 
 from configs import default
 from configs import test
@@ -305,8 +306,7 @@ class OgbgMolpcbaTrainTest(parameterized.TestCase):
     self.assertGreaterEqual(evaluate_metrics_vals['loss'], 0)
     self.assertGreaterEqual(evaluate_metrics_vals['accuracy'], 0)
     self.assertLessEqual(evaluate_metrics_vals['accuracy'], 1)
-    self.assertGreaterEqual(evaluate_metrics_vals['mean_average_precision'], 0)
-    self.assertLessEqual(evaluate_metrics_vals['mean_average_precision'], 1)
+    self.assertTrue(np.isnan(evaluate_metrics_vals['mean_average_precision']))
 
   def test_train_and_evaluate(self):
     # Create a temporary directory where TensorBoard metrics are written.


### PR DESCRIPTION
# What does this PR do?

Add python `3.8` and `3.9` as targets on CI.

### Notes
* I had to modify / fix a test in the `ogbg_molpcba` example due to changes in behaviour in numpy and scikit learn on 3.8 and 3.9.