### PR TITLE
Allow specifying method as a string

### DIFF
--- a/tests/linen/linen_module_test.py
+++ b/tests/linen/linen_module_test.py
@@ -826,6 +826,7 @@ class ModuleTest(absltest.TestCase):
   def test_module_apply_method(self):
 
     class Foo(nn.Module):
+      not_callable: int = 1
 
       @nn.compact
       def __call__(self):
@@ -849,8 +850,17 @@ class ModuleTest(absltest.TestCase):
     with self.assertRaisesRegex(errors.ApplyModuleInvalidMethodError, msg):
       Foo().apply({}, method=lambda: True)
 
-    with self.assertRaisesRegex(errors.ApplyModuleInvalidMethodError, msg):
+    # string method names are also allowed.
+    Foo().apply({}, method='test')
+
+    # non-existent attribute names will yield AttributeError.
+    with self.assertRaisesRegex(AttributeError, "allowed_apply_fn"):
       Foo().apply({}, method='allowed_apply_fn')
+
+    # attributes which are not callables yield TypeError.
+    with self.assertRaisesRegex(TypeError, "'Foo.not_callable' must be a callable"):
+      Foo().apply({}, method='not_callable')
+
 
   def test_call_unbound_compact_module_methods(self):
     dense = Dense(3)

--- a/tests/linen/linen_module_test.py
+++ b/tests/linen/linen_module_test.py
@@ -852,14 +852,20 @@ class ModuleTest(absltest.TestCase):
 
     # string method names are also allowed.
     Foo().apply({}, method='test')
+    # test same for init.
+    Foo().init({}, method='test')
 
     # non-existent attribute names will yield AttributeError.
     with self.assertRaisesRegex(AttributeError, "allowed_apply_fn"):
       Foo().apply({}, method='allowed_apply_fn')
+      # test same for init.
+      Foo().init({}, method='allowed_apply_fn')
 
     # attributes which are not callables yield TypeError.
     with self.assertRaisesRegex(TypeError, "'Foo.not_callable' must be a callable"):
       Foo().apply({}, method='not_callable')
+      # test same for init.
+      Foo().init({}, method='not_callable')
 
 
   def test_call_unbound_compact_module_methods(self):


### PR DESCRIPTION
# What does this PR do?

Allows passing `method` as a string to `apply`. This will simply get the specified attribute from `self`.

## Rationale

Being able to specify the method without having direct access to the instance is important to improve the ergonomics of abstractions like `TrainState` where you only have access to `apply` via `TrainState.apply_fn`. 

Currently we promote the use of `state` like this:

```python
@jax.jit
def train_step(state, batch):
  ...
  logits = state.apply_fn({'params': state.params, ...)
  ...
```
However, if you happen to need to use a method you now have to pass it somehow e.g:

```python
@partial(jax.jit, static_argnums=(2,))
def train_step(state, batch, method):
  ...
  logits = state.apply_fn({'params': state.params, ..., method=method)
  ...
```
This involves a couple of changes throughout the code base for a relatively simple operation. With the proposed change you can now specify it very simply as:

```python
@jax.jit
def train_step(state, batch):
  ...
  logits = state.apply_fn({'params': state.params, ..., method='some_method')
  ...
```
