### PR TITLE
Add Tensorstore back to required dependencies.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ install_requires = [
     "matplotlib",  # only needed for tensorboard export
     "msgpack",
     "optax",
+    "tensorstore",
     "rich>=11.1",
     "typing_extensions>=4.1.1",
     "PyYAML>=5.4.1",


### PR DESCRIPTION
It was reversed back when user reported https://github.com/google/flax/issues/2341, but it was now fixed and verified.
