### PR TITLE
Fix LogicalNames type

### DIFF
--- a/flax/core/meta.py
+++ b/flax/core/meta.py
@@ -164,7 +164,7 @@ def replace_boxed(tree: Any, updates: Any) -> Any:
 
 
 PARTITION_NAME = 'partition_name'
-LogicalNames = Tuple[Tuple[str, Union[str, Tuple[str], None]], ...]
+LogicalNames = Tuple[Union[str, None], ...]
 
 
 def _global_mesh_defined() -> bool:


### PR DESCRIPTION
# What does this PR do?

This PR changes the type of `LogicalNames` to

```python
Tuple[Union[str, None], ...]
```
This new difinition succesfully represents inputs such as `(None, 'data')`.