### PR TITLE
Introduce flax.io.NotFoundError to remove tensorflow dependency

### DIFF
--- a/flax/io.py
+++ b/flax/io.py
@@ -47,6 +47,16 @@ else:
   io_mode = BackendMode.DEFAULT
 
 
+# Constants and Exceptions
+
+
+if io_mode == BackendMode.TF:
+  from tensorflow import errors as tf_errors  # type: ignore
+  NotFoundError = tf_errors.NotFoundError
+else:
+  NotFoundError = FileNotFoundError
+
+
 # Overrides for testing.
 
 

--- a/flax/training/checkpoints.py
+++ b/flax/training/checkpoints.py
@@ -39,7 +39,6 @@ from jax import sharding
 from jax.experimental.global_device_array import GlobalDeviceArray
 from jax.experimental.multihost_utils import sync_global_devices
 import orbax.checkpoint as orbax
-from tensorflow import errors as tf_errors
 
 
 _IMPORT_GDAM_SUCCESSFUL = False
@@ -107,7 +106,7 @@ def _checkpoint_path_step(path: str) -> Optional[float]:
 def _allowempty_listdir(path: str):
   try:
     return io.listdir(path)
-  except tf_errors.NotFoundError:
+  except io.NotFoundError:
     return []
 
 def _safe_remove(path: str):


### PR DESCRIPTION
# What does this PR do?

This fixes up a small mistake in #2586, where tensorflow is still being imported from `flax.training.checkpoints`. To avoid the tensorflow dependency, an alias `flax.io.NotFoundError` is added which can be either `tf_errors.NotFoundError` or `FileNotFoundError` depending on the backend mode.

Fixes #2456

## Checklist
- [x] This PR fixes a minor issue (e.g.: typo or small bug) or improves the docs (you can dismiss the other checks if that's the case).
- [ ] This change is discussed in a Github issue/[discussion](https://github.com/google/flax/discussions) (please add a link).
- [ ] The documentation and docstrings adhere to the [documentation guidelines](https://github.com/google/flax/blob/main/docs/README.md#how-to-write-code-documentation).
- [ ] This change includes necessary high-coverage tests. (No quality testing = no merge!)

/cc @IvyZX, @chiamp
