### PR TITLE
Adds extract_field method

### DIFF
--- a/docs/api_reference/flax.linen.rst
+++ b/docs/api_reference/flax.linen.rst
@@ -12,7 +12,7 @@ Module
 ------------------------
 
 .. autoclass:: Module
-   :members: setup, variable, param, bind, apply, init, init_with_output, make_rng, sow, variables, Variable, __setattr__, tabulate, is_initializing, perturb
+   :members: setup, variable, param, bind, apply, init, init_with_output, make_rng, sow, variables, Variable, __setattr__, tabulate, is_initializing, perturb, extract_field
 
 Init/Apply
 ------------------------


### PR DESCRIPTION
# What does this PR do?

Fixes #2609. Adds the `Module.extract_field` method, useful to extract submodules that are defined inside `.setup` and their corresponding variables. 

#### Sample Usage

```python
class MyModule(nn.Module):
  def setup(self):
    self.submodule = nn.Dense(4)

  def __call__(self, x):
    return self.submodule(x)

module = MyModule()
variables = module.init(jax.random.PRNGKey(0), jnp.ones((1, 2)))

submodule, submodule_vars = module.extract_field('submodule', variables)
assert submodule.features == 4
```

Also works for nested object by passing a lambda:
```python
nested_module, nested_vars = module.extract_field(
  lambda m: m.some['deeply']['nested'].submodule, variables)