### PR TITLE
Fix get_type_hints again

### DIFF
--- a/flax/linen/module.py
+++ b/flax/linen/module.py
@@ -528,7 +528,6 @@ tuple_init = lambda: ()
 capture_call_intermediates = lambda _, method_name: method_name == '__call__'
 
 
-
 class ParentDescriptor:
   """Wraps parent module references in weak refs.
 
@@ -1650,7 +1649,6 @@ class Module:
 
 
 _ParentType = Union[Type[Module], Type[Scope], Type[_Sentinel], None]
-
 
 def merge_param(name: str, a: Optional[T], b: Optional[T]) -> T:
   """Merges construction and call time argument.

--- a/flax/linen/module.py
+++ b/flax/linen/module.py
@@ -528,8 +528,6 @@ tuple_init = lambda: ()
 capture_call_intermediates = lambda _, method_name: method_name == '__call__'
 
 
-_ParentType = Union[Type['Module'], Type[Scope], Type[_Sentinel], None]
-
 
 class ParentDescriptor:
   """Wraps parent module references in weak refs.
@@ -1649,6 +1647,9 @@ class Module:
                                    show_repeated=show_repeated, mutable=mutable,
                                    console_kwargs=console_kwargs)
     return tabulate_fn(*args, **kwargs)
+
+
+_ParentType = Union[Type[Module], Type[Scope], Type[_Sentinel], None]
 
 
 def merge_param(name: str, a: Optional[T], b: Optional[T]) -> T:

--- a/tests/linen/linen_module_test.py
+++ b/tests/linen/linen_module_test.py
@@ -21,7 +21,7 @@ import gc
 import inspect
 import operator
 from typing import (Any, Callable, Generic, Mapping, NamedTuple, Sequence,
-                    Tuple, TypeVar)
+                    Tuple, TypeVar, get_type_hints)
 
 from absl.testing import absltest
 from flax import errors
@@ -1800,6 +1800,13 @@ class ModuleTest(absltest.TestCase):
 
     self.assertIs(unspecified_parent,
                   copy.deepcopy(unspecified_parent))
+
+  def test_type_hints(self):
+    class Network(nn.Module):
+        layers: int
+
+    type_hints = get_type_hints(Network)
+    self.assertEqual(type_hints['layers'], int)
 
 
 class LeakTests(absltest.TestCase):


### PR DESCRIPTION
# What does this PR do?

Fixes #2636. Delays the definition of `_ParentType` such that `Module` type can be directly reference instead of using a string placeholder. Also adds a test to make sure `get_type_hints` works correctly in the future.