### PR TITLE
Added utility functions to frozen_dict api

### DIFF
--- a/docs/api_reference/flax.core.frozen_dict.rst
+++ b/docs/api_reference/flax.core.frozen_dict.rst
@@ -10,3 +10,7 @@ flax.core.frozen_dict package
 .. autofunction:: freeze
 
 .. autofunction:: unfreeze
+
+.. autofunction:: copy
+
+.. autofunction:: pop


### PR DESCRIPTION
Added utility functions `copy` and `pop` to [frozen_dict api](https://flax--2975.org.readthedocs.build/en/2975/api_reference/flax.core.frozen_dict.html)