### PR TITLE
Add 'all' install group

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,7 +72,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install standalone dependencies only
       run: |
-        pip install -e .
+        pip install -e .[all]
     - name: Test importing Flax
       run: |
         python -c "import flax"
@@ -112,13 +112,13 @@ jobs:
       run: |
         if [ -d "venv" ]; then rm -rf venv; fi
         python3 -m venv venv
-        venv/bin/python3 -m pip install .
+        venv/bin/python3 -m pip install .[all]
         venv/bin/python3 -m pip install .[testing]
         venv/bin/python3 -m pip install tensorflow_datasets[dev]
         venv/bin/python3 -m pip install -r docs/requirements.txt
     - name: Install Flax
       run: |
-        venv/bin/python3 -m pip install -e .
+        venv/bin/python3 -m pip install -e .[all]
     - name: Cached mypy cache
       id: mypy_cache
       uses: actions/cache@v3

--- a/README.md
+++ b/README.md
@@ -84,6 +84,12 @@ To upgrade to the latest version of Flax, you can use:
 ```
 pip install --upgrade git+https://github.com/google/flax.git
 ```
+To install some additional dependencies (like `matplotlib`) that are required but not included
+by some dependencies, you can use:
+
+```bash
+pip install flax[all]
+```
 
 ## What does Flax look like?
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -58,8 +58,8 @@ To contribute code to Flax on GitHub, follow these steps:
    ```bash
    git clone https://github.com/YOUR_USERNAME/flax
    cd flax
-   pip install ".[testing]"
-   pip install -e .
+   pip install -e .[all]
+   pip install -e .[testing]
    pip install -r docs/requirements.txt
    ```
 

--- a/setup.py
+++ b/setup.py
@@ -25,38 +25,40 @@ except OSError:
   README = ""
 
 install_requires = [
-    "numpy>=1.12",
-    "jax>=0.4.2",
-    "matplotlib",  # only needed for tensorboard export
-    "msgpack",
-    "optax",
-    "orbax",
-    "tensorstore",
-    "rich>=11.1",
-    "typing_extensions>=4.1.1",
-    "PyYAML>=5.4.1",
+  "numpy>=1.12",
+  "jax>=0.4.2",
+  "msgpack",
+  "optax",
+  "orbax",
+  "tensorstore",
+  "rich>=11.1",
+  "typing_extensions>=4.1.1",
+  "PyYAML>=5.4.1",
+]
+all_requires = [
+  "matplotlib",  # only needed for tensorboard export
 ]
 
 tests_require = [
-    "atari-py==0.2.5",  # Last version does not have the ROMs we test on pre-packaged
-    "clu",  # All examples.
-    "gym==0.18.3",
-    "jaxlib",
-    "jraph>=0.0.6dev0",
-    "ml-collections",
-    "mypy",
-    "opencv-python",
-    "pytest",
-    "pytest-cov",
-    "pytest-custom_exit_code",
-    "pytest-xdist==1.34.0",  # upgrading to 2.0 broke tests, need to investigate
-    "pytype",
-    "sentencepiece",  # WMT/LM1B examples
-    "tensorflow_text>=2.11.0",  # WMT/LM1B examples
-    "tensorflow_datasets",
-    "tensorflow",
-    "torch",
-    "nbstripout",
+  "atari-py==0.2.5",  # Last version does not have the ROMs we test on pre-packaged
+  "clu",  # All examples.
+  "gym==0.18.3",
+  "jaxlib",
+  "jraph>=0.0.6dev0",
+  "ml-collections",
+  "mypy",
+  "opencv-python",
+  "pytest",
+  "pytest-cov",
+  "pytest-custom_exit_code",
+  "pytest-xdist==1.34.0",  # upgrading to 2.0 broke tests, need to investigate
+  "pytype",
+  "sentencepiece",  # WMT/LM1B examples
+  "tensorflow_text>=2.11.0",  # WMT/LM1B examples
+  "tensorflow_datasets",
+  "tensorflow",
+  "torch",
+  "nbstripout",
 ]
 
 __version__ = None
@@ -65,28 +67,29 @@ with open("flax/version.py") as f:
   exec(f.read(), globals())
 
 setup(
-    name="flax",
-    version=__version__,
-    description="Flax: A neural network library for JAX designed for flexibility",
-    long_description="\n\n".join([README]),
-    long_description_content_type="text/markdown",
-    classifiers=[
-        "Development Status :: 3 - Alpha",
-        "Intended Audience :: Developers",
-        "Intended Audience :: Science/Research",
-        "License :: OSI Approved :: Apache Software License",
-        "Programming Language :: Python :: 3.7",
-        "Topic :: Scientific/Engineering :: Artificial Intelligence",
-        ],
-    keywords="",
-    author="Flax team",
-    author_email="flax-dev@google.com",
-    url="https://github.com/google/flax",
-    packages=find_packages(),
-    package_data={"flax": ["py.typed"]},
-    zip_safe=False,
-    install_requires=install_requires,
-    extras_require={
-        "testing": tests_require,
-        },
-    )
+  name="flax",
+  version=__version__,
+  description="Flax: A neural network library for JAX designed for flexibility",
+  long_description="\n\n".join([README]),
+  long_description_content_type="text/markdown",
+  classifiers=[
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Intended Audience :: Science/Research",
+    "License :: OSI Approved :: Apache Software License",
+    "Programming Language :: Python :: 3.7",
+    "Topic :: Scientific/Engineering :: Artificial Intelligence",
+  ],
+  keywords="",
+  author="Flax team",
+  author_email="flax-dev@google.com",
+  url="https://github.com/google/flax",
+  packages=find_packages(),
+  package_data={"flax": ["py.typed"]},
+  zip_safe=False,
+  install_requires=install_requires,
+  extras_require={
+    "testing": tests_require,
+    "all": all_requires,
+  },
+)


### PR DESCRIPTION
# What does this PR do?

Fixes #2883. Move `matplotlib` to a new `all` requirements group.  If you want to have the additonal `matplotlib` optional requirement (we can possibly add more in the future) you can now use:

```bash
pip install flax[all]
```