### PR TITLE
Added builder functions for zeros and ones initializers

### DIFF
--- a/flax/linen/initializers.py
+++ b/flax/linen/initializers.py
@@ -34,4 +34,30 @@ from jax.nn.initializers import variance_scaling as variance_scaling
 from jax.nn.initializers import xavier_normal as xavier_normal
 from jax.nn.initializers import xavier_uniform as xavier_uniform
 from jax.nn.initializers import zeros as zeros
+from jax.nn.initializers import Initializer as Initializer
 # pylint: enable=unused-import
+
+def zeros_init() -> Initializer:
+  """Builds an initializer that returns a constant array full of zeros.
+
+  >>> import jax, jax.numpy as jnp
+  >>> from flax.linen.initializers import zeros_init
+  >>> zeros_initializer = zeros_init()
+  >>> zeros_initializer(jax.random.PRNGKey(42), (2, 3), jnp.float32)
+  Array([[0., 0., 0.],
+         [0., 0., 0.]], dtype=float32)
+  """
+  return zeros
+
+def ones_init() -> Initializer:
+  """Builds an initializer that returns a constant array full of ones.
+
+  >>> import jax, jax.numpy as jnp
+  >>> from flax.linen.initializers import ones_init
+  >>> ones_initializer = ones_init()
+  >>> ones_initializer(jax.random.PRNGKey(42), (3, 2), jnp.float32)
+  Array([[1., 1.],
+         [1., 1.],
+         [1., 1.]], dtype=float32)
+  """
+  return ones

--- a/tests/linen/initializers_test.py
+++ b/tests/linen/initializers_test.py
@@ -30,7 +30,7 @@ import numpy as np
 jax.config.parse_flags_with_absl()
 
 
-class AttentionTest(parameterized.TestCase):
+class InitializersTest(parameterized.TestCase):
 
   @parameterized.parameters(
     {

--- a/tests/linen/initializers_test.py
+++ b/tests/linen/initializers_test.py
@@ -1,0 +1,64 @@
+# Copyright 2022 The Flax Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for flax.linen.initializers."""
+
+from absl.testing import absltest
+from absl.testing import parameterized
+
+from flax import linen as nn
+from flax.linen.initializers import zeros_init, ones_init
+
+import jax
+from jax import random
+import jax.numpy as jnp
+
+import numpy as np
+
+# Parse absl flags test_srcdir and test_tmpdir.
+jax.config.parse_flags_with_absl()
+
+
+class AttentionTest(parameterized.TestCase):
+
+  @parameterized.parameters(
+    {
+      'builder_fn': zeros_init,
+      'params_shape': (2, 3),
+      'expected_params': jnp.zeros((2, 3)),
+    }, {
+      'builder_fn': ones_init,
+      'params_shape': (3, 2),
+      'expected_params': jnp.ones((3, 2)),
+    })
+  def test_call_builder(self, builder_fn, params_shape, expected_params):
+    params = builder_fn()(random.PRNGKey(42), params_shape, jnp.float32)
+    np.testing.assert_allclose(params, expected_params)
+
+  @parameterized.parameters(
+    {
+      'builder_fn': zeros_init,
+      'expected_params': jnp.zeros((2, 5)),
+    }, {
+      'builder_fn': ones_init,
+      'expected_params': jnp.ones((2, 5)),
+    })
+  def test_kernel_builder(self, builder_fn, expected_params):
+    layer = nn.Dense(5, kernel_init=builder_fn())
+    params = layer.init(random.PRNGKey(42), jnp.empty((3, 2)))['params']
+    np.testing.assert_allclose(params['kernel'], expected_params)
+
+
+if __name__ == '__main__':
+  absltest.main()


### PR DESCRIPTION
Addresses part of #2002 and is mentioned by @marcvanzee [here](https://github.com/google/flax/pull/2776#discussion_r1064544968).

Added builder functions for zeros and ones initializers.