### PR TITLE
added zeros_init and ones_init builder to initializers list

### DIFF
--- a/docs/api_reference/flax.linen.rst
+++ b/docs/api_reference/flax.linen.rst
@@ -206,6 +206,7 @@ Initializers
     lecun_uniform
     normal
     ones
+    ones_init
     orthogonal
     uniform
     standardize
@@ -213,6 +214,7 @@ Initializers
     xavier_normal
     xavier_uniform
     zeros
+    zeros_init
 
 
 Combinators


### PR DESCRIPTION
As a follow up to #2790, updated initializers list to include `zeros_init` and `ones_init`. View the list [here](https://flax--2806.org.readthedocs.build/en/2806/api_reference/flax.linen.html#module-flax.linen.initializers).