### PR TITLE
Raise error when path given to `restore_checkpoint()` doesn't exist

### DIFF
--- a/examples/imagenet/configs/default.py
+++ b/examples/imagenet/configs/default.py
@@ -54,4 +54,8 @@ def get_config():
   # num_epochs using the entire dataset. Similarly for steps_per_eval.
   config.num_train_steps = -1
   config.steps_per_eval = -1
+  
+  # Whether to restore from existing model checkpoints.
+  config.restore_checkpoints = True
+  
   return config

--- a/examples/imagenet/train.py
+++ b/examples/imagenet/train.py
@@ -313,7 +313,8 @@ def train_and_evaluate(config: ml_collections.ConfigDict,
       config, base_learning_rate, steps_per_epoch)
 
   state = create_train_state(rng, config, model, image_size, learning_rate_fn)
-  state = restore_checkpoint(state, workdir)
+  if config.restore_checkpoints:
+    state = restore_checkpoint(state, workdir)
   # step_offset > 0 if restarting from checkpoint
   step_offset = int(state.step)
   state = jax_utils.replicate(state)

--- a/examples/imagenet/train_test.py
+++ b/examples/imagenet/train_test.py
@@ -81,6 +81,7 @@ class TrainTest(parameterized.TestCase):
     config.num_epochs = 1
     config.num_train_steps = 1
     config.steps_per_eval = 1
+    config.restore_checkpoints = False
 
     with tfds.testing.mock_data(num_examples=1, data_dir=data_dir):
       train.train_and_evaluate(workdir=workdir, config=config)

--- a/examples/lm1b/train_test.py
+++ b/examples/lm1b/train_test.py
@@ -53,6 +53,8 @@ class TrainTest(absltest.TestCase):
     config.max_target_length = 32
     config.max_eval_target_length = 32
     config.max_predict_length = 32
+    
+    config.restore_checkpoints = False
 
     workdir = tempfile.mkdtemp()
 

--- a/examples/ppo/configs/default.py
+++ b/examples/ppo/configs/default.py
@@ -51,4 +51,6 @@ def get_config():
   # Linearly decay learning rate and clipping parameter to zero during
   # the training.
   config.decaying_lr_and_clip_param = True
+  # Whether to restore from existing model checkpoints.
+  config.restore_checkpoints = True
   return config

--- a/examples/ppo/ppo_lib.py
+++ b/examples/ppo/ppo_lib.py
@@ -307,7 +307,8 @@ def train(
   state = create_train_state(initial_params, model, config,
                              loop_steps * config.num_epochs * iterations_per_step)
   del initial_params
-  state = checkpoints.restore_checkpoint(model_dir, state)
+  if config.restore_checkpoints:
+    state = checkpoints.restore_checkpoint(model_dir, state)
   # number of train iterations done by each train_step
 
   start_step = int(state.step) // config.num_epochs // iterations_per_step

--- a/examples/wmt/train_test.py
+++ b/examples/wmt/train_test.py
@@ -53,6 +53,8 @@ class TrainTest(absltest.TestCase):
     config.max_target_length = 32
     config.max_eval_target_length = 32
     config.max_predict_length = 32
+    
+    config.restore_checkpoints = False
 
     workdir = tempfile.mkdtemp()
 

--- a/flax/training/checkpoints.py
+++ b/flax/training/checkpoints.py
@@ -693,9 +693,7 @@ def restore_checkpoint(
   Returns:
     Restored `target` updated from checkpoint file, or if no step specified and
     no checkpoint files present, returns the passed-in `target` unchanged.
-    If a file path is specified and is not found, the passed-in `target` will be
-    returned. This is to match the behavior of the case where a directory path
-    is specified but the directory has not yet been created.
+    If a file path is specified and is not found, raise ValueError.
   """
   ckpt_dir = os.fspath(ckpt_dir)  # Pathlib -> str
   ckpt_dir = safe_normpath(ckpt_dir)
@@ -705,16 +703,13 @@ def restore_checkpoint(
       raise ValueError(f'Matching checkpoint not found: {ckpt_path}')
   else:
     if not gfile.exists(ckpt_dir):
-      logging.info('Found no checkpoint directory at %s', ckpt_dir)
-      return target
+      raise ValueError(f'Found no checkpoint directory at {ckpt_dir}')
     if not gfile.isdir(ckpt_dir):
       ckpt_path = ckpt_dir
     else:
       ckpt_path = latest_checkpoint(ckpt_dir, prefix)
       if not ckpt_path:
-        logging.info('Found no checkpoint files in %s with prefix %s',
-                     ckpt_dir, prefix)
-        return target
+        raise ValueError(f'Found no checkpoint files in {ckpt_dir} with prefix {prefix}')
 
   logging.info('Restoring checkpoint from %s', ckpt_path)
   with gfile.GFile(ckpt_path, 'rb') as fp:

--- a/tests/checkpoints_test.py
+++ b/tests/checkpoints_test.py
@@ -97,9 +97,9 @@ class CheckpointsTest(parameterized.TestCase):
                     'b': np.array([1, 1, 1], np.int32)}
     test_object2 = {'a': np.array([4, 5, 6], np.int32),
                     'b': np.array([2, 2, 2], np.int32)}
-    new_object = checkpoints.restore_checkpoint(
-        tmp_dir, test_object0, prefix='test_')
-    jtu.check_eq(new_object, test_object0)
+    with self.assertRaises(ValueError):
+        checkpoints.restore_checkpoint(
+            tmp_dir, test_object0, prefix='test_')
     # Create leftover temporary checkpoint, which should be ignored.
     gfile.GFile(os.path.join(tmp_dir, 'test_tmp'), 'w')
     checkpoints.save_checkpoint(
@@ -129,12 +129,10 @@ class CheckpointsTest(parameterized.TestCase):
     new_object = checkpoints.restore_checkpoint(
         os.path.join(tmp_dir, 'test_3'), test_object0)
     jtu.check_eq(new_object, test_object2)
-    # If a specific path is specified, but it does not exist, the same behavior
-    # as when a directory is empty should apply: the target is returned
-    # unchanged.
-    new_object = checkpoints.restore_checkpoint(
-        os.path.join(tmp_dir, 'test_not_there'), test_object0)
-    jtu.check_eq(new_object, test_object0)
+    # If a specific path is specified, but it does not exist, raise error.
+    with self.assertRaises(ValueError):
+      checkpoints.restore_checkpoint(
+          os.path.join(tmp_dir, 'test_not_there'), test_object0)
     with self.assertRaises(ValueError):
       checkpoints.restore_checkpoint(
           tmp_dir, test_object0, step=5, prefix='test_')
@@ -277,9 +275,6 @@ class CheckpointsTest(parameterized.TestCase):
                     'b': np.random.normal(size=(1000, 1000))}
     test_object3 = {'a': np.random.normal(size=(1000, 1000)),
                     'b': np.random.normal(size=(1000, 1000))}
-    new_object = checkpoints.restore_checkpoint(
-        tmp_dir, test_object0, prefix='test_')
-    jtu.check_eq(new_object, test_object0)
     # Create leftover temporary checkpoint, which should be ignored.
     gfile.GFile(os.path.join(tmp_dir, 'test_tmp'), 'w')
     am = checkpoints.AsyncManager()
@@ -330,9 +325,8 @@ class CheckpointsTest(parameterized.TestCase):
     tmp_dir = pathlib.Path(self.create_tempdir().full_path)
     test_object0 = {'a': jnp.zeros(3), 'b': jnp.arange(3)}
     test_object1 = {'a': jnp.ones(3), 'b': jnp.arange(3, 6)}
-    new_object = checkpoints.restore_checkpoint(
-        tmp_dir, test_object0, prefix='test_')
-    jtu.check_eq(new_object, test_object0)
+    with self.assertRaises(ValueError):
+        checkpoints.restore_checkpoint(tmp_dir, test_object0, prefix='test_')
     # Create leftover temporary checkpoint, which should be ignored.
     gfile.GFile(os.path.join(tmp_dir, 'test_tmp'), 'w')
     checkpoints.save_checkpoint(


### PR DESCRIPTION
# What does this PR do?
Explicitly raise an error instead of silently return when the path given to `checkpoints.restore_checkpoint()` is nonexistent.

Fixes #1631

## Checklist
- [x] This change is discussed in a Github issue (#1631) & [discussion](https://github.com/google/flax/discussions/1612)
- [x] The documentation and docstrings adhere to the
      [documentation guidelines](https://github.com/google/flax/blob/main/docs/README.md#how-to-write-code-documentation).
- [x] This change includes necessary high-coverage tests.
      (No quality testing = no merge!)
