### PR TITLE
example/imagenet: use absolute path to locate the Flax root dir

### DIFF
--- a/examples/imagenet/imagenet_fake_data_benchmark.py
+++ b/examples/imagenet/imagenet_fake_data_benchmark.py
@@ -38,7 +38,7 @@ class ImagenetBenchmarkFakeData(Benchmark):
     workdir = self.get_tmp_model_dir()
     config = config_lib.get_config()
     # Go two directories up to the root of the flax directory.
-    flax_root_dir = pathlib.Path(__file__).parents[2]
+    flax_root_dir = pathlib.Path(__file__).absolute().parents[2]
     data_dir = str(flax_root_dir) + '/.tfds/metadata'
 
     # Warm-up first so that we are not measuring just compilation.


### PR DESCRIPTION
# What does this PR do?

Allow `imagenet_fake_data_benchmark.py` to be run from within the `examples/imagenet` folder.

Currently, if I run `python imagenet_fake_data_benchmark.py` from inside the folder, I will get the following error:
```
ERROR: test_fake_data (__main__.ImagenetBenchmarkFakeData)
ImagenetBenchmarkFakeData.test_fake_data
----------------------------------------------------------------------
Traceback (most recent call last):
  File "imagenet_fake_data_benchmark.py", line 41, in test_fake_data
    flax_root_dir = pathlib.Path(__file__).parents[2]
  File "/usr/lib/python3.8/pathlib.py", line 621, in __getitem__
    raise IndexError(idx)
IndexError: 2
```

This is because at line 41, we have
```
flax_root_dir = pathlib.Path(__file__).parents[2]
```
where `pathlib.Path(__file__)` resolves to `.` if the script was run from within the folder.

Using an absolute path fixes the problem.

## Checklist
- [x] This PR fixes a minor issue (e.g.: typo or small bug) or improves the docs (you can dismiss the other
      checks if that's the case).
- [ ] This change is discussed in a Github issue/
      [discussion](https://github.com/google/flax/discussions) (please add a
      link).
- [ ] The documentation and docstrings adhere to the
      [documentation guidelines](https://github.com/google/flax/blob/main/docs/README.md#how-to-write-code-documentation).
- [ ] This change includes necessary high-coverage tests.
      (No quality testing = no merge!)
