### PR TITLE
Add metadata helper transform for adding axis metadata.

### DIFF
--- a/flax/linen/__init__.py
+++ b/flax/linen/__init__.py
@@ -135,6 +135,7 @@ from .transforms import (
   while_loop as while_loop,
   cond as cond,
   switch as switch,
+  add_metadata_axis,
 )
 from .summary import tabulate
 # pylint: enable=g-multiple-import

--- a/tests/linen/linen_transforms_test.py
+++ b/tests/linen/linen_transforms_test.py
@@ -1633,6 +1633,37 @@ class TransformTest(absltest.TestCase):
         jax.random.PRNGKey(0),
         x=jnp.ones(3))
 
+  def test_add_metadata_axis(self):
+    vars_copy = None
+    class Foo(nn.Module):
+      @nn.compact
+      def __call__(self, x):
+        nonlocal vars_copy
+        kernel_init=nn.with_partitioning(
+            nn.initializers.lecun_normal(), ('foo', 'bar'))
+        vars_copy = self.variables
+        return nn.Dense(4, kernel_init=kernel_init, use_bias=False, name="dense")(x)
+    class Test(nn.Module):
+      @partial(nn.add_metadata_axis,
+               variable_axes={'params': 0},
+               metadata_params={nn.PARTITION_NAME: 'baz'})
+      @nn.compact
+      def __call__(self, x):
+        return Foo(name="foo")(x)
+
+    k = random.PRNGKey(0)
+    x = jnp.ones((4,4), dtype=jnp.float32)
+    vs = Test().init(k, x)
+    y = Test().apply(vs, x)
+    outer_expect = jax.tree_map(jnp.shape,
+        freeze({'params': {'foo': {'dense': {'kernel':
+            nn.Partitioned(jnp.ones((4, 4)), names=('baz', 'foo', 'bar'))}}}}))
+    inner_expect = jax.tree_map(jnp.shape,
+        freeze({'params': {'dense': {'kernel':
+            nn.Partitioned(jnp.ones((4, 4)), names=('foo', 'bar'))}}}))
+    self.assertEqual(jax.tree_map(jnp.shape, vs), outer_expect)
+    self.assertEqual(jax.tree_map(jnp.shape, vars_copy), inner_expect)
+
 
 if __name__ == '__main__':
   absltest.main()


### PR DESCRIPTION
Some users have custom combinatory/transform layers that effectively add an axis to their layer parameters, but that aren't simple vmaps or scans.  This adds a metadata helper transform for adding an axis annotation "on the way out" for inits and mutations, and removing that axis "on the way in" during application, exactly the same as the behavior used in scan/vmap - but only touching the metadata of boxed variables, and not modifying any traced variables.

