### PR TITLE
ignore import tf warning

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -14,3 +14,5 @@ filterwarnings =
     ignore:`flax.traverse_util.Traversal` will be deprecated.*:DeprecationWarning
 # distutils DeprecationWarning
     ignore:distutils Version classes are deprecated.*:DeprecationWarning
+# distutils DeprecationWarning
+    ignore:`np.bool8` is a deprecated alias for `np.bool_`.


### PR DESCRIPTION
`import tensorflow as tf` is firing a `DeprecationWarning` on our CI: 

```
___________________ ERROR collecting tests/jax_utils_test.py ___________________
tests/jax_utils_test.py:23: in <module>
    import tensorflow as tf
venv/lib/python3.8/site-packages/tensorflow/__init__.py:37: in <module>
    from tensorflow.python.tools import module_util as _module_util
venv/lib/python3.8/site-packages/tensorflow/python/__init__.py:42: in <module>
    from tensorflow.python import data
venv/lib/python3.8/site-packages/tensorflow/python/data/__init__.py:21: in <module>
    from tensorflow.python.data import experimental
venv/lib/python3.8/site-packages/tensorflow/python/data/experimental/__init__.py:96: in <module>
    from tensorflow.python.data.experimental import service
venv/lib/python3.8/site-packages/tensorflow/python/data/experimental/service/__init__.py:419: in <module>
    from tensorflow.python.data.experimental.ops.data_service_ops import distribute
venv/lib/python3.8/site-packages/tensorflow/python/data/experimental/ops/data_service_ops.py:22: in <module>
    from tensorflow.python.data.experimental.ops import compression_ops
venv/lib/python3.8/site-packages/tensorflow/python/data/experimental/ops/compression_ops.py:16: in <module>
    from tensorflow.python.data.util import structure
venv/lib/python3.8/site-packages/tensorflow/python/data/util/structure.py:22: in <module>
    from tensorflow.python.data.util import nest
venv/lib/python3.8/site-packages/tensorflow/python/data/util/nest.py:34: in <module>
    from tensorflow.python.framework import sparse_tensor as _sparse_tensor
venv/lib/python3.8/site-packages/tensorflow/python/framework/sparse_tensor.py:24: in <module>
    from tensorflow.python.framework import constant_op
venv/lib/python3.8/site-packages/tensorflow/python/framework/constant_op.py:25: in <module>
    from tensorflow.python.eager import execute
venv/lib/python3.8/site-packages/tensorflow/python/eager/execute.py:21: in <module>
    from tensorflow.python.framework import dtypes
venv/lib/python3.8/site-packages/tensorflow/python/framework/dtypes.py:246: in <module>
    np.bool8: (False, True),
venv/lib/python3.8/site-packages/numpy/__init__.py:260: in __getattr__
    warnings.warn(msg, DeprecationWarning, stacklevel=2)
E   DeprecationWarning: `np.bool8` is a deprecated alias for `np.bool_`.  (Deprecated NumPy 1.24)
```

Since this seems to be originated from `import tensorflow`, ignore it for now.
