### PR TITLE
[Trivial] [Post-release] Bump up the HEAD version number

### DIFF
--- a/flax/version.py
+++ b/flax/version.py
@@ -13,5 +13,5 @@
 # limitations under the License.
 
 """Current Flax version at head on Github."""
-__version__ = "0.6.7"
+__version__ = "0.6.8"
 


### PR DESCRIPTION
Similar to https://github.com/google/flax/pull/2936, this will make HEAD user happier.