### PR TITLE
Use a different rng key for each batch element in DenseGeneral init

### DIFF
--- a/tests/linen/linen_linear_test.py
+++ b/tests/linen/linen_linear_test.py
@@ -77,13 +77,13 @@ class LinearTest(parameterized.TestCase):
         use_bias=True,
         bias_init=initializers.normal(),
     )
-    y1, _ = dense_module.init_with_output(dict(params=random.PRNGKey(1)), x)
+    y1, params = dense_module.init_with_output(dict(params=random.PRNGKey(1)), x)
     dg_module = nn.DenseGeneral(
         features=4,
         use_bias=True,
         bias_init=initializers.normal(),
     )
-    y2, _ = dg_module.init_with_output(dict(params=random.PRNGKey(1)), x)
+    y2 = dg_module.apply(params, x)
 
     np.testing.assert_allclose(y1, y2)
 


### PR DESCRIPTION
This fixes a very minor issue: different elements of the batch of params in a batched DenseGeneral were initializing to the same value, because a JAX rng was being reused, without doing `jax.random.split`.

After this fix Dense and DenseGeneral necessarily initialize with different parameters, so I had to weaken `test_dense_is_dense_general` to only check that the result of _applying_ is identical between Dense and DenseGeneral, i.e. the init params are allowed to differ.

## Checklist
- [x] This PR fixes a minor issue (e.g.: typo or small bug) or improves the docs.