### PR TITLE
Add epub and pdf RDT formats

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -12,6 +12,8 @@ sphinx:
 # Optionally build your docs in additional formats such as PDF and ePub
 formats:
   - htmlzip
+  - epub
+  - pdf
 
 # Optionally set the version of Python and requirements required to build your docs
 python:

--- a/flax/linen/stochastic.py
+++ b/flax/linen/stochastic.py
@@ -29,7 +29,7 @@ class Dropout(Module):
 
     Note: When using :meth:`Module.apply() <flax.linen.Module.apply>`, make sure
     to include an RNG seed named `'dropout'`. For example::
-    
+
       model.apply({'params': params}, inputs=inputs, train=True, rngs={'dropout': dropout_rng})`
 
     Attributes:

--- a/flax/struct.py
+++ b/flax/struct.py
@@ -98,7 +98,7 @@ def dataclass(clz: _T) -> _T:
   # check if already a flax dataclass
   if '_flax_dataclass' in clz.__dict__:
     return clz
-      
+
   data_clz = dataclasses.dataclass(frozen=True)(clz)
   meta_fields = []
   data_fields = []

--- a/tests/struct_test.py
+++ b/tests/struct_test.py
@@ -67,7 +67,7 @@ class StructTest(absltest.TestCase):
       raise e('in_axes')
 
   def test_double_wrap_no_op(self):
-    
+
     class A:
       a: int
 


### PR DESCRIPTION
# What does this PR do?

Fixes #2463. Adds the `epub` and `pdf` format to RDT config file. Additionally, it also fixes some issues related to `trailing-whitespace` that where detected by CI.