### PR TITLE
Update checkpointing guide with Orbax APIs

### DIFF
--- a/docs/guides/use_checkpointing.ipynb
+++ b/docs/guides/use_checkpointing.ipynb
@@ -1,6 +1,7 @@
 {
  "cells": [
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "6e9134fa",
    "metadata": {
@@ -9,18 +10,37 @@
    "source": [
     "# Save and load checkpoints\n",
     "\n",
-    "In this guide, you will learn about saving and loading checkpoints with Flax and [Orbax](https://github.com/google/orbax). With Flax, you can save and load model parameters, metadata, and a variety of Python data using Orbax.\n",
+    "This guide demonstrates how to save and load Flax checkpoints with [Orbax](https://github.com/google/orbax).\n",
     "\n",
-    "Orbax provides a customizable and flexible API for various array types and storage formats. In addition, Flax provides basic features for versioning, automatic bookkeeping of past checkpoints, and asynchronous saving to reduce training wait time.\n",
+    "Orbax provides a variety of features for saving and loading model data, which you will learn about in this doc:\n",
     "\n",
-    "> **_Ongoing migration:_** In the foreseeable future, Flax's checkpointing functionality will gradually be migrated to Orbax from `flax.training.checkpoints`. All existing features in the Flax API will continue to be supported, but the API will change. You are encouraged to try out the new API by creating an [`orbax.checkpoint.Checkpointer`](https://github.com/google/orbax/blob/main/orbax/checkpoint/checkpointer.py) and pass it in your Flax API calls as an argument `orbax_checkpointer`, as demonstrated later in this guide. This guide provides the most up-to-date code examples for using Orbax and Flax for checkpointing. The Orbax features described below are presented in a very limited fashion: see [Orbax](https://github.com/google/orbax/blob/main/docs/checkpoint.md) for full documentation.\n",
+    "*  Support for various array types and storage formats\n",
+    "*  Asynchronous saving to reduce training wait time\n",
+    "*  Versioning and automatic bookkeeping of past checkpoints\n",
+    "*  Flexible [`transformations`](https://github.com/google/orbax/blob/main/docs/checkpoint.md#transformations) to tweak and load old checkpoints\n",
+    "*  [`jax.sharding`](https://jax.readthedocs.io/en/latest/notebooks/Distributed_arrays_and_automatic_parallelization.html)-based API to save and load in multi-host scenarios\n",
     "\n",
-    "This guide covers the following:\n",
+    "---\n",
+    "**_Ongoing migration to Orbax:_** \n",
     "\n",
-    "* Basic saving and loading of checkpoints with [`orbax.checkpoint.Checkpointer`](https://github.com/google/orbax/blob/main/orbax/checkpoint/checkpointer.py) and [`flax.training.checkpoints.save_checkpoint`](https://flax.readthedocs.io/en/latest/api_reference/flax.training.html#flax.training.checkpoints.save_checkpoint).\n",
-    "* More flexible and sustainable ways to load checkpoints ([`flax.training.checkpoints.restore_checkpoint`](https://flax.readthedocs.io/en/latest/api_reference/flax.training.html#flax.training.checkpoints.restore_checkpoint)).\n",
-    "* How to save and load checkpoints when you run in multi-host scenarios with\n",
-    "[`flax.training.checkpoints.save_checkpoint_multiprocess`](https://flax.readthedocs.io/en/latest/api_reference/flax.training.html#flax.training.checkpoints.save_checkpoint_multiprocess)."
+    "After July 30 2023, Flax's legacy `flax.training.checkpoints` API will be deprecated in favor of [Orbax](https://github.com/google/orbax).\n",
+    "\n",
+    "*  **If you are a new Flax user**: Use the new `orbax.checkpoint` API, as demonstrated in this guide.\n",
+    "\n",
+    "*  **If you have legacy `flax.training.checkpoints` code in your project**: Consider the following options:\n",
+    "\n",
+    "   * **Migrating your code to Orbax (Recommended)**: Migrate your API calls to `orbax.checkpoint` API by following this [migration guide](https://flax.readthedocs.io/en/latest/guides/orbax_upgrade_guide.html).\n",
+    "\n",
+    "   * **Automatically use the Orbax backend**: Add `flax.config.update('flax_use_orbax_checkpointing', True)` to your project, which will let your `flax.training.checkpoints` calls automatically use the Orbax backend to save your checkpoints.\n",
+    "     \n",
+    "     * **Scheduled flip**: This will become the default mode after **May 2023** (tentative date).\n",
+    "\n",
+    "     * Visit [Orbax-as-backend troubleshooting section](https://flax.readthedocs.io/en/latest/guides/use_checkpointing.html#orbax-as-backend-troubleshooting) if you meet any issue in the automatic migration.\n",
+    "---\n",
+    "\n",
+    "For backward-compatibility, this guide shows the Orbax-equivalent calls in the Flax legacy `flax.training.checkpoints` API.\n",
+    "\n",
+    "If you need to learn more about `orbax.checkpoint`, refer to the [Orbax docs](https://github.com/google/orbax/blob/main/docs/checkpoint.md).\n"
    ]
   },
   {
@@ -37,7 +57,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 76,
+   "execution_count": 1,
    "id": "e80f8743",
    "metadata": {
     "tags": [
@@ -46,26 +66,24 @@
    },
    "outputs": [],
    "source": [
-    "# replace with `pip install flax` after release 0.6.9.\n",
-    "! pip install -U \"git+https://github.com/google/flax.git@main#egg=flax\"\n",
-    "\n",
-    "# Orbax needs to enable asyncio in a Colab environment.\n",
-    "! pip install -qq nest_asyncio"
+    "# replace with `pip install -U flax` after release 0.6.9.\n",
+    "! pip install -U -qq \"git+https://github.com/google/flax.git@main#egg=flax\""
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "-icO30rwmKYj",
    "metadata": {
     "id": "-icO30rwmKYj"
    },
    "source": [
-    "Note: Before running `import jax`, create eight fake devices to mimic [multi-host environment](https://jax.readthedocs.io/en/latest/jax-101/06-parallelism.html?#aside-hosts-and-devices-in-jax) this notebook. Note that the order of imports is important here. The `os.environ[\"XLA_FLAGS\"] = '--xla_force_host_platform_device_count=8'` command works only with the CPU backend. This means it won't work with GPU/TPU acceleration on if you're running this notebook in Google Colab. If you are already running the code on multiple devices (for example, in a 4x2 TPU environment), you can skip running the next cell."
+    "Note: Before running `import jax`, create eight fake devices to mimic a [multi-host environment](https://jax.readthedocs.io/en/latest/jax-101/06-parallelism.html?#aside-hosts-and-devices-in-jax) in this notebook. Note that the order of imports is important here. The `os.environ[\"XLA_FLAGS\"] = '--xla_force_host_platform_device_count=8'` command works only with the CPU backend, which means it won't work with GPU/TPU acceleration on if you're running this notebook in Google Colab. If you are already running the code on multiple devices (for example, in a 4x2 TPU environment), you can skip running the next cell."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 2,
    "id": "ArKLnsyGRxGv",
    "metadata": {
     "id": "ArKLnsyGRxGv"
@@ -78,7 +96,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 3,
    "id": "SJT9DTxTytjn",
    "metadata": {
     "id": "SJT9DTxTytjn"
@@ -88,8 +106,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/Users/ivyzheng/0w0/flax-orbax-upgrade-guide/flax/core/frozen_dict.py:169: FutureWarning: jax.tree_util.register_keypaths is deprecated, and will be removed in a future release. Please use `register_pytree_with_keys()` instead.\n",
-      "  jax.tree_util.register_keypaths(\n"
+      "WARNING:absl:Tensorflow library not found, tensorflow.io.gfile operations will use native shim calls. GCS paths (i.e. 'gs://...') cannot be accessed.\n"
      ]
     }
    ],
@@ -107,9 +124,20 @@
     "from flax import struct, serialization\n",
     "import orbax.checkpoint\n",
     "\n",
-    "import optax\n",
-    "import nest_asyncio\n",
-    "nest_asyncio.apply()"
+    "import optax"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "afd6db30",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ckpt_dir = 'tmp'\n",
+    "\n",
+    "if os.path.exists(ckpt_dir):\n",
+    "    shutil.rmtree(ckpt_dir)  # Remove any existing checkpoints from the last notebook run."
    ]
   },
   {
@@ -121,14 +149,14 @@
    "source": [
     "## Save checkpoints\n",
     "\n",
-    "In Flax, you save and load any given JAX [pytree](https://jax.readthedocs.io/en/latest/pytrees.html) using the `flax.training.checkpoints` package. This includes not only typical Python and NumPy containers, but also customized classes extended from [`flax.struct.dataclass`](https://flax.readthedocs.io/en/latest/api_reference/flax.struct.html#flax.struct.dataclass). That means you can store almost any data generated—not only your model parameters, but any arrays/dictionaries, metadata/configs, and so on.\n",
+    "In Orbax and Flax, you can save and load any given JAX [pytree](https://jax.readthedocs.io/en/latest/pytrees.html). This includes not only typical Python and NumPy containers, but also customized classes extended from [`flax.struct.dataclass`](https://flax.readthedocs.io/en/latest/api_reference/flax.struct.html#flax.struct.dataclass). That means you can store almost any data generated — not only your model parameters, but any arrays/dictionaries, metadata/configs, and so on.\n",
     "\n",
-    "Create a pytree with many data structures and containers, and play with it:"
+    "First, create a pytree with many data structures and containers, and play with it:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 5,
    "id": "56dec3f6",
    "metadata": {
     "id": "56dec3f6",
@@ -155,12 +183,12 @@
        "            [ 0.36260957,  0.18276349, -0.6856061 ],\n",
        "            [-0.8519373 , -0.6416717 , -0.4818122 ],\n",
        "            [-0.6886102 , -0.33987316, -0.05898903]], dtype=float32),\n",
-       " }), tx=GradientTransformation(init=<function chain.<locals>.init_fn at 0x156587e50>, update=<function chain.<locals>.update_fn at 0x1565fb670>), opt_state=(EmptyState(), EmptyState())),\n",
+       " }), tx=GradientTransformation(init=<function chain.<locals>.init_fn at 0x12ab6d1f0>, update=<function chain.<locals>.update_fn at 0x12abb7ca0>), opt_state=(EmptyState(), EmptyState())),\n",
        " 'config': {'dimensions': array([5, 3]), 'name': 'dense'},\n",
        " 'data': [Array([0.59902626, 0.2172144 , 2.4202902 , 0.03266738, 1.2164948 ],      dtype=float32)]}"
       ]
      },
-     "execution_count": 3,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -192,21 +220,100 @@
   },
   {
    "cell_type": "markdown",
+   "id": "8c715b95",
+   "metadata": {},
+   "source": [
+    "### With Orbax"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "6fc59dfa",
    "metadata": {
     "id": "6fc59dfa"
    },
    "source": [
-    "Now save the checkpoint with Flax and Orbax. You can add annotations like step number, prefix, and so on to your checkpoint.\n",
+    "Save the checkpoint with `orbax.checkpoint.PyTreeCheckpointer`, directly to the `tmp/orbax/single_save` directory.\n",
     "\n",
-    "When saving a checkpoint, Flax will bookkeep the existing checkpoints based on your arguments. For example, by setting `overwrite=False` in [`flax.checkpoints.save_checkpoint`](https://flax.readthedocs.io/en/latest/api_reference/flax.training.html#flax.training.checkpoints.save_checkpoint), Flax will not automatically save your checkpoint if there is already a step that is equal to or newer than the current one presently in the checkpoint directory. By setting `keep=2`, Flax will keep a maximum of 2 checkpoints in the directory. Learn more in the [API reference](https://flax.readthedocs.io/en/latest/api_reference/flax.training.html#module-flax.training.checkpoints).\n",
-    "\n",
-    "You can start to use Orbax to handle the underlying save by creating an [`orbax.checkpoint.Checkpointer`](https://github.com/google/orbax/blob/main/orbax/checkpoint/checkpointer.py), and pass it into the `flax.checkpoints.save_checkpoint` call."
+    "Note: An optional `save_args` is provided. This is recommended for performance speedups, as it bundles smaller arrays in your pytree to a single large file instead of multiple smaller files."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 6,
+   "id": "61b12da2",
+   "metadata": {
+    "id": "0pp4QtEqW9k7"
+   },
+   "outputs": [],
+   "source": [
+    "from flax.training import orbax_utils\n",
+    "\n",
+    "orbax_checkpointer = orbax.checkpoint.PyTreeCheckpointer()\n",
+    "save_args = orbax_utils.save_args_from_target(ckpt)\n",
+    "orbax_checkpointer.save('tmp/orbax/single_save', ckpt, save_args=save_args)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "07d4de1a",
+   "metadata": {},
+   "source": [
+    "Next, to use versioning and automatic bookkeeping features, you need to wrap `orbax.checkpoint.CheckpointManager` over `orbax.checkpoint.PyTreeCheckpointer`. \n",
+    "\n",
+    "In addition, provide `orbax.checkpoint.CheckpointManagerOptions` that customizes your needs, such as how often and on what criteria you prefer old checkpoints be deleted. See [documentation](https://github.com/google/orbax/blob/main/docs/checkpoint.md#checkpointmanager) for a full list of options offered.\n",
+    "\n",
+    "`orbax.checkpoint.CheckpointManager` should be placed at the top-level outside your training steps to manage your saves."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "d3686ea5",
+   "metadata": {
+    "id": "T6T8V4UBXB1R",
+    "outputId": "b7132933-566d-440d-c34e-c5468d87cbdc"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['4', '3']"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "options = orbax.checkpoint.CheckpointManagerOptions(max_to_keep=2, create=True)\n",
+    "checkpoint_manager = orbax.checkpoint.CheckpointManager(\n",
+    "    'tmp/orbax/managed', orbax_checkpointer, options)\n",
+    "\n",
+    "# Inside a training loop\n",
+    "for step in range(5):\n",
+    "    # ... do your training\n",
+    "    checkpoint_manager.save(step, ckpt, save_kwargs={'save_args': save_args})\n",
+    "\n",
+    "os.listdir('tmp/orbax/managed')  # Because max_to_keep=2, only step 3 and 4 are retained"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8ecbc4cc",
+   "metadata": {
+    "id": "OQkUOkHVW_4e"
+   },
+   "source": [
+    "### With the legacy API\n",
+    "\n",
+    "And here's how to save with the legacy Flax checkpointing utilities (note that this provides less management features compared with `orbax.checkpoint.CheckpointManagerOptions`):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
    "id": "4cdb35ef",
    "metadata": {
     "id": "4cdb35ef",
@@ -219,7 +326,7 @@
        "'tmp/flax-checkpointing/checkpoint_0'"
       ]
      },
-     "execution_count": 4,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -228,84 +335,11 @@
     "# Import Flax Checkpoints.\n",
     "from flax.training import checkpoints\n",
     "\n",
-    "ckpt_dir = 'tmp/flax-checkpointing'\n",
-    "\n",
-    "if os.path.exists(ckpt_dir):\n",
-    "    shutil.rmtree(ckpt_dir)  # Remove any existing checkpoints from the last notebook run.\n",
-    "\n",
-    "orbax_checkpointer = orbax.checkpoint.PyTreeCheckpointer()\n",
-    "checkpoints.save_checkpoint(ckpt_dir=ckpt_dir,\n",
+    "checkpoints.save_checkpoint(ckpt_dir='tmp/flax-checkpointing',\n",
     "                            target=ckpt,\n",
     "                            step=0,\n",
-    "                            overwrite=False,\n",
-    "                            keep=2,\n",
-    "                            orbax_checkpointer=orbax_checkpointer)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "63058304",
-   "metadata": {
-    "id": "JPcVYi74W6zM"
-   },
-   "source": [
-    "This can be expressed equivalently using Orbax without Flax wrappers. See [Orbax](https://github.com/google/orbax) documentation for more information on how save behavior can be customized."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 5,
-   "id": "61b12da2",
-   "metadata": {
-    "id": "0pp4QtEqW9k7"
-   },
-   "outputs": [],
-   "source": [
-    "save_args = jax.tree_util.tree_map(\n",
-    "    lambda _: orbax.checkpoint.SaveArgs(aggregate=True), ckpt)\n",
-    "orbax_checkpointer.save(os.path.join(ckpt_dir, 'orbax_checkpoint'),\n",
-    "    ckpt,\n",
-    "    save_args=save_args)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "8ecbc4cc",
-   "metadata": {
-    "id": "OQkUOkHVW_4e"
-   },
-   "source": [
-    "It is also possible to use pure Orbax to manage multiple checkpoints across different steps. Again, see [Orbax](https://github.com/google/orbax) documentation for detailed information."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 6,
-   "id": "d3686ea5",
-   "metadata": {
-    "id": "T6T8V4UBXB1R",
-    "outputId": "b7132933-566d-440d-c34e-c5468d87cbdc"
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "True"
-      ]
-     },
-     "execution_count": 6,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "orbax_ckpt_dir = 'tmp/orbax-checkpointing'\n",
-    "if os.path.exists(orbax_ckpt_dir):\n",
-    "    shutil.rmtree(orbax_ckpt_dir)  # Remove any existing checkpoints from the last notebook run.\n",
-    "os.mkdir(orbax_ckpt_dir)\n",
-    "options = orbax.checkpoint.CheckpointManagerOptions(max_to_keep=2)\n",
-    "checkpoint_manager = orbax.checkpoint.CheckpointManager(orbax_ckpt_dir, orbax_checkpointer, options)\n",
-    "checkpoint_manager.save(0, ckpt, save_kwargs={'save_args': save_args})"
+    "                            overwrite=True,\n",
+    "                            keep=2)"
    ]
   },
   {
@@ -317,61 +351,14 @@
    "source": [
     "## Restore checkpoints\n",
     "\n",
-    "To restore a checkpoint, use [`flax.training.checkpoints.restore_checkpoint`](https://flax.readthedocs.io/en/latest/api_reference/flax.training.html#flax.training.checkpoints.restore_checkpoint) and pass in the checkpoint directory. Flax will automatically select the latest checkpoint in the directory. You can also choose to specify a step number or the path of the checkpoint file.\n",
+    "### With Orbax\n",
     "\n",
-    "With the migration to Orbax in progress, `restore_checkpoint` can automatically identify whether a checkpoint is saved in the legacy (Flax) or Orbax version, and restore the pytree correctly.\n",
-    "\n",
-    "You can always restore a pytree out of your checkpoints by setting `target=None`."
+    "In Orbax, call `.restore()` for either `orbax.checkpoint.PyTreeCheckpointer` or `orbax.checkpoint.CheckpointManager` to restore your checkpoint in the raw pytree format."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
-   "id": "150b20a0",
-   "metadata": {
-    "id": "150b20a0",
-    "outputId": "85ffceca-f38d-46b8-e567-d9d38b7885f9"
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'config': {'dimensions': array([5, 3]), 'name': 'dense'},\n",
-       " 'data': {'0': array([0.59902626, 0.2172144 , 2.4202902 , 0.03266738, 1.2164948 ],\n",
-       "        dtype=float32)},\n",
-       " 'model': {'opt_state': {'0': None, '1': None},\n",
-       "  'params': {'bias': array([-0.001, -0.001, -0.001], dtype=float32),\n",
-       "   'kernel': array([[ 0.26048955, -0.61399287, -0.23458514],\n",
-       "          [ 0.11050402, -0.8765793 ,  0.9800635 ],\n",
-       "          [ 0.36260957,  0.18276349, -0.6856061 ],\n",
-       "          [-0.8519373 , -0.6416717 , -0.4818122 ],\n",
-       "          [-0.6886102 , -0.33987316, -0.05898903]], dtype=float32)},\n",
-       "  'step': 1}}"
-      ]
-     },
-     "execution_count": 7,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "raw_restored = checkpoints.restore_checkpoint(ckpt_dir=ckpt_dir, target=None)\n",
-    "raw_restored"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "c7fe3bc8",
-   "metadata": {
-    "id": "VKJrfSyLXGrc"
-   },
-   "source": [
-    "Equivalently using pure Orbax:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "id": "a807a9c1",
    "metadata": {
     "id": "WgRJj3wjXIaN",
@@ -394,13 +381,102 @@
        "  'step': 1}}"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "raw_restored = orbax_checkpointer.restore(os.path.join(ckpt_dir, 'orbax_checkpoint'))\n",
+    "raw_restored = orbax_checkpointer.restore('tmp/orbax/single_save')\n",
+    "raw_restored"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8c015a22",
+   "metadata": {},
+   "source": [
+    "Note that the `step` number is required for `CheckpointManger`. You can also use `.latest_step()` to find the latest step available."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "251d7085",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'config': {'dimensions': array([5, 3]), 'name': 'dense'},\n",
+       " 'data': [array([0.59902626, 0.2172144 , 2.4202902 , 0.03266738, 1.2164948 ],\n",
+       "        dtype=float32)],\n",
+       " 'model': {'opt_state': [None, None],\n",
+       "  'params': {'bias': array([-0.001, -0.001, -0.001], dtype=float32),\n",
+       "   'kernel': array([[ 0.26048955, -0.61399287, -0.23458514],\n",
+       "          [ 0.11050402, -0.8765793 ,  0.9800635 ],\n",
+       "          [ 0.36260957,  0.18276349, -0.6856061 ],\n",
+       "          [-0.8519373 , -0.6416717 , -0.4818122 ],\n",
+       "          [-0.6886102 , -0.33987316, -0.05898903]], dtype=float32)},\n",
+       "  'step': 1}}"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "step = checkpoint_manager.latest_step()  # step = 4\n",
+    "checkpoint_manager.restore(step)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c7fe3bc8",
+   "metadata": {
+    "id": "VKJrfSyLXGrc"
+   },
+   "source": [
+    "### With the legacy API\n",
+    "\n",
+    "Note that with the migration to Orbax in progress, `flax.training.checkpointing.restore_checkpoint` can automatically identify whether a checkpoint is saved in the legacy Flax format or with an Orbax backend, and restore the pytree correctly. Therefore, adding `flax.config.update('flax_use_orbax_checkpointing', True)` won't hurt your ability to restore old checkpoints.\n",
+    "\n",
+    "Here's how to restore checkpoints using the legacy API: "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "150b20a0",
+   "metadata": {
+    "id": "150b20a0",
+    "outputId": "85ffceca-f38d-46b8-e567-d9d38b7885f9"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'model': {'step': 1,\n",
+       "  'params': {'bias': array([-0.001, -0.001, -0.001], dtype=float32),\n",
+       "   'kernel': array([[ 0.26048955, -0.61399287, -0.23458514],\n",
+       "          [ 0.11050402, -0.8765793 ,  0.9800635 ],\n",
+       "          [ 0.36260957,  0.18276349, -0.6856061 ],\n",
+       "          [-0.8519373 , -0.6416717 , -0.4818122 ],\n",
+       "          [-0.6886102 , -0.33987316, -0.05898903]], dtype=float32)},\n",
+       "  'opt_state': {'0': {}, '1': {}}},\n",
+       " 'config': {'dimensions': array([5, 3]), 'name': 'dense'},\n",
+       " 'data': {'0': array([0.59902626, 0.2172144 , 2.4202902 , 0.03266738, 1.2164948 ],\n",
+       "        dtype=float32)}}"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "raw_restored = checkpoints.restore_checkpoint(ckpt_dir='tmp/flax-checkpointing', target=None)\n",
     "raw_restored"
    ]
   },
@@ -411,27 +487,127 @@
     "id": "987b981f"
    },
    "source": [
-    "However, when using `target=None`, the restored `raw_restored` will be different from the original `ckpt` in the following ways:\n",
+    "## Restore with custom dataclasses\n",
     "\n",
-    "1. There is no TrainState now, and only some raw weights and Optax state numbers remain.\n",
-    "1. `metadata.dimensions` and `data` should be arrays, but restored as dictionaries with integers as keys.\n",
-    "1. Previously, `data[0]` was a JAX NumPy array (`jnp.array`) —now it's a NumPy array (`numpy.array`).\n",
+    "### With Orbax\n",
     "\n",
-    "While (3) would not affect future work because JAX will [automatically convert](https://jax.readthedocs.io/en/latest/jax-101/01-jax-basics.html) NumPy arrays to JAX arrays once the computation starts, (1) and (2) may lead to confusions.\n",
+    "*  The pytrees restored in the previous examples are in the form of raw dictionaries. Original pytrees contain custom dataclasses like [`TrainState`](https://flax.readthedocs.io/en/latest/flip/1009-optimizer-api.html?#train-state) and `optax` states.\n",
+    "*  This is because when restoring a pytree, the program does not yet know which structure it once belonged to.\n",
+    "*  To resolve this, you should first provide an example pytree to let Orbax or Flax know exactly which structure to restore to.\n",
     "\n",
-    "To resolve this, you should pass an example `target` in `flax.training.checkpoints.restore_checkpoint` to let Flax know exactly what structure it should restore to. The `target` should introduce any custom Flax dataclasses explicitly, and have the same structure as the saved checkpoint.\n",
+    "This section demonstrates how to set up any custom Flax dataclass explicitly, and have the same structure as a saved checkpoint.\n",
     "\n",
-    "It's often recommended to refactor out the process of initializing a checkpoint's structure (for example, a [`TrainState`](https://flax.readthedocs.io/en/latest/flip/1009-optimizer-api.html?#train-state)), so that saving/loading is easier and less error-prone. This is because complicated objects like `apply_fn` and `tx` (optimizer) are not stored in the checkpoint file and must be initiated by code."
+    "Note: Data that was a JAX NumPy array (`jnp.array`) format will be restored as a NumPy array (`numpy.array`). This would not affect your work because JAX will [automatically convert](https://jax.readthedocs.io/en/latest/jax-101/01-jax-basics.html) NumPy arrays to JAX arrays once the computation starts."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 12,
    "id": "58f42513",
    "metadata": {
     "id": "58f42513",
     "outputId": "110c6b6e-fe42-4179-e5d8-6b92d355e11b"
    },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'config': {'dimensions': array([5, 3]), 'name': 'dense'},\n",
+       " 'data': [array([0.59902626, 0.2172144 , 2.4202902 , 0.03266738, 1.2164948 ],\n",
+       "        dtype=float32)],\n",
+       " 'model': TrainState(step=1, apply_fn=<bound method Module.apply of Dense(\n",
+       "     # attributes\n",
+       "     features = 3\n",
+       "     use_bias = True\n",
+       "     dtype = None\n",
+       "     param_dtype = float32\n",
+       "     precision = None\n",
+       "     kernel_init = init\n",
+       "     bias_init = zeros\n",
+       "     dot_general = dot_general\n",
+       " )>, params=FrozenDict({\n",
+       "     bias: array([-0.001, -0.001, -0.001], dtype=float32),\n",
+       "     kernel: array([[ 0.26048955, -0.61399287, -0.23458514],\n",
+       "            [ 0.11050402, -0.8765793 ,  0.9800635 ],\n",
+       "            [ 0.36260957,  0.18276349, -0.6856061 ],\n",
+       "            [-0.8519373 , -0.6416717 , -0.4818122 ],\n",
+       "            [-0.6886102 , -0.33987316, -0.05898903]], dtype=float32),\n",
+       " }), tx=GradientTransformation(init=<function chain.<locals>.init_fn at 0x12ab6d1f0>, update=<function chain.<locals>.update_fn at 0x12abb7ca0>), opt_state=(EmptyState(), EmptyState()))}"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "empty_state = train_state.TrainState.create(\n",
+    "    apply_fn=model.apply,\n",
+    "    params=jax.tree_map(np.zeros_like, variables['params']),  # values of the tree leaf doesn't matter\n",
+    "    tx=tx,\n",
+    ")\n",
+    "empty_config = {'dimensions': np.array([0, 0]), 'name': ''}\n",
+    "target = {'model': empty_state, 'config': empty_config, 'data': [jnp.zeros_like(x1)]}\n",
+    "state_restored = orbax_checkpointer.restore('tmp/orbax/single_save', item=target)\n",
+    "state_restored"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f1c18bc6",
+   "metadata": {},
+   "source": [
+    "### With the legacy API\n",
+    "\n",
+    "Alternatively, you can restore from Orbax `CheckpointManager` and from the legacy Flax code as follows:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "a61e9a66",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'config': {'dimensions': array([5, 3]), 'name': 'dense'},\n",
+       " 'data': [array([0.59902626, 0.2172144 , 2.4202902 , 0.03266738, 1.2164948 ],\n",
+       "        dtype=float32)],\n",
+       " 'model': TrainState(step=1, apply_fn=<bound method Module.apply of Dense(\n",
+       "     # attributes\n",
+       "     features = 3\n",
+       "     use_bias = True\n",
+       "     dtype = None\n",
+       "     param_dtype = float32\n",
+       "     precision = None\n",
+       "     kernel_init = init\n",
+       "     bias_init = zeros\n",
+       "     dot_general = dot_general\n",
+       " )>, params=FrozenDict({\n",
+       "     bias: array([-0.001, -0.001, -0.001], dtype=float32),\n",
+       "     kernel: array([[ 0.26048955, -0.61399287, -0.23458514],\n",
+       "            [ 0.11050402, -0.8765793 ,  0.9800635 ],\n",
+       "            [ 0.36260957,  0.18276349, -0.6856061 ],\n",
+       "            [-0.8519373 , -0.6416717 , -0.4818122 ],\n",
+       "            [-0.6886102 , -0.33987316, -0.05898903]], dtype=float32),\n",
+       " }), tx=GradientTransformation(init=<function chain.<locals>.init_fn at 0x12ab6d1f0>, update=<function chain.<locals>.update_fn at 0x12abb7ca0>), opt_state=(EmptyState(), EmptyState()))}"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "checkpoint_manager.restore(4, items=target)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "412af50e",
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -453,46 +629,51 @@
        "            [ 0.36260957,  0.18276349, -0.6856061 ],\n",
        "            [-0.8519373 , -0.6416717 , -0.4818122 ],\n",
        "            [-0.6886102 , -0.33987316, -0.05898903]], dtype=float32),\n",
-       " }), tx=GradientTransformation(init=<function chain.<locals>.init_fn at 0x156587e50>, update=<function chain.<locals>.update_fn at 0x1565fb670>), opt_state=(EmptyState(), EmptyState())),\n",
+       " }), tx=GradientTransformation(init=<function chain.<locals>.init_fn at 0x12ab6d1f0>, update=<function chain.<locals>.update_fn at 0x12abb7ca0>), opt_state=(EmptyState(), EmptyState())),\n",
        " 'config': {'dimensions': array([5, 3]), 'name': 'dense'},\n",
        " 'data': [array([0.59902626, 0.2172144 , 2.4202902 , 0.03266738, 1.2164948 ],\n",
        "        dtype=float32)]}"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "empty_state = train_state.TrainState.create(\n",
-    "    apply_fn=model.apply,\n",
-    "    params=jax.tree_map(np.zeros_like, variables['params']),  # values of the tree leaf doesn't matter\n",
-    "    tx=tx,\n",
-    ")\n",
-    "empty_config = {'dimensions': np.array([0, 0]), 'name': ''}\n",
-    "target = {'model': empty_state, 'config': empty_config, 'data': [jnp.zeros_like(x1)]}\n",
-    "state_restored = checkpoints.restore_checkpoint(ckpt_dir, target=target, step=0)\n",
-    "state_restored"
+    "checkpoints.restore_checkpoint(ckpt_dir='tmp/flax-checkpointing', target=target)"
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "27461ac8",
+   "metadata": {},
+   "source": [
+    "It's often recommended to refactor out the process of initializing a checkpoint's structure (for example, a [`TrainState`](https://flax.readthedocs.io/en/latest/flip/1009-optimizer-api.html?#train-state)), so that saving/loading is easier and less error-prone. This is because functions and complex objects like `apply_fn` and `tx` (optimizer) cannot be serialized into the checkpoint file and must be initialized by code."
+   ]
+  },
+  {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "136a300a",
    "metadata": {
     "id": "136a300a"
    },
    "source": [
-    "### Backward/forward dataclass compatibility\n",
+    "## Restore when checkpoint structures differ\n",
     "\n",
-    "The flexibility of using *Flax dataclasses*—[`flax.struct.dataclass`](https://flax.readthedocs.io/en/latest/api_reference/flax.struct.html#flax.struct.dataclass)—means that changes in Flax dataclass fields may break your existing checkpoints. For example, if you decide to add a field `batch_stats` to your `TrainState` (like when using [batch normalization](https://flax.readthedocs.io/en/latest/guides/batch_norm.html)), old checkpoints without this field may not be successfully restored. Same goes for removing a field in your dataclass.\n",
+    "During your development, your checkpoint structure will change when changing the model, adding/removing fields during tweaking, and so on.\n",
     "\n",
-    "Note: Flax supports [`flax.struct.dataclass`](https://flax.readthedocs.io/en/latest/api_reference/flax.struct.html#flax.struct.dataclass), not Python's built-in `dataclasses.dataclass`."
+    "This section explains how to load old data to your new code.\n",
+    "\n",
+    "Below is  a simple example — a `CustomTrainState` extended from `flax.training.train_state.TrainState` that contains an extra field called `batch_stats`. When working on a real-world model, you may need this when applying [batch normalization](https://flax.readthedocs.io/en/latest/guides/batch_norm.html).\n",
+    "\n",
+    "Here, you store the new `CustomTrainState` as step 5, while step 4 contains the old/previous `TrainState`."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 15,
    "id": "be65d4af",
    "metadata": {
     "id": "be65d4af",
@@ -500,18 +681,76 @@
    },
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "KeyError when target state has an unmentioned field:\n",
-      "'batch_stats'\n",
-      "\n"
-     ]
-    },
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "class CustomTrainState(train_state.TrainState):\n",
+    "    batch_stats: Any = None\n",
+    "\n",
+    "custom_state = CustomTrainState.create(\n",
+    "    apply_fn=state.apply_fn,\n",
+    "    params=state.params,\n",
+    "    tx=state.tx,\n",
+    "    batch_stats=np.arange(10),\n",
+    ")\n",
+    "\n",
+    "custom_ckpt = {'model': custom_state, 'config': config, 'data': [x1]}\n",
+    "# Use a custom state to read the old `TrainState` checkpoint.\n",
+    "custom_target = {'model': custom_state, 'config': None, 'data': [jnp.zeros_like(x1)]}\n",
+    "\n",
+    "# Save it in Orbax.\n",
+    "custom_save_args = orbax_utils.save_args_from_target(custom_ckpt)\n",
+    "checkpoint_manager.save(5, custom_ckpt, save_kwargs={'save_args': custom_save_args})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "379c2255",
+   "metadata": {
+    "id": "379c2255"
+   },
+   "source": [
+    "It is recommended to keep your checkpoints up-to-date with your pytree dataclass definitions. However, you might be forced to restore the checkpoints with incompatible reference objects at runtime. When this happens, the checkpoint restoration will try to respect the structure of the reference when given.\n",
+    "\n",
+    "Below are examples of a few common scenarios."
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "d5fa9652",
+   "metadata": {},
+   "source": [
+    "### Scenario 1: When a reference object is partial\n",
+    "\n",
+    "If your reference object is a subtree of your checkpoint, the restoration will ignore the additional field(s) and restore a checkpoint with the same structure as the reference. \n",
+    "\n",
+    "Like in the example below, the `batch_stats` field in `CustomTrainState` was ignored, and the checkpoint was restored as a `TrainState`.\n",
+    "\n",
+    "This can also be useful for reading only part of your checkpoint."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "68828029",
+   "metadata": {},
+   "outputs": [
     {
      "data": {
       "text/plain": [
-       "{'model': TrainState(step=0, apply_fn=<bound method Module.apply of Dense(\n",
+       "{'config': {'dimensions': array([5, 3]), 'name': 'dense'},\n",
+       " 'data': [array([0.59902626, 0.2172144 , 2.4202902 , 0.03266738, 1.2164948 ],\n",
+       "        dtype=float32)],\n",
+       " 'model': TrainState(step=0, apply_fn=<bound method Module.apply of Dense(\n",
        "     # attributes\n",
        "     features = 3\n",
        "     use_bias = True\n",
@@ -528,71 +767,54 @@
        "            [ 0.36260957,  0.18276349, -0.6856061 ],\n",
        "            [-0.8519373 , -0.6416717 , -0.4818122 ],\n",
        "            [-0.6886102 , -0.33987316, -0.05898903]], dtype=float32),\n",
-       " }), tx=GradientTransformation(init=<function chain.<locals>.init_fn at 0x156587e50>, update=<function chain.<locals>.update_fn at 0x1565fb670>), opt_state=(EmptyState(), EmptyState())),\n",
-       " 'config': {'dimensions': array([5, 3]), 'name': 'dense'},\n",
-       " 'data': [array([0.59902626, 0.2172144 , 2.4202902 , 0.03266738, 1.2164948 ],\n",
-       "        dtype=float32)]}"
+       " }), tx=GradientTransformation(init=<function chain.<locals>.init_fn at 0x12ab6d1f0>, update=<function chain.<locals>.update_fn at 0x12abb7ca0>), opt_state=(EmptyState(), EmptyState()))}"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 16,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "class CustomTrainState(train_state.TrainState):\n",
-    "    batch_stats: Any = None\n",
-    "\n",
-    "custom_state = CustomTrainState.create(\n",
-    "    apply_fn=state.apply_fn,\n",
-    "    params=state.params,\n",
-    "    tx=state.tx,\n",
-    "    batch_stats=np.arange(10),\n",
-    ")\n",
-    "\n",
-    "# Use a custom state to read the old `TrainState` checkpoint.\n",
-    "custom_target = {'model': custom_state, 'config': None, 'data': [jnp.zeros_like(x1)]}\n",
-    "try:\n",
-    "    checkpoints.restore_checkpoint(ckpt_dir, target=custom_target, step=0)\n",
-    "except KeyError as e:\n",
-    "    print('KeyError when target state has an unmentioned field:')\n",
-    "    print(e)\n",
-    "    print('')\n",
-    "\n",
-    "\n",
-    "# Use the old `TrainState` to read the custom state checkpoint.\n",
-    "custom_ckpt = {'model': custom_state, 'config': config, 'data': [x1]}\n",
-    "checkpoints.save_checkpoint(ckpt_dir, custom_ckpt, step=1, overwrite=True,\n",
-    "                            keep=2, orbax_checkpointer=orbax_checkpointer)\n",
-    "print('Fields not present target state (\"batch_stats\" in this case) are skipped:')\n",
-    "checkpoints.restore_checkpoint(ckpt_dir, target=target, step=1)"
+    "restored = checkpoint_manager.restore(5, items=target)\n",
+    "assert not hasattr(restored, 'batch_stats')\n",
+    "assert type(restored['model']) == train_state.TrainState\n",
+    "restored"
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
-   "id": "379c2255",
-   "metadata": {
-    "id": "379c2255"
-   },
+   "id": "5c6822c6",
+   "metadata": {},
    "source": [
-    "It is recommended to keep your checkpoints up to date with your pytree dataclass definitions. You can keep a copy of your code along with your checkpoints.\n",
+    "### Scenario 2: When a checkpoint is partial\n",
     "\n",
-    "But if you must restore checkpoints and Flax dataclasses with incompatible fields, you can manually add/remove corresponding fields before passing in the correct target structure:"
+    "On the other hand, if the reference object contains a value that is not available in the checkpoint, the checkpointing code will by default warn that some data is not compatible.\n",
+    "\n",
+    "To bypass the error, you need to pass an Orbax [`transform`](https://github.com/google/orbax/blob/main/docs/checkpoint.md#transformations) that teaches Orbax how to conform this checkpoint into the structure of the `custom_target`.\n",
+    "\n",
+    "In this case, pass a default `{}` that lets Orbax use values in the `custom_target` to fill in the blank. This allows you to restore an old checkpoint into a new data structure, the `CustomTrainState`."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
-   "id": "29fd1e33",
-   "metadata": {
-    "id": "29fd1e33",
-    "outputId": "cdbb9247-d1eb-4458-aa83-8db0332af7cb"
-   },
+   "execution_count": 17,
+   "id": "a5d14c9f",
+   "metadata": {},
    "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "KeyError when target state has an unmentioned field: 'batch_stats'\n",
+      "\n"
+     ]
+    },
     {
      "data": {
       "text/plain": [
-       "{'config': {'dimensions': array([5, 3]), 'name': 'dense'},\n",
+       "{'config': None,\n",
        " 'data': [array([0.59902626, 0.2172144 , 2.4202902 , 0.03266738, 1.2164948 ],\n",
        "        dtype=float32)],\n",
        " 'model': CustomTrainState(step=1, apply_fn=<bound method Module.apply of Dense(\n",
@@ -612,21 +834,157 @@
        "            [ 0.36260957,  0.18276349, -0.6856061 ],\n",
        "            [-0.8519373 , -0.6416717 , -0.4818122 ],\n",
        "            [-0.6886102 , -0.33987316, -0.05898903]], dtype=float32),\n",
-       " }), tx=GradientTransformation(init=<function chain.<locals>.init_fn at 0x156587e50>, update=<function chain.<locals>.update_fn at 0x1565fb670>), opt_state=(None, None), batch_stats=array([9, 8, 7, 6, 5, 4, 3, 2, 1, 0]))}"
+       " }), tx=GradientTransformation(init=<function chain.<locals>.init_fn at 0x12ab6d1f0>, update=<function chain.<locals>.update_fn at 0x12abb7ca0>), opt_state=(EmptyState(), EmptyState()), batch_stats=array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]))}"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
+    "try:\n",
+    "    checkpoint_manager.restore(4, items=custom_target)\n",
+    "except KeyError as e:\n",
+    "    print(f'KeyError when target state has an unmentioned field: {e}')\n",
+    "    print('')\n",
+    "\n",
+    "# Step 4 is an original `TrainState`, without the `batch_stats`\n",
+    "restored = checkpoint_manager.restore(4, items=custom_target, \n",
+    "                                      restore_kwargs={'transforms': {}})\n",
+    "assert type(restored['model']) == CustomTrainState\n",
+    "np.testing.assert_equal(restored['model'].batch_stats, \n",
+    "                        custom_target['model'].batch_stats)\n",
+    "restored"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "74a4b0fd",
+   "metadata": {},
+   "source": [
+    "##### With Orbax\n",
+    "\n",
+    "If you have already saved your checkpoints with the Orbax backend, you can use `orbax_transforms` to access this `transforms` argument in the Flax API."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "29fd1e33",
+   "metadata": {
+    "id": "29fd1e33",
+    "outputId": "cdbb9247-d1eb-4458-aa83-8db0332af7cb"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'model': CustomTrainState(step=1, apply_fn=<bound method Module.apply of Dense(\n",
+       "     # attributes\n",
+       "     features = 3\n",
+       "     use_bias = True\n",
+       "     dtype = None\n",
+       "     param_dtype = float32\n",
+       "     precision = None\n",
+       "     kernel_init = init\n",
+       "     bias_init = zeros\n",
+       "     dot_general = dot_general\n",
+       " )>, params=FrozenDict({\n",
+       "     bias: array([-0.001, -0.001, -0.001], dtype=float32),\n",
+       "     kernel: array([[ 0.26048955, -0.61399287, -0.23458514],\n",
+       "            [ 0.11050402, -0.8765793 ,  0.9800635 ],\n",
+       "            [ 0.36260957,  0.18276349, -0.6856061 ],\n",
+       "            [-0.8519373 , -0.6416717 , -0.4818122 ],\n",
+       "            [-0.6886102 , -0.33987316, -0.05898903]], dtype=float32),\n",
+       " }), tx=GradientTransformation(init=<function chain.<locals>.init_fn at 0x12ab6d1f0>, update=<function chain.<locals>.update_fn at 0x12abb7ca0>), opt_state=(EmptyState(), EmptyState()), batch_stats=array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])),\n",
+       " 'config': None,\n",
+       " 'data': [array([0.59902626, 0.2172144 , 2.4202902 , 0.03266738, 1.2164948 ],\n",
+       "        dtype=float32)]}"
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Save in the \"Flax-with-Orbax\" backend.\n",
+    "flax.config.update('flax_use_orbax_checkpointing', True)\n",
+    "checkpoints.save_checkpoint(ckpt_dir='tmp/flax-checkpointing',\n",
+    "                            target=ckpt,\n",
+    "                            step=4,\n",
+    "                            overwrite=True,\n",
+    "                            keep=2)\n",
+    "\n",
+    "checkpoints.restore_checkpoint('tmp/flax-checkpointing', target=custom_target, step=4,\n",
+    "                               orbax_transforms={})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "830ef07c",
+   "metadata": {},
+   "source": [
+    "##### With the legacy API\n",
+    "\n",
+    "Using the legacy `flax.training.checkpoints` API, similar things are doable too, but they are not as flexible as the [Orbax Transformations](https://github.com/google/orbax/blob/main/docs/checkpoint.md#transformations).\n",
+    "\n",
+    "You need to restore the checkpoint to a raw dict with `target=None`, modify the structure accordingly, and then deserialize it back to the original target."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "051e7a16",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'model': CustomTrainState(step=1, apply_fn=<bound method Module.apply of Dense(\n",
+       "     # attributes\n",
+       "     features = 3\n",
+       "     use_bias = True\n",
+       "     dtype = None\n",
+       "     param_dtype = float32\n",
+       "     precision = None\n",
+       "     kernel_init = init\n",
+       "     bias_init = zeros\n",
+       "     dot_general = dot_general\n",
+       " )>, params=FrozenDict({\n",
+       "     bias: array([-0.001, -0.001, -0.001], dtype=float32),\n",
+       "     kernel: array([[ 0.26048955, -0.61399287, -0.23458514],\n",
+       "            [ 0.11050402, -0.8765793 ,  0.9800635 ],\n",
+       "            [ 0.36260957,  0.18276349, -0.6856061 ],\n",
+       "            [-0.8519373 , -0.6416717 , -0.4818122 ],\n",
+       "            [-0.6886102 , -0.33987316, -0.05898903]], dtype=float32),\n",
+       " }), tx=GradientTransformation(init=<function chain.<locals>.init_fn at 0x12ab6d1f0>, update=<function chain.<locals>.update_fn at 0x12abb7ca0>), opt_state=(EmptyState(), EmptyState()), batch_stats=array([9, 8, 7, 6, 5, 4, 3, 2, 1, 0])),\n",
+       " 'config': {'dimensions': array([5, 3]), 'name': 'dense'},\n",
+       " 'data': [array([0.59902626, 0.2172144 , 2.4202902 , 0.03266738, 1.2164948 ],\n",
+       "        dtype=float32)]}"
+      ]
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Save using the legacy Flax `checkpoints` API.\n",
+    "flax.config.update('flax_use_orbax_checkpointing', False)\n",
+    "checkpoints.save_checkpoint(ckpt_dir='tmp/flax-checkpointing',\n",
+    "                            target=ckpt,\n",
+    "                            step=5,\n",
+    "                            overwrite=True,\n",
+    "                            keep=2)\n",
+    "\n",
     "# Pass no target to get a raw state dictionary first.\n",
-    "raw_state_dict = checkpoints.restore_checkpoint(ckpt_dir, target=None, step=0)\n",
+    "raw_state_dict = checkpoints.restore_checkpoint('tmp/flax-checkpointing', target=None, step=5)\n",
     "# Add/remove fields as needed.\n",
     "raw_state_dict['model']['batch_stats'] = np.flip(np.arange(10))\n",
     "# Restore the classes with correct target now\n",
-    "orbax.checkpoint.utils.deserialize_tree(custom_target, raw_state_dict, keep_empty_nodes=True)"
+    "flax.serialization.from_state_dict(custom_target, raw_state_dict)"
    ]
   },
   {
@@ -640,16 +998,16 @@
     "\n",
     "Checkpointing is I/O heavy, and if you have a large amount of data to save, it may be worthwhile to put it into a background thread, while continuing with your training.\n",
     "\n",
-    "You can do this by creating an [`orbax.checkpoint.AsyncCheckpointer`](https://github.com/google/orbax/blob/main/orbax/checkpoint/async_checkpointer.py) (as demonstrated in the code cell below) and let it track your save thread.\n",
+    "You can do this by creating an [`orbax.checkpoint.AsyncCheckpointer`](https://github.com/google/orbax/blob/main/orbax/checkpoint/async_checkpointer.py) in place of the `orbax.checkpoint.PyTreeCheckpointer`.\n",
     "\n",
     "Note: You should use the same `async_checkpointer` to handle all your async saves across your training steps, so that it can make sure that a previous async save is done before the next one begins. This enables bookkeeping, such as `keep` (the number of checkpoints) and `overwrite` to be consistent across steps.\n",
     "\n",
-    "Whenever you want to explicitly wait until an async save is done, you can call `async_checkpointer.wait_until_finished()`. Alternatively, you can pass in `orbax_checkpointer=async_checkpointer` when running `restore_checkpoint` and Flax will automatically wait and restore safely."
+    "Whenever you want to explicitly wait until an async save is done, you can call `async_checkpointer.wait_until_finished()`."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 20,
    "id": "85be68a6",
    "metadata": {
     "id": "85be68a6",
@@ -660,19 +1018,29 @@
      "data": {
       "text/plain": [
        "{'config': {'dimensions': array([5, 3]), 'name': 'dense'},\n",
-       " 'data': {'0': array([0.59902626, 0.2172144 , 2.4202902 , 0.03266738, 1.2164948 ],\n",
-       "        dtype=float32)},\n",
-       " 'model': {'opt_state': {'0': None, '1': None},\n",
-       "  'params': {'bias': array([-0.001, -0.001, -0.001], dtype=float32),\n",
-       "   'kernel': array([[ 0.26048955, -0.61399287, -0.23458514],\n",
-       "          [ 0.11050402, -0.8765793 ,  0.9800635 ],\n",
-       "          [ 0.36260957,  0.18276349, -0.6856061 ],\n",
-       "          [-0.8519373 , -0.6416717 , -0.4818122 ],\n",
-       "          [-0.6886102 , -0.33987316, -0.05898903]], dtype=float32)},\n",
-       "  'step': 1}}"
+       " 'data': [array([0.59902626, 0.2172144 , 2.4202902 , 0.03266738, 1.2164948 ],\n",
+       "        dtype=float32)],\n",
+       " 'model': TrainState(step=1, apply_fn=<bound method Module.apply of Dense(\n",
+       "     # attributes\n",
+       "     features = 3\n",
+       "     use_bias = True\n",
+       "     dtype = None\n",
+       "     param_dtype = float32\n",
+       "     precision = None\n",
+       "     kernel_init = init\n",
+       "     bias_init = zeros\n",
+       "     dot_general = dot_general\n",
+       " )>, params=FrozenDict({\n",
+       "     bias: array([-0.001, -0.001, -0.001], dtype=float32),\n",
+       "     kernel: array([[ 0.26048955, -0.61399287, -0.23458514],\n",
+       "            [ 0.11050402, -0.8765793 ,  0.9800635 ],\n",
+       "            [ 0.36260957,  0.18276349, -0.6856061 ],\n",
+       "            [-0.8519373 , -0.6416717 , -0.4818122 ],\n",
+       "            [-0.6886102 , -0.33987316, -0.05898903]], dtype=float32),\n",
+       " }), tx=GradientTransformation(init=<function chain.<locals>.init_fn at 0x12ab6d1f0>, update=<function chain.<locals>.update_fn at 0x12abb7ca0>), opt_state=(EmptyState(), EmptyState()))}"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 20,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -680,22 +1048,21 @@
    "source": [
     "# `orbax.checkpoint.AsyncCheckpointer` needs some multi-process initialization, because it was\n",
     "# originally designed for multi-process large model checkpointing.\n",
-    "# For Python notebooks or other single-process setting, just set up with `num_processes=1`.\n",
+    "# For Python notebooks or other single-process settings, just set up with `num_processes=1`.\n",
     "# Refer to https://jax.readthedocs.io/en/latest/multi_process.html#initializing-the-cluster\n",
     "# for how to set it up in multi-process scenarios.\n",
     "jax.distributed.initialize(\"localhost:8889\", num_processes=1, process_id=0)\n",
     "\n",
-    "async_checkpointer = orbax.checkpoint.AsyncCheckpointer(orbax.checkpoint.PyTreeCheckpointHandler(), timeout_secs=50)\n",
+    "async_checkpointer = orbax.checkpoint.AsyncCheckpointer(\n",
+    "    orbax.checkpoint.PyTreeCheckpointHandler(), timeout_secs=50)\n",
     "\n",
-    "# Mimic a training loop here:\n",
-    "for step in range(2, 3):\n",
-    "    checkpoints.save_checkpoint(ckpt_dir, ckpt, step=2, overwrite=True, keep=3,\n",
-    "                                orbax_checkpointer=async_checkpointer)\n",
-    "    # ... Continue with your work...\n",
+    "# Save your job:\n",
+    "async_checkpointer.save('tmp/orbax/single_save_async', ckpt, save_args=save_args)\n",
+    "# ... Continue with your work...\n",
     "\n",
     "# ... Until a time when you want to wait until the save completes:\n",
     "async_checkpointer.wait_until_finished()  # Blocks until the checkpoint saving is completed.\n",
-    "checkpoints.restore_checkpoint(ckpt_dir, target=None, step=2)"
+    "async_checkpointer.restore('tmp/orbax/single_save_async', item=target)"
    ]
   },
   {
@@ -705,7 +1072,19 @@
     "id": "QpuTCeMVXOBn"
    },
    "source": [
-    "To save and restore with pure Orbax, `AsyncCheckpointer` can be used with the same APIs as `Checkpointer` as shown above."
+    "If you are using Orbax `CheckpointManager`, just pass in the async_checkpointer when initializing it. Then, in practice, call `async_checkpoint_manager.wait_until_finished()` instead."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "id": "af33b138",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async_checkpoint_manager = orbax.checkpoint.CheckpointManager(\n",
+    "    'tmp/orbax/managed_async', async_checkpointer, options)\n",
+    "async_checkpoint_manager.wait_until_finished()"
    ]
   },
   {
@@ -719,53 +1098,93 @@
     "\n",
     "JAX provides a few ways to scale up your code on multiple hosts at the same time. This usually happens when the number of devices (CPU/GPU/TPU) is so large that different devices are managed by different hosts (CPU). To get started on JAX in multi-process settings, check out [Using JAX in multi-host and multi-process environments](https://jax.readthedocs.io/en/latest/multi_process.html) and the [distributed array guide](https://jax.readthedocs.io/en/latest/notebooks/Distributed_arrays_and_automatic_parallelization.html).\n",
     "\n",
-    "In the [Single Program Multi Data (SPMD)](https://jax.readthedocs.io/en/latest/glossary.html#term-SPMD) paradigm with JAX [`pjit`](https://jax.readthedocs.io/en/latest/jax.experimental.pjit.html), a large multi-process array can have its data sharded across different devices (check out the `pjit` [JAX-101 tutorial](https://jax.readthedocs.io/en/latest/jax-101/08-pjit.html)). When a multi-process array is serialized, each host dumps its data shards to a single shared storage, such as a Google Cloud bucket.\n",
+    "In the [Single Program Multi Data (SPMD)](https://jax.readthedocs.io/en/latest/glossary.html#term-SPMD) paradigm with JAX `jit`, a large multi-process array can have its data sharded across different devices. (Note that JAX `pjit` and `jit` have been merged into a single unified interface. To learn about compiling and executing JAX functions in multi-host or multi-core environments, refer to [this guide](https://jax.readthedocs.io/en/latest/notebooks/Distributed_arrays_and_automatic_parallelization.html) and the [jax.Array migration guide](https://jax.readthedocs.io/en/latest/jax_array_migration.html).) When a multi-process array is serialized, each host dumps its data shards to a single shared storage, such as a Google Cloud bucket.\n",
     "\n",
-    "Orbax supports saving and loading pytrees with multi-process arrays in the same fashion as single-process pytrees. However, it's recommended to use the asynchronized [`orbax.AsyncCheckpointer`](https://github.com/google/orbax/blob/main/orbax/checkpoint/async_checkpointer.py) to save large multi-process arrays on another thread, so that you can perform computation alongside the saves. With pure Orbax, saving checkpoints in a multiprocess context uses the same API as in a single process context.\n",
-    "\n",
-    "To save multi-process arrays, use [`flax.training.checkpoints.save_checkpoint_multiprocess()`](https://flax.readthedocs.io/en/latest/api_reference/flax.training.html#flax.training.checkpoints.save_checkpoint_multiprocess) in place of `save_checkpoint()` and with the same arguments.\n",
-    "\n",
-    "Unfortunately, Python Jupyter notebooks are single-host only and cannot activate the multi-host mode. You can treat the following code as an example for running your multi-host checkpointing:"
+    "Orbax supports saving and loading pytrees with multi-process arrays in the same fashion as single-process pytrees. However, it's recommended to use the asynchronized [`orbax.AsyncCheckpointer`](https://github.com/google/orbax/blob/main/orbax/checkpoint/async_checkpointer.py) to save large multi-process arrays on another thread, so that you can perform computation alongside the saves. With pure Orbax, saving checkpoints in a multi-process context uses the same API as in a single-process context."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
-   "id": "d199c8fa",
-   "metadata": {
-    "id": "d199c8fa"
-   },
-   "outputs": [],
-   "source": [
-    "# Multi-host related imports.\n",
-    "from jax.sharding import PartitionSpec\n",
-    "from jax.experimental import pjit"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 22,
    "id": "ubdUvyMrhD-1",
    "metadata": {
     "id": "ubdUvyMrhD-1"
    },
    "outputs": [],
    "source": [
-    "# Create a multi-process array.\n",
+    "from jax.sharding import PartitionSpec, NamedSharding\n",
+    "\n",
+    "# Create an array sharded across multiple devices.\n",
     "mesh_shape = (4, 2)\n",
     "devices = np.asarray(jax.devices()).reshape(*mesh_shape)\n",
     "mesh = jax.sharding.Mesh(devices, ('x', 'y'))\n",
     "\n",
-    "f = pjit.pjit(\n",
-    "  lambda x: x,\n",
-    "  in_axis_resources=None,\n",
-    "  out_axis_resources=PartitionSpec('x', 'y'))\n",
+    "mp_array = jax.device_put(np.arange(8 * 2).reshape(8, 2),\n",
+    "                          NamedSharding(mesh, PartitionSpec('x', 'y')))\n",
     "\n",
-    "with jax.sharding.Mesh(mesh.devices, mesh.axis_names):\n",
-    "    mp_array = f(np.arange(8 * 2).reshape(8, 2))\n",
-    "\n",
-    "# Make it a pytree as usual.\n",
+    "# Make it a pytree.\n",
     "mp_ckpt = {'model': mp_array}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "id": "a669bc05",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async_checkpoint_manager.save(0, mp_ckpt)\n",
+    "async_checkpoint_manager.wait_until_finished()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4deee32e",
+   "metadata": {},
+   "source": [
+    "When restoring a checkpoint with multi-process arrays, you need to specify what `sharding` each array should be restored back to. Otherwise, they will be restored as large `np.array`s on process 0, costing time and memory.\n",
+    "\n",
+    "(In this notebook, since we are on single-process, it will be restored as `np.array` even if we provide shardings.)\n",
+    "\n",
+    "### With Orbax\n",
+    "\n",
+    "Orbax allows you to specify this by passing a pytree of `sharding`s in `restore_args`. If you already have a reference pytree that has all the arrays with the right sharding, you can use `orbax_utils.restore_args_from_target` to transform it into the `restore_args` that Orbax needs."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "id": "b8e7daaa",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'model': array([[ 0,  1],\n",
+       "        [ 2,  3],\n",
+       "        [ 4,  5],\n",
+       "        [ 6,  7],\n",
+       "        [ 8,  9],\n",
+       "        [10, 11],\n",
+       "        [12, 13],\n",
+       "        [14, 15]], dtype=int32)}"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# The reference doesn't need to be as large as your checkpoint!\n",
+    "# Just make sure it has the `.sharding` you want.\n",
+    "mp_smaller = jax.device_put(np.arange(8).reshape(4, 2),\n",
+    "                            NamedSharding(mesh, PartitionSpec('x', 'y')))\n",
+    "ref_ckpt = {'model': mp_smaller}\n",
+    "\n",
+    "restore_args = orbax_utils.restore_args_from_target(ref_ckpt)\n",
+    "async_checkpoint_manager.restore(\n",
+    "    0, items=ref_ckpt, restore_kwargs={'restore_args': restore_args})"
    ]
   },
   {
@@ -775,16 +1194,16 @@
     "id": "edc355ce"
    },
    "source": [
-    "### Example: Save a checkpoint in a multi-process setting with `save_checkpoint_multiprocess`\n",
+    "### With the legacy Flax: use `save_checkpoint_multiprocess`\n",
     "\n",
-    "The arguments in [`flax.training.checkpoints.save_checkpoint_multiprocess`](https://flax.readthedocs.io/en/latest/api_reference/flax.training.html#flax.training.checkpoints.save_checkpoint_multiprocess) are the same as in [`flax.training.checkpoints.save_checkpoint`](https://flax.readthedocs.io/en/latest/api_reference/flax.training.html#flax.training.checkpoints.save_checkpoint).\n",
+    "In legacy Flax, to save multi-process arrays, use [`flax.training.checkpoints.save_checkpoint_multiprocess()`](https://flax.readthedocs.io/en/latest/api_reference/flax.training.html#flax.training.checkpoints.save_checkpoint_multiprocess) in place of `save_checkpoint()` and with the same arguments.\n",
     "\n",
     "If your checkpoint is too large, you can specify `timeout_secs` in the manager and give it more time to finish writing."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 25,
    "id": "5d10039b",
    "metadata": {
     "id": "5d10039b",
@@ -794,10 +1213,10 @@
     {
      "data": {
       "text/plain": [
-       "'tmp/flax-checkpointing/checkpoint_3'"
+       "'tmp/checkpoint_3'"
       ]
      },
-     "execution_count": 15,
+     "execution_count": 25,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -813,20 +1232,8 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "id": "d954c3c7",
-   "metadata": {
-    "id": "d954c3c7"
-   },
-   "source": [
-    "### Example: Restoring a checkpoint with `flax.training.checkpoints.restore_checkpoint`\n",
-    "\n",
-    "Note that, when using [`flax.training.checkpoints.restore_checkpoint`](https://flax.readthedocs.io/en/latest/api_reference/flax.training.html#flax.training.checkpoints.restore_checkpoint), you need to pass a `target` with valid multi-process arrays at the correct structural location. Flax only uses the `target` arrays' meshes and mesh axes to restore the checkpoint. This means that the multi-process array in the `target` arg doesn't have to be as large as your checkpoint's size (the shape of the multi-process array doesn't need to have the same shape as the actual array in your checkpoint)."
-   ]
-  },
-  {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 26,
    "id": "a9f9724c",
    "metadata": {
     "id": "a9f9724c",
@@ -846,21 +1253,70 @@
        "        [14, 15]], dtype=int32)}"
       ]
      },
-     "execution_count": 16,
+     "execution_count": 26,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "with jax.sharding.Mesh(mesh.devices, mesh.axis_names):\n",
-    "    mp_smaller_array = f(np.zeros(8).reshape(4, 2))\n",
-    "\n",
-    "mp_target = {'model': mp_smaller_array}\n",
     "mp_restored = checkpoints.restore_checkpoint(ckpt_dir,\n",
-    "                                             target=mp_target,\n",
+    "                                             target=ref_ckpt,\n",
     "                                             step=3,\n",
     "                                             orbax_checkpointer=async_checkpointer)\n",
     "mp_restored"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "65cfdd59",
+   "metadata": {},
+   "source": [
+    "## Orbax-as-backend troubleshooting\n",
+    "\n",
+    "As an intermediate stage of the migration (to Orbax from the legacy Flax `checkpoints` API), `flax.training.checkpoints` APIs will start to use Orbax as their backend when saving checkpoints starting from May 15, 2023.\n",
+    "\n",
+    "Checkpoints saved with the Orbax backend can be readable by either `flax.training.checkpoints.restore_checkpoint` or `orbax.checkpoint.PyTreeCheckpointer`.\n",
+    "\n",
+    "Code-wise, this is equivalent to setting the config flag [`flax.config.flax_use_orbax_checkpointing`](https://github.com/google/flax/blob/main/flax/configurations.py#L103) default to `True`. You can overwrite this value in your project with `flax.config.update('flax_use_orbax_checkpointing', <BoolValue>)` at any time.\n",
+    "\n",
+    "In general, this automatic migration will not affect most users. However, you may encounter issues if your API usage follows some specific pattern. Check out the sections below for troubleshooting."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "415bceb1",
+   "metadata": {},
+   "source": [
+    "### If your devices hang when writing checkpoints\n",
+    "\n",
+    "If you are running in a multi-host environment (usually anything larger than 8 TPU devices) and your devices hang when writing checkpoints, check if your code is in the following pattern (that is, the `save_checkpoint` only ran on host `0`):\n",
+    "\n",
+    "```\n",
+    "if jax.process_index() == 0:\n",
+    "  flax.training.checkpoints.save_checkpoint(...)\n",
+    "```\n",
+    "\n",
+    "Unfortunately this is a legacy pattern that will be deprecated and won't be supported, because in a multi-process environment, the checkpointing code should coordinate among hosts instead of being triggered only on the host `0`. Replacing the code above with the following should resolve the hang issue:\n",
+    "\n",
+    "```\n",
+    "flax.training.checkpoints.save_checkpoint_multiprocess(...)\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "70e0ebb3",
+   "metadata": {},
+   "source": [
+    "### If you don't save pytrees\n",
+    "\n",
+    "Orbax uses `orbax.checkpoint.PyTreeCheckpointHandler` to save checkpoints, which means they only save pytrees.\n",
+    "\n",
+    "If you want to save singular arrays or numbers, you have two options:\n",
+    "\n",
+    "1. Use `orbax.ArrayCheckpointHandler` to save them following [this migration section](https://flax.readthedocs.io/en/latest/guides/orbax_upgrade_guide.html#saving-loading-a-single-jax-or-numpy-array).\n",
+    "\n",
+    "1. Wrap it inside a pytree and save as usual."
    ]
   }
  ],

--- a/docs/guides/use_checkpointing.md
+++ b/docs/guides/use_checkpointing.md
@@ -13,18 +13,38 @@ jupyter:
 <!-- #region id="6e9134fa" -->
 # Save and load checkpoints
 
-In this guide, you will learn about saving and loading checkpoints with Flax and [Orbax](https://github.com/google/orbax). With Flax, you can save and load model parameters, metadata, and a variety of Python data using Orbax.
+This guide demonstrates how to save and load Flax checkpoints with [Orbax](https://github.com/google/orbax).
 
-Orbax provides a customizable and flexible API for various array types and storage formats. In addition, Flax provides basic features for versioning, automatic bookkeeping of past checkpoints, and asynchronous saving to reduce training wait time.
+Orbax provides a variety of features for saving and loading model data, which you will learn about in this doc:
 
-> **_Ongoing migration:_** In the foreseeable future, Flax's checkpointing functionality will gradually be migrated to Orbax from `flax.training.checkpoints`. All existing features in the Flax API will continue to be supported, but the API will change. You are encouraged to try out the new API by creating an [`orbax.checkpoint.Checkpointer`](https://github.com/google/orbax/blob/main/orbax/checkpoint/checkpointer.py) and pass it in your Flax API calls as an argument `orbax_checkpointer`, as demonstrated later in this guide. This guide provides the most up-to-date code examples for using Orbax and Flax for checkpointing. The Orbax features described below are presented in a very limited fashion: see [Orbax](https://github.com/google/orbax/blob/main/docs/checkpoint.md) for full documentation.
+*  Support for various array types and storage formats
+*  Asynchronous saving to reduce training wait time
+*  Versioning and automatic bookkeeping of past checkpoints
+*  Flexible [`transformations`](https://github.com/google/orbax/blob/main/docs/checkpoint.md#transformations) to tweak and load old checkpoints
+*  [`jax.sharding`](https://jax.readthedocs.io/en/latest/notebooks/Distributed_arrays_and_automatic_parallelization.html)-based API to save and load in multi-host scenarios
 
-This guide covers the following:
+---
+**_Ongoing migration to Orbax:_** 
 
-* Basic saving and loading of checkpoints with [`orbax.checkpoint.Checkpointer`](https://github.com/google/orbax/blob/main/orbax/checkpoint/checkpointer.py) and [`flax.training.checkpoints.save_checkpoint`](https://flax.readthedocs.io/en/latest/api_reference/flax.training.html#flax.training.checkpoints.save_checkpoint).
-* More flexible and sustainable ways to load checkpoints ([`flax.training.checkpoints.restore_checkpoint`](https://flax.readthedocs.io/en/latest/api_reference/flax.training.html#flax.training.checkpoints.restore_checkpoint)).
-* How to save and load checkpoints when you run in multi-host scenarios with
-[`flax.training.checkpoints.save_checkpoint_multiprocess`](https://flax.readthedocs.io/en/latest/api_reference/flax.training.html#flax.training.checkpoints.save_checkpoint_multiprocess).
+After July 30 2023, Flax's legacy `flax.training.checkpoints` API will be deprecated in favor of [Orbax](https://github.com/google/orbax).
+
+*  **If you are a new Flax user**: Use the new `orbax.checkpoint` API, as demonstrated in this guide.
+
+*  **If you have legacy `flax.training.checkpoints` code in your project**: Consider the following options:
+
+   * **Migrating your code to Orbax (Recommended)**: Migrate your API calls to `orbax.checkpoint` API by following this [migration guide](https://flax.readthedocs.io/en/latest/guides/orbax_upgrade_guide.html).
+
+   * **Automatically use the Orbax backend**: Add `flax.config.update('flax_use_orbax_checkpointing', True)` to your project, which will let your `flax.training.checkpoints` calls automatically use the Orbax backend to save your checkpoints.
+     
+     * **Scheduled flip**: This will become the default mode after **May 2023** (tentative date).
+
+     * Visit [Orbax-as-backend troubleshooting section](https://flax.readthedocs.io/en/latest/guides/use_checkpointing.html#orbax-as-backend-troubleshooting) if you meet any issue in the automatic migration.
+---
+
+For backward-compatibility, this guide shows the Orbax-equivalent calls in the Flax legacy `flax.training.checkpoints` API.
+
+If you need to learn more about `orbax.checkpoint`, refer to the [Orbax docs](https://github.com/google/orbax/blob/main/docs/checkpoint.md).
+
 <!-- #endregion -->
 
 <!-- #region id="5a2f6aae" -->
@@ -34,15 +54,12 @@ Install/upgrade Flax and [Orbax](https://github.com/google/orbax). For JAX insta
 <!-- #endregion -->
 
 ```python tags=["skip-execution"]
-# replace with `pip install flax` after release 0.6.9.
-! pip install -U "git+https://github.com/google/flax.git@main#egg=flax"
-
-# Orbax needs to enable asyncio in a Colab environment.
-! pip install -qq nest_asyncio
+# replace with `pip install -U flax` after release 0.6.9.
+! pip install -U -qq "git+https://github.com/google/flax.git@main#egg=flax"
 ```
 
 <!-- #region id="-icO30rwmKYj" -->
-Note: Before running `import jax`, create eight fake devices to mimic [multi-host environment](https://jax.readthedocs.io/en/latest/jax-101/06-parallelism.html?#aside-hosts-and-devices-in-jax) this notebook. Note that the order of imports is important here. The `os.environ["XLA_FLAGS"] = '--xla_force_host_platform_device_count=8'` command works only with the CPU backend. This means it won't work with GPU/TPU acceleration on if you're running this notebook in Google Colab. If you are already running the code on multiple devices (for example, in a 4x2 TPU environment), you can skip running the next cell.
+Note: Before running `import jax`, create eight fake devices to mimic a [multi-host environment](https://jax.readthedocs.io/en/latest/jax-101/06-parallelism.html?#aside-hosts-and-devices-in-jax) in this notebook. Note that the order of imports is important here. The `os.environ["XLA_FLAGS"] = '--xla_force_host_platform_device_count=8'` command works only with the CPU backend, which means it won't work with GPU/TPU acceleration on if you're running this notebook in Google Colab. If you are already running the code on multiple devices (for example, in a 4x2 TPU environment), you can skip running the next cell.
 <!-- #endregion -->
 
 ```python id="ArKLnsyGRxGv"
@@ -65,16 +82,21 @@ from flax import struct, serialization
 import orbax.checkpoint
 
 import optax
-import nest_asyncio
-nest_asyncio.apply()
+```
+
+```python
+ckpt_dir = 'tmp'
+
+if os.path.exists(ckpt_dir):
+    shutil.rmtree(ckpt_dir)  # Remove any existing checkpoints from the last notebook run.
 ```
 
 <!-- #region id="40d434cd" -->
 ## Save checkpoints
 
-In Flax, you save and load any given JAX [pytree](https://jax.readthedocs.io/en/latest/pytrees.html) using the `flax.training.checkpoints` package. This includes not only typical Python and NumPy containers, but also customized classes extended from [`flax.struct.dataclass`](https://flax.readthedocs.io/en/latest/api_reference/flax.struct.html#flax.struct.dataclass). That means you can store almost any data generated—not only your model parameters, but any arrays/dictionaries, metadata/configs, and so on.
+In Orbax and Flax, you can save and load any given JAX [pytree](https://jax.readthedocs.io/en/latest/pytrees.html). This includes not only typical Python and NumPy containers, but also customized classes extended from [`flax.struct.dataclass`](https://flax.readthedocs.io/en/latest/api_reference/flax.struct.html#flax.struct.dataclass). That means you can store almost any data generated — not only your model parameters, but any arrays/dictionaries, metadata/configs, and so on.
 
-Create a pytree with many data structures and containers, and play with it:
+First, create a pytree with many data structures and containers, and play with it:
 <!-- #endregion -->
 
 ```python id="56dec3f6" outputId="f1856d96-1961-48ed-bb7c-cb63fbaa7567"
@@ -102,94 +124,103 @@ ckpt = {'model': state, 'config': config, 'data': [x1]}
 ckpt
 ```
 
+### With Orbax
+
 <!-- #region id="6fc59dfa" -->
-Now save the checkpoint with Flax and Orbax. You can add annotations like step number, prefix, and so on to your checkpoint.
+Save the checkpoint with `orbax.checkpoint.PyTreeCheckpointer`, directly to the `tmp/orbax/single_save` directory.
 
-When saving a checkpoint, Flax will bookkeep the existing checkpoints based on your arguments. For example, by setting `overwrite=False` in [`flax.checkpoints.save_checkpoint`](https://flax.readthedocs.io/en/latest/api_reference/flax.training.html#flax.training.checkpoints.save_checkpoint), Flax will not automatically save your checkpoint if there is already a step that is equal to or newer than the current one presently in the checkpoint directory. By setting `keep=2`, Flax will keep a maximum of 2 checkpoints in the directory. Learn more in the [API reference](https://flax.readthedocs.io/en/latest/api_reference/flax.training.html#module-flax.training.checkpoints).
+Note: An optional `save_args` is provided. This is recommended for performance speedups, as it bundles smaller arrays in your pytree to a single large file instead of multiple smaller files.
+<!-- #endregion -->
 
-You can start to use Orbax to handle the underlying save by creating an [`orbax.checkpoint.Checkpointer`](https://github.com/google/orbax/blob/main/orbax/checkpoint/checkpointer.py), and pass it into the `flax.checkpoints.save_checkpoint` call.
+```python id="0pp4QtEqW9k7"
+from flax.training import orbax_utils
+
+orbax_checkpointer = orbax.checkpoint.PyTreeCheckpointer()
+save_args = orbax_utils.save_args_from_target(ckpt)
+orbax_checkpointer.save('tmp/orbax/single_save', ckpt, save_args=save_args)
+```
+
+Next, to use versioning and automatic bookkeeping features, you need to wrap `orbax.checkpoint.CheckpointManager` over `orbax.checkpoint.PyTreeCheckpointer`. 
+
+In addition, provide `orbax.checkpoint.CheckpointManagerOptions` that customizes your needs, such as how often and on what criteria you prefer old checkpoints be deleted. See [documentation](https://github.com/google/orbax/blob/main/docs/checkpoint.md#checkpointmanager) for a full list of options offered.
+
+`orbax.checkpoint.CheckpointManager` should be placed at the top-level outside your training steps to manage your saves.
+
+```python id="T6T8V4UBXB1R" outputId="b7132933-566d-440d-c34e-c5468d87cbdc"
+options = orbax.checkpoint.CheckpointManagerOptions(max_to_keep=2, create=True)
+checkpoint_manager = orbax.checkpoint.CheckpointManager(
+    'tmp/orbax/managed', orbax_checkpointer, options)
+
+# Inside a training loop
+for step in range(5):
+    # ... do your training
+    checkpoint_manager.save(step, ckpt, save_kwargs={'save_args': save_args})
+
+os.listdir('tmp/orbax/managed')  # Because max_to_keep=2, only step 3 and 4 are retained
+```
+
+<!-- #region id="OQkUOkHVW_4e" -->
+### With the legacy API
+
+And here's how to save with the legacy Flax checkpointing utilities (note that this provides less management features compared with `orbax.checkpoint.CheckpointManagerOptions`):
 <!-- #endregion -->
 
 ```python id="4cdb35ef" outputId="6d849273-15ce-4480-8864-726d1838ac1f"
 # Import Flax Checkpoints.
 from flax.training import checkpoints
 
-ckpt_dir = 'tmp/flax-checkpointing'
-
-if os.path.exists(ckpt_dir):
-    shutil.rmtree(ckpt_dir)  # Remove any existing checkpoints from the last notebook run.
-
-orbax_checkpointer = orbax.checkpoint.PyTreeCheckpointer()
-checkpoints.save_checkpoint(ckpt_dir=ckpt_dir,
+checkpoints.save_checkpoint(ckpt_dir='tmp/flax-checkpointing',
                             target=ckpt,
                             step=0,
-                            overwrite=False,
-                            keep=2,
-                            orbax_checkpointer=orbax_checkpointer)
-```
-
-<!-- #region id="JPcVYi74W6zM" -->
-This can be expressed equivalently using Orbax without Flax wrappers. See [Orbax](https://github.com/google/orbax) documentation for more information on how save behavior can be customized.
-<!-- #endregion -->
-
-```python id="0pp4QtEqW9k7"
-save_args = jax.tree_util.tree_map(
-    lambda _: orbax.checkpoint.SaveArgs(aggregate=True), ckpt)
-orbax_checkpointer.save(os.path.join(ckpt_dir, 'orbax_checkpoint'),
-    ckpt,
-    save_args=save_args)
-```
-
-<!-- #region id="OQkUOkHVW_4e" -->
-It is also possible to use pure Orbax to manage multiple checkpoints across different steps. Again, see [Orbax](https://github.com/google/orbax) documentation for detailed information.
-<!-- #endregion -->
-
-```python id="T6T8V4UBXB1R" outputId="b7132933-566d-440d-c34e-c5468d87cbdc"
-orbax_ckpt_dir = 'tmp/orbax-checkpointing'
-if os.path.exists(orbax_ckpt_dir):
-    shutil.rmtree(orbax_ckpt_dir)  # Remove any existing checkpoints from the last notebook run.
-os.mkdir(orbax_ckpt_dir)
-options = orbax.checkpoint.CheckpointManagerOptions(max_to_keep=2)
-checkpoint_manager = orbax.checkpoint.CheckpointManager(orbax_ckpt_dir, orbax_checkpointer, options)
-checkpoint_manager.save(0, ckpt, save_kwargs={'save_args': save_args})
+                            overwrite=True,
+                            keep=2)
 ```
 
 <!-- #region id="6b658bd1" -->
 ## Restore checkpoints
 
-To restore a checkpoint, use [`flax.training.checkpoints.restore_checkpoint`](https://flax.readthedocs.io/en/latest/api_reference/flax.training.html#flax.training.checkpoints.restore_checkpoint) and pass in the checkpoint directory. Flax will automatically select the latest checkpoint in the directory. You can also choose to specify a step number or the path of the checkpoint file.
+### With Orbax
 
-With the migration to Orbax in progress, `restore_checkpoint` can automatically identify whether a checkpoint is saved in the legacy (Flax) or Orbax version, and restore the pytree correctly.
-
-You can always restore a pytree out of your checkpoints by setting `target=None`.
-<!-- #endregion -->
-
-```python id="150b20a0" outputId="85ffceca-f38d-46b8-e567-d9d38b7885f9"
-raw_restored = checkpoints.restore_checkpoint(ckpt_dir=ckpt_dir, target=None)
-raw_restored
-```
-
-<!-- #region id="VKJrfSyLXGrc" -->
-Equivalently using pure Orbax:
+In Orbax, call `.restore()` for either `orbax.checkpoint.PyTreeCheckpointer` or `orbax.checkpoint.CheckpointManager` to restore your checkpoint in the raw pytree format.
 <!-- #endregion -->
 
 ```python id="WgRJj3wjXIaN" outputId="b4af1ef4-f22f-459b-bdca-2e6bfa16c08b"
-raw_restored = orbax_checkpointer.restore(os.path.join(ckpt_dir, 'orbax_checkpoint'))
+raw_restored = orbax_checkpointer.restore('tmp/orbax/single_save')
+raw_restored
+```
+
+Note that the `step` number is required for `CheckpointManger`. You can also use `.latest_step()` to find the latest step available.
+
+```python
+step = checkpoint_manager.latest_step()  # step = 4
+checkpoint_manager.restore(step)
+```
+
+<!-- #region id="VKJrfSyLXGrc" -->
+### With the legacy API
+
+Note that with the migration to Orbax in progress, `flax.training.checkpointing.restore_checkpoint` can automatically identify whether a checkpoint is saved in the legacy Flax format or with an Orbax backend, and restore the pytree correctly. Therefore, adding `flax.config.update('flax_use_orbax_checkpointing', True)` won't hurt your ability to restore old checkpoints.
+
+Here's how to restore checkpoints using the legacy API: 
+<!-- #endregion -->
+
+```python id="150b20a0" outputId="85ffceca-f38d-46b8-e567-d9d38b7885f9"
+raw_restored = checkpoints.restore_checkpoint(ckpt_dir='tmp/flax-checkpointing', target=None)
 raw_restored
 ```
 
 <!-- #region id="987b981f" -->
-However, when using `target=None`, the restored `raw_restored` will be different from the original `ckpt` in the following ways:
+## Restore with custom dataclasses
 
-1. There is no TrainState now, and only some raw weights and Optax state numbers remain.
-1. `metadata.dimensions` and `data` should be arrays, but restored as dictionaries with integers as keys.
-1. Previously, `data[0]` was a JAX NumPy array (`jnp.array`) —now it's a NumPy array (`numpy.array`).
+### With Orbax
 
-While (3) would not affect future work because JAX will [automatically convert](https://jax.readthedocs.io/en/latest/jax-101/01-jax-basics.html) NumPy arrays to JAX arrays once the computation starts, (1) and (2) may lead to confusions.
+*  The pytrees restored in the previous examples are in the form of raw dictionaries. Original pytrees contain custom dataclasses like [`TrainState`](https://flax.readthedocs.io/en/latest/flip/1009-optimizer-api.html?#train-state) and `optax` states.
+*  This is because when restoring a pytree, the program does not yet know which structure it once belonged to.
+*  To resolve this, you should first provide an example pytree to let Orbax or Flax know exactly which structure to restore to.
 
-To resolve this, you should pass an example `target` in `flax.training.checkpoints.restore_checkpoint` to let Flax know exactly what structure it should restore to. The `target` should introduce any custom Flax dataclasses explicitly, and have the same structure as the saved checkpoint.
+This section demonstrates how to set up any custom Flax dataclass explicitly, and have the same structure as a saved checkpoint.
 
-It's often recommended to refactor out the process of initializing a checkpoint's structure (for example, a [`TrainState`](https://flax.readthedocs.io/en/latest/flip/1009-optimizer-api.html?#train-state)), so that saving/loading is easier and less error-prone. This is because complicated objects like `apply_fn` and `tx` (optimizer) are not stored in the checkpoint file and must be initiated by code.
+Note: Data that was a JAX NumPy array (`jnp.array`) format will be restored as a NumPy array (`numpy.array`). This would not affect your work because JAX will [automatically convert](https://jax.readthedocs.io/en/latest/jax-101/01-jax-basics.html) NumPy arrays to JAX arrays once the computation starts.
 <!-- #endregion -->
 
 ```python id="58f42513" outputId="110c6b6e-fe42-4179-e5d8-6b92d355e11b"
@@ -200,16 +231,34 @@ empty_state = train_state.TrainState.create(
 )
 empty_config = {'dimensions': np.array([0, 0]), 'name': ''}
 target = {'model': empty_state, 'config': empty_config, 'data': [jnp.zeros_like(x1)]}
-state_restored = checkpoints.restore_checkpoint(ckpt_dir, target=target, step=0)
+state_restored = orbax_checkpointer.restore('tmp/orbax/single_save', item=target)
 state_restored
 ```
 
+### With the legacy API
+
+Alternatively, you can restore from Orbax `CheckpointManager` and from the legacy Flax code as follows:
+
+```python
+checkpoint_manager.restore(4, items=target)
+```
+
+```python
+checkpoints.restore_checkpoint(ckpt_dir='tmp/flax-checkpointing', target=target)
+```
+
+It's often recommended to refactor out the process of initializing a checkpoint's structure (for example, a [`TrainState`](https://flax.readthedocs.io/en/latest/flip/1009-optimizer-api.html?#train-state)), so that saving/loading is easier and less error-prone. This is because functions and complex objects like `apply_fn` and `tx` (optimizer) cannot be serialized into the checkpoint file and must be initialized by code.
+
 <!-- #region id="136a300a" -->
-### Backward/forward dataclass compatibility
+## Restore when checkpoint structures differ
 
-The flexibility of using *Flax dataclasses*—[`flax.struct.dataclass`](https://flax.readthedocs.io/en/latest/api_reference/flax.struct.html#flax.struct.dataclass)—means that changes in Flax dataclass fields may break your existing checkpoints. For example, if you decide to add a field `batch_stats` to your `TrainState` (like when using [batch normalization](https://flax.readthedocs.io/en/latest/guides/batch_norm.html)), old checkpoints without this field may not be successfully restored. Same goes for removing a field in your dataclass.
+During your development, your checkpoint structure will change when changing the model, adding/removing fields during tweaking, and so on.
 
-Note: Flax supports [`flax.struct.dataclass`](https://flax.readthedocs.io/en/latest/api_reference/flax.struct.html#flax.struct.dataclass), not Python's built-in `dataclasses.dataclass`.
+This section explains how to load old data to your new code.
+
+Below is  a simple example — a `CustomTrainState` extended from `flax.training.train_state.TrainState` that contains an extra field called `batch_stats`. When working on a real-world model, you may need this when applying [batch normalization](https://flax.readthedocs.io/en/latest/guides/batch_norm.html).
+
+Here, you store the new `CustomTrainState` as step 5, while step 4 contains the old/previous `TrainState`.
 <!-- #endregion -->
 
 ```python id="be65d4af" outputId="4fe776f0-65f8-4fc4-d64a-990520b36dce"
@@ -223,37 +272,98 @@ custom_state = CustomTrainState.create(
     batch_stats=np.arange(10),
 )
 
+custom_ckpt = {'model': custom_state, 'config': config, 'data': [x1]}
 # Use a custom state to read the old `TrainState` checkpoint.
 custom_target = {'model': custom_state, 'config': None, 'data': [jnp.zeros_like(x1)]}
-try:
-    checkpoints.restore_checkpoint(ckpt_dir, target=custom_target, step=0)
-except KeyError as e:
-    print('KeyError when target state has an unmentioned field:')
-    print(e)
-    print('')
 
-
-# Use the old `TrainState` to read the custom state checkpoint.
-custom_ckpt = {'model': custom_state, 'config': config, 'data': [x1]}
-checkpoints.save_checkpoint(ckpt_dir, custom_ckpt, step=1, overwrite=True,
-                            keep=2, orbax_checkpointer=orbax_checkpointer)
-print('Fields not present target state ("batch_stats" in this case) are skipped:')
-checkpoints.restore_checkpoint(ckpt_dir, target=target, step=1)
+# Save it in Orbax.
+custom_save_args = orbax_utils.save_args_from_target(custom_ckpt)
+checkpoint_manager.save(5, custom_ckpt, save_kwargs={'save_args': custom_save_args})
 ```
 
 <!-- #region id="379c2255" -->
-It is recommended to keep your checkpoints up to date with your pytree dataclass definitions. You can keep a copy of your code along with your checkpoints.
+It is recommended to keep your checkpoints up-to-date with your pytree dataclass definitions. However, you might be forced to restore the checkpoints with incompatible reference objects at runtime. When this happens, the checkpoint restoration will try to respect the structure of the reference when given.
 
-But if you must restore checkpoints and Flax dataclasses with incompatible fields, you can manually add/remove corresponding fields before passing in the correct target structure:
+Below are examples of a few common scenarios.
 <!-- #endregion -->
 
+### Scenario 1: When a reference object is partial
+
+If your reference object is a subtree of your checkpoint, the restoration will ignore the additional field(s) and restore a checkpoint with the same structure as the reference. 
+
+Like in the example below, the `batch_stats` field in `CustomTrainState` was ignored, and the checkpoint was restored as a `TrainState`.
+
+This can also be useful for reading only part of your checkpoint.
+
+```python
+restored = checkpoint_manager.restore(5, items=target)
+assert not hasattr(restored, 'batch_stats')
+assert type(restored['model']) == train_state.TrainState
+restored
+```
+
+### Scenario 2: When a checkpoint is partial
+
+On the other hand, if the reference object contains a value that is not available in the checkpoint, the checkpointing code will by default warn that some data is not compatible.
+
+To bypass the error, you need to pass an Orbax [`transform`](https://github.com/google/orbax/blob/main/docs/checkpoint.md#transformations) that teaches Orbax how to conform this checkpoint into the structure of the `custom_target`.
+
+In this case, pass a default `{}` that lets Orbax use values in the `custom_target` to fill in the blank. This allows you to restore an old checkpoint into a new data structure, the `CustomTrainState`.
+
+```python
+try:
+    checkpoint_manager.restore(4, items=custom_target)
+except KeyError as e:
+    print(f'KeyError when target state has an unmentioned field: {e}')
+    print('')
+
+# Step 4 is an original `TrainState`, without the `batch_stats`
+restored = checkpoint_manager.restore(4, items=custom_target, 
+                                      restore_kwargs={'transforms': {}})
+assert type(restored['model']) == CustomTrainState
+np.testing.assert_equal(restored['model'].batch_stats, 
+                        custom_target['model'].batch_stats)
+restored
+```
+
+##### With Orbax
+
+If you have already saved your checkpoints with the Orbax backend, you can use `orbax_transforms` to access this `transforms` argument in the Flax API.
+
 ```python id="29fd1e33" outputId="cdbb9247-d1eb-4458-aa83-8db0332af7cb"
+# Save in the "Flax-with-Orbax" backend.
+flax.config.update('flax_use_orbax_checkpointing', True)
+checkpoints.save_checkpoint(ckpt_dir='tmp/flax-checkpointing',
+                            target=ckpt,
+                            step=4,
+                            overwrite=True,
+                            keep=2)
+
+checkpoints.restore_checkpoint('tmp/flax-checkpointing', target=custom_target, step=4,
+                               orbax_transforms={})
+```
+
+##### With the legacy API
+
+Using the legacy `flax.training.checkpoints` API, similar things are doable too, but they are not as flexible as the [Orbax Transformations](https://github.com/google/orbax/blob/main/docs/checkpoint.md#transformations).
+
+You need to restore the checkpoint to a raw dict with `target=None`, modify the structure accordingly, and then deserialize it back to the original target.
+
+```python
+# Save using the legacy Flax `checkpoints` API.
+flax.config.update('flax_use_orbax_checkpointing', False)
+checkpoints.save_checkpoint(ckpt_dir='tmp/flax-checkpointing',
+                            target=ckpt,
+                            step=5,
+                            overwrite=True,
+                            keep=2)
+
 # Pass no target to get a raw state dictionary first.
-raw_state_dict = checkpoints.restore_checkpoint(ckpt_dir, target=None, step=0)
+raw_state_dict = checkpoints.restore_checkpoint('tmp/flax-checkpointing', target=None, step=5)
 # Add/remove fields as needed.
 raw_state_dict['model']['batch_stats'] = np.flip(np.arange(10))
 # Restore the classes with correct target now
-orbax.checkpoint.utils.deserialize_tree(custom_target, raw_state_dict, keep_empty_nodes=True)
+flax.serialization.from_state_dict(custom_target, raw_state_dict)
 ```
 
 <!-- #region id="a6b39501" -->
@@ -261,80 +371,97 @@ orbax.checkpoint.utils.deserialize_tree(custom_target, raw_state_dict, keep_empt
 
 Checkpointing is I/O heavy, and if you have a large amount of data to save, it may be worthwhile to put it into a background thread, while continuing with your training.
 
-You can do this by creating an [`orbax.checkpoint.AsyncCheckpointer`](https://github.com/google/orbax/blob/main/orbax/checkpoint/async_checkpointer.py) (as demonstrated in the code cell below) and let it track your save thread.
+You can do this by creating an [`orbax.checkpoint.AsyncCheckpointer`](https://github.com/google/orbax/blob/main/orbax/checkpoint/async_checkpointer.py) in place of the `orbax.checkpoint.PyTreeCheckpointer`.
 
 Note: You should use the same `async_checkpointer` to handle all your async saves across your training steps, so that it can make sure that a previous async save is done before the next one begins. This enables bookkeeping, such as `keep` (the number of checkpoints) and `overwrite` to be consistent across steps.
 
-Whenever you want to explicitly wait until an async save is done, you can call `async_checkpointer.wait_until_finished()`. Alternatively, you can pass in `orbax_checkpointer=async_checkpointer` when running `restore_checkpoint` and Flax will automatically wait and restore safely.
+Whenever you want to explicitly wait until an async save is done, you can call `async_checkpointer.wait_until_finished()`.
 <!-- #endregion -->
 
 ```python id="85be68a6" outputId="aefce94c-8bae-4355-c142-05f2b61c39e2"
 # `orbax.checkpoint.AsyncCheckpointer` needs some multi-process initialization, because it was
 # originally designed for multi-process large model checkpointing.
-# For Python notebooks or other single-process setting, just set up with `num_processes=1`.
+# For Python notebooks or other single-process settings, just set up with `num_processes=1`.
 # Refer to https://jax.readthedocs.io/en/latest/multi_process.html#initializing-the-cluster
 # for how to set it up in multi-process scenarios.
 jax.distributed.initialize("localhost:8889", num_processes=1, process_id=0)
 
-async_checkpointer = orbax.checkpoint.AsyncCheckpointer(orbax.checkpoint.PyTreeCheckpointHandler(), timeout_secs=50)
+async_checkpointer = orbax.checkpoint.AsyncCheckpointer(
+    orbax.checkpoint.PyTreeCheckpointHandler(), timeout_secs=50)
 
-# Mimic a training loop here:
-for step in range(2, 3):
-    checkpoints.save_checkpoint(ckpt_dir, ckpt, step=2, overwrite=True, keep=3,
-                                orbax_checkpointer=async_checkpointer)
-    # ... Continue with your work...
+# Save your job:
+async_checkpointer.save('tmp/orbax/single_save_async', ckpt, save_args=save_args)
+# ... Continue with your work...
 
 # ... Until a time when you want to wait until the save completes:
 async_checkpointer.wait_until_finished()  # Blocks until the checkpoint saving is completed.
-checkpoints.restore_checkpoint(ckpt_dir, target=None, step=2)
+async_checkpointer.restore('tmp/orbax/single_save_async', item=target)
 ```
 
 <!-- #region id="QpuTCeMVXOBn" -->
-To save and restore with pure Orbax, `AsyncCheckpointer` can be used with the same APIs as `Checkpointer` as shown above.
+If you are using Orbax `CheckpointManager`, just pass in the async_checkpointer when initializing it. Then, in practice, call `async_checkpoint_manager.wait_until_finished()` instead.
 <!-- #endregion -->
+
+```python
+async_checkpoint_manager = orbax.checkpoint.CheckpointManager(
+    'tmp/orbax/managed_async', async_checkpointer, options)
+async_checkpoint_manager.wait_until_finished()
+```
 
 <!-- #region id="13e93db6" -->
 ## Multi-host/multi-process checkpointing
 
 JAX provides a few ways to scale up your code on multiple hosts at the same time. This usually happens when the number of devices (CPU/GPU/TPU) is so large that different devices are managed by different hosts (CPU). To get started on JAX in multi-process settings, check out [Using JAX in multi-host and multi-process environments](https://jax.readthedocs.io/en/latest/multi_process.html) and the [distributed array guide](https://jax.readthedocs.io/en/latest/notebooks/Distributed_arrays_and_automatic_parallelization.html).
 
-In the [Single Program Multi Data (SPMD)](https://jax.readthedocs.io/en/latest/glossary.html#term-SPMD) paradigm with JAX [`pjit`](https://jax.readthedocs.io/en/latest/jax.experimental.pjit.html), a large multi-process array can have its data sharded across different devices (check out the `pjit` [JAX-101 tutorial](https://jax.readthedocs.io/en/latest/jax-101/08-pjit.html)). When a multi-process array is serialized, each host dumps its data shards to a single shared storage, such as a Google Cloud bucket.
+In the [Single Program Multi Data (SPMD)](https://jax.readthedocs.io/en/latest/glossary.html#term-SPMD) paradigm with JAX `jit`, a large multi-process array can have its data sharded across different devices. (Note that JAX `pjit` and `jit` have been merged into a single unified interface. To learn about compiling and executing JAX functions in multi-host or multi-core environments, refer to [this guide](https://jax.readthedocs.io/en/latest/notebooks/Distributed_arrays_and_automatic_parallelization.html) and the [jax.Array migration guide](https://jax.readthedocs.io/en/latest/jax_array_migration.html).) When a multi-process array is serialized, each host dumps its data shards to a single shared storage, such as a Google Cloud bucket.
 
-Orbax supports saving and loading pytrees with multi-process arrays in the same fashion as single-process pytrees. However, it's recommended to use the asynchronized [`orbax.AsyncCheckpointer`](https://github.com/google/orbax/blob/main/orbax/checkpoint/async_checkpointer.py) to save large multi-process arrays on another thread, so that you can perform computation alongside the saves. With pure Orbax, saving checkpoints in a multiprocess context uses the same API as in a single process context.
-
-To save multi-process arrays, use [`flax.training.checkpoints.save_checkpoint_multiprocess()`](https://flax.readthedocs.io/en/latest/api_reference/flax.training.html#flax.training.checkpoints.save_checkpoint_multiprocess) in place of `save_checkpoint()` and with the same arguments.
-
-Unfortunately, Python Jupyter notebooks are single-host only and cannot activate the multi-host mode. You can treat the following code as an example for running your multi-host checkpointing:
+Orbax supports saving and loading pytrees with multi-process arrays in the same fashion as single-process pytrees. However, it's recommended to use the asynchronized [`orbax.AsyncCheckpointer`](https://github.com/google/orbax/blob/main/orbax/checkpoint/async_checkpointer.py) to save large multi-process arrays on another thread, so that you can perform computation alongside the saves. With pure Orbax, saving checkpoints in a multi-process context uses the same API as in a single-process context.
 <!-- #endregion -->
 
-```python id="d199c8fa"
-# Multi-host related imports.
-from jax.sharding import PartitionSpec
-from jax.experimental import pjit
-```
-
 ```python id="ubdUvyMrhD-1"
-# Create a multi-process array.
+from jax.sharding import PartitionSpec, NamedSharding
+
+# Create an array sharded across multiple devices.
 mesh_shape = (4, 2)
 devices = np.asarray(jax.devices()).reshape(*mesh_shape)
 mesh = jax.sharding.Mesh(devices, ('x', 'y'))
 
-f = pjit.pjit(
-  lambda x: x,
-  in_axis_resources=None,
-  out_axis_resources=PartitionSpec('x', 'y'))
+mp_array = jax.device_put(np.arange(8 * 2).reshape(8, 2),
+                          NamedSharding(mesh, PartitionSpec('x', 'y')))
 
-with jax.sharding.Mesh(mesh.devices, mesh.axis_names):
-    mp_array = f(np.arange(8 * 2).reshape(8, 2))
-
-# Make it a pytree as usual.
+# Make it a pytree.
 mp_ckpt = {'model': mp_array}
 ```
 
-<!-- #region id="edc355ce" -->
-### Example: Save a checkpoint in a multi-process setting with `save_checkpoint_multiprocess`
+```python
+async_checkpoint_manager.save(0, mp_ckpt)
+async_checkpoint_manager.wait_until_finished()
+```
 
-The arguments in [`flax.training.checkpoints.save_checkpoint_multiprocess`](https://flax.readthedocs.io/en/latest/api_reference/flax.training.html#flax.training.checkpoints.save_checkpoint_multiprocess) are the same as in [`flax.training.checkpoints.save_checkpoint`](https://flax.readthedocs.io/en/latest/api_reference/flax.training.html#flax.training.checkpoints.save_checkpoint).
+When restoring a checkpoint with multi-process arrays, you need to specify what `sharding` each array should be restored back to. Otherwise, they will be restored as large `np.array`s on process 0, costing time and memory.
+
+(In this notebook, since we are on single-process, it will be restored as `np.array` even if we provide shardings.)
+
+### With Orbax
+
+Orbax allows you to specify this by passing a pytree of `sharding`s in `restore_args`. If you already have a reference pytree that has all the arrays with the right sharding, you can use `orbax_utils.restore_args_from_target` to transform it into the `restore_args` that Orbax needs.
+
+```python
+# The reference doesn't need to be as large as your checkpoint!
+# Just make sure it has the `.sharding` you want.
+mp_smaller = jax.device_put(np.arange(8).reshape(4, 2),
+                            NamedSharding(mesh, PartitionSpec('x', 'y')))
+ref_ckpt = {'model': mp_smaller}
+
+restore_args = orbax_utils.restore_args_from_target(ref_ckpt)
+async_checkpoint_manager.restore(
+    0, items=ref_ckpt, restore_kwargs={'restore_args': restore_args})
+```
+
+<!-- #region id="edc355ce" -->
+### With the legacy Flax: use `save_checkpoint_multiprocess`
+
+In legacy Flax, to save multi-process arrays, use [`flax.training.checkpoints.save_checkpoint_multiprocess()`](https://flax.readthedocs.io/en/latest/api_reference/flax.training.html#flax.training.checkpoints.save_checkpoint_multiprocess) in place of `save_checkpoint()` and with the same arguments.
 
 If your checkpoint is too large, you can specify `timeout_secs` in the manager and give it more time to finish writing.
 <!-- #endregion -->
@@ -349,20 +476,47 @@ checkpoints.save_checkpoint_multiprocess(ckpt_dir,
                                          orbax_checkpointer=async_checkpointer)
 ```
 
-<!-- #region id="d954c3c7" -->
-### Example: Restoring a checkpoint with `flax.training.checkpoints.restore_checkpoint`
-
-Note that, when using [`flax.training.checkpoints.restore_checkpoint`](https://flax.readthedocs.io/en/latest/api_reference/flax.training.html#flax.training.checkpoints.restore_checkpoint), you need to pass a `target` with valid multi-process arrays at the correct structural location. Flax only uses the `target` arrays' meshes and mesh axes to restore the checkpoint. This means that the multi-process array in the `target` arg doesn't have to be as large as your checkpoint's size (the shape of the multi-process array doesn't need to have the same shape as the actual array in your checkpoint).
-<!-- #endregion -->
-
 ```python id="a9f9724c" outputId="393c4a0e-8a8c-4ca6-c609-93c8bab38e75"
-with jax.sharding.Mesh(mesh.devices, mesh.axis_names):
-    mp_smaller_array = f(np.zeros(8).reshape(4, 2))
-
-mp_target = {'model': mp_smaller_array}
 mp_restored = checkpoints.restore_checkpoint(ckpt_dir,
-                                             target=mp_target,
+                                             target=ref_ckpt,
                                              step=3,
                                              orbax_checkpointer=async_checkpointer)
 mp_restored
 ```
+
+## Orbax-as-backend troubleshooting
+
+As an intermediate stage of the migration (to Orbax from the legacy Flax `checkpoints` API), `flax.training.checkpoints` APIs will start to use Orbax as their backend when saving checkpoints starting from May 15, 2023.
+
+Checkpoints saved with the Orbax backend can be readable by either `flax.training.checkpoints.restore_checkpoint` or `orbax.checkpoint.PyTreeCheckpointer`.
+
+Code-wise, this is equivalent to setting the config flag [`flax.config.flax_use_orbax_checkpointing`](https://github.com/google/flax/blob/main/flax/configurations.py#L103) default to `True`. You can overwrite this value in your project with `flax.config.update('flax_use_orbax_checkpointing', <BoolValue>)` at any time.
+
+In general, this automatic migration will not affect most users. However, you may encounter issues if your API usage follows some specific pattern. Check out the sections below for troubleshooting.
+
+
+### If your devices hang when writing checkpoints
+
+If you are running in a multi-host environment (usually anything larger than 8 TPU devices) and your devices hang when writing checkpoints, check if your code is in the following pattern (that is, the `save_checkpoint` only ran on host `0`):
+
+```
+if jax.process_index() == 0:
+  flax.training.checkpoints.save_checkpoint(...)
+```
+
+Unfortunately this is a legacy pattern that will be deprecated and won't be supported, because in a multi-process environment, the checkpointing code should coordinate among hosts instead of being triggered only on the host `0`. Replacing the code above with the following should resolve the hang issue:
+
+```
+flax.training.checkpoints.save_checkpoint_multiprocess(...)
+```
+
+
+### If you don't save pytrees
+
+Orbax uses `orbax.checkpoint.PyTreeCheckpointHandler` to save checkpoints, which means they only save pytrees.
+
+If you want to save singular arrays or numbers, you have two options:
+
+1. Use `orbax.ArrayCheckpointHandler` to save them following [this migration section](https://flax.readthedocs.io/en/latest/guides/orbax_upgrade_guide.html#saving-loading-a-single-jax-or-numpy-array).
+
+1. Wrap it inside a pytree and save as usual.


### PR DESCRIPTION
Improved the doc:
* Timeline and troubleshooting for the auto Orbax-as-backend migration
* Guide on using Orbax API to do everything (I love Orbax transforms)
* Using the latest `jax.jit` APIs when showcasing multihost

Also two small bug fixes:
* Add `orbax_transforms` to restore API
* Fix an IO bug in `restore_checkpoint()` that happens when Tensorflow is not installed/used.

(Commits were squashed, but thanks @8bitmp3 for collaborating with PR https://github.com/IvyZX/flax/pull/5)