### PR TITLE
Added dict utility functions

### DIFF
--- a/flax/core/__init__.py
+++ b/flax/core/__init__.py
@@ -16,7 +16,9 @@ from .axes_scan import broadcast as broadcast
 from .frozen_dict import (
   FrozenDict as FrozenDict,
   freeze as freeze,
-  unfreeze as unfreeze
+  unfreeze as unfreeze,
+  copy as copy,
+  pop as pop
 )
 
 from .tracers import (

--- a/flax/core/frozen_dict.py
+++ b/flax/core/frozen_dict.py
@@ -215,6 +215,46 @@ def unfreeze(x: FrozenDict[Any, Any]) -> Dict[Any, Any]:
     return x
 
 
+def copy(x: Dict[str, Any], add_or_replace: Dict[str, Any]) -> Dict[str, Any]:
+  """Create a new dict with additional and/or replaced entries. This is a utility
+  function for regular dicts that mimics the behavior of `FrozenDict.copy`.
+
+  Example::
+
+  new_variables = copy(variables, {'additional_entries': 1})
+
+  Args:
+    x: the dictionary to be copied and updated
+    add_or_replace: dictionary of key-value pairs to add or replace in the dict x
+  Returns:
+    A new dict with the additional and/or replaced entries.
+  """
+
+  new_dict = jax.tree_map(lambda x: x, x) # make a deep copy of dict x
+  new_dict.update(add_or_replace)
+  return new_dict
+
+
+def pop(x: Dict[str, Any], key: str) -> Tuple[Dict[str, Any], Any]:
+  """Create a new dict where one entry is removed. This is a utility
+  function for regular dicts that mimics the behavior of `FrozenDict.pop`.
+
+  Example::
+
+    state, params = pop(variables, 'params')
+
+  Args:
+    x: the dictionary to remove the entry from
+    key: the key to remove from the dict
+  Returns:
+    A pair with the new dict and the removed value.
+  """
+
+  new_dict = jax.tree_map(lambda x: x, x) # make a deep copy of dict x
+  value = new_dict.pop(key)
+  return new_dict, value
+
+
 def _frozen_dict_state_dict(xs):
   return {key: serialization.to_state_dict(value) for key, value in xs.items()}
 

--- a/tests/core/core_frozen_dict_test.py
+++ b/tests/core/core_frozen_dict_test.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from flax.core import FrozenDict, unfreeze, freeze
+from flax.core import FrozenDict, unfreeze, freeze, copy, pop
 
 import jax
 
@@ -83,6 +83,17 @@ class FrozenDictTest(absltest.TestCase):
   def test_frozen_dict_copy_reserved_name(self):
     result = FrozenDict({'a': 1}).copy({'cls': 2})
     self.assertEqual(result, {'a': 1, 'cls': 2})
+
+  def test_utility_pop(self):
+    x = {'a': 1, 'b': {'c': 2}}
+    new_x, value = pop(x, 'b')
+    self.assertEqual(new_x, {'a': 1})
+    self.assertEqual(value, {'c': 2})
+
+  def test_utility_copy(self):
+    x = {'a': 1, 'b': {'c': 2}}
+    new_x = copy(x, add_or_replace={'b': {'c': -1, 'd': 3}})
+    self.assertEqual(new_x, {'a': 1, 'b': {'c': -1, 'd': 3}})
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Added utility functions for regular dicts that mimic the behavior of [`FrozenDict` methods](https://flax.readthedocs.io/en/latest/api_reference/flax.core.frozen_dict.html).

Part of migrating FrozenDicts to regular dicts (original issue described in #1223).