### PR TITLE
Move Flax - The Sharp Bits ToC location

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -264,9 +264,9 @@ Notable examples include:
    :maxdepth: 2
 
    Getting Started <getting_started>
-   🔪 Flax - The Sharp Bits 🔪 <notebooks/flax_sharp_bits>
    guides/index
    examples
    advanced_topics/index
+   🔪 Flax - The Sharp Bits 🔪 <notebooks/flax_sharp_bits>
    contributing/index
    api_reference/index


### PR DESCRIPTION
Below the "Advancted" section. @marcvanzee.