### PR TITLE
Fix `get_partition_spec` on replicated array

### DIFF
--- a/docs/api_reference/flax.linen.rst
+++ b/docs/api_reference/flax.linen.rst
@@ -104,12 +104,14 @@ SPMD
     Partitioned
     with_partitioning
     get_partition_spec
+    get_sharding
     LogicallyPartitioned
     logical_axis_rules
     set_logical_axis_rules
     get_logical_axis_rules
     logical_to_mesh_axes
     logical_to_mesh
+    logical_to_mesh_sharding
     with_logical_constraint
     with_logical_partitioning
 

--- a/flax/linen/__init__.py
+++ b/flax/linen/__init__.py
@@ -65,6 +65,7 @@ from ..core.meta import (
     Partitioned as Partitioned,
     with_partitioning as with_partitioning,
     get_partition_spec as get_partition_spec,
+    get_sharding as get_sharding,
     unbox as unbox,
     PARTITION_NAME as PARTITION_NAME,
 )
@@ -74,6 +75,7 @@ from .spmd import (
     get_logical_axis_rules as get_logical_axis_rules,
     logical_to_mesh_axes,
     logical_to_mesh,
+    logical_to_mesh_sharding,
     with_logical_constraint,
     LogicallyPartitioned as LogicallyPartitioned,
     with_logical_partitioning as with_logical_partitioning,

--- a/flax/linen/spmd.py
+++ b/flax/linen/spmd.py
@@ -189,6 +189,19 @@ def logical_to_mesh(
   )
 
 
+def logical_to_mesh_sharding(
+    tree: Any,
+    mesh: jax.sharding.Mesh,
+    rules: Optional[LogicalRules] = None,
+) -> Any:
+  """Convert pytrees of logical PartitionSpecs to shardings."""
+  return jax.tree_map(
+      lambda x: jax.sharding.NamedSharding(mesh, x),
+      logical_to_mesh(tree, rules),
+      is_leaf=lambda x: isinstance(x, jax.sharding.PartitionSpec),
+  )
+
+
 def _global_mesh_defined() -> bool:
   """Checks if global xmap/pjit mesh resource environment is defined."""
   maps_env = maps.thread_resources.env

--- a/tests/linen/partitioning_test.py
+++ b/tests/linen/partitioning_test.py
@@ -473,8 +473,7 @@ class PartitioningTest(parameterized.TestCase):
       module = Foo()
       variables = module.init(random.PRNGKey(0), jnp.zeros((8, 4)))
       logical_spec = nn.get_partition_spec(variables)
-      spec = nn.logical_to_mesh(logical_spec, rules)
-      shardings = jax.tree_map(lambda s: sharding.NamedSharding(mesh, s), spec)
+      shardings = nn.logical_to_mesh_sharding(logical_spec, mesh, rules)
       variables = jax.lax.with_sharding_constraint(variables, shardings)
       return variables
 


### PR DESCRIPTION
`get_partition_spec` now returns an empty `PartitionSpec()` instead of `None`. This is required when passing sharding layouts through the `jax.jit` API. (`pjit` didn't seem to be affected by this, for some reason.)

Also added some utils that directly returns `jax.sharding`s, which will be helpful for writing #2755 (will be another PR).
