### PR TITLE
Adding link to Bayesian Inference example that uses Flax

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -179,6 +179,10 @@ Examples
       - `@vasudevgupta7 <https://github.com/vasudevgupta7>`__
       - Question-Answering
       - https://arxiv.org/abs/2007.14062
+    * - `BlackJAX using MNIST <https://blackjax-devs.github.io/blackjax/examples/SGMCMC.html>`__
+      - `@rlouf <https://github.com/rlouf>`__
+      - Bayesian Inference, SGMCMC
+      - https://arxiv.org/abs/1402.4102
     * - `DCGAN <https://github.com/bkkaggle/jax-dcgan>`__
       - `@bkkaggle <https://github.com/bkkaggle>`__
       - Image Synthesis

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -179,7 +179,7 @@ Examples
       - `@vasudevgupta7 <https://github.com/vasudevgupta7>`__
       - Question-Answering
       - https://arxiv.org/abs/2007.14062
-    * - `BlackJAX using MNIST <https://blackjax-devs.github.io/blackjax/examples/SGMCMC.html>`__
+    * - `Bayesian Networks with BlackJAX <https://blackjax-devs.github.io/blackjax/examples/SGMCMC.html>`__
       - `@rlouf <https://github.com/rlouf>`__
       - Bayesian Inference, SGMCMC
       - https://arxiv.org/abs/1402.4102


### PR DESCRIPTION
This PR adds a link to a BlackJAX example which uses Flax to train a Bayesian neural network using Stochastic Gradient HMC.

Fixes # (issue)

## Checklist
- [x] This PR fixes a minor issue (e.g.: typo or small bug) or improves the docs (you can dismiss the other
      checks if that's the case).

