### PR TITLE
Use `gfile.remove` for files because it doesn't work on GCS files.

### DIFF
--- a/flax/linen/stochastic.py
+++ b/flax/linen/stochastic.py
@@ -29,7 +29,7 @@ class Dropout(Module):
 
     Note: When using :meth:`Module.apply() <flax.linen.Module.apply>`, make sure
     to include an RNG seed named `'dropout'`. For example::
-    
+
       model.apply({'params': params}, inputs=inputs, train=True, rngs={'dropout': dropout_rng})`
 
     Attributes:

--- a/flax/struct.py
+++ b/flax/struct.py
@@ -98,7 +98,7 @@ def dataclass(clz: _T) -> _T:
   # check if already a flax dataclass
   if '_flax_dataclass' in clz.__dict__:
     return clz
-      
+
   data_clz = dataclasses.dataclass(frozen=True)(clz)
   meta_fields = []
   data_fields = []

--- a/flax/training/checkpoints.py
+++ b/flax/training/checkpoints.py
@@ -353,7 +353,7 @@ def _remove_invalid_ckpts(ckpt_path: str, base_path: str, keep: int,
         # checkpoint folder and before deleting the main checkpoint.
         if gfile.exists(path + MP_ARRAY_POSTFIX):
           gfile.rmtree(path + MP_ARRAY_POSTFIX)
-      gfile.rmtree(path)
+      gfile.remove(path)
 
   # Remove old checkpoint files.
   last_kept = -float('inf')
@@ -374,7 +374,7 @@ def _remove_invalid_ckpts(ckpt_path: str, base_path: str, keep: int,
         # MPA might be removed already but the main ckpt is still there.
         if gfile.exists(path + MP_ARRAY_POSTFIX):
           gfile.rmtree(path + MP_ARRAY_POSTFIX)
-      gfile.rmtree(path)
+      gfile.remove(path)
 
 
 def _save_commit(ckpt_tmp_path: str, ckpt_path: str, base_path: str, keep: int,

--- a/tests/struct_test.py
+++ b/tests/struct_test.py
@@ -67,7 +67,7 @@ class StructTest(absltest.TestCase):
       raise e('in_axes')
 
   def test_double_wrap_no_op(self):
-    
+
     class A:
       a: int
 


### PR DESCRIPTION
Fixes #2508

## Checklist
- [x] This PR fixes a minor issue (e.g.: typo or small bug) or improves the docs (you can dismiss the other
      checks if that's the case).
