### PR TITLE
no-op when double wrapping with struct.dataclass

### DIFF
--- a/flax/struct.py
+++ b/flax/struct.py
@@ -95,6 +95,11 @@ def dataclass(clz: _T) -> _T:
   Returns:
     The new class.
   """
+  # check if the class is already a dataclass
+  
+  if '_flax_dataclass' in clz.__dict__:
+    return clz
+      
   data_clz = dataclasses.dataclass(frozen=True)(clz)
   meta_fields = []
   data_fields = []
@@ -155,6 +160,9 @@ def dataclass(clz: _T) -> _T:
 
   serialization.register_serialization_state(
       data_clz, to_state_dict, from_state_dict)
+
+  # add a _flax_dataclass flag to distinguish from regular dataclasses
+  data_clz._flax_dataclass = True
 
   return data_clz
 

--- a/flax/struct.py
+++ b/flax/struct.py
@@ -95,8 +95,7 @@ def dataclass(clz: _T) -> _T:
   Returns:
     The new class.
   """
-  # check if the class is already a dataclass
-  
+  # check if already a flax dataclass
   if '_flax_dataclass' in clz.__dict__:
     return clz
       

--- a/tests/struct_test.py
+++ b/tests/struct_test.py
@@ -66,6 +66,23 @@ class StructTest(absltest.TestCase):
     with self.assertRaisesRegex(ValueError, r'in_axes\.y'):
       raise e('in_axes')
 
+  def test_double_wrap_no_op(self):
+    
+    class A:
+      a: int
+
+    self.assertFalse(hasattr(A, '_flax_dataclass'))
+
+    A = struct.dataclass(A)
+    self.assertTrue(hasattr(A, '_flax_dataclass'))
+
+    A = struct.dataclass(A) # no-op
+    self.assertTrue(hasattr(A, '_flax_dataclass'))
+
+  def test_wrap_pytree_node_no_error(self):
+    @struct.dataclass
+    class A(struct.PyTreeNode):
+      a: int
 
 if __name__ == '__main__':
   absltest.main()


### PR DESCRIPTION
# What does this PR do?

Makes double wrapping with `struct.dataclass` a no-op when wrapping an existing Flax dataclass. Also raises an error if you try to wrap an existing non-Flax dataclass.