### PR TITLE
Add missing Bidirectional api reference

### DIFF
--- a/docs/api_reference/flax.linen.rst
+++ b/docs/api_reference/flax.linen.rst
@@ -275,3 +275,4 @@ RNN primitives
     GRUCell
     RNNCellBase
     RNN
+    Bidirectional


### PR DESCRIPTION
# What does this PR do?

* Adds the entry for `Bidirectional` in `flax.linen.rst`.