### PR TITLE
Implement lazy init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ vNext
 -
 -
 -
--
+- Add ``Module.lazy_init`` to avoid compute during Module initialization.
 -
 -
 -

--- a/flax/core/__init__.py
+++ b/flax/core/__init__.py
@@ -31,6 +31,7 @@ from .scope import (
   DenyList as DenyList,
   apply as apply,
   init as init,
+  lazy_init as lazy_init,
   bind as bind)
 
 from .lift import (

--- a/flax/core/partial_eval.py
+++ b/flax/core/partial_eval.py
@@ -17,20 +17,20 @@ def _maybe_unknown(x: Any) -> pe.PartialVal:
 
 
 def lazy_init(fn):
-  """Lazily evaluate a function by using the shapes of the inputs.
+  """Lazily evaluates a function by using the shapes of the inputs.
 
   The returned function accepts a combination of JAX values and
   ``jax.ShapeDtypeStruct`` instances for the inputs for which we
   don't need concrete values (only the shape and dtype).
 
   This API is used by ``core.lazy_init`` or ``Module.lazy_init``
-  to initialize variables without doing any actual compute on the
+  to initialize variables without doing any actual computation on the
   inputs.
 
   Args:
     fn: the function to be lazily evaluated.
   Returns:
-    A new function that accepts a mix of concrete valeus and
+    A new function that accepts a mix of concrete values and
     ``jax.ShapeDtypeStruct`` instances.
   """
   @functools.wraps(fn)
@@ -40,7 +40,7 @@ def lazy_init(fn):
     inputs_flat, in_tree = jax.tree_util.tree_flatten((args, kwargs))
     f_flat, out_tree = jax.api_util.flatten_fun(lu.wrap_init(fn), in_tree)
     # map inputs to PartialVal known/unknown
-    # only compute depending on knowns will be computed
+    # only the computations depending on knowns will be executed
     in_pvals = [_maybe_unknown(x) for x in inputs_flat]
     _, out_pvals, _ = pe.trace_to_jaxpr_nounits(f_flat, in_pvals)
     # all outputs should be knowns. If this fails

--- a/flax/core/partial_eval.py
+++ b/flax/core/partial_eval.py
@@ -1,0 +1,58 @@
+from typing import Any
+
+import functools
+
+import jax
+from jax import linear_util as lu
+from jax.interpreters import partial_eval as pe
+
+from flax import errors
+
+
+def _maybe_unknown(x: Any) -> pe.PartialVal:
+  if isinstance(x, jax.ShapeDtypeStruct):
+    return pe.PartialVal.unknown(jax.ShapedArray(x.shape, x.dtype))
+  else:
+    return pe.PartialVal.known(x)
+
+
+def lazy_init(fn):
+  """Lazily evaluate a function by using the shapes of the inputs.
+
+  The returned function accepts a combination of JAX values and
+  ``jax.ShapeDtypeStruct`` instances for the inputs for which we
+  don't need concrete values (only the shape and dtype).
+
+  This API is used by ``core.lazy_init`` or ``Module.lazy_init``
+  to initialize variables without doing any actual compute on the
+  inputs.
+
+  Args:
+    fn: the function to be lazily evaluated.
+  Returns:
+    A new function that accepts a mix of concrete valeus and
+    ``jax.ShapeDtypeStruct`` instances.
+  """
+  @functools.wraps(fn)
+  def wrapper(*args, **kwargs):
+    # TODO(mattjj,jheek): use a public JAX API
+    # flatten fn and prepare for internal JAX transform
+    inputs_flat, in_tree = jax.tree_util.tree_flatten((args, kwargs))
+    f_flat, out_tree = jax.api_util.flatten_fun(lu.wrap_init(fn), in_tree)
+    # map inputs to PartialVal known/unknown
+    # only compute depending on knowns will be computed
+    in_pvals = [_maybe_unknown(x) for x in inputs_flat]
+    _, out_pvals, _ = pe.trace_to_jaxpr_nounits(f_flat, in_pvals)
+    # all outputs should be knowns. If this fails
+    # the user is creating variables that depend on a
+    # argument that was passed as a ShapeDtypeStruct.
+    out_flat = []
+    for pv, const in out_pvals:
+      if pv is None:
+        # const is the actual value of the known output
+        out_flat.append(const)
+      else:
+        raise errors.LazyInitError(pv)
+    return jax.tree_util.tree_unflatten(out_tree(), out_flat)
+
+  return wrapper

--- a/flax/core/scope.py
+++ b/flax/core/scope.py
@@ -947,7 +947,7 @@ def init(fn: Callable[..., Any],
 def lazy_init(fn: Callable[..., Any],
          mutable: CollectionFilter = True,
          flags: Optional[Mapping] = None) -> Callable[..., Any]:
-  """Functionalize a `Scope` function for lazy initialization.
+  """Functionalizes a `Scope` function for lazy initialization.
 
   Similair to ``init`` except that the init function now accepts
   ``jax.ShapeDtypeStruct`` instances for arguments that do not

--- a/flax/errors.py
+++ b/flax/errors.py
@@ -60,6 +60,37 @@ class FlaxError(Exception):
 
 
 #################################################
+# lazy_init.py errors                           #
+#################################################
+
+
+class LazyInitError(FlaxError):
+  """Lazy Init function has uncomputable return values.
+
+  This happens when passing an argument to lazy_init with ``jax.ShapeDtypeStruct``
+  that affects the initialized variables.
+  Make sure the init function only uses the shape and dtype or pass an
+  actual JAX array if this is impossible.
+
+  Example::
+
+    class Foo(nn.Module):
+      @compact
+      def __call__(self, x):
+        # This parameter depends on the input x
+        # this causes an error when using lazy_init.
+        k = self.param("kernel", lambda _: x)
+        return x * k
+    Foo().lazy_init(random.PRNGKey(0), jax.ShapeDtypeStruct((8, 4), jnp.float32))
+  """
+
+  def __init__(self, partial_val):
+    super().__init__(
+        f'Lazy init encoutered a value that could with '
+        f'the given inputs (shape: {partial_val}).')
+
+
+#################################################
 # scope.py errors                               #
 #################################################
 

--- a/flax/linen/module.py
+++ b/flax/linen/module.py
@@ -1545,6 +1545,14 @@ class Module:
       model = nn.Dense(features=256)
       variables = model.lazy_init(rng, jax.ShapeDtypeStruct((1, 128), jnp.float32))
 
+    The args and kwargs args passed to ``lazy_init`` can be a mix of
+    concrete (jax arrays, scalars, bools) and abstract (ShapeDtypeStruct) values.
+    Concrete values are only necessary for arguments that affect
+    the initialization of variables. For example, the model might expect
+    a keyword arg that enables/disables a subpart of the model.
+    In this case, an explicit value (True/Flase) should be passed otherwise
+    ``lazy_init`` cannot infer which variables should be initialized.
+
     Args:
       rngs: The rngs for the variable collections.
       *args: arguments passed to the init function.

--- a/tests/core/core_scope_test.py
+++ b/tests/core/core_scope_test.py
@@ -14,7 +14,7 @@
 
 import unittest
 from flax import errors
-from flax.core import Scope, scope, freeze, init, apply, nn
+from flax.core import Scope, scope, freeze, lazy_init, init, apply, nn
 from flax.core.scope import LazyRng
 
 import jax
@@ -217,6 +217,23 @@ class ScopeTest(absltest.TestCase):
     scope.put_variable('state', 'a', {'x': jnp.array(1., jnp.float32)})
     self.assertEqual(scope.variables()['state']['a']['x'], subscope.variables()['state']['x'])
 
+  def test_lazy_init(self):
+    def f(scope, x):
+      k = scope.param("kernel", nn.initializers.lecun_normal(), (x.shape[-1], x.shape[-1]))
+      return x @ k
+    init_fn = lazy_init(f)
+    # provide a massive input message which would OOM if any compute ops were actually executed
+    variables = init_fn(random.PRNGKey(0), jax.ShapeDtypeStruct((1024 * 1024 * 1024, 128), jnp.float32))
+    self.assertEqual(variables["params"]["kernel"].shape, (128, 128))
+
+  def test_lazy_init_fails_on_data_dependence(self):
+    def f(scope, x):
+      # kernel is initialized with x so params are now dependent on the input
+      k = scope.param("kernel", lambda _: x)
+      return x * k
+    init_fn = lazy_init(f)
+    with self.assertRaises(errors.LazyInitError):
+      init_fn(random.PRNGKey(0), jax.ShapeDtypeStruct((8, 4), jnp.float32))
 
 if __name__ == '__main__':
   absltest.main()

--- a/tests/linen/linen_module_test.py
+++ b/tests/linen/linen_module_test.py
@@ -76,6 +76,27 @@ class ModuleTest(absltest.TestCase):
     np.testing.assert_allclose(y, jnp.array([2.]))
     self.assertEqual(params, {'bias': jnp.array([1.])})
 
+  def test_lazy_init(self):
+
+    class Foo(nn.Module):
+      @compact
+      def __call__(self, x):
+        k = self.param("kernel", nn.initializers.lecun_normal(), (x.shape[-1], x.shape[-1]))
+        return x @ k
+    # provide a massive input message which would OOM if any compute ops were actually executed
+    variables = Foo().lazy_init(random.PRNGKey(0), jax.ShapeDtypeStruct((1024 * 1024 * 1024, 128), jnp.float32))
+    self.assertEqual(variables["params"]["kernel"].shape, (128, 128))
+
+  def test_lazy_init_fails_on_data_dependence(self):
+    class Foo(nn.Module):
+      @compact
+      def __call__(self, x):
+        k = self.param("kernel", lambda _: x)
+        return x * k
+
+    with self.assertRaises(errors.LazyInitError):
+      Foo().lazy_init(random.PRNGKey(0), jax.ShapeDtypeStruct((8, 4), jnp.float32))
+
   def test_arg_module(self):
     rngkey = jax.random.PRNGKey(0)
     x = jnp.ones((10,))


### PR DESCRIPTION
Re-implement lazy init, Fixes #2428 

With this PR you can call ``module.lazy_init(rng, jax.ShapeDtypeStruct(input_shape, input_dtype)`` to init without computing the forward pass.