### PR TITLE
Remove incorrect SPMD section in linen.rst

### DIFF
--- a/docs/api_reference/flax.linen.rst
+++ b/docs/api_reference/flax.linen.rst
@@ -282,15 +282,3 @@ RNN primitives
     LSTMCell
     OptimizedLSTMCell
     GRUCell
-
-
-SPMD
-------------------------
-
-.. autosummary::
-  :toctree: _autosummary
-  :template: flax_module
-
-    LSTMCell
-    OptimizedLSTMCell
-    GRUCell


### PR DESCRIPTION
# What does this PR do?

Removes a `SPMD` section at the end of `flax.linen.rst` which is just a copy of `RNN primitives`.