### PR TITLE
Check file or directory before removing checkpoints.

### DIFF
--- a/flax/io.py
+++ b/flax/io.py
@@ -159,6 +159,7 @@ def glob(pattern):
 
 
 def remove(path):
+  """Remove the file at path. Might fail if used on a directory path."""
   if io_mode == BackendMode.DEFAULT:
     return os.remove(path)
   elif io_mode == BackendMode.TF:
@@ -168,6 +169,7 @@ def remove(path):
 
 
 def rmtree(path):
+  """Remove a directory and recursively all contents inside. Might fail if used on a file path."""
   if io_mode == BackendMode.DEFAULT:
     return shutil.rmtree(path)
   elif io_mode == BackendMode.TF:

--- a/flax/training/checkpoints.py
+++ b/flax/training/checkpoints.py
@@ -110,6 +110,13 @@ def _allowempty_listdir(path: str):
   except tf_errors.NotFoundError:
     return []
 
+def _safe_remove(path: str):
+  """Identify whether a path is a dir or list and choose the correct remove method."""
+  if io.isdir(path):
+    io.rmtree(path)
+  else:
+    io.remove(path)
+
 class AsyncManager():
   """A simple object to track async checkpointing.
 
@@ -361,7 +368,7 @@ def _remove_invalid_ckpts(ckpt_path: str, base_path: str, keep: int,
         # checkpoint folder and before deleting the main checkpoint.
         if io.exists(path + MP_ARRAY_POSTFIX):
           io.rmtree(path + MP_ARRAY_POSTFIX)
-      io.rmtree(path)
+      _safe_remove(path)
 
   # Remove old checkpoint files.
   last_kept = -float('inf')
@@ -382,7 +389,7 @@ def _remove_invalid_ckpts(ckpt_path: str, base_path: str, keep: int,
         # MPA might be removed already but the main ckpt is still there.
         if io.exists(path + MP_ARRAY_POSTFIX):
           io.rmtree(path + MP_ARRAY_POSTFIX)
-      io.rmtree(path)
+      _safe_remove(path)
 
 
 def _save_commit(ckpt_tmp_path: str, ckpt_path: str, base_path: str, keep: int,


### PR DESCRIPTION
Seems like we cannot use `remove` and `rmtree` interchangeably everywhere. `gfile` doesn't support it in GCS, and our `os`-based shim doesn't support it in typical Linux file systems either.

In the future, legacy Flax checkpoints are files and new Orbax checkpoints are directories, so we do need to support removing both. Checking with `isdir` before removing seems to be the only valid approach.

Fixes #2672
