### PR TITLE
Drop tensorstore dependency; require it for tests only

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,6 @@ install_requires = [
     "msgpack",
     "optax",
     "orbax",
-    "tensorstore",
     "rich>=11.1",
     "typing_extensions>=4.1.1",
     "PyYAML>=5.4.1",
@@ -54,6 +53,7 @@ tests_require = [
     "tensorflow_text>=2.4.0",  # WMT example.
     "tensorflow_datasets",
     "tensorflow",
+    "tensorstore",
     "torch",
 ]
 


### PR DESCRIPTION
# What does this PR do?


tensorstore is an optional dependency for flax. In #2520 it was added back as the normal dependency, but on some Linux and macOS environments as well as in python 3.11, tensorstore still fails to build (see #2341, google/tensorstore#63).

/cc @IvyZX 


Fixes #2341 (again)

## Checklist
- [x] This PR fixes a minor issue (e.g.: typo or small bug) or improves the docs (you can dismiss the other checks if that's the case).
- [ ] This change is discussed in a Github issue/[discussion](https://github.com/google/flax/discussions) (please add alink).
- [ ] The documentation and docstrings adhere to the [documentation guidelines](https://github.com/google/flax/blob/main/docs/README.md#how-to-write-code-documentation).
- [ ] This change includes necessary high-coverage tests. (No quality testing = no merge!)
