### PR TITLE
Properly setup input submodules

### DIFF
--- a/tests/linen/linen_module_test.py
+++ b/tests/linen/linen_module_test.py
@@ -21,10 +21,11 @@ import functools
 import gc
 import inspect
 import operator
-from typing import (Any, Callable, Generic, Mapping, NamedTuple, Sequence,
+from typing import (Any, Callable, Generic, List, Mapping, NamedTuple, Sequence,
                     Tuple, TypeVar, get_type_hints)
 
 from absl.testing import absltest
+import pytest
 from flax import config
 from flax import errors
 from flax import linen as nn
@@ -1992,6 +1993,222 @@ class ModuleTest(absltest.TestCase):
     with self.assertRaisesRegex(errors.DescriptorAttributeError,
                                 'Trying to access a property that'):
       foo.apply({})
+
+  def test_basic_setup_test(self):
+    class Foo(nn.Module):
+      def setup(self):
+        self.b = 10
+
+      def __call__(self, x):
+        return self.b + x
+
+    module = Foo()
+    variables = module.bind({})
+
+  @pytest.mark.skip(reason='Testing for an internal error')
+  def test_binding_in_setup(self):
+    test = self
+    class Baz(nn.Module):
+      @nn.compact
+      def __call__(self, x):
+        return nn.Dense(1)(x)
+
+    class Bar(nn.Module):
+      baz: Baz
+      def __call__(self, x):
+        return self.baz(x)
+
+    class Foo(nn.Module):
+      def setup(self):
+        self.bar = Bar(baz=Baz())
+
+        # test.assertIs(self.bar.parent, self)
+        # test.assertIs(self.bar.baz.parent, None)
+        # test.assertIs(self.__dict__['bar'].parent, self)
+        test.assertIs(self.__dict__['bar'].__dict__['baz'].parent, None)
+
+      def __call__(self, x):
+        return self.bar(x)
+
+    module = Foo()
+    variables = module.init(jax.random.PRNGKey(0), jnp.ones((1, 1)))
+
+  def test_nested_external_modules(self):
+    class Baz(nn.Module):
+      a: int
+
+      def setup(self):
+        self.b = self.param('b', lambda k: 2)
+
+      def __call__(self, x):
+        return x + self.a * self.b
+
+    class Bar(nn.Module):
+      baz: Baz
+
+      def __call__(self, x):
+        return self.baz(x)
+
+    class Foo(nn.Module):
+      def setup(self):
+        self.bar = Bar(baz=Baz(a=1))
+
+      def __call__(self, x):
+        return self.bar.baz(x)
+
+    module = Foo()
+    y, variables = module.init_with_output(jax.random.PRNGKey(0), 1)
+    self.assertEqual(y, 3)
+
+  def test_getattribute_triggers_setup(self):
+    class B(nn.Module):
+      def setup(self):
+        self.p1 = self.param('p1', lambda k: jnp.ones((2,)))
+      def fn1(self, x):
+        return self.p1 + x
+    class A(nn.Module):
+      b: nn.Module
+      def __call__(self, x):
+        return self.b.fn1(x)
+    a = A(b=B())
+    k = random.PRNGKey(0)
+    x = jnp.zeros((2,))
+    vs = nn.init(lambda a,x: a(x), a)(k, x)
+    y = nn.apply(lambda a,x: a.b.fn1(x), a)(vs, x)
+    np.testing.assert_array_equal(y, jnp.ones((2,)))
+
+  def test_nested_sequential_in_call(self):
+    class Foo(nn.Module):
+      def setup(self):
+        self.seq = nn.Sequential([nn.Dense(10) for i in range(10)])
+
+      def __call__(self, x):
+        # try calling only the first layer
+        return self.seq.layers[0](x)
+
+
+    module = Foo()
+    variables = module.init(jax.random.PRNGKey(0), jnp.ones((1, 10)))
+
+  def test_setup_called_bounded_submodules(self):
+    module = nn.Sequential([
+      nn.Sequential([
+        nn.Dense(2),
+        nn.relu,
+        nn.Dense(2),
+      ]),
+      nn.relu,
+      nn.Dense(2),
+    ])
+    x = jnp.ones((1, 3))
+    variables = module.init(jax.random.PRNGKey(0), x)
+    bound_module = module.bind(variables)
+
+    self.assertIsNotNone(bound_module.layers[0].layers[0].scope)
+    self.assertIsNotNone(bound_module.layers[0].layers[2].scope)
+    self.assertIsNotNone(bound_module.layers[2].scope)
+
+  def test_call_bounded_toplevel_mutable(self):
+    class Bar(nn.Module):
+      a: int
+
+      def setup(self):
+        self.b = self.param('b', lambda k: 1)
+
+      def __call__(self, x):
+        return x + self.a * self.b
+
+    class Foo(nn.Module):
+      bars: Sequence[Bar]
+
+      def __call__(self, x):
+        for bar in self.bars:
+          x = bar(x)
+        return x
+
+
+    module = Foo(bars=[])
+    module.bars = [Bar(a=1)]
+
+    variables = module.init(jax.random.PRNGKey(0), jnp.ones(()))
+    bound_module = module.bind(variables)
+
+    bar1 = bound_module.bars[0]
+    self.assertIsNotNone(bar1.scope)
+
+  # @pytest.mark.skip(reason="Leaving it here to tackle it later")
+  def test_nested_shared(self):
+    class Shared(nn.Module):
+      @nn.compact
+      def __call__(self, x):
+        return nn.Dense(1)(x)
+
+    class Unshared(nn.Module):
+      shared: nn.Module
+      def __call__(self, x):
+        return self.shared(x)
+
+    class Super(nn.Module):
+      a: nn.Module
+      b: nn.Module
+      def run_a(self, x):
+        return self.a(x)
+      def run_b(self, x):
+        return self.b(x)
+      def __call__(self, x):
+        return self.a(x) + self.b(x)
+
+
+    sh = Shared()
+    a = Unshared(shared=sh)
+    b = Unshared(shared=sh)
+    module = Super(a=a, b=b)
+
+    rng = jax.random.PRNGKey(0)
+    params = module.init(rng, jnp.ones(1))["params"]
+
+    module.apply({"params": params}, jnp.ones(1))  # works as expected
+    module.apply({"params": params}, jnp.ones(1), method="run_a")  # works as expected
+    module.apply({"params": params}, jnp.ones(1), method="run_b")  # ScopeParamNotFoundError: Could not find parameter named "kernel" in scope "/b/shared/Dense_0"
+
+  def test_nested_init(self):
+    class Baz(nn.Module):
+      a: int
+
+      def setup(self):
+        self.b = self.param('b', lambda k: jnp.ones(()))
+
+      def __call__(self, x):
+        return x + self.a * self.b
+
+    class Bar(nn.Module):
+      baz: Baz
+
+      def setup(self):
+        a = 1
+
+      def __call__(self, x):
+        return self.baz(x)
+
+    class Foo(nn.Module):
+
+      def setup(self):
+        self.bar: Bar = Bar(baz=Baz(a=1))
+
+      def __call__(self, x):
+        # y = self.bar(x)
+        y, bar_vars = self.bar.init_with_output(jax.random.PRNGKey(0), x)
+        return y, bar_vars
+
+    # create foo
+    module = Foo()
+
+    # run foo
+    (y, bar_vars), variables = module.init_with_output(
+      jax.random.PRNGKey(0), jnp.ones(()))
+
+    self.assertIn('params', bar_vars)
+
 
   def test_repr(self):
 


### PR DESCRIPTION
# What does this PR do?

Solves a couple of issues regarding the process of binding submodules from dataclass fields.

## Current situation: when does X happen?
* **module gets a scope**: when you use `init`/`bind`/`apply` on a Module `.clone(parent=scope)` is ran, during `__post_init__` (which happens at the end of `clone`) there is a simple line that directly sets 
```python
self.scope = self.parent
```
* **submodules are bounded**: this is a two step process:
  1. A process to bind a submodule of a bounded module must trigger, there are several of these:
     *  When a submodule set to a non-dataclass field (`__setattr__`) of a bounded module, this mostly happens during `setup`:
         ```python
         def setup(self): # self is bounded
           self.dense = nn.Dense(10) # triggers __setattr__
         ```
     *  `_try_setup` is called, this happens either before a method is called (`_call_wrapped_method`) or when a non-dataclass field is accessed (`__getattr__`).  
  2. The previous processes internally call `_register_submodules` on one or more submodules, `__setattr__` calls it on the Module being set while `_try_setup` looks through all dataclass fields in addition to calling `setup` (which possibly triggers the previous case). `_register_submodules` clones the Modules being registered (while preserving sharing), then sets the registering Module as the `parent` of the Module being registered, and finally calls `__post_init__` on the registered submodule which internally runs `scope.push` to create a scope for the registered child:
    ```python
    self.scope = self.parent.scope.push(self.name, reuse=reuse_scopes)
    ```

## Case 1: Situation with externally defined submodules
The situation above relies a lot in lazy behavior i.e. `_try_setup` is only called when a method is called or someone tries a yet undefined field that is lazily defined inside `setup`, because its initially undefined `__getattr__` is triggered which calls `_try_setup`. There is a hole with this setup mechanism: _submodules passed from the outside via dataclass fields **do exist** at all time_. This means `__getatrr__` is never triggered and nested submodules are possibly unbounded, here is a edge case that one would expect to work but doesn't in the current code base:

```python

import jax
import jax.numpy as jnp
import flax.linen as nn

class Foo(nn.Module):
  def setup(self):
    self.seq = nn.Sequential([nn.Dense(10) for i in range(10)])

  def __call__(self, x):
    # try calling only the first layer
    return self.seq.layers[0](x) # Error: Can't call compact methods on unbound modules
  

module = Foo()
variables = module.init(jax.random.PRNGKey(0), jnp.ones((1, 10)))
``` 
An identical situation would happen if you where to try to use `bind` instead:
```python
module = nn.Sequential([nn.Dense(10) for i in range(10)])
x = jnp.ones((1, 10))
variables = module.init(jax.random.PRNGKey(0), x)
bounded_module = module.bind(variables)

# try calling only the first layer
module.layers[0](x) # Error: Can't call compact methods on unbound modules
```
### Solution
The main problem with the scenarios described above is that `__getattr__` only gets triggered if the requested attribute is not currently found on the object, therefore, when you access `.layers` in the examples above `__getattr__` is not triggered because `layers` is present at construction time. So solve this, this PR proposes the implementation of the `__getattribute__` method. 

`__getattribute__` is triggered when you access any attribute from the object, so we can use it to detect when dataclass attributes are being requested to solve the above problem. However, we have to be careful because `__getattribute__` actually gets triggered A LOT (e.g. method, fields, class properties, etc), to minimize python overhead we create a `_submodule_dataclass_fields` during `__post_init__` that contains the names of the fields that contain submodules within them and triggered `_try_setup` if only these are are being accessed.

### Additional Fix: Deep cloning
When testing this change it was revealed that some internal code was now breaking because of this change, possibly because we where now binding more submodules that before and the existing code relied heavily on lazy binding. The culprit ended up being that we getting some scopes leaked into `init`/`apply`. The solution was to add a private `_deep_clone: bool = False` flag to the `clone` method that would clone all child submodules as well to get rid of any external scopes, this flag is only activated by `init`, `apply`, and `bind`. 

## Case 2: Naming race conditions with externally defined submodules
Laziness makes is very difficult to reason about certain situations and interestingly can trigger naming race conditions on some cases, here is an edge case where a shared Module can get assigned under different paths depending on which branch runs first:

```python
class Shared(nn.Module):
  @nn.compact
  def __call__(self, x):
    return nn.Dense(1)(x)

class Unshared(nn.Module):
  shared: nn.Module
  def __call__(self, x):
    return self.shared(x)

class Super(nn.Module):
  a: nn.Module
  b: nn.Module

  def run_a(self, x):
    return self.a(x)

  def run_b(self, x):
    return self.b(x)'

  def __call__(self, x):
    return self.a(x) + self.b(x) # 'a' runs first, variables are initialized with an 'a' path

sh = Shared()
module = Super(a=Unshared(shared=sh), b=Unshared(shared=sh))

rng = jax.random.PRNGKey(0)
params = module.init(rng, jnp.ones(1))["params"]

module.apply({"params": params}, jnp.ones(1))  # works as expected
module.apply({"params": params}, jnp.ones(1), method="run_a")  # works because 'a' is present
# this case fails because self.b runs first but variables only contain 'a'
module.apply({"params": params}, jnp.ones(1), method="run_b")  # ScopeParamNotFoundError: Could not find 
```
So the problem is that even though all of `Super`'s submodules are defined on construction, when a `Super` instance gets a scope during `init`/`apply` its submodules don't immediately get one, its up to runtime behavior to see which submodules get a scope and when.

### Solution
The main idea to solve this is to recursively call `_register_submodules` as soon on all child Modules from dataclass fields as soon a parent Module gets a scope, this avoids any race condition since binding would always occur in the same order. Currently this is only being done inside at the end of `clone` when `_deep_clone is True`, this works for the reported case, but one might wonder this could be called more often e.g. at the end of `__post_init__` if `self.scope is not None`. 

On detail during the implementation is that to call `_register_submodule` without it complaining about being called outside of `setup` we had to trick it by temporarily setting `_state.in_setup = True`:

```python
try:
  self._state.in_setup = True
  self._register_submodules(field_name, value)
finally:
  self._state.in_setup = current_in_setup
```
We can consider adding a new state that `_register_submodules` recognizes to avoid abusing the mechanism. 
