### PR TITLE
Generalize pool to handle multiple batch dimensions

### DIFF
--- a/flax/linen/pooling.py
+++ b/flax/linen/pooling.py
@@ -41,17 +41,20 @@ def pool(inputs, init, reduce_fn, window_shape, strides, padding):
   Returns:
     The output of the reduction for each window slice.
   """
+  num_batch_dims = inputs.ndim - (len(window_shape) + 1)
   strides = strides or (1,) * len(window_shape)
   assert len(window_shape) == len(strides), (
       f"len({window_shape}) must equal len({strides})")
-  strides = (1,) + strides + (1,)
-  dims = (1,) + window_shape + (1,)
+  strides = (1,) * num_batch_dims + strides + (1,)
+  dims = (1,) * num_batch_dims + window_shape + (1,)
 
   is_single_input = False
-  if inputs.ndim == len(dims) - 1:
+  if num_batch_dims == 0:
     # add singleton batch dimension because lax.reduce_window always
     # needs a batch dimension.
     inputs = inputs[None]
+    strides = (1,) + strides
+    dims = (1,) + dims
     is_single_input = True
 
   assert inputs.ndim == len(dims), f"len({inputs.shape}) != len({dims})"

--- a/tests/linen/linen_test.py
+++ b/tests/linen/linen_test.py
@@ -119,6 +119,17 @@ class PoolTest(parameterized.TestCase):
       expected_y = jnp.array([10.0 / 4, 6.0 / 2, 7.0 / 2, 4.0 / 1]).reshape((1, 2, 2, 1))
     np.testing.assert_allclose(y, expected_y)
 
+  def test_pooling_variable_batch_dims(self):
+    x = jnp.zeros((1, 8, 32, 32, 3), dtype=jnp.float32)
+    y = nn.max_pool(x, (2, 2), (2, 2))
+
+    assert y.shape == (1, 8, 16, 16, 3)
+
+  def test_pooling_no_batch_dims(self):
+    x = jnp.zeros((32, 32, 3), dtype=jnp.float32)
+    y = nn.max_pool(x, (2, 2), (2, 2))
+
+    assert y.shape == (16, 16, 3)
 
 class NormalizationTest(parameterized.TestCase):
 


### PR DESCRIPTION
# What does this PR do?

Fixes #2590. Generalizes `pool` so it can handle multiple batch dimensions. 