### PR TITLE
Restructure Flax guides, add sections, update copyright year

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -40,7 +40,7 @@ import docs.conf_sphinx_patch
 # -- Project information -----------------------------------------------------
 
 project = 'Flax'
-copyright = '2021, The Flax authors'  # pylint: disable=redefined-builtin
+copyright = '2023, The Flax authors'  # pylint: disable=redefined-builtin
 author = 'The Flax authors'
 
 

--- a/docs/guides/index.rst
+++ b/docs/guides/index.rst
@@ -1,30 +1,13 @@
 Guides
-==========
+======
 
 .. toctree::
-   :maxdepth: 1
+   :maxdepth: 2
 
-   jax_for_the_impatient
-   flax_basics
-   arguments
-   state_params
-   setup_or_nncompact
-   dropout
-   batch_norm
-   model_surgery
-   transfer_learning
-   extracting_intermediates
-   lr_schedule
-   use_checkpointing
-   flax_on_pjit
-
-.. toctree::
-   :maxdepth: 1
-   :caption: Tips and tricks
-
-   ensembling
-   full_eval
-   convert_pytorch_to_flax
-   optax_update_guide
-   linen_upgrade_guide
+   index_flax_fundamentals
+   index_data_preprocessing
+   index_training_techniques
+   index_parallel_training
+   index_model_inspection
+   index_converting_and_upgrading
    The Sharp Bits <../notebooks/flax_sharp_bits>

--- a/docs/guides/index_converting_and_upgrading.rst
+++ b/docs/guides/index_converting_and_upgrading.rst
@@ -1,0 +1,9 @@
+Converting and upgrading
+========================
+
+.. toctree::
+   :maxdepth: 1
+
+   convert_pytorch_to_flax
+   optax_update_guide
+   linen_upgrade_guide

--- a/docs/guides/index_data_preprocessing.rst
+++ b/docs/guides/index_data_preprocessing.rst
@@ -1,0 +1,7 @@
+Data preprocesing
+=================
+
+.. toctree::
+   :maxdepth: 1
+
+   full_eval

--- a/docs/guides/index_flax_fundamentals.rst
+++ b/docs/guides/index_flax_fundamentals.rst
@@ -1,0 +1,11 @@
+Flax fundamentals
+=================
+
+.. toctree::
+   :maxdepth: 1
+
+   JAX 101 <https://jax.readthedocs.io/en/latest/jax-101/index.html>
+   flax_basics
+   state_params
+   setup_or_nncompact
+   arguments

--- a/docs/guides/index_model_inspection.rst
+++ b/docs/guides/index_model_inspection.rst
@@ -1,0 +1,8 @@
+Model inspection
+================
+
+.. toctree::
+   :maxdepth: 1
+
+   model_surgery
+   extracting_intermediates

--- a/docs/guides/index_parallel_training.rst
+++ b/docs/guides/index_parallel_training.rst
@@ -1,0 +1,8 @@
+Parallel training
+=================
+
+.. toctree::
+   :maxdepth: 1
+
+   ensembling
+   flax_on_pjit

--- a/docs/guides/index_training_techniques.rst
+++ b/docs/guides/index_training_techniques.rst
@@ -1,0 +1,11 @@
+Training techniques
+===================
+
+.. toctree::
+   :maxdepth: 1
+
+   batch_norm
+   dropout
+   lr_schedule
+   transfer_learning
+   use_checkpointing


### PR DESCRIPTION
Addresses proposal https://github.com/google/flax/issues/2627 by @marcvanzee, follows PR https://github.com/google/flax/pull/2788

cc @andsteing @cgarciae @IvyZX @chiamp 

Preview: https://flax--2800.org.readthedocs.build/en/2800/

Introducing new sections in _Guides_ (fundamentals, data preprocessing, training techniques, parallel training, model inspection, converting/upgrading):

```
* Flax fundamentals
  * JAX 101
  * Flax Basics
  * Managing Parameters and State
  * setup vs compact
  * Dealing with Flax Module arguments
* Data preprocesing
  * Processing the entire Dataset
  * Training techniques
  * Batch normalization
  * Dropout
  * Learning rate scheduling
  * Transfer learning
  * Save and load checkpoints
* Parallel training
  * Ensembling on multiple devices
  * Scale up Flax Modules on multiple devices with pjit
* Model inspection
  * Model surgery
  * Extracting intermediate values
  * Extracting gradients of intermediate values
* Converting and upgrading
  * Convert PyTorch models to Flax
  * Upgrading my codebase to Optax
  * Upgrading my codebase to Linen
* The Sharp Bits
```