### PR TITLE
permit passing mesh or rules to spmd primitives

### DIFF
--- a/docs/examples_google_research_examples.rst
+++ b/docs/examples_google_research_examples.rst
@@ -29,7 +29,7 @@ Self-attention Does Not Need O(n^2) Memory
 - Research paper:
 
   - `Self-attention Does Not Need O(n^2) Memory <https://arxiv.org/abs/2112.05682>`__ (Rabe and Staats, 2021)
-  
+
     - *"We present a very simple algorithm for attention that requires O(1) memory with respect to sequence length and an extension to self-attention that requires O(log n) memory. This is in contrast with the frequently stated belief that self-attention requires O(n^2) memory. While the time complexity is still O(n^2), device memory rather than compute capability is often the limiting factor on modern accelerators. Thus, reducing the memory requirements of attention allows processing of longer sequences than might otherwise be feasible..."*
 
 Computer vision

--- a/flax/core/meta.py
+++ b/flax/core/meta.py
@@ -287,6 +287,8 @@ def with_partitioning(
   Args:
     fn: The function to be wrapped. Typically this is an initializer.
     names: The logical axis passed to ``Partitioned``.
+    mesh: The mesh to use for the partitioning. If None, the global mesh
+      resource is used if available.
   Returns:
     A function wrapping ``fn`` that will return an instance of ``Partitioned``.
   """

--- a/flax/core/meta.py
+++ b/flax/core/meta.py
@@ -23,7 +23,7 @@ to keep track of how variables should be partitioned with ``jax.pjit``.
 
 import abc
 import functools
-from typing import Any, Callable, Dict, Mapping, Tuple, TypeVar, Union
+from typing import Any, Callable, Dict, Mapping, Optional, Tuple, TypeVar, Union
 
 from flax import errors
 from flax import struct
@@ -231,12 +231,16 @@ class Partitioned(struct.PyTreeNode, AxisMetadata):
   """
   value: Any
   names: LogicalNames = struct.field(pytree_node=False)
+  mesh: Optional[jax.sharding.Mesh] = struct.field(default=None, pytree_node=False)
 
   def unbox(self, apply_constraint=True) -> Any:
     """Returns the wrapped value with the partitioning applied as a sharding constraint."""
-    if apply_constraint and _global_mesh_defined():
-      return pjit.with_sharding_constraint(
-          self.value, self.get_partition_spec())
+    if apply_constraint and (_global_mesh_defined() or self.mesh is not None):
+      axis_resource = self.get_partition_spec()
+      if self.mesh is not None:
+        axis_resource = jax.sharding.NamedSharding(self.mesh, axis_resource)
+      return jax.lax.with_sharding_constraint(
+          self.value, axis_resource)
     else:
       return self.value
 
@@ -269,7 +273,9 @@ class Partitioned(struct.PyTreeNode, AxisMetadata):
 
 def with_partitioning(
     fn: Callable[..., Any],
-    names: LogicalNames) ->  Callable[..., Partitioned]:
+    names: LogicalNames,
+    mesh: Optional[jax.sharding.Mesh] = None,
+  ) ->  Callable[..., Partitioned]:
   """Wraps a function's return value with Partitioned.
 
   Example::
@@ -286,7 +292,7 @@ def with_partitioning(
   """
   @functools.wraps(fn)
   def wrapper(*args, **kwargs):
-    return Partitioned(fn(*args, **kwargs), names)
+    return Partitioned(fn(*args, **kwargs), names, mesh=mesh)
   return wrapper
 
 

--- a/flax/linen/attention.py
+++ b/flax/linen/attention.py
@@ -351,7 +351,7 @@ class MultiHeadDotProductAttention(Module):
         param_dtype=self.param_dtype,
         precision=self.precision,
         dot_general=self.out_dot_general,
-        name='out',
+        name='out', # type: ignore[call-arg]
     )(x)
     return out
 

--- a/flax/linen/recurrent.py
+++ b/flax/linen/recurrent.py
@@ -277,12 +277,12 @@ class OptimizedLSTMCell(RNNCellBase):
           features=hidden_features, use_bias=False,
           param_dtype=self.param_dtype,
           kernel_init=self.kernel_init, bias_init=self.bias_init,
-          name=f'i{component}')(inputs)
+          name=f'i{component}')(inputs) # type: ignore[call-arg]
       dense_params_h[component] = DenseParams(
           features=hidden_features, use_bias=True,
           param_dtype=self.param_dtype,
           kernel_init=self.recurrent_kernel_init, bias_init=self.bias_init,
-          name=f'h{component}')(h)
+          name=f'h{component}')(h) # type: ignore[call-arg]
     dense_h = _concat_dense(h, dense_params_h, use_bias=True)
     dense_i = _concat_dense(inputs, dense_params_i, use_bias=False)
 

--- a/flax/linen/spmd.py
+++ b/flax/linen/spmd.py
@@ -283,8 +283,8 @@ class LogicallyPartitioned(meta.Partitioned):
 def with_logical_partitioning(
     fn: Callable[..., Any],
     names: meta.LogicalNames,
-    rules: Optional[LogicalRules] = None,
     mesh: Optional[jax.sharding.Mesh] = None,
+    rules: Optional[LogicalRules] = None,
   ) ->  Callable[..., LogicallyPartitioned]:
   """Wraps a function's return value with LogicallyPartitioned.
 
@@ -297,6 +297,10 @@ def with_logical_partitioning(
   Args:
     fn: The function to be wrapped. Typically this is an initializer.
     names: The logical axis passed to ``LogicallyPartitioned``.
+    mesh: The mesh to use for the partitioning. If None, the global mesh
+      resource is used if available.
+    rules: Optional logical to mesh rules use. If None, the global rules
+      are used if available.
   Returns:
     A function wrapping ``fn`` that will return an instance of
     ``LogicallyPartitioned``.

--- a/flax/linen/spmd.py
+++ b/flax/linen/spmd.py
@@ -26,18 +26,19 @@ introducing logical axis metadata into a model's variables.
 
 import collections
 import contextlib
+import dataclasses
 import enum
 import functools
 import threading
-from typing import (Any, Callable, List, Optional, Sequence, Tuple, Union)
-import dataclasses
+from typing import Any, Callable, List, Optional, Sequence, Tuple, Union
+
+import jax
+from jax.experimental import maps, pjit
+from flax import struct
 
 from flax.core import meta
 from flax.core.lift import In as ScanIn  # pylint: disable=unused-import
 from flax.core.lift import Out as ScanOut  # pylint: disable=unused-import
-import jax
-from jax.experimental import maps
-from jax.experimental import pjit
 
 # Real types and dummy aliases for documentation
 LogicalRules = Sequence[Tuple[str, Union[str, Tuple[str], None]]]
@@ -203,22 +204,27 @@ class RulesFallback(enum.Enum):
 
 def _with_sharding_constraint(
     x: Array,
-    axis_resources: Optional[jax.sharding.PartitionSpec]):
+    axis_resources: Optional[jax.sharding.PartitionSpec],
+    mesh: Optional[jax.sharding.Mesh] = None):
   """Wrapper for pjit with_sharding_constraint, no-op on cpu or outside pjit."""
-  if jax.devices()[0].platform == 'cpu' or not _global_mesh_defined():
+  if jax.devices()[0].platform == 'cpu' or (not _global_mesh_defined() and mesh is None):
     return x
   else:
+    if mesh is not None:
+      axis_resources = jax.sharding.NamedSharding(mesh, axis_resources)
     return pjit.with_sharding_constraint(x, axis_resources)
 
 
 def _with_sharding_constraint_one_fallback(
     axis_resources: LogicalPartitionSpec,
     x: Array,
-    fallback: RulesFallback = RulesFallback.AXIS_IS_UNSHARDED):
+    fallback: RulesFallback = RulesFallback.AXIS_IS_UNSHARDED,
+    rules: Optional[LogicalRules] = None,
+    mesh: Optional[jax.sharding.Mesh] = None):
   """Either imposes a sharding constraint or applies fallback."""
-  mesh_axes = _logical_to_mesh_axes(axis_resources)
+  mesh_axes = _logical_to_mesh_axes(axis_resources, rules)
   if mesh_axes is None:
-    return _with_sharding_constraint(x, None)
+    return _with_sharding_constraint(x, None, mesh=mesh)
 
   if fallback == RulesFallback.AXIS_IS_UNSHARDED:
     mesh_axes = [None if x is _unassigned_axis else x for x in mesh_axes]
@@ -228,7 +234,7 @@ def _with_sharding_constraint_one_fallback(
         raise ValueError(f'Axis names {axis_resources} did not match a rule')
       else:
         return x
-  return _with_sharding_constraint(x, jax.sharding.PartitionSpec(*mesh_axes))
+  return _with_sharding_constraint(x, jax.sharding.PartitionSpec(*mesh_axes), mesh=mesh)
 
 
 def _is_logical_spec(x):
@@ -239,15 +245,20 @@ def _is_logical_spec(x):
 def with_logical_constraint(
     x: ArrayPytree,
     logical_axis_resources: LogicalPartitionSpecPytree,
+    rules: Optional[LogicalRules] = None,
+    mesh: Optional[jax.sharding.Mesh] = None,
     fallback: RulesFallback = RulesFallback.AXIS_IS_UNSHARDED):
   """Version of pjit's with_sharding_constraint that uses logical axis names."""
   # If no axis binding is set, this is a no-op.
-  if not _axis_rules.rules or logical_axis_resources is None:
+  if rules is None:
+    rules = _axis_rules.rules
+  if not rules or logical_axis_resources is None:
     return x
   # Translate logical names to mesh assignments.
   return jax.tree_util.tree_map(
       functools.partial(
-          _with_sharding_constraint_one_fallback, fallback=fallback),
+          _with_sharding_constraint_one_fallback, fallback=fallback,
+          rules=rules, mesh=mesh),
       logical_axis_resources,
       x,
       is_leaf=_is_logical_spec)
@@ -258,18 +269,23 @@ def with_logical_constraint(
 
 
 class LogicallyPartitioned(meta.Partitioned):
+  rules: Optional[LogicalRules] = struct.field(default=None, pytree_node=False)
   def unbox(self, apply_constraint=True) -> Any:
     """Returns the wrapped value with the partitioning constraint applied."""
-    if apply_constraint and _global_mesh_defined():
+    if apply_constraint and (_global_mesh_defined() or self.mesh is not None):
       return with_logical_constraint(
-          self.value, self.get_partition_spec())
+          self.value, self.get_partition_spec(),
+          rules=self.rules, mesh=self.mesh)
     else:
       return self.value
 
 
 def with_logical_partitioning(
     fn: Callable[..., Any],
-    names: meta.LogicalNames) ->  Callable[..., LogicallyPartitioned]:
+    names: meta.LogicalNames,
+    rules: Optional[LogicalRules] = None,
+    mesh: Optional[jax.sharding.Mesh] = None,
+  ) ->  Callable[..., LogicallyPartitioned]:
   """Wraps a function's return value with LogicallyPartitioned.
 
   Example::
@@ -287,5 +303,6 @@ def with_logical_partitioning(
   """
   @functools.wraps(fn)
   def wrapper(*args, **kwargs):
-    return LogicallyPartitioned(fn(*args, **kwargs), names)
+    return LogicallyPartitioned(fn(*args, **kwargs), names,
+                                rules=rules, mesh=mesh)
   return wrapper

--- a/flax/struct.py
+++ b/flax/struct.py
@@ -31,7 +31,7 @@ def field(pytree_node=True, **kwargs):
   return dataclasses.field(metadata={'pytree_node': pytree_node}, **kwargs)
 
 
-@dataclass_transform(field_descriptors=(field,))
+@dataclass_transform(field_descriptors=(field,)) # type: ignore[literal-required]
 def dataclass(clz: _T) -> _T:
   """Create a class which can be passed to functional transformations.
 
@@ -183,7 +183,7 @@ def dataclass(clz: _T) -> _T:
 TNode = TypeVar('TNode', bound='PyTreeNode')
 
 
-@dataclass_transform(field_descriptors=(field,))
+@dataclass_transform(field_descriptors=(field,)) # type: ignore[literal-required]
 class PyTreeNode:
   """Base class for dataclasses that should act like a JAX pytree node.
 

--- a/flax/training/train_state.py
+++ b/flax/training/train_state.py
@@ -51,9 +51,9 @@ class TrainState(struct.PyTreeNode):
   """
   step: int
   apply_fn: Callable = struct.field(pytree_node=False)
-  params: core.FrozenDict[str, Any]
+  params: core.FrozenDict[str, Any] = struct.field(pytree_node=True)
   tx: optax.GradientTransformation = struct.field(pytree_node=False)
-  opt_state: optax.OptState
+  opt_state: optax.OptState = struct.field(pytree_node=True)
 
   def apply_gradients(self, *, grads, **kwargs):
     """Updates `step`, `params`, `opt_state` and `**kwargs` in return value.

--- a/pytest.ini
+++ b/pytest.ini
@@ -21,3 +21,5 @@ filterwarnings =
     ignore:jax.experimental.maps.Mesh is deprecated. Use jax.sharding.Mesh.*:DeprecationWarning
 # Deprecated legacy checkpoint - just want to keep the tests running for a while
     ignore:Flax Checkpointing will soon be deprecated in favor of Orbax.*:DeprecationWarning
+# Future warning from jax
+    ignore:jax.tree_util.register_keypaths is deprecated.*:FutureWarning


### PR DESCRIPTION
# What does this PR do?

Fixes #2938. Optionally lets users explicitly pass a mesh or rules into the various smpd primitives instead or relying exclusively on context managers.