### PR TITLE
Bind submodules using __getattribute__

### DIFF
--- a/docs/guides/convert_pytorch_to_flax.rst
+++ b/docs/guides/convert_pytorch_to_flax.rst
@@ -42,7 +42,7 @@ and the Flax kernel has shape [inC, outC]. Transposing the kernel will do the tr
   t_out = t_fc(t_x)
   t_out = t_out.detach().cpu().numpy()
 
-  np.testing.assert_almost_equal(j_out, t_out)
+  np.testing.assert_almost_equal(j_out, t_out, decimal=5)
 
 
 Convolutions

--- a/flax/linen/module.py
+++ b/flax/linen/module.py
@@ -1144,7 +1144,7 @@ class Module:
     attrs.update(parent=parent, **updates)
 
     if _deep_clone != False:
-      cache = weakref.WeakValueDictionary() if _deep_clone is True else _deep_clone
+      cache = weakref.WeakValueDictionary() if isinstance(_deep_clone, bool) else _deep_clone
       def clone_fn(m: Module) -> Module:
         key = m._id
         if key in cache:

--- a/flax/linen/module.py
+++ b/flax/linen/module.py
@@ -990,7 +990,6 @@ class Module:
       raise ValueError('parent must be None, Module or Scope')
 
     self._state.is_initialized = True
-    # self._try_setup()
 
   def __repr__(self) -> str:
     return _module_repr(self)
@@ -1069,8 +1068,6 @@ class Module:
     object.__setattr__(self, name, val)
     for x in queue:
       x.__post_init__()
-    # call _try_setup on all submodules
-    _map_submodules(lambda m: m._try_setup(), val)
 
   def _try_setup(self, shallow: bool = False) -> None:
     """Tries to setup module if scope is available and setup has not been called yet."""

--- a/tests/linen/linen_module_test.py
+++ b/tests/linen/linen_module_test.py
@@ -2096,7 +2096,7 @@ class ModuleTest(absltest.TestCase):
     bar1 = bound_module.bars[0]
     self.assertIsNotNone(bar1.scope)
 
-  @pytest.mark.skip(reason="Leaving it here to tackle it later")
+  # @pytest.mark.skip(reason="Leaving it here to tackle it later")
   def test_nested_shared(self):
     class Shared(nn.Module):
       @nn.compact

--- a/tests/linen/linen_module_test.py
+++ b/tests/linen/linen_module_test.py
@@ -21,7 +21,7 @@ import functools
 import gc
 import inspect
 import operator
-from typing import (Any, Callable, Generic, Mapping, NamedTuple, Sequence,
+from typing import (Any, Callable, Generic, List, Mapping, NamedTuple, Sequence,
                     Tuple, TypeVar, get_type_hints)
 
 from absl.testing import absltest
@@ -1993,6 +1993,184 @@ class ModuleTest(absltest.TestCase):
     with self.assertRaisesRegex(errors.DescriptorAttributeError,
                                 'Trying to access a property that'):
       foo.apply({})
+
+  def test_basic_setup_test(self):
+    class Foo(nn.Module):
+      def setup(self):
+        self.b = 10
+
+      def __call__(self, x):
+        return self.b + x
+
+    module = Foo()
+    variables = module.bind({})
+
+  def test_nested_external_modules(self):
+    class Baz(nn.Module):
+      a: int
+
+      def setup(self):
+        self.b = self.param('b', lambda k: 2)
+
+      def __call__(self, x):
+        return x + self.a * self.b
+
+    class Bar(nn.Module):
+      baz: Baz
+
+      def __call__(self, x):
+        return self.baz(x)
+
+    class Foo(nn.Module):
+      def setup(self):
+        self.bar = Bar(baz=Baz(a=1))
+
+      def __call__(self, x):
+        return self.bar.baz(x)
+
+    module = Foo()
+    y, variables = module.init_with_output(jax.random.PRNGKey(0), 1)
+    self.assertEqual(y, 3)
+
+  def test_getattribute_triggers_setup(self):
+    class B(nn.Module):
+      def setup(self):
+        self.p1 = self.param('p1', lambda k: jnp.ones((2,)))
+      def fn1(self, x):
+        return self.p1 + x
+    class A(nn.Module):
+      b: nn.Module
+      def __call__(self, x):
+        return self.b.fn1(x)
+    a = A(b=B())
+    k = random.PRNGKey(0)
+    x = jnp.zeros((2,))
+    vs = nn.init(lambda a,x: a(x), a)(k, x)
+    y = nn.apply(lambda a,x: a.b.fn1(x), a)(vs, x)
+    np.testing.assert_array_equal(y, jnp.ones((2,)))
+
+  def test_setup_called_bounded_submodules(self):
+    module = nn.Sequential([
+      nn.Sequential([
+        nn.Dense(2),
+        nn.relu,
+        nn.Dense(2),
+      ]),
+      nn.relu,
+      nn.Dense(2),
+    ])
+    x = jnp.ones((1, 3))
+    variables = module.init(jax.random.PRNGKey(0), x)
+    bound_module = module.bind(variables)
+
+    self.assertIsNotNone(bound_module.layers[0].layers[0].scope)
+    self.assertIsNotNone(bound_module.layers[0].layers[2].scope)
+    self.assertIsNotNone(bound_module.layers[2].scope)
+
+  def test_call_bounded_toplevel_mutable(self):
+    class Bar(nn.Module):
+      a: int
+
+      def setup(self):
+        self.b = self.param('b', lambda k: 1)
+
+      def __call__(self, x):
+        return x + self.a * self.b
+
+    class Foo(nn.Module):
+      bars: Sequence[Bar]
+
+      def __call__(self, x):
+        for bar in self.bars:
+          x = bar(x)
+        return x
+
+
+    module = Foo(bars=[])
+    module.bars = [Bar(a=1)]
+
+    variables = module.init(jax.random.PRNGKey(0), jnp.ones(()))
+    bound_module = module.bind(variables)
+
+    bar1 = bound_module.bars[0]
+    self.assertIsNotNone(bar1.scope)
+
+  def test_nested_shared(self):
+    class Shared(nn.Module):
+      @nn.compact
+      def __call__(self, x):
+        return nn.Dense(1)(x)
+
+    class Unshared(nn.Module):
+      shared: nn.Module
+
+      def __call__(self, x):
+        return self.shared(x)
+
+    class Super(nn.Module):
+      a: nn.Module
+      b: nn.Module
+
+      def run_a(self, x):
+        return self.a(x)
+
+      def run_b(self, x):
+        return self.b(x)
+
+      def __call__(self, x):
+        return self.a(x) + self.b(x)
+
+
+    sh = Shared()
+    a = Unshared(shared=sh)
+    b = Unshared(shared=sh)
+    module = Super(a=a, b=b)
+
+    rng = jax.random.PRNGKey(0)
+    params = module.init(rng, jnp.ones(1))["params"]
+
+    module.apply({"params": params}, jnp.ones(1))  # works as expected
+    module.apply({"params": params}, jnp.ones(1), method="run_a")  # works as expected
+    module.apply({"params": params}, jnp.ones(1), method="run_b")  # ScopeParamNotFoundError: Could not find parameter named "kernel" in scope "/b/shared/Dense_0"
+
+  def test_nested_init(self):
+    class Baz(nn.Module):
+      a: int
+
+      def setup(self):
+        self.b = self.param('b', lambda k: jnp.ones(()))
+
+      def __call__(self, x):
+        return x + self.a * self.b
+
+    class Bar(nn.Module):
+      baz: Baz
+
+      def setup(self):
+        a = 1
+
+      def __call__(self, x):
+        return self.baz(x)
+
+    class Foo(nn.Module):
+
+      def setup(self):
+        self.bar: Bar = Bar(baz=Baz(a=1))
+
+      def __call__(self, x):
+        # y = self.bar(x)
+        y, bar_vars = self.bar.init_with_output(jax.random.PRNGKey(0), x)
+        return y, bar_vars
+
+    # create foo
+    module = Foo()
+
+    # run foo
+    (y, bar_vars), variables = module.init_with_output(
+      jax.random.PRNGKey(0), jnp.ones(()))
+
+    self.assertIn('params', bar_vars)
+
 
   def test_repr(self):
 

--- a/tests/linen/linen_module_test.py
+++ b/tests/linen/linen_module_test.py
@@ -25,6 +25,7 @@ from typing import (Any, Callable, Generic, List, Mapping, NamedTuple, Sequence,
                     Tuple, TypeVar, get_type_hints)
 
 from absl.testing import absltest
+import pytest
 from flax import config
 from flax import errors
 from flax import linen as nn
@@ -2095,6 +2096,7 @@ class ModuleTest(absltest.TestCase):
     bar1 = bound_module.bars[0]
     self.assertIsNotNone(bar1.scope)
 
+  @pytest.mark.skip(reason="Leaving it here to tackle it later")
   def test_nested_shared(self):
     class Shared(nn.Module):
       @nn.compact


### PR DESCRIPTION
Fixes #2744. Uses `__getattribute__` to call `_try_setup` when accessing a dataclass field. This properly binds submodules that are passed as constructor arguments instead of being defined in `setup`. This PR is based on #2028 with some minor modifications.

**NOTE**: #2028 was originally rolled back as it broke some internal tests, this PR will likely do the same. The solution would be to fix forward the internal code / tests.