### PR TITLE
make utility functions work on FrozenDicts and regular dicts

### DIFF
--- a/tests/core/core_frozen_dict_test.py
+++ b/tests/core/core_frozen_dict_test.py
@@ -17,10 +17,10 @@ from flax.core import FrozenDict, unfreeze, freeze, copy, pop
 import jax
 
 
-from absl.testing import absltest
+from absl.testing import absltest, parameterized
 
 
-class FrozenDictTest(absltest.TestCase):
+class FrozenDictTest(parameterized.TestCase):
 
   def test_frozen_dict_copies(self):
     xs = {'a': 1, 'b': {'c': 2}}
@@ -84,16 +84,38 @@ class FrozenDictTest(absltest.TestCase):
     result = FrozenDict({'a': 1}).copy({'cls': 2})
     self.assertEqual(result, {'a': 1, 'cls': 2})
 
-  def test_utility_pop(self):
-    x = {'a': 1, 'b': {'c': 2}}
-    new_x, value = pop(x, 'b')
-    self.assertEqual(new_x, {'a': 1})
-    self.assertEqual(value, {'c': 2})
+  @parameterized.parameters(
+    {
+      'x': {'a': 1, 'b': {'c': 2}},
+      'key': 'b',
+      'actual_new_x': {'a': 1},
+      'actual_value': {'c': 2}
+    }, {
+      'x': FrozenDict({'a': 1, 'b': {'c': 2}}),
+      'key': 'b',
+      'actual_new_x': FrozenDict({'a': 1}),
+      'actual_value': FrozenDict({'c': 2})
+    },
+  )
+  def test_utility_pop(self, x, key, actual_new_x, actual_value):
+    new_x, value = pop(x, key)
+    self.assertTrue(new_x == actual_new_x and isinstance(new_x, type(actual_new_x)))
+    self.assertTrue(value == actual_value and isinstance(value, type(actual_value)))
 
-  def test_utility_copy(self):
-    x = {'a': 1, 'b': {'c': 2}}
-    new_x = copy(x, add_or_replace={'b': {'c': -1, 'd': 3}})
-    self.assertEqual(new_x, {'a': 1, 'b': {'c': -1, 'd': 3}})
+  @parameterized.parameters(
+    {
+      'x': {'a': 1, 'b': {'c': 2}},
+      'add_or_replace': {'b': {'c': -1, 'd': 3}},
+      'actual_new_x': {'a': 1, 'b': {'c': -1, 'd': 3}},
+    }, {
+      'x': FrozenDict({'a': 1, 'b': {'c': 2}}),
+      'add_or_replace': FrozenDict({'b': {'c': -1, 'd': 3}}),
+      'actual_new_x': FrozenDict({'a': 1, 'b': {'c': -1, 'd': 3}}),
+    },
+  )
+  def test_utility_copy(self, x, add_or_replace, actual_new_x):
+    new_x = copy(x, add_or_replace=add_or_replace)
+    self.assertTrue(new_x == actual_new_x and isinstance(new_x, type(actual_new_x)))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Follow-up from #2897.

These utility functions will be useful for allowing tests to accommodate both FrozenDicts and regular dicts.