### PR TITLE
Fixes `launch_gce.sh` with imagenet example.

### DIFF
--- a/examples/cloud/launch_gce.py
+++ b/examples/cloud/launch_gce.py
@@ -24,7 +24,6 @@ from typing import Sequence
 
 from absl import app
 from absl import flags
-from absl import logging
 
 # General options.
 flags.DEFINE_bool(
@@ -130,7 +129,7 @@ def launch_gce(*, vm_name: str, startup_script: str):
   args = [
       'gcloud', 'compute', 'instances', 'create', vm_name,
       f'--project={FLAGS.project}', f'--zone={FLAGS.zone}',
-      '--image=c1-deeplearning-tf-2-4-cu110-v20210512-debian-10',
+      '--image=c1-deeplearning-tf-2-10-cu113-v20221107-debian-10',
       '--image-project=ml-images', f'--machine-type={FLAGS.machine_type}',
       '--scopes=cloud-platform,storage-full', '--boot-disk-size=256GB',
       '--boot-disk-type=pd-ssd', '--metadata=install-nvidia-driver=True',

--- a/examples/cloud/launch_gce.py
+++ b/examples/cloud/launch_gce.py
@@ -39,7 +39,7 @@ flags.DEFINE_bool(
     'wait', False,
     help='If set, then the script will wait until VM is ready. If VM_READY_CMD '
     'is set in environment, then that command will be executed once the VM '
-    'is ready. Useful for sending a notification, e.g. "osascript"')
+    'is ready. Useful for sending a notification, e.g. "osascript" (mac).')
 
 # Machine configuration.
 flags.DEFINE_string('project', None, help='Name of the Google Cloud project.')
@@ -53,6 +53,12 @@ flags.DEFINE_string(
     '',
     help='Type of accelerator to use, or empty. '
     'See "gcloud compute accelerator-types list".'
+)
+flags.DEFINE_integer(
+    'shutdown_secs',
+    300,
+    help='How long to wait (after successful/failed training) before shutting '
+    'down the VM. Set to 0 to disable.'
 )
 flags.DEFINE_integer(
     'accelerator_count', 8, help='Number of accelerators to use.')
@@ -116,6 +122,7 @@ def generate_startup_file(vm_name: str) -> str:
       ('__GCS_WORKDIR_BASE__', FLAGS.gcs_workdir_base),
       ('__TFDS_DATA_DIR__', FLAGS.tfds_data_dir),
       ('__ACCELERATOR_TYPE__', FLAGS.accelerator_type),
+      ('__SHUTDOWN_SECS__', str(FLAGS.shutdown_secs))
   ):
     startup_script_content = startup_script_content.replace(from_str, to_str)
   with open(startup_script_dst, 'w', encoding='utf8') as f:
@@ -159,6 +166,9 @@ def launch_gce(*, vm_name: str, startup_script: str):
 
 def print_howto(login_args: Sequence[str]):
   print(f'''
+###############################################################################
+###############################################################################
+
 You can start/stop the instace via the web UI:
 https://console.cloud.google.com/compute/instances?project={FLAGS.project}
 
@@ -173,6 +183,12 @@ To observe the training via Tensorboard, simply run in your local computer:
 
 $ tensorboard --logdir={FLAGS.gcs_workdir_base}
 
+You can also browse the files at
+
+https://console.cloud.google.com/storage/browser/{FLAGS.gcs_workdir_base.replace('gs://', '')}
+
+###############################################################################
+###############################################################################
 ''')
 
 
@@ -231,6 +247,11 @@ def main(_):
           time.sleep(20)
         else:
           raise ValueError(f'Unknown error: {stderr}')
+      except ValueError as e:
+        if 'HTTP 502' not in str(e):
+          raise e
+        print('(Bad Gateway - waiting a little longer...)')
+        time.sleep(20)
       except subprocess.TimeoutExpired:
         print('(Timeout - waiting a little longer...)')
         time.sleep(20)

--- a/examples/cloud/startup_script.sh
+++ b/examples/cloud/startup_script.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-HOME=/train
+BASE=/train
 
 # Replaced by launch_gce.py
 REPO='__REPO__'
@@ -12,7 +12,7 @@ ARGS='__ARGS__'
 GCS_WORKDIR_BASE='__GCS_WORKDIR_BASE__'
 TFDS_DATA_DIR='__TFDS_DATA_DIR__'
 ACCELERATOR_TYPE='__ACCELERATOR_TYPE__'
-WORKDIR="$HOME/workdir_base/$NAME"
+WORKDIR="$BASE/workdir_base/$NAME"
 
 
 # Login directly with:
@@ -22,8 +22,8 @@ chmod a+x /sudo_tmux_a.sh
 echo -e '#!/bin/bash\ntmux a' > /tmux_a.sh
 chmod a+x /tmux_a.sh
 
-mkdir -p $HOME
-cd $HOME
+mkdir -p $BASE
+cd $BASE
 
 tmux new-session -s flax -d htop ENTER
 tmux split-window
@@ -32,27 +32,25 @@ tmux send "
 (
   set -x
 
+  conda activate flax &&
+
   [ -d flax ] || (
-    git clone -b $BRANCH $REPO &&
+    git clone --depth 1 -b $BRANCH $REPO &&
     cd flax &&
 
-    python3 -m pip install virtualenv &&
-    python3 -m virtualenv env &&
-    . env/bin/activate &&
+    conda create -yn flax python==3.9 &&
+    conda activate flax &&
 
     pip install -U pip &&
     pip install -e . &&
-    if [[ '$ACCELERATOR_TYPE' =~ ^nvidia- ]]; then
-      pip install --upgrade jax jaxlib==0.1.69+cuda110 -f https://storage.googleapis.com/jax-releases/jax_releases.html
-    fi &&
 
     cd examples/$EXAMPLE &&
     pip install -r requirements.txt &&
-    cd $HOME
+    cd $BASE
   ) &&
 
+  conda activate flax &&
   cd flax &&
-  . env/bin/activate &&
   cd examples/$EXAMPLE &&
 
   TFDS_DATA_DIR='$TFDS_DATA_DIR' python main.py --workdir=$WORKDIR $ARGS

--- a/examples/cloud/startup_script.sh
+++ b/examples/cloud/startup_script.sh
@@ -1,19 +1,11 @@
 #!/bin/bash
 
-BASE=/train
+# Note that all __XYZ__ strings are replaced by launch_gce.py
 
-# Replaced by launch_gce.py
-REPO='__REPO__'
-BRANCH='__BRANCH__'
-EXAMPLE='__EXAMPLE__'
-TIMESTAMP='__TIMESTAMP__'
-NAME='__EXAMPLE__/__NAME__/__TIMESTAMP__'
-ARGS='__ARGS__'
-GCS_WORKDIR_BASE='__GCS_WORKDIR_BASE__'
-TFDS_DATA_DIR='__TFDS_DATA_DIR__'
-ACCELERATOR_TYPE='__ACCELERATOR_TYPE__'
-WORKDIR="$BASE/workdir_base/$NAME"
+WORKDIR="/train/workdir_base/__EXAMPLE__/__NAME__/__TIMESTAMP__"
 
+mkdir -p /train
+cd /train
 
 # Login directly with:
 # gcloud compute ssh $VM -- /sudo_tmux_a.sh
@@ -22,20 +14,14 @@ chmod a+x /sudo_tmux_a.sh
 echo -e '#!/bin/bash\ntmux a' > /tmux_a.sh
 chmod a+x /tmux_a.sh
 
-mkdir -p $BASE
-cd $BASE
-
-tmux new-session -s flax -d htop ENTER
-tmux split-window
-tmux send "
-
+# Main script running in bottom left tmux pane.
+cat >/install_train_stop.sh <<EOF
+set -x
 (
-  set -x
-
   conda activate flax &&
 
   [ -d flax ] || (
-    git clone --depth 1 -b $BRANCH $REPO &&
+    git clone --depth 1 -b __BRANCH__ __REPO__ &&
     cd flax &&
 
     conda create -yn flax python==3.9 &&
@@ -44,27 +30,48 @@ tmux send "
     pip install -U pip &&
     pip install -e . &&
 
-    cd examples/$EXAMPLE &&
+    cd examples/__EXAMPLE__ &&
     pip install -r requirements.txt &&
-    cd $BASE
+    cd /train
   ) &&
 
   conda activate flax &&
   cd flax &&
-  cd examples/$EXAMPLE &&
+  cd examples/__EXAMPLE__ &&
 
-  TFDS_DATA_DIR='$TFDS_DATA_DIR' python main.py --workdir=$WORKDIR $ARGS
+  TFDS_DATA_DIR='__TFDS_DATA_DIR__' python main.py --workdir=$WORKDIR __ARGS__
 
 ) 2>&1 | tee -a $WORKDIR/setup_train_log_${TIMESTAMP}.txt
 
-echo
-echo WILL SHUT DOWN IN 5 MIN ...
-sleep 300 && sudo shutdown now
-"
+if [ __SHUTDOWN_SECS__ -gt 0 ]; then
+  echo
+  echo WILL SHUT DOWN IN $((__SHUTDOWN_SECS__/60)) MIN ...
+  sleep __SHUTDOWN_SECS__ && shutdown now
+fi
+
+EOF
+
+
+# Set up TMUX panes:
+tmux new-session -s flax -d
+# - top left: htop
+tmux send 'htop
+'
+tmux split-window
+tmux selectp -U
 tmux split-window -h
+# - top right: htop
+tmux send 'watch nvidia-smi
+'
+tmux selectp -D
+# - bottom left: main script
+tmux send '. /install_train_stop.sh
+'
+tmux split-window -h
+# - bottom right: rsync files to GCS bucket.
 tmux send "
 while true; do
-  gsutil rsync -r workdir_base $GCS_WORKDIR_BASE
+  gsutil rsync -r workdir_base __GCS_WORKDIR_BASE__
   sleep 60
-done 2>&1 | tee -a $WORKDIR/gcs_rsync_${TIMESTAMP}.txt
-" ENTER
+done 2>&1 | tee -a $WORKDIR/gcs_rsync_'__TIMESTAMP__'.txt
+"

--- a/examples/imagenet/requirements.txt
+++ b/examples/imagenet/requirements.txt
@@ -3,7 +3,7 @@ clu==0.0.6
 flax==0.6.0
 -f https://storage.googleapis.com/jax-releases/libtpu_releases.html
 -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
-jax[gpu]==0.3.16  # change to jax[tpu] if running on tpus
+jax[cuda11_cudnn805]>=0.3.16  # change to jax[tpu] if running on tpus
 ml-collections==0.1.0
 numpy==1.22.0
 optax==0.1.3

--- a/examples/wmt/requirements.txt
+++ b/examples/wmt/requirements.txt
@@ -3,7 +3,7 @@ clu==0.0.6
 flax==0.6.0
 -f https://storage.googleapis.com/jax-releases/libtpu_releases.html
 -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
-jax[gpu]==0.3.16  # change to jax[tpu] if running on tpus
+jax[cuda11_cudnn805]>=0.3.16  # change to jax[tpu] if running on tpus
 ml-collections==0.1.0
 numpy==1.22.0
 optax==0.1.0


### PR DESCRIPTION
This PR mainly updates the automated launch script `examples/cloud/launch_gce.sh` - while fixing this, the requirements for the `imagenet` example also required updating for new JAX versioning.

Updates script to work with newer containers. See [`examples/cloud/README.md`](https://github.com/google/flax/blob/main/examples/cloud/README.md) for more details.

Tested with:

```
# Update these for your project...
PROJECT=flax-xgcp
WORKDIR_BASE=gs://flax_eu/examples
TFDS_BASE=gs://tensorflow-datasets/datasets

# Run directly from this PR
REPO=https://github.com/andsteing/flax
BRANCH=examples

# Launch VM with 1x V100 in west1-a
python examples/cloud/launch_gce.py \
   --project=$PROJECT \
   --zone=us-west1-a \
   --machine_type=n1-standard-8 \
   --accelerator_type=nvidia-tesla-v100 \
   --accelerator_count=1 \
   --gcs_workdir_base=$WORKDIR_BASE \
   --tfds_data_dir=$TFDS_BASE \
   --repo=$REPO \
   --branch=$BRANCH \
   --example=imagenet \
   --args='--config=configs/default.py' \
   --name=imagenet_v100
```

Command for launching on 2 GPUs (note that this also allows us to scale CPUs from 8 to 16)

```
python examples/cloud/launch_gce.py \
   --project=$PROJECT \
   --zone=us-west1-a \
   --machine_type=n1-standard-16 \
   --accelerator_type=nvidia-tesla-v100 \
   --accelerator_count=2 \
   --gcs_workdir_base=$WORKDIR_BASE \
   --tfds_data_dir=$TFDS_BASE \
   --repo=$REPO \
   --branch=$BRANCH \
   --example=imagenet \
   --args='--config=configs/default.py' \
   --name=imagenet_v100
```

Note that you can add `--wait` or `--connect` to above commands to make the command wait until all is launched or connect into the VM once it's ready (and then detach from [tmux](https://github.com/tmux/tmux/wiki) via `CTRL-b d`.

When logged in, you'll see the ongoing training like this:

<img width="1526" alt="image" src="https://user-images.githubusercontent.com/16050001/201061500-cafed41f-40ef-4202-ac63-8f8c1dea4523.png">

Above launcher will also output commands to follow the training using TensorBoard

![image](https://user-images.githubusercontent.com/16050001/201061871-02e6b5c1-1c07-4a2b-a9d0-bbef54d6a039.png)

And links to training artifacts and logs on GCS:

![image](https://user-images.githubusercontent.com/16050001/201062044-408dad60-3d9f-4867-a4eb-b07b081b83f5.png)
