### PR TITLE
return None if no _parent_ref is set

### DIFF
--- a/flax/linen/module.py
+++ b/flax/linen/module.py
@@ -536,6 +536,9 @@ class ParentDescriptor:
   logic applies in subclasses even after various dataclass transforms.
   """
   def __get__(self, obj, objtype=None):
+    # check if obj is None, happens during %autoreload
+    if obj is None:
+      return None
     parent = object.__getattribute__(obj, "_parent_ref")
     return parent() if isinstance(parent, weakref.ReferenceType) else parent
 
@@ -610,8 +613,8 @@ class Module:
     cls._state = _uninitialized_module_internal_state
     cls.scope: Optional[Scope] = None
     # Handles weak referencing of parent Modules to prevent reference cycles.
-    cls.parent = ParentDescriptor()
     cls._parent_ref = None
+    cls.parent = ParentDescriptor()
 
   @classmethod
   def _customized_dataclass_transform(cls):

--- a/flax/linen/module.py
+++ b/flax/linen/module.py
@@ -611,6 +611,7 @@ class Module:
     cls.scope: Optional[Scope] = None
     # Handles weak referencing of parent Modules to prevent reference cycles.
     cls.parent = ParentDescriptor()
+    cls._parent_ref = None
 
   @classmethod
   def _customized_dataclass_transform(cls):


### PR DESCRIPTION
# What does this PR do?

Related to #2286. If no `_parent_ref` is set `ParentDescriptor.__get__` returns None.  This fixes an issue with ipython's `autoreload`.