### PR TITLE
Refactor and separate out name relaxation policy changes.

### DIFF
--- a/flax/configurations.py
+++ b/flax/configurations.py
@@ -88,5 +88,10 @@ flax_use_orbax_checkpointing = define_bool_state(
 
 flax_relaxed_naming = define_bool_state(
     name='relaxed_naming',
-    default=False,
+    default=True,
     help=('Whether to relax naming constraints.'))
+
+flax_preserve_adopted_names = define_bool_state(
+    name='preserve_adopted_names',
+    default=False,
+    help=("When adopting outside modules, don't clobber existing names."))

--- a/pytest.ini
+++ b/pytest.ini
@@ -17,3 +17,5 @@ filterwarnings =
 # Deprecated numpy for Python 3.9
     ignore:`np.bool.*` is a deprecated alias:DeprecationWarning
     ignore:NumPy will stop allowing conversion of out-of-bound Python integers to integer arrays:DeprecationWarning
+# Deprecated sharding symbol
+    ignore:jax.experimental.maps.Mesh is deprecated. Use jax.sharding.Mesh.*:DeprecationWarning


### PR DESCRIPTION
A previous PR introduced "relaxed naming", but mixed up two very safe true relaxations of constraints with one potentially breaking change, delaying our ability to land these changes while fixing user code.

We separate the staging flag 'flax_relaxed_naming' into an additional 'flax_preserve_adopted_names' flag to control the potentially breaking change that preserves module names on adoption.

We enable by default the safe name conflict policy relaxations in this change.

Both changes are expected to be flipped on and the flags removed in the near future, but this refactor should make landing everything simpler.

