### PR TITLE
migrate tests to regular dicts

### DIFF
--- a/flax/linen/summary.py
+++ b/flax/linen/summary.py
@@ -310,7 +310,7 @@ def _get_path_variables(path: Tuple[str, ...], variables: FrozenVariableDict) ->
   path_variables = {}
 
   for collection in variables:
-    collection_variables = variables[collection]
+    collection_variables = jax.tree_util.tree_map(lambda x: x, variables[collection]) # make a deep copy
     for name in path:
       if name not in collection_variables:
         collection_variables = None
@@ -318,7 +318,7 @@ def _get_path_variables(path: Tuple[str, ...], variables: FrozenVariableDict) ->
       collection_variables = collection_variables[name]
 
     if collection_variables is not None:
-      path_variables[collection] = collection_variables.unfreeze()
+      path_variables[collection] = collection_variables
 
   return path_variables
 

--- a/tests/core/core_meta_test.py
+++ b/tests/core/core_meta_test.py
@@ -110,7 +110,7 @@ class MetaTest(absltest.TestCase):
       return c
 
     _, variables = init(f)(random.PRNGKey(0), jnp.zeros((8, 3)))
-    boxed_shapes = jax.tree_map(jnp.shape, variables['params'].unfreeze())
+    boxed_shapes = jax.tree_map(jnp.shape, variables['params'])
     self.assertEqual(boxed_shapes, {
         'kernel': meta.Partitioned((8, 3, 3), ('layers', 'in', 'out')),
         'bias': (8, 3),

--- a/tests/linen/linen_attention_test.py
+++ b/tests/linen/linen_attention_test.py
@@ -19,6 +19,8 @@ from absl.testing import parameterized
 
 from flax import linen as nn
 from flax import jax_utils
+from flax.core import pop
+from flax.configurations import use_regular_dict
 
 import jax
 from jax import lax
@@ -30,7 +32,6 @@ import numpy as np
 
 # Parse absl flags test_srcdir and test_tmpdir.
 jax.config.parse_flags_with_absl()
-
 
 class AttentionTest(parameterized.TestCase):
 
@@ -102,6 +103,7 @@ class AttentionTest(parameterized.TestCase):
     np.testing.assert_allclose(mask_1d, mask_1d_simple,)
 
   @parameterized.parameters([((5,), (1,)), ((6, 5), (2,))])
+  @use_regular_dict()
   def test_decoding(self, spatial_shape, attn_dims):
     bs = 2
     num_heads = 3
@@ -119,7 +121,7 @@ class AttentionTest(parameterized.TestCase):
     decode_module = module.clone(decode=True)
 
     initial_vars = decode_module.init(key2, inputs)
-    state, params = initial_vars.pop('params')
+    state, params = pop(initial_vars, 'params')
     causal_mask = nn.attention.make_causal_mask(jnp.ones((bs,) + spatial_shape))
     y_ref = jax.jit(lambda x, y: module.apply(initial_vars, x, y))(
         inputs, causal_mask)

--- a/tests/linen/linen_meta_test.py
+++ b/tests/linen/linen_meta_test.py
@@ -144,7 +144,7 @@ class LinenMetaTest(absltest.TestCase):
     x = jnp.ones((8, 128))
     spec = nn.get_partition_spec(
         jax.eval_shape(model.init, random.PRNGKey(0), x))
-    self.assertEqual(spec.unfreeze(), {
+    self.assertEqual(spec, {
         'params': {
             'MLP_0': {
                 'Dense_0': {

--- a/tests/linen/linen_module_test.py
+++ b/tests/linen/linen_module_test.py
@@ -31,6 +31,7 @@ from flax import linen as nn
 from flax import struct
 from flax.core import Scope, freeze, FrozenDict, tracers
 from flax.linen import compact
+from flax.configurations import use_regular_dict
 import jax
 from jax import random
 from jax.nn import initializers
@@ -40,7 +41,6 @@ from unittest.mock import patch
 
 # Parse absl flags test_srcdir and test_tmpdir.
 jax.config.parse_flags_with_absl()
-
 
 def tree_equals(x, y):
   return jax.tree_util.tree_all(jax.tree_util.tree_map(operator.eq, x, y))
@@ -1140,6 +1140,7 @@ class ModuleTest(absltest.TestCase):
     A().test()
     self.assertFalse(setup_called)
 
+  @use_regular_dict()
   def test_module_pass_as_attr(self):
 
     class A(nn.Module):
@@ -1158,7 +1159,7 @@ class ModuleTest(absltest.TestCase):
 
     variables = A().init(random.PRNGKey(0), jnp.ones((1,)))
     var_shapes = jax.tree_util.tree_map(jnp.shape, variables)
-    ref_var_shapes = freeze({
+    ref_var_shapes = {
         'params': {
             'b': {
                 'foo': {
@@ -1167,9 +1168,10 @@ class ModuleTest(absltest.TestCase):
                 }
             },
         },
-    })
+    }
     self.assertTrue(tree_equals(var_shapes, ref_var_shapes))
 
+  @use_regular_dict()
   def test_module_pass_in_closure(self):
     a = nn.Dense(2)
 
@@ -1183,17 +1185,18 @@ class ModuleTest(absltest.TestCase):
 
     variables = B().init(random.PRNGKey(0), jnp.ones((1,)))
     var_shapes = jax.tree_util.tree_map(jnp.shape, variables)
-    ref_var_shapes = freeze({
+    ref_var_shapes = {
         'params': {
             'foo': {
                 'bias': (2,),
                 'kernel': (1, 2),
             }
         },
-    })
+    }
     self.assertTrue(tree_equals(var_shapes, ref_var_shapes))
     self.assertIsNone(a.name)
 
+  @use_regular_dict()
   def test_toplevel_submodule_adoption(self):
 
     class Encoder(nn.Module):
@@ -1233,7 +1236,7 @@ class ModuleTest(absltest.TestCase):
     self.assertEqual(y.shape, (4, 5))
 
     var_shapes = jax.tree_util.tree_map(jnp.shape, variables)
-    ref_var_shapes = freeze({
+    ref_var_shapes = {
         'params': {
             'dense_out': {
                 'bias': (5,),
@@ -1246,9 +1249,10 @@ class ModuleTest(absltest.TestCase):
                 },
             },
         },
-    })
+    }
     self.assertTrue(tree_equals(var_shapes, ref_var_shapes))
 
+  @use_regular_dict()
   def test_toplevel_submodule_adoption_pytree(self):
 
     class A(nn.Module):
@@ -1276,7 +1280,7 @@ class ModuleTest(absltest.TestCase):
 
     params = B(a_pytree).init(key, x, x)
     unused_y, counters = b.apply(params, x, x, mutable='counter')
-    ref_counters = freeze({
+    ref_counters = {
         'counter': {
             'A_bar': {
                 'i': jnp.array(2.0),
@@ -1285,13 +1289,14 @@ class ModuleTest(absltest.TestCase):
                 'i': jnp.array(2.0),
             },
         },
-    })
+    }
     self.assertTrue(
         jax.tree_util.tree_all(
             jax.tree_util.tree_map(
                 lambda x, y: np.testing.assert_allclose(x, y, atol=1e-7),
                 counters, ref_counters)))
 
+  @use_regular_dict()
   def test_toplevel_submodule_adoption_sharing(self):
     dense = functools.partial(nn.Dense, use_bias=False)
 
@@ -1323,7 +1328,7 @@ class ModuleTest(absltest.TestCase):
     c = C(a, b)
     p = c.init(key, x)
     var_shapes = jax.tree_util.tree_map(jnp.shape, p)
-    ref_var_shapes = freeze({
+    ref_var_shapes = {
         'params': {
             'Dense_0': {
                 'kernel': (2, 2),
@@ -1339,9 +1344,10 @@ class ModuleTest(absltest.TestCase):
                 },
             },
         },
-    })
+    }
     self.assertTrue(tree_equals(var_shapes, ref_var_shapes))
 
+  @use_regular_dict()
   def test_toplevel_named_submodule_adoption(self):
     dense = functools.partial(nn.Dense, use_bias=False)
 
@@ -1369,7 +1375,7 @@ class ModuleTest(absltest.TestCase):
     init_vars = b.init(k, x)
     var_shapes = jax.tree_util.tree_map(jnp.shape, init_vars)
     if config.flax_preserve_adopted_names:
-      ref_var_shapes = freeze({
+      ref_var_shapes = {
           'params': {
               'foo': {
                   'dense': {
@@ -1380,9 +1386,9 @@ class ModuleTest(absltest.TestCase):
                   'kernel': (4, 6),
               },
           },
-      })
+      }
     else:
-      ref_var_shapes = freeze({
+      ref_var_shapes = {
           'params': {
               'a': {
                   'dense': {
@@ -1393,9 +1399,10 @@ class ModuleTest(absltest.TestCase):
                   'kernel': (4, 6),
               },
           },
-      })
+      }
     self.assertTrue(tree_equals(var_shapes, ref_var_shapes))
 
+  @use_regular_dict()
   def test_toplevel_submodule_pytree_adoption_sharing(self):
 
     class A(nn.Module):
@@ -1423,13 +1430,13 @@ class ModuleTest(absltest.TestCase):
 
     params = b.init(key, x)
     _, counters = b.apply(params, x, mutable='counter')
-    ref_counters = freeze({
+    ref_counters = {
         'counter': {
             'A_bar': {
                 'i': jnp.array(6.0),
             },
         },
-    })
+    }
     self.assertTrue(tree_equals(counters, ref_counters))
 
   def test_inner_class_def(self):
@@ -1650,7 +1657,6 @@ class ModuleTest(absltest.TestCase):
 
     x = jnp.ones((3,))
     variables = Foo().init(random.PRNGKey(0), x)
-    variables = variables.unfreeze()
     y = Foo().apply(variables, x)
     self.assertEqual(y.shape, (2,))
 

--- a/tests/linen/summary_test.py
+++ b/tests/linen/summary_test.py
@@ -24,6 +24,7 @@ from flax import linen as nn
 from flax.core.scope import Array
 from flax.linen import summary
 from flax import struct
+from flax.configurations import use_regular_dict
 
 # Parse absl flags test_srcdir and test_tmpdir.
 jax.config.parse_flags_with_absl()
@@ -180,6 +181,7 @@ class SummaryTest(absltest.TestCase):
         row.counted_variables,
       )
 
+  @use_regular_dict()
   def test_module_summary_with_depth(self):
     """
     This test creates a Table using `module_summary` set the `depth` argument to `1`,
@@ -238,6 +240,7 @@ class SummaryTest(absltest.TestCase):
     self.assertEqual(table[3].module_variables, table[3].counted_variables)
 
 
+  @use_regular_dict()
   def test_tabulate(self):
     """
     This test creates a string representation of a Module using `Module.tabulate`
@@ -320,6 +323,7 @@ class SummaryTest(absltest.TestCase):
     self.assertIn("(block_method)", module_repr)
     self.assertIn("(cnn_method)", module_repr)
 
+  @use_regular_dict()
   def test_tabulate_function(self):
     """
     This test creates a string representation of a Module using `Module.tabulate`
@@ -366,6 +370,7 @@ class SummaryTest(absltest.TestCase):
     self.assertIn("79.4 KB", lines[-3])
 
 
+  @use_regular_dict()
   def test_lifted_transform(self):
     class LSTM(nn.Module):
       batch_size: int
@@ -402,6 +407,7 @@ class SummaryTest(absltest.TestCase):
     self.assertIn("ScanLSTM/ii", lines[13])
     self.assertIn("Dense", lines[13])
 
+  @use_regular_dict()
   def test_lifted_transform_no_rename(self):
     class LSTM(nn.Module):
       batch_size: int
@@ -438,6 +444,7 @@ class SummaryTest(absltest.TestCase):
     self.assertIn("ScanLSTMCell_0/ii", lines[13])
     self.assertIn("Dense", lines[13])
 
+  @use_regular_dict()
   def test_module_reuse(self):
     class ConvBlock(nn.Module):
       @nn.compact
@@ -519,6 +526,7 @@ class SummaryTest(absltest.TestCase):
     self.assertIn('x: 3.141592', lines[7])
     self.assertIn('4.141592', lines[7])
 
+  @use_regular_dict()
   def test_partitioned_params(self):
 
     class Classifier(nn.Module):


### PR DESCRIPTION
Switching to regular dicts for tests, as part of the FrozenDict to regular dict migration (#1223).