### PR TITLE
Added RMS normalization layer

### DIFF
--- a/flax/linen/__init__.py
+++ b/flax/linen/__init__.py
@@ -108,7 +108,8 @@ from .module import (
 from .normalization import (
   BatchNorm as BatchNorm,
   GroupNorm as GroupNorm,
-  LayerNorm as LayerNorm
+  LayerNorm as LayerNorm,
+  RMSNorm as RMSNorm
 )
 from .pooling import (
   avg_pool as avg_pool,

--- a/tests/linen/linen_test.py
+++ b/tests/linen/linen_test.py
@@ -192,6 +192,23 @@ class NormalizationTest(parameterized.TestCase):
                    jax.lax.rsqrt(x.var(axis=reduction_axes, keepdims=True) + e))
     np.testing.assert_allclose(y_one_liner, y, atol=1e-4)
 
+  @parameterized.parameters(
+      {'reduction_axes': -1},
+      {'reduction_axes': 1},
+      {'reduction_axes': (1, 2)})
+  def test_rms_norm(self, reduction_axes):
+    rng = random.PRNGKey(0)
+    key1, key2 = random.split(rng)
+    e = 1e-5
+    x = random.normal(key1, (2, 3, 4))
+    model_cls = nn.RMSNorm(use_scale=False, epsilon=e,
+                           reduction_axes=reduction_axes)
+    y, _ = model_cls.init_with_output(key2, x)
+    self.assertEqual(x.dtype, y.dtype)
+    self.assertEqual(x.shape, y.shape)
+    y_one_liner = (x * jax.lax.rsqrt(jnp.mean(jax.lax.square(x), axis=reduction_axes, keepdims=True) + e))
+    np.testing.assert_allclose(y_one_liner, y, atol=1e-4)
+
   def test_group_norm(self):
     rng = random.PRNGKey(0)
     key1, key2 = random.split(rng)


### PR DESCRIPTION
Resolves #2849.

Added an optional argument `use_mean` in the `_compute_stats` function in `flax/linen/normalization.py`, which will compute the mean and variance if set to `True`, and will set the mean to 0 and compute the variance without subtracting the mean if set to `False`. The latter mode is useful as square rooting this "variance" value (which is done in the `_normalize` function) will give you the RMS.