### PR TITLE
Register Jax key paths for `FrozenDict`

### DIFF
--- a/flax/struct.py
+++ b/flax/struct.py
@@ -130,10 +130,9 @@ def dataclass(clz: _T) -> _T:
                                      iterate_clz,
                                      clz_from_iterable)
 
-  if tuple(map(int, jax.version.__version__.split('.'))) >= (0, 3, 1):
-    def keypaths(_):
-      return [jax.tree_util.AttributeKeyPathEntry(name) for name in data_fields]
-    jax.tree_util.register_keypaths(data_clz, keypaths)
+  def keypaths(_):
+    return [jax.tree_util.AttributeKeyPathEntry(name) for name in data_fields]
+  jax.tree_util.register_keypaths(data_clz, keypaths)
 
   def to_state_dict(x):
     state_dict = {name: serialization.to_state_dict(getattr(x, name))

--- a/tests/core/core_frozen_dict_test.py
+++ b/tests/core/core_frozen_dict_test.py
@@ -15,6 +15,7 @@
 from flax.core import FrozenDict, unfreeze, freeze
 
 import jax
+from jax._src.tree_util import prefix_errors
 
 
 from absl.testing import absltest
@@ -83,6 +84,14 @@ class FrozenDictTest(absltest.TestCase):
   def test_frozen_dict_copy_reserved_name(self):
     result = FrozenDict({'a': 1}).copy({'cls': 2})
     self.assertEqual(result, {'a': 1, 'cls': 2})
+
+  def test_frozen_dict_keypaths(self):
+    tree = FrozenDict({'a': {'b': {'c': 1}}})
+    bad_prefix_tree = FrozenDict({'a': {'b': {'d': 1}}})
+
+    e, = prefix_errors(bad_prefix_tree, tree)
+    with self.assertRaisesRegex(ValueError, r'different pytree metadata at key path\s*tree\[\'a\'\]\[\'b\'\]\n'):
+      raise e('tree')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
# What does this PR do?

<!--

Great, you are contributing to Flax!

But... please read the following carefully so we can make sure your PR is merged
easily.

Replace this text block with a description of the change and which issue it
fixes (if applicable). Please also include relevant motivation/context.

Once you're done, someone in the Flax team will review your PR shortly. They may
suggest changes to make the code even better. If no one reviewed your PR after a
week has passed, don't hesitate to post a new comment @-mentioning the same
persons (sometimes notifications get lost).
-->

Register `FrozenDict`'s key paths with Jax. This allows for better error messages as well as other features such as natively mapping tree leaves with their corresponding path. `PyTreeNode` was already registered but it seems that `FrozenDict` was forgotten about.

A couple of things to note:

1. I removed the version check when registering key paths as Flax now depends on `jax>=0.3.16` which includes the key path changes.
2. I modified how `FrozenDict` is flattened and unflattened. The old method wasn't really a flat format and could cause spurious errors, e.g., calling `jax.tree_util.flatten_one_level` would do nothing as there is an empty root level with the current method. The new flattening method is how Jax internally flattens dictionaries by using the values as data and the keys as metadata.


## Checklist
- [x] This PR fixes a minor issue (e.g.: typo or small bug) or improves the docs (you can dismiss the other
      checks if that's the case).
- [ ] This change is discussed in a Github issue/
      [discussion](https://github.com/google/flax/discussions) (please add a
      link).
- [ ] The documentation and docstrings adhere to the
      [documentation guidelines](https://github.com/google/flax/blob/main/docs/README.md#how-to-write-code-documentation).
- [x] This change includes necessary high-coverage tests.
      (No quality testing = no merge!)
