### PR TITLE
Adds missing api references

### DIFF
--- a/docs/api_reference/flax.linen.rst
+++ b/docs/api_reference/flax.linen.rst
@@ -101,13 +101,16 @@ SPMD
 .. autosummary::
   :toctree: _autosummary
 
+    Partitioned
+    with_partitioning
+    get_partition_spec
+    LogicallyPartitioned
     logical_axis_rules
     set_logical_axis_rules
     get_logical_axis_rules
     logical_to_mesh_axes
     logical_to_mesh
     with_logical_constraint
-    LogicallyPartitioned
     with_logical_partitioning
 
 


### PR DESCRIPTION
# What does this PR do?

Adds missing API references for:
* `Partitioned`
* `with_partitioning`
* `get_partition_spec`