### PR TITLE
Re-enable faster github CI runners

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,7 +79,7 @@ jobs:
   tests:
     name: Run Tests
     needs: [cancel-previous, pre-commit, commit-count, test-import]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04-16core
     strategy:
       matrix:
         python-version: ['3.8', '3.9', '3.10']


### PR DESCRIPTION
new test runners are working again.