### PR TITLE
Pin jupytext version in requirements.txt

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -8,7 +8,7 @@ myst_nb
 recommonmark
 ipython_genutils
 sphinx-design
-jupytext
+jupytext==1.13.8
 
 # Need to pin docutils to 0.16 to make bulleted lists appear correctly on
 # ReadTheDocs: https://stackoverflow.com/a/68008428


### PR DESCRIPTION
Pin jupytext version in requirements.txt because it was pinned in presubmit hook. Otherwise user have to manually reinstall the correct version.

# What does this PR do?

## Checklist
- [x] This PR fixes a minor issue (e.g.: typo or small bug) or improves the docs (you can dismiss the other
      checks if that's the case).
