### PR TITLE
Update readthedocs build to python 3.8

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -17,6 +17,6 @@ formats:
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-  version: 3.7
+  version: 3.8
   install:
     - requirements: docs/requirements.txt


### PR DESCRIPTION
JAX dropped 3.7 and its latest release `0.4.1` is not on 3.7. We should move to 3.8 too.