### PR TITLE
Added explicit warning if flax.io is using default Python I/O operations

### DIFF
--- a/flax/io.py
+++ b/flax/io.py
@@ -42,7 +42,8 @@ if importlib.util.find_spec('tensorflow'):
   io_mode = BackendMode.TF
 else:
   logging.warning("Tensorflow library not found, tensorflow.io.gfile "
-                  "operations will use slower native shim calls.")
+                  "operations will use native shim calls. "
+                  "GCS paths (i.e. 'gs://...') cannot be accessed.")
   io_mode = BackendMode.DEFAULT
 
 


### PR DESCRIPTION
Addresses #2624

Added explicit warning if flax.io is using default Python I/O operations.