### PR TITLE
Add Bidirectional

### DIFF
--- a/flax/linen/__init__.py
+++ b/flax/linen/__init__.py
@@ -121,8 +121,9 @@ from .recurrent import (
   GRUCell as GRUCell,
   LSTMCell as LSTMCell,
   OptimizedLSTMCell as OptimizedLSTMCell,
-  RNNCellBase as RNNCellBase,
   RNN as RNN,
+  RNNCellBase as RNNCellBase,
+  Bidirectional as Bidirectional,
 )
 from .stochastic import Dropout as Dropout
 from .transforms import (

--- a/tests/linen/linen_recurrent_test.py
+++ b/tests/linen/linen_recurrent_test.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 """Recurrent tests."""
 
 
@@ -24,7 +23,7 @@ from flax import errors
 from flax import linen as nn
 import pytest
 import einops
-from flax.linen.recurrent import _select_last
+from flax.linen.recurrent import flip_sequences
 
 # Parse absl flags test_srcdir and test_tmpdir.
 jax.config.parse_flags_with_absl()
@@ -154,40 +153,6 @@ class RNNTest(absltest.TestCase):
       self.assertIn(layer_params['kernel'].shape[2], [channels_in, channels_out, channels_out * 4])
       self.assertEqual(layer_params['kernel'].shape[3], channels_out * 4)
 
-  @pytest.mark.skip(reason='TODO: discuss supporting reverse instead of flip_sequences')
-  def test_go_backwards(self):
-    batch_size = 10
-    seq_len = 40
-    channels_in = 5
-    channels_out = 15
-
-    rnn = nn.RNN(nn.LSTMCell(), channels_out, reverse=True)
-
-    xs = jnp.ones((batch_size, seq_len, channels_in))
-    variables = rnn.init(jax.random.PRNGKey(0), xs)
-
-    # carry state should be zeros on init
-    for carry in jax.tree_leaves(variables['memory']['carry']):
-      assert np.allclose(carry, jnp.zeros_like(carry))
-      self.assertEqual(carry.shape, (batch_size, channels_out))
-
-    ys: jnp.ndarray
-    ys, updates = rnn.apply(variables, xs, mutable=['memory'])
-    variables = variables.copy(updates)
-
-    # carry state should not be zeros after apply
-    for carry in jax.tree_leaves(variables['memory']['carry']):
-      assert not np.allclose(carry, jnp.zeros_like(carry))
-      self.assertEqual(carry.shape, (batch_size, channels_out))
-
-    self.assertEqual(ys.shape, (batch_size, seq_len, channels_out))
-
-    for layer_params in variables['params']['cell'].values():
-      if 'bias' in layer_params:
-          self.assertEqual(layer_params['bias'].shape, (channels_out,))
-      self.assertIn(layer_params['kernel'].shape[0], [channels_in, channels_out])
-      self.assertEqual(layer_params['kernel'].shape[1], channels_out)
-
   def test_numerical_equivalence(self):
     batch_size = 3
     seq_len = 4
@@ -241,7 +206,6 @@ class RNNTest(absltest.TestCase):
       for carries_t_, carry_ in zip(carries[t], carry):
         np.testing.assert_allclose(carries_t_[batch_idx], carry_[batch_idx], rtol=1e-5)
 
-  @pytest.mark.skip(reason='TODO: possible bug with scan')
   def test_numerical_equivalence_single_batch(self):
     batch_size = 3
     seq_len = 4
@@ -261,9 +225,10 @@ class RNNTest(absltest.TestCase):
 
       for i in range(seq_len):
         cell_carry, y = rnn.cell.apply({'params': cell_params}, cell_carry, xs[batch_idx, i, :][None])
-        np.testing.assert_allclose(y[0], ys[batch_idx, i, :])
+        np.testing.assert_allclose(y[0], ys[batch_idx, i, :], rtol=1e-6)
 
-      np.testing.assert_allclose(cell_carry, carry)
+      carry_i = jax.tree_map(lambda x: x[batch_idx:batch_idx+1], carry)
+      np.testing.assert_allclose(cell_carry, carry_i, rtol=1e-6)
 
   def test_numerical_equivalence_single_batch_nn_scan(self):
     batch_size = 3
@@ -319,3 +284,185 @@ class RNNTest(absltest.TestCase):
       np.testing.assert_allclose(y, ys[:, i, :], rtol=1e-4)
 
     np.testing.assert_allclose(cell_carry, carry, rtol=1e-4)
+
+  def test_reverse(self):
+    batch_size = 3
+    seq_len = 4
+    channels_in = 5
+    channels_out = 6
+
+    rnn = nn.RNN(nn.LSTMCell(), channels_out, return_carry=True, reverse=True)
+
+    xs = jnp.ones((batch_size, seq_len, channels_in))
+    ys: jnp.ndarray
+    (carry, ys), variables = rnn.init_with_output(jax.random.PRNGKey(0), xs)
+
+    cell_params = variables['params']['cell']
+
+    for batch_idx in range(batch_size):
+      cell_carry = rnn.cell.initialize_carry(jax.random.PRNGKey(0), (1,), channels_out)
+
+      for i in range(seq_len):
+        cell_carry, y = rnn.cell.apply({'params': cell_params}, cell_carry, xs[batch_idx, seq_len - i - 1, :][None])
+        np.testing.assert_allclose(y[0], ys[batch_idx, i, :], rtol=1e-5)
+
+      np.testing.assert_allclose(
+        cell_carry, jax.tree_map(lambda x: x[batch_idx:batch_idx+1], carry), rtol=1e-5)
+
+  def test_reverse_but_keep_order(self):
+    batch_size = 3
+    seq_len = 4
+    channels_in = 5
+    channels_out = 6
+
+    rnn = nn.RNN(nn.LSTMCell(), channels_out, return_carry=True, reverse=True, keep_order=True)
+
+    xs = jnp.ones((batch_size, seq_len, channels_in))
+    ys: jnp.ndarray
+    (carry, ys), variables = rnn.init_with_output(jax.random.PRNGKey(0), xs)
+
+    cell_params = variables['params']['cell']
+
+    for batch_idx in range(batch_size):
+      cell_carry = rnn.cell.initialize_carry(jax.random.PRNGKey(0), (1,), channels_out)
+
+      for i in range(seq_len):
+        cell_carry, y = rnn.cell.apply({'params': cell_params}, cell_carry, xs[batch_idx, seq_len - i - 1, :][None])
+        np.testing.assert_allclose(y[0], ys[batch_idx, seq_len - i - 1, :], rtol=1e-5)
+
+      np.testing.assert_allclose(
+        cell_carry, jax.tree_map(lambda x: x[batch_idx:batch_idx+1], carry), rtol=1e-5)
+
+  def test_flip_sequence(self):
+    x = jnp.arange(2 * 5).reshape((2, 5))
+    segmentation_mask = jnp.array([[1, 1, 1, 1, 0], [1, 1, 0, 0, 0]])
+
+    flipped = flip_sequences(x, segmentation_mask, num_batch_dims=1, time_major=False)
+
+    self.assertEqual(flipped.shape, (2, 5))
+    np.testing.assert_allclose(flipped[0, :4], [3, 2, 1, 0])
+    np.testing.assert_allclose(flipped[1, :2], [6, 5])
+
+  def test_flip_sequence_more_feature_dims(self):
+    x = jnp.arange(2 * 5 * 3).reshape((2, 5, 3))
+    segmentation_mask = jnp.array([[1, 1, 1, 1, 0], [1, 1, 0, 0, 0]])
+
+    flipped = flip_sequences(x, segmentation_mask, num_batch_dims=1, time_major=False)
+
+    self.assertEqual(flipped.shape, (2, 5, 3))
+    np.testing.assert_allclose(flipped[0, :4], x[0, :4][::-1])
+    np.testing.assert_allclose(flipped[1, :2], x[1, :2][::-1])
+
+  def test_flip_sequence_time_major(self):
+    x = jnp.arange(2 * 5).reshape((5, 2))
+    segmentation_mask = jnp.array([
+      [1, 1],
+      [1, 1],
+      [1, 0],
+      [1, 0],
+      [0, 0],
+    ])
+
+    flipped = flip_sequences(x, segmentation_mask, num_batch_dims=1, time_major=True)
+
+    self.assertEqual(flipped.shape, (5, 2))
+    np.testing.assert_allclose(flipped[:4, 0], x[:4, 0][::-1])
+    np.testing.assert_allclose(flipped[:2, 1], x[:2, 1][::-1])
+
+  def test_flip_sequence_time_major_more_feature_dims(self):
+    x = jnp.arange(2 * 5 * 3).reshape((5, 2, 3))
+    segmentation_mask = jnp.array([
+      [1, 1],
+      [1, 1],
+      [1, 0],
+      [1, 0],
+      [0, 0],
+    ])
+
+    flipped = flip_sequences(x, segmentation_mask, num_batch_dims=1, time_major=True)
+
+    self.assertEqual(flipped.shape, (5, 2, 3))
+    np.testing.assert_allclose(flipped[:4, 0], x[:4, 0][::-1])
+    np.testing.assert_allclose(flipped[:2, 1], x[:2, 1][::-1])
+
+class BidirectionalTest(absltest.TestCase):
+
+  def test_bidirectional(self):
+    batch_size = 3
+    seq_len = 4
+    channels_in = 5
+    channels_out = 6
+
+    bdirectional = nn.Bidirectional(
+      nn.RNN(nn.LSTMCell(), channels_out),
+      nn.RNN(nn.LSTMCell(), channels_out)
+    )
+
+    xs = jnp.ones((batch_size, seq_len, channels_in))
+    ys: jnp.ndarray
+    ys, variables = bdirectional.init_with_output(jax.random.PRNGKey(0), xs)
+
+    self.assertEqual(ys.shape, (batch_size, seq_len, channels_out * 2))
+
+  def test_shared_cell(self):
+    batch_size = 3
+    seq_len = 4
+    channels_in = 5
+    channels_out = 6
+
+    cell = nn.LSTMCell()
+    bdirectional = nn.Bidirectional(
+      nn.RNN(cell, channels_out),
+      nn.RNN(cell, channels_out)
+    )
+
+    xs = jnp.ones((batch_size, seq_len, channels_in))
+    ys: jnp.ndarray
+    ys, variables = bdirectional.init_with_output(jax.random.PRNGKey(0), xs)
+
+    self.assertEqual(ys.shape, (batch_size, seq_len, channels_out * 2))
+
+  def test_custom_merge_fn(self):
+    batch_size = 3
+    seq_len = 4
+    channels_in = 5
+    channels_out = 6
+
+    bdirectional = nn.Bidirectional(
+      nn.RNN(nn.LSTMCell(), channels_out),
+      nn.RNN(nn.LSTMCell(), channels_out),
+      merge_fn=lambda x, y: x + y
+    )
+
+    xs = jnp.ones((batch_size, seq_len, channels_in))
+    ys: jnp.ndarray
+    ys, variables = bdirectional.init_with_output(jax.random.PRNGKey(0), xs)
+
+    self.assertEqual(ys.shape, (batch_size, seq_len, channels_out))
+
+  def test_return_carry(self):
+    batch_size = 3
+    seq_len = 4
+    channels_in = 5
+    channels_out = 6
+
+    bdirectional = nn.Bidirectional(
+      nn.RNN(nn.LSTMCell(), channels_out),
+      nn.RNN(nn.LSTMCell(), channels_out),
+      return_carry=True
+    )
+
+    xs = jnp.ones((batch_size, seq_len, channels_in))
+    ys: jnp.ndarray
+    (carry, ys), variables = bdirectional.init_with_output(jax.random.PRNGKey(0), xs)
+    carry_forward, carry_backward = carry
+
+    self.assertEqual(ys.shape, (batch_size, seq_len, channels_out * 2))
+    self.assertEqual(
+      jax.tree_map(jnp.shape, carry_forward),
+      ((batch_size, channels_out), (batch_size, channels_out))
+    )
+    self.assertEqual(
+      jax.tree_map(jnp.shape, carry_backward),
+      ((batch_size, channels_out), (batch_size, channels_out))
+    )


### PR DESCRIPTION
# What does this PR do?

* Adds a `Bidirectional` Module that takes two `RNN` instances and applies the bidirectional logic.
* Adds the `reverse` and `keep_order` arguments to `RNN` to allow the implementation of the bidirectional logic.
* Changes the type of `Array` from `Any` to `jax.Array` and fixes some type errors.
