### PR TITLE
add unbind

### DIFF
--- a/docs/api_reference/flax.linen.rst
+++ b/docs/api_reference/flax.linen.rst
@@ -12,7 +12,7 @@ Module
 ------------------------
 
 .. autoclass:: Module
-   :members: setup, variable, param, bind, apply, init, init_with_output, make_rng, sow, variables, Variable, __setattr__, tabulate, is_initializing, perturb
+   :members: setup, variable, param, bind, unbind, apply, init, init_with_output, make_rng, sow, variables, Variable, __setattr__, tabulate, is_initializing, perturb
 
 Init/Apply
 ------------------------
@@ -90,22 +90,6 @@ Transformations
     while_loop
     cond
     switch
-
-Metadata
-----------------------
-
-.. automodule:: flax.linen.meta
-.. currentmodule:: flax.linen
-
-.. autosummary::
-  :toctree: _autosummary
-
-    AxisMetadata
-    map_axis_meta
-    unbox
-    Partitioned
-    with_partitioning
-    get_partition_spec
 
 
 Linear modules

--- a/docs/api_reference/flax.linen.rst
+++ b/docs/api_reference/flax.linen.rst
@@ -92,7 +92,7 @@ Transformations
     switch
 
 
-Linear modules
+Linear Modules
 ------------------------
 
 .. autosummary::

--- a/docs/guides/transfer_learning.ipynb
+++ b/docs/guides/transfer_learning.ipynb
@@ -92,7 +92,7 @@
     "\n",
     "Calling `load_model` from the snippet above returns the `FlaxCLIPModule`, which is composed of `text_model` and `vision_model` submodules.\n",
     "\n",
-    "An easy way to extract the `vision_model` submodule defined inside `.setup()` and its variables is to use [`nn.apply`](https://flax.readthedocs.io/en/latest/api_reference/flax.linen.html#flax.linen.apply) to run a `extract_submodule` helper function, inside this function the `clip` Module is bounded to its variables and fields defined in `.setup()` are accessible:"
+    "An easy way to extract the `vision_model` submodule defined inside `.setup()` and its variables is to use [`bind`](https://flax.readthedocs.io/en/latest/api_reference/flax.linen.html#flax.linen.Module.bind) on the `clip` Module immediatly followed by [`unbind`](https://flax.readthedocs.io/en/latest/api_reference/flax.linen.html#flax.linen.Module.unbind) on the `vision_model` submodule."
    ]
   },
   {
@@ -104,21 +104,13 @@
     "import flax.linen as nn\n",
     "\n",
     "clip, clip_variables = load_model()\n",
-    "\n",
-    "def extract_submodule(clip):\n",
-    "    vision_model = clip.vision_model.clone()\n",
-    "    variables = clip.vision_model.variables\n",
-    "    return vision_model, variables\n",
-    "\n",
-    "vision_model, vision_model_variables = nn.apply(extract_submodule, clip)(clip_variables)"
+    "vision_model, vision_model_vars = clip.bind(clip_variables).vision_model.unbind()"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Note that `.clone()` must be used to get an unbounded copy of `vision_model` to avoid leakage as bounded modules contain their variables.\n",
-    "\n",
     "### Creating a classifier\n",
     "\n",
     "To create a classifier define a new Flax [`Module`](https://flax.readthedocs.io/en/latest/guides/flax_basics.html#module-basics) consisting of a `backbone` (the pretrained vision model) and a `head` (the classifier) submodules."
@@ -173,8 +165,7 @@
    "metadata": {},
    "source": [
     "## Transfering the parameters\n",
-    "\n",
-    "Since `params` are currently random, the pretrained parameters from `vision_model_variables` have to be transfered to the `params` structure at the appropriate location. This can be done by unfreezing `params`, updating the `backbone` parameters, and freezing the `params` again:"
+    "Since `params` are currently random, the pretrained parameters from `vision_model_vars` have to be transfered to the `params` structure at the appropriate location. This can be done by unfreezing `params`, updating the `backbone` parameters, and freezing the `params` again:"
    ]
   },
   {
@@ -186,7 +177,7 @@
     "from flax.core.frozen_dict import freeze\n",
     "\n",
     "params = params.unfreeze()\n",
-    "params['backbone'] = vision_model_variables['params']\n",
+    "params['backbone'] = vision_model_vars['params']\n",
     "params = freeze(params)"
    ]
   },

--- a/docs/guides/transfer_learning.ipynb
+++ b/docs/guides/transfer_learning.ipynb
@@ -92,7 +92,7 @@
     "\n",
     "Calling `load_model` from the snippet above returns the `FlaxCLIPModule`, which is composed of `text_model` and `vision_model` submodules.\n",
     "\n",
-    "An easy way to extract the `vision_model` submodule defined inside `.setup()` and its variables is to use [`bind`](https://flax.readthedocs.io/en/latest/api_reference/flax.linen.html#flax.linen.Module.bind) on the `clip` Module immediatly followed by [`unbind`](https://flax.readthedocs.io/en/latest/api_reference/flax.linen.html#flax.linen.Module.unbind) on the `vision_model` submodule."
+    "An easy way to extract the `vision_model` sub-Module defined inside `.setup()` and its variables is to use [`flax.linen.Module.bind`](https://flax.readthedocs.io/en/latest/api_reference/flax.linen.html#flax.linen.Module.bind) on the `clip` Module immediately followed by [`flax.linen.Module.unbind`](https://flax.readthedocs.io/en/latest/api_reference/flax.linen.html#flax.linen.Module.unbind) on the `vision_model` sub-Module."
    ]
   },
   {

--- a/docs/guides/transfer_learning.md
+++ b/docs/guides/transfer_learning.md
@@ -72,7 +72,7 @@ Note that `FlaxCLIPVisionModel` itself is not a Flax `Module` which is why we ne
 
 Calling `load_model` from the snippet above returns the `FlaxCLIPModule`, which is composed of `text_model` and `vision_model` submodules.
 
-An easy way to extract the `vision_model` submodule defined inside `.setup()` and its variables is to use [`bind`](https://flax.readthedocs.io/en/latest/api_reference/flax.linen.html#flax.linen.Module.bind) on the `clip` Module immediatly followed by [`unbind`](https://flax.readthedocs.io/en/latest/api_reference/flax.linen.html#flax.linen.Module.unbind) on the `vision_model` submodule.
+An easy way to extract the `vision_model` sub-Module defined inside `.setup()` and its variables is to use [`flax.linen.Module.bind`](https://flax.readthedocs.io/en/latest/api_reference/flax.linen.html#flax.linen.Module.bind) on the `clip` Module immediately followed by [`flax.linen.Module.unbind`](https://flax.readthedocs.io/en/latest/api_reference/flax.linen.html#flax.linen.Module.unbind) on the `vision_model` sub-Module.
 
 ```{code-cell} ipython3
 import flax.linen as nn

--- a/docs/guides/transfer_learning.md
+++ b/docs/guides/transfer_learning.md
@@ -72,22 +72,14 @@ Note that `FlaxCLIPVisionModel` itself is not a Flax `Module` which is why we ne
 
 Calling `load_model` from the snippet above returns the `FlaxCLIPModule`, which is composed of `text_model` and `vision_model` submodules.
 
-An easy way to extract the `vision_model` submodule defined inside `.setup()` and its variables is to use [`nn.apply`](https://flax.readthedocs.io/en/latest/api_reference/flax.linen.html#flax.linen.apply) to run a `extract_submodule` helper function, inside this function the `clip` Module is bounded to its variables and fields defined in `.setup()` are accessible:
+An easy way to extract the `vision_model` submodule defined inside `.setup()` and its variables is to use [`bind`](https://flax.readthedocs.io/en/latest/api_reference/flax.linen.html#flax.linen.Module.bind) on the `clip` Module immediatly followed by [`unbind`](https://flax.readthedocs.io/en/latest/api_reference/flax.linen.html#flax.linen.Module.unbind) on the `vision_model` submodule.
 
 ```{code-cell} ipython3
 import flax.linen as nn
 
 clip, clip_variables = load_model()
-
-def extract_submodule(clip):
-    vision_model = clip.vision_model.clone()
-    variables = clip.vision_model.variables
-    return vision_model, variables
-
-vision_model, vision_model_variables = nn.apply(extract_submodule, clip)(clip_variables)
+vision_model, vision_model_vars = clip.bind(clip_variables).vision_model.unbind()
 ```
-
-Note that `.clone()` must be used to get an unbounded copy of `vision_model` to avoid leakage as bounded modules contain their variables.
 
 ### Creating a classifier
 
@@ -123,14 +115,13 @@ params = variables['params']
 ```
 
 ## Transfering the parameters
-
-Since `params` are currently random, the pretrained parameters from `vision_model_variables` have to be transfered to the `params` structure at the appropriate location. This can be done by unfreezing `params`, updating the `backbone` parameters, and freezing the `params` again:
+Since `params` are currently random, the pretrained parameters from `vision_model_vars` have to be transfered to the `params` structure at the appropriate location. This can be done by unfreezing `params`, updating the `backbone` parameters, and freezing the `params` again:
 
 ```{code-cell} ipython3
 from flax.core.frozen_dict import freeze
 
 params = params.unfreeze()
-params['backbone'] = vision_model_variables['params']
+params['backbone'] = vision_model_vars['params']
 params = freeze(params)
 ```
 

--- a/flax/errors.py
+++ b/flax/errors.py
@@ -608,7 +608,7 @@ class CallSetupUnboundModuleError(FlaxError):
 
 class CallUnbindOnUnboundModuleError(FlaxError):
   """This error occurs when you are trying to call ``.unbind()`` on an unbound
-  module. For instance, when you try running the following example,
+  Module. For instance, when you try running the following example,
   an error will be raised::
 
     from flax import linen as nn
@@ -621,7 +621,7 @@ class CallUnbindOnUnboundModuleError(FlaxError):
     module = MyModule()
     module.unbind() # <-- ERROR!
 
-  Instead, you should ``bind`` the module to a variable collection before calling
+  Instead, you should ``bind`` the Module to a variable collection before calling
   ``.unbind()``::
 
     bound_module = module.bind(variables)

--- a/flax/errors.py
+++ b/flax/errors.py
@@ -606,6 +606,30 @@ class CallSetupUnboundModuleError(FlaxError):
   def __init__(self):
     super().__init__('Can\'t call compact methods on unbound modules')
 
+class CallUnbindOnUnboundModuleError(FlaxError):
+  """This error occurs when you are trying to call ``.unbind()`` on an unbound
+  module. For instance, when you try running the following example,
+  an error will be raised::
+
+    from flax import linen as nn
+
+    class MyModule(nn.Module):
+      @nn.compact
+      def __call__(self, x):
+        return nn.Dense(features=10)(x)
+
+    module = MyModule()
+    module.unbind() # <-- ERROR!
+
+  Instead, you should ``bind`` the module to a variable collection before calling
+  ``.unbind()``::
+
+    bound_module = module.bind(variables)
+    ... # do something with bound_module
+    module = bound_module.unbind() # <-- OK!
+  """
+  def __init__(self):
+    super().__init__('Can\'t call `unbind()` on unbound modules')
 
 class InvalidInstanceModuleError(FlaxError):
   """This error occurs when you are trying to call `.init()`, `.init_with_output()`, `.apply() or `.bind()`

--- a/flax/linen/module.py
+++ b/flax/linen/module.py
@@ -1342,7 +1342,7 @@ class Module:
       module = AutoEncoder()
       variables = module.init(jax.random.PRNGKey(0), jnp.ones((1, 784)))
       ...
-      # extract the Encoder submodule and its variables
+      # Extract the Encoder sub-Module and its variables
       encoder, encoder_vars = module.bind(variables).encoder.unbind()
 
     Returns:

--- a/flax/linen/module.py
+++ b/flax/linen/module.py
@@ -1327,7 +1327,7 @@ class Module:
 
     ``unbind`` helps create a stateless version of a bound Module.
 
-    An example of a common use case: to extract a sub-Module defined inside 
+    An example of a common use case: to extract a sub-Module defined inside
     ``setup()`` and its corresponding variables: 1) temporarily ``bind`` the parent
     Module; and then 2) ``unbind`` the desired sub-Module. (Recall that ``setup()``
     is only called when the Module is bound.)::

--- a/flax/linen/module.py
+++ b/flax/linen/module.py
@@ -1322,14 +1322,14 @@ class Module:
     return self.clone(parent=scope)
 
   def unbind(self: M) -> Tuple[M, VariableDict]:
-    """Returns an unbound copy of this Module and its variables.
+    """Returns an unbound copy of a Module and its variables.
 
-    ``unbind`` is useful for creating a stateless version of a bound Module.
-    A common use case araises when you want extract a submodule defined inside
-    ``setup()``, since ``setup()`` is only called when the Module is bound, a
-    simple way to get hold of the submodule and its corresponding variables is
-    to ``bind`` the parent Module temporarily and then ``unbind`` the desired
-    submodule::
+    ``unbind`` helps create a stateless version of a bound Module.
+
+    An example of a common use case: to extract a sub-Module defined inside 
+    ``setup()`` and its corresponding variables: 1) temporarily ``bind`` the parent
+    Module; and then 2) ``unbind`` the desired sub-Module. (Recall that ``setup()``
+    is only called when the Module is bound.)::
 
       class AutoEncoder(nn.Module):
         def setup(self):


### PR DESCRIPTION
# What does this PR do?

Fixes #2478. Adds the `Module.unbind` method which returns an unbound version of the module and its variables.

### Usage
```python
submodule, submodule_vars = module.bind(variables).submodule.unbind()
```

## Context
While `bind` lets the user manipulate the module in a more natural way since it can now rely on direct access fields, there are edge cases and limitations which users needs to be aware of. There is a sentiment that instead of shying away from using `bind` to avoid its pitfalls, we should create documentation around it and add more APIs like `unbind` that make its use a bit more safe in certain cases. 