### PR TITLE
Add missing fields from repr

### DIFF
--- a/flax/linen/module.py
+++ b/flax/linen/module.py
@@ -97,8 +97,9 @@ def _module_repr(module: 'Module', num_spaces: int = 4):
   cls = type(module)
   cls_name = cls.__name__
   rep = ''
-  attributes = {k: v for k, v in cls.__annotations__.items()
-                if k not in ('parent', 'name')}
+
+  attributes = {f.name: f.type for f in dataclasses.fields(cls)
+                if f.name not in ('parent', 'name')}
   child_modules = {k: v for k, v in module._state.children.items()  # pytype: disable=attribute-error
                    if isinstance(v, Module)}
   if attributes:

--- a/tests/linen/linen_module_test.py
+++ b/tests/linen/linen_module_test.py
@@ -1897,6 +1897,24 @@ class ModuleTest(absltest.TestCase):
                                 'Trying to access a property that'):
       foo.apply({})
 
+  def test_repr(self):
+
+    class Base1(nn.Module):
+      a: int
+
+    class Base2(nn.Module):
+        b: str
+
+    class Foo(Base2, Base1):
+        c: float
+
+    module = Foo(a=1, b='ok', c=3.0)
+    str_rep = repr(module)
+
+    self.assertIn('a = 1', str_rep)
+    self.assertIn("b = 'ok'", str_rep)
+    self.assertIn('c = 3.0', str_rep)
+
 
 class LeakTests(absltest.TestCase):
 


### PR DESCRIPTION
# What does this PR do?

Fixes #2791. Uses `dataclass.fields` instead of `__annotations__` to select field in `__repr__`.