### PR TITLE
Adds CallSetupUnboundModuleError

### DIFF
--- a/flax/errors.py
+++ b/flax/errors.py
@@ -538,6 +538,37 @@ class CallCompactUnboundModuleError(FlaxError):
   def __init__(self):
     super().__init__('Can\'t call compact methods on unbound modules')
 
+class CallSetupUnboundModuleError(FlaxError):
+  """
+  This error occurs when you are trying to call `.setup()` directly. For instance, the
+  error will be raised when trying to run this code::
+
+    from flax import linen as nn
+    import jax.numpy as jnp
+
+    class MyModule(nn.Module):
+      def setup(self):
+        self.submodule = MySubModule()
+
+    module = MyModule()
+    module.setup() # <-- ERROR!
+    submodule = module.submodule
+
+  In general you shouldn't call `.setup()` yourself, if you need to get access
+  to a field or submodule defined inside `setup` you can instead create a function
+  to extract it and pass it to `nn.apply`::
+
+    # setup() will be called automatically by `nn.apply`
+    def get_submodule(module):
+      return module.submodule.clone() # avoid leaking the Scope
+
+    empty_variables = {} # you can also use the real variables
+    submodule = nn.apply(get_submodule, module)(empty_variables)
+
+  """
+  def __init__(self):
+    super().__init__('Can\'t call compact methods on unbound modules')
+
 
 class InvalidCheckpointError(FlaxError):
   """

--- a/flax/linen/module.py
+++ b/flax/linen/module.py
@@ -681,6 +681,8 @@ class Module:
     add_call_info = not is_setup_method and len(_context.call_info_stack) > 0
     # We lazily call setup() only when needed.
     if is_setup_method:
+      if self.scope is None:
+        raise errors.CallSetupUnboundModuleError()
       is_recurrent = self._state.in_setup
       self._state.in_setup = True
     else:


### PR DESCRIPTION
# What does this PR do?

Fixes #667. Raises a new `CallSetupUnboundModuleError` when trying to call `.setup()` while `scope` is None.