### PR TITLE
fix tabulate duplicating parameters

### DIFF
--- a/flax/linen/summary.py
+++ b/flax/linen/summary.py
@@ -17,6 +17,7 @@ from abc import ABC, abstractmethod
 import dataclasses
 import io
 from typing import Any, Callable, Dict, Iterable, List, Mapping, Optional, Sequence, Set, Tuple, Type, Union
+from flax.core import unfreeze
 
 import flax.linen.module as module_lib
 from flax.core import meta
@@ -310,7 +311,7 @@ def _get_path_variables(path: Tuple[str, ...], variables: FrozenVariableDict) ->
   path_variables = {}
 
   for collection in variables:
-    collection_variables = jax.tree_util.tree_map(lambda x: x, variables[collection]) # make a deep copy
+    collection_variables = variables[collection]
     for name in path:
       if name not in collection_variables:
         collection_variables = None
@@ -318,7 +319,7 @@ def _get_path_variables(path: Tuple[str, ...], variables: FrozenVariableDict) ->
       collection_variables = collection_variables[name]
 
     if collection_variables is not None:
-      path_variables[collection] = collection_variables
+      path_variables[collection] = unfreeze(collection_variables)
 
   return path_variables
 

--- a/tests/linen/summary_test.py
+++ b/tests/linen/summary_test.py
@@ -571,6 +571,18 @@ class SummaryTest(absltest.TestCase):
     self.assertIn('baz', lines[7])
     self.assertIn('qux', lines[8])
 
+  def test_tabulate_param_count(self):
+    class Foo(nn.Module):
+      @nn.compact
+      def __call__(self, x):
+        h = nn.Dense(4)(x)
+        return nn.Dense(2)(h)
+
+    x = jnp.ones((16, 9))
+    rep = Foo().tabulate(jax.random.PRNGKey(0), x, console_kwargs=CONSOLE_TEST_KWARGS)
+    lines = rep.splitlines()
+    self.assertIn('Total Parameters: 50', lines[-2])
+
 
 if __name__ == '__main__':
   absltest.main()


### PR DESCRIPTION
# What does this PR do?

Fixes #2930. Recent changes from #2898 silently broke `tabulate`, this PR use the `unfreeze` function to both unfreeze the and deep clone a dictionary structure, in the future if `FrozenDict`s are no longer returned this will still work as `unfreeze` works on regular dicts (does a deep clone). Also added the sample from #2930 as a unit test.