### PR TITLE
Consistent loss logging in flax basics guide

### DIFF
--- a/docs/guides/flax_basics.ipynb
+++ b/docs/guides/flax_basics.ipynb
@@ -369,7 +369,7 @@
     "  loss_val, grads = loss_grad_fn(params, x_samples, y_samples)\n",
     "  params = update_params(params, learning_rate, grads)\n",
     "  if i % 10 == 0:\n",
-    "    print(f'Loss step {i}: ', loss_val)"
+    "    print(f'Loss step {i}: {loss_val}')"
    ]
   },
   {
@@ -449,7 +449,7 @@
     "  updates, opt_state = tx.update(grads, opt_state)\n",
     "  params = optax.apply_updates(params, updates)\n",
     "  if i % 10 == 0:\n",
-    "    print('Loss step {}: '.format(i), loss_val)"
+    "    print(f'Loss step {i}: {loss_val}')"
    ]
   },
   {
@@ -1065,6 +1065,20 @@
  "metadata": {
   "jupytext": {
    "formats": "ipynb,md:myst"
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10.6"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "916dbcbb3f70747c44a77c7bcd40155683ae19c65e1c03b4aa3499c5328201f1"
+   }
   }
  },
  "nbformat": 4,

--- a/docs/guides/flax_basics.md
+++ b/docs/guides/flax_basics.md
@@ -198,7 +198,7 @@ for i in range(101):
   loss_val, grads = loss_grad_fn(params, x_samples, y_samples)
   params = update_params(params, learning_rate, grads)
   if i % 10 == 0:
-    print(f'Loss step {i}: ', loss_val)
+    print(f'Loss step {i}: {loss_val}')
 ```
 
 +++ {"id": "zqEnJ9Poyb6q"}
@@ -245,7 +245,7 @@ for i in range(101):
   updates, opt_state = tx.update(grads, opt_state)
   params = optax.apply_updates(params, updates)
   if i % 10 == 0:
-    print('Loss step {}: '.format(i), loss_val)
+    print(f'Loss step {i}: {loss_val}')
 ```
 
 +++ {"id": "0eAPPwtpXYu7"}


### PR DESCRIPTION
# What does this PR do?
More consistent code for printing losses in the flax basics guide.
Currently, it was a mix of using f-strings, and `.format()`. Pretty minor, but I thought it would be better to have a consistent way to log the losses.

Cheers!


Fixes # (issue)

## Checklist
- [x] This PR fixes a minor issue (e.g.: typo or small bug) or improves the docs (you can dismiss the other
      checks if that's the case).
- [ ] This change is discussed in a Github issue/
      [discussion](https://github.com/google/flax/discussions) (please add a
      link).
- [ ] The documentation and docstrings adhere to the
      [documentation guidelines](https://github.com/google/flax/blob/main/docs/README.md#how-to-write-code-documentation).
- [ ] This change includes necessary high-coverage tests.
      (No quality testing = no merge!)
