### PR TITLE
Introduce relaxed naming policy behind a feature flag.

### DIFF
--- a/flax/configurations.py
+++ b/flax/configurations.py
@@ -85,3 +85,8 @@ flax_use_orbax_checkpointing = define_bool_state(
     name='use_orbax_checkpointing',
     default=False,
     help=('Whether to use Orbax to save checkpoints.'))
+
+flax_relaxed_naming = define_bool_state(
+    name='relaxed_naming',
+    default=False,
+    help=('Whether to relax naming constraints.'))

--- a/flax/linen/module.py
+++ b/flax/linen/module.py
@@ -1016,9 +1016,14 @@ class Module:
     queue = []
     def adopt_attr_modules(cache, queue, suffix, subvalue):
       if isinstance(subvalue, Module):
+        adopted_name = None
         if subvalue.parent is None:
           # Module was passed from outside. It needs to be cloned.
-          # Outside modules are named by attachment, not an outer name.
+          # Outside modules are named by attachment, not an outer name,
+          # UNLESS we're using new relaxed naming, in which case an existing
+          # name will be used.
+          if config.flax_relaxed_naming:
+            adopted_name = object.__getattribute__(subvalue, 'name')
           object.__setattr__(subvalue, 'name', None)
           # Preserve sharing-by-reference relationships during adoption
           # via cache keyed on unique instance ids.
@@ -1031,7 +1036,9 @@ class Module:
             cache[key] = subvalue
         if subvalue.name is None:
           object.__setattr__(subvalue, 'parent', self)
-          object.__setattr__(subvalue, 'name', f'{name}{suffix}')
+          if adopted_name is None:
+            adopted_name = f'{name}{suffix}'
+          object.__setattr__(subvalue, 'name', adopted_name)
           queue.append(subvalue)
       return subvalue
     val = _freeze_attr(_map_over_modules_in_tree(
@@ -1074,7 +1081,13 @@ class Module:
   def _name_taken(self,
                   name: str,
                   module: Optional['Module'] = None,
-                  reuse_scopes: bool = False) -> bool:
+                  reuse_scopes: bool = False,
+                  collection: Optional[str] = None) -> bool:
+    # with relaxed naming don't force non-overlap with python attribute names.
+    if config.flax_relaxed_naming:
+      if reuse_scopes:
+        return False
+      return self.scope.name_reserved(name, collection)
     if name in _all_names_on_object(self):
       val = getattr(self, name, None)
       if module is not None and val is module:
@@ -1146,7 +1159,7 @@ class Module:
       raise ValueError(
           'Variables must be initialized in `setup()` or in a method '
           'wrapped in `@compact`')
-    if self._name_taken(name):
+    if self._name_taken(name, collection=col):
       raise errors.NameInUseError('variable', name, self.__class__.__name__)
     v = self.scope.variable(col, name, init_fn, *init_args, unbox=unbox)
     self._state.children[name] = col
@@ -1186,7 +1199,7 @@ class Module:
       raise ValueError(
           'Parameters must be initialized in `setup()` or in a method '
           'wrapped in `@compact`')
-    if self._name_taken(name):
+    if self._name_taken(name, collection='params'):
       raise errors.NameInUseError('param', name, self.__class__.__name__)
     v = self.scope.param(name, init_fn, *init_args, unbox=unbox)
     self._state.children[name] = 'params'

--- a/tests/linen/linen_transforms_test.py
+++ b/tests/linen/linen_transforms_test.py
@@ -24,6 +24,7 @@ import jax
 from jax import random
 import jax.numpy as jnp
 import numpy as np
+from flax import config
 from flax import errors
 from flax import linen as nn
 from flax.core import freeze
@@ -1289,9 +1290,13 @@ class TransformTest(absltest.TestCase):
     k = random.PRNGKey(0)
     x = jnp.array([1.])
 
-    msg = 'Duplicate use of scope name: "sub"'
-    with self.assertRaisesWithLiteralMatch(ValueError, msg):
-      y = Test().init(k, x)
+    if config.flax_relaxed_naming:
+      with self.assertRaises(errors.NameInUseError):
+        y = Test().init(k, x)
+    else:
+      msg = 'Duplicate use of scope name: "sub"'
+      with self.assertRaisesWithLiteralMatch(ValueError, msg):
+        y = Test().init(k, x)
 
   def test_transform_with_setup_and_methods_on_submodule_pytrees(self):
     class Foo(nn.Module):


### PR DESCRIPTION
Historically Flax had strong opinions about how variables and submodules could be named, in the spirit of maintaining a single coherent namespace amongst python attributes, variable, and submodule names.

It turns out we never really enforced that "single namespace" concept correctly, and furthermore, that the motivations for such a thing were very weak at best and any possible advantages left unrealized.

In practice, these name constraints are just really annoying to our users and mostly just get in the way, especially with advanced configuration systems.

This PR removes the pointless constraints:

 - "Adopted" modules brought in from the outside, as commonly occurs with configuration systems like fiddle, gin, etc. are now able to carry "scope names" which are not reset on adoption during module construction.
 - Variables in different collections in the same scope/module can have the same "scope name" in the variable nested dict.  Conflicts between submodule names and variable names are still enforced.
 - We no longer force non-interference of variable "scope names" with python attributes on the module.  We only enforce non-collision within the backing scope itself.

Since some of these changes could potentially change checkpoints in certain situations, this new behavior is released behind a flag `flax_relaxed_naming` for the time being.