### PR TITLE
Improve Flax dark mode - remove hard-coded text color

### DIFF
--- a/docs/getting_started.ipynb
+++ b/docs/getting_started.ipynb
@@ -10,7 +10,7 @@
     "[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/google/flax/blob/main/docs/getting_started.ipynb)\n",
     "[![Open On GitHub](https://img.shields.io/badge/Open-on%20GitHub-blue?logo=GitHub)](https://github.com/google/flax/blob/main/docs/getting_started.ipynb)\n",
     "\n",
-    "# Quick Start\n",
+    "# Quickstart\n",
     "\n",
     "Welcome to Flax!\n",
     "\n",

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -14,7 +14,7 @@ jupytext:
 [![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/google/flax/blob/main/docs/getting_started.ipynb)
 [![Open On GitHub](https://img.shields.io/badge/Open-on%20GitHub-blue?logo=GitHub)](https://github.com/google/flax/blob/main/docs/getting_started.ipynb)
 
-# Quick Start
+# Quickstart
 
 Welcome to Flax!
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -43,7 +43,7 @@ Features
       :columns: 12 12 12 6
 
       .. card:: Safety
-         :class-card: sd-text-black sd-border-0
+         :class-card: sd-border-0
          :shadow: none
          :class-title: sd-fs-5
 
@@ -57,7 +57,7 @@ Features
       :columns: 12 12 12 6
 
       .. card:: Control
-         :class-card: sd-text-black sd-border-0
+         :class-card: sd-border-0
          :shadow: none
          :class-title: sd-fs-5
 
@@ -70,7 +70,7 @@ Features
       :columns: 12 12 12 6
 
       .. card:: Functional API
-         :class-card: sd-text-black sd-border-0
+         :class-card: sd-border-0
          :shadow: none
          :class-title: sd-fs-5
 
@@ -82,7 +82,7 @@ Features
       :columns: 12 12 12 6
 
       .. card:: Terse code
-         :class-card: sd-text-black sd-border-0
+         :class-card: sd-border-0
          :shadow: none
          :class-title: sd-fs-5
 
@@ -203,7 +203,7 @@ Notable examples in Flax include:
       :columns: 6 6 6 4
 
       .. card:: `🤗 Hugging Face <https://huggingface.co/flax-community>`__
-         :class-card: sd-text-black sd-border-0
+         :class-card: sd-border-0
          :shadow: none
          :class-title: sd-text-center sd-fs-5
 
@@ -215,7 +215,7 @@ Notable examples in Flax include:
       :columns: 6 6 6 4
 
       .. card:: `🥑 DALLE Mini <https://huggingface.co/dalle-mini>`__
-         :class-card: sd-text-black sd-border-0
+         :class-card: sd-border-0
          :shadow: none
          :class-title: sd-text-center sd-fs-5
 
@@ -227,7 +227,7 @@ Notable examples in Flax include:
       :columns: 6 6 6 4
 
       .. card:: `PaLM <https://ai.googleblog.com/2022/04/pathways-language-model-palm-scaling-to.html>`__
-         :class-card: sd-text-black sd-border-0
+         :class-card: sd-border-0
          :shadow: none
          :class-title: sd-text-center sd-fs-5
 
@@ -239,7 +239,7 @@ Notable examples in Flax include:
       :columns: 6 6 6 4
 
       .. card:: `Imagen <https://imagen.research.google>`__
-         :class-card: sd-text-black sd-border-0
+         :class-card: sd-border-0
          :shadow: none
          :class-title: sd-text-center sd-fs-5
 
@@ -251,7 +251,7 @@ Notable examples in Flax include:
       :columns: 6 6 6 4
 
       .. card:: `Scenic <https://github.com/google-research/scenic/>`__
-         :class-card: sd-text-black sd-border-0
+         :class-card: sd-border-0
          :shadow: none
          :class-title: sd-text-center sd-fs-5
 
@@ -263,7 +263,7 @@ Notable examples in Flax include:
       :columns: 6 6 6 4
 
       .. card:: `Big Vision <https://github.com/google-research/big_vision>`__
-         :class-card: sd-text-black sd-border-0
+         :class-card: sd-border-0
          :shadow: none
          :class-title: sd-text-center sd-fs-5
 
@@ -275,7 +275,7 @@ Notable examples in Flax include:
       :columns: 6 6 6 4
 
       .. card:: `T5x <https://github.com/google-research/t5x>`__
-         :class-card: sd-text-black sd-border-0
+         :class-card: sd-border-0
          :shadow: none
          :class-title: sd-text-center sd-fs-5
 
@@ -287,7 +287,7 @@ Notable examples in Flax include:
       :columns: 6 6 6 4
 
       .. card:: `Brax <https://github.com/google/brax>`__
-         :class-card: sd-text-black sd-border-0
+         :class-card: sd-border-0
          :shadow: none
          :class-title: sd-text-center sd-fs-5
 
@@ -302,7 +302,7 @@ Notable examples in Flax include:
    :hidden:
    :maxdepth: 2
 
-   Quick Start <getting_started>
+   Quick start <getting_started>
    guides/index
    examples
    glossary


### PR DESCRIPTION
This PR removes hard-coded text color. This should fix the issue with the text color in dark mode:

![image](https://user-images.githubusercontent.com/19637339/222584061-36c2e032-48af-4cdf-8eea-9ce004fe5031.png)

Also "quick start" -> "quickstart" (in-line with the JAX quickstart).