### PR TITLE
Add extracting gradients section to capture intermediates guide

### DIFF
--- a/docs/guides/extracting_intermediates.rst
+++ b/docs/guides/extracting_intermediates.rst
@@ -263,3 +263,44 @@ your model more explicitly.
 
   params = init(jax.random.PRNGKey(0), batch)
   features(params, batch)
+
+Extracting gradients of intermediate values
+===========================================
+For debugging purposes, it can be useful to extract the gradients of intermediate values.
+This can be done by using the ``.perturb()`` method over the desired values.
+
+.. testcode::
+
+  class Model(nn.Module):
+    @nn.compact
+    def __call__(self, x):
+      x = nn.relu(nn.Dense(8)(x))
+      x = self.perturb('hidden', x)
+      x = nn.Dense(2)(x)
+      x = self.perturb('logits', x)
+      return x
+
+``perturb`` adds a variable to a ``perturbations`` collection by default,
+it behaves like an identity function and the gradient of the perturbation
+matches the gradient of the input. To get the perturbations just initialize
+the model:
+
+.. testcode::
+
+  x = jnp.empty((1, 4)) # random data
+  y = jnp.empty((1, 2)) # random data
+
+  model = Model()
+  variables = model.init(jax.random.PRNGKey(1), x)
+  params, perturbations = variables['params'], variables['perturbations']
+
+Finally compute the gradients of the loss with respect to the perturbations,
+these will match the gradients of the intermediates:
+
+.. testcode::
+
+  def loss_fn(params, perturbations, x, y):
+    y_pred = model.apply({'params': params, 'perturbations': perturbations}, x)
+    return jnp.mean((y_pred - y) ** 2)
+
+  intermediate_grads = jax.grad(loss_fn, argnums=1)(params, perturbations, x, y)


### PR DESCRIPTION
# What does this PR do?

Adds an "Extracting gradients of intermediate values" to `extracting_intermediates` showcasing how to use `.perturb()`.