### PR TITLE
added feature flag for FrozenDicts

### DIFF
--- a/flax/configurations.py
+++ b/flax/configurations.py
@@ -95,3 +95,8 @@ flax_preserve_adopted_names = define_bool_state(
     name='preserve_adopted_names',
     default=False,
     help=("When adopting outside modules, don't clobber existing names."))
+
+flax_return_frozendict = define_bool_state(
+    name='return_frozendict',
+    default=True,
+    help=('Whether to return FrozenDicts when calling init or apply.'))

--- a/flax/linen/module.py
+++ b/flax/linen/module.py
@@ -1370,7 +1370,7 @@ class Module:
             method: Union[Callable[..., Any], str, None] = None,
             mutable: CollectionFilter = False,
             capture_intermediates: Union[bool, Callable[['Module', str], bool]] = False,
-            **kwargs) -> Union[Any, Tuple[Any, FrozenVariableDict]]:
+            **kwargs) -> Union[Any, Tuple[Any, Union[FrozenVariableDict, Dict[str, Any]]]]:
     """Applies a module method to variables and returns output and modified variables.
 
     Note that `method` should be set if one would like to call `apply` on a
@@ -1452,7 +1452,7 @@ class Module:
                        method: Union[Callable[..., Any], str, None] = None,
                        mutable: CollectionFilter = DenyList('intermediates'),
                        capture_intermediates: Union[bool, Callable[['Module', str], bool]] = False,
-                       **kwargs) -> Tuple[Any, FrozenVariableDict]:
+                       **kwargs) -> Tuple[Any, Union[FrozenVariableDict, Dict[str, Any]]]:
     """Initializes a module method with variables and returns output and modified variables.
 
     Args:
@@ -1509,7 +1509,7 @@ class Module:
            method: Union[Callable[..., Any], str, None] = None,
            mutable: CollectionFilter = DenyList('intermediates'),
            capture_intermediates: Union[bool, Callable[['Module', str], bool]] = False,
-           **kwargs) -> FrozenVariableDict:
+           **kwargs) -> Union[FrozenVariableDict, Dict[str, Any]]:
     """Initializes a module method with variables and returns modified variables.
 
     ``init`` takes as first argument either a single ``PRNGKey``, or a dictionary mapping variable collections names to their ``PRNGKeys``, and will call ``method`` (which is the module's ``__call__`` function by default) passing ``*args`` and ``**kwargs``, and returns
@@ -2025,7 +2025,7 @@ def apply(fn: Callable[..., Any], module: Module,
 def init_with_output(fn: Callable[..., Any], module: Module,
                      mutable: CollectionFilter = DenyList('intermediates'),
                      capture_intermediates: Union[bool, Callable[[Module, str], bool]] = False,
-                     ) -> Callable[..., Tuple[Any, FrozenVariableDict]]:
+                     ) -> Callable[..., Tuple[Any, Union[FrozenVariableDict, Dict[str, Any]]]]:
   """Creates an init function to call ``fn`` with a bound module that also returns the function outputs.
 
   Unlike ``Module.init_with_output`` this function returns a new function with the signature
@@ -2086,7 +2086,7 @@ def init_with_output(fn: Callable[..., Any], module: Module,
 def init(fn: Callable[..., Any], module: Module,
          mutable: CollectionFilter = DenyList('intermediates'),
          capture_intermediates: Union[bool, Callable[[Module, str], bool]] = False,
-         ) -> Callable[..., FrozenVariableDict]:
+         ) -> Callable[..., Union[FrozenVariableDict, Dict[str, Any]]]:
   """Creates an init function to call ``fn`` with a bound module.
 
   Unlike ``Module.init`` this function returns a new function with the signature


### PR DESCRIPTION
Addresses #1223.

Adding a feature flag that will temporarily allow `.init` and `.apply` to return either FrozenDicts or regular dicts. Part of a migration plan that will eventually transition Flax to returning regular dicts only.