### PR TITLE
Expose module.merge_param in RTD and fix docstring

### DIFF
--- a/flax/linen/module.py
+++ b/flax/linen/module.py
@@ -1657,9 +1657,9 @@ class Module:
 _ParentType = Union[Type[Module], Type[Scope], Type[_Sentinel], None]
 
 def merge_param(name: str, a: Optional[T], b: Optional[T]) -> T:
-  """Merges construction-and call-time argument.
+  """Merges construction- and call-time argument.
 
-  This is a utility for supporting the pattern where a Module hyperparameter
+  This is a utility for supporting a pattern where a Module hyperparameter
   can be passed either to ``__init__`` or ``__call__``, and the value that is
   not `None` will be used.
 

--- a/flax/linen/module.py
+++ b/flax/linen/module.py
@@ -1657,10 +1657,11 @@ class Module:
 _ParentType = Union[Type[Module], Type[Scope], Type[_Sentinel], None]
 
 def merge_param(name: str, a: Optional[T], b: Optional[T]) -> T:
-  """Merges construction and call time argument.
+  """Merges construction-and call-time argument.
 
-  This is a utility for supporting the pattern where a Module hyper parameter
-  can be passed to ``__init__`` or ``__call__``.
+  This is a utility for supporting the pattern where a Module hyperparameter
+  can be passed either to ``__init__`` or ``__call__``, and the value that is
+  not `None` will be used.
 
   Example::
 
@@ -1670,7 +1671,8 @@ def merge_param(name: str, a: Optional[T], b: Optional[T]) -> T:
       def __call__(self, train: Optional[bool] = None):
         train = nn.merge_param('train', self.train, train)
 
-  An error is thrown when both arguments are `None` or both values are not `None`.
+  An error is thrown when both arguments are `None` or both values are not
+  `None`.
 
   Args:
     name: the name of the parameter. Used for error messages.


### PR DESCRIPTION
This is a function that we use in e.g. Dropout. I propose we expose it in RTD so we can refer to it from the Dropout guide.