### PR TITLE
Improve lifted transform docstring

### DIFF
--- a/flax/linen/transforms.py
+++ b/flax/linen/transforms.py
@@ -1070,7 +1070,7 @@ def while_loop(
           y = nn.Dense(c.shape[-1])(c)
           return y
         c = x
-        if self.is_mutable_collection('params'):
+        if self.is_initializing():
           return body_fn(self, c)
         else:
           return nn.while_loop(cond_fn, body_fn, self, c,
@@ -1219,7 +1219,7 @@ def switch(
         branches = [head_fn(i) for i in range(len(self.heads))]
 
         # run all branches on init
-        if self.is_mutable_collection('params'):
+        if self.is_initializing():
           for branch in branches:
             _ = branch(self, x)
 

--- a/flax/linen/transforms.py
+++ b/flax/linen/transforms.py
@@ -780,7 +780,8 @@ def scan(target: Target,
 
   Args:
     target: a ``Module`` or a function taking a ``Module``
-      as its first argument.
+      as its first argument. Scanning happens from the third and all
+      subsequent arguments of the function.
     variable_axes: the variable collections that are scanned over.
     variable_broadcast: Specifies the broadcasted variable collections. A
       broadcasted variable should not depend on any computation that cannot be
@@ -791,6 +792,7 @@ def scan(target: Target,
       and will be preserved when the scan finishes.
     split_rngs: Split PRNG sequences will be different for each loop iterations.
       If split is False the PRNGs will be the same across iterations.
+      (default: True)
     in_axes: Specifies the axis to scan over for the arguments. Should be a
       prefix tree of the arguments. Use `flax.core.broadcast` to feed an entire
       input to each iteration of the scan body.


### PR DESCRIPTION
This improves the docstrings in some of the lifted transform functions. Fixing the examples and clarifying some of the arguments. This addresses some of the concerns in #1977