### PR TITLE
Upgrade the `pjit` guide to `jax.jit`

### DIFF
--- a/docs/guides/flax_on_pjit.ipynb
+++ b/docs/guides/flax_on_pjit.ipynb
@@ -12,23 +12,27 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "id": "b1e0e5fc8bc1"
+   },
    "source": [
     "## Flax and `jax.jit` scaled up\n",
     "\n",
-    "`jax.jit` follows the [Single Program Multi Data (SPMD)](https://jax.readthedocs.io/en/latest/glossary.html#term-SPMD) paradigm and automatically compiles your code to run it on multiple devices. You need to only specify how you want the input and output of your code to be partitioned, and the compiler will figure out how to: 1) partition everything inside; and 2) compile inter-device communications.\n",
-    "\n",
-    "To learn more about `jax.jit` APIs for scaling-up, refer to [JAX in multi-process environments](https://jax.readthedocs.io/en/latest/multi_process.html) and [Distributed arrays and automatic parallelization](https://jax.readthedocs.io/en/latest/notebooks/Distributed_arrays_and_automatic_parallelization.html).\n",
+    "[`jax.jit`](https://jax.readthedocs.io/en/latest/_autosummary/jax.jit.html) follows the [Single Program Multi Data (SPMD)](https://jax.readthedocs.io/en/latest/glossary.html#term-SPMD) paradigm and automatically compiles your code to run it on multiple devices. You need to only specify how you want the input and output of your code to be partitioned, and the compiler will figure out how to: 1) partition everything inside; and 2) compile inter-device communications.\n",
     "\n",
     "Flax provides several functionalities that can help you use auto-SPMD on [Flax Modules](https://flax.readthedocs.io/en/latest/developer_notes/module_lifecycle.html), including:\n",
     "\n",
     "1. An interface to specify partitions of your data when defining [`flax.linen.Module`](https://flax.readthedocs.io/en/latest/api_reference/flax.linen.html#module).\n",
     "2. Utility functions to generate the sharding information that `jax.jit` requires to run.\n",
-    "3. An interface to customize your axis names called \"logical axis annotations\" to decouple both your Module code and partition plan to experiment with different partition layouts more easily."
+    "3. An interface to customize your axis names called \"logical axis annotations\" to decouple both your Module code and partition plan to experiment with different partition layouts more easily.\n",
+    "\n",
+    "You can learn more about `jax.jit` APIs for scaling up in [JAX in multi-process environments](https://jax.readthedocs.io/en/latest/multi_process.html) and [Distributed arrays and automatic parallelization](https://jax.readthedocs.io/en/latest/notebooks/Distributed_arrays_and_automatic_parallelization.html) on JAX's documentation site."
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "id": "a9601432b448"
@@ -38,7 +42,7 @@
     "\n",
     "Import some necessary dependencies.\n",
     "\n",
-    "**Note:** This guide uses the `--xla_force_host_platform_device_count=8` flag to emulate multiple devices in a CPU environment in a Google Colab/Jupyter Notebook. You don't need this if you are already running on a multi-device TPU environment."
+    "**Note:** This guide uses the `--xla_force_host_platform_device_count=8` flag to emulate multiple devices in a CPU environment in a Google Colab/Jupyter Notebook. You don't need this if you are already using a multi-device TPU environment."
    ]
   },
   {
@@ -52,7 +56,7 @@
    },
    "outputs": [],
    "source": [
-    "# Once Flax v0.6.10 is released, no need to do this.\n",
+    "# Once Flax v0.6.10 is released, there is no need to do this.\n",
     "# ! pip3 install -qq \"git+https://github.com/google/flax.git@main#egg=flax\""
    ]
   },
@@ -94,7 +98,9 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {},
+   "metadata": {
+    "id": "bcc30de1d6eb"
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -109,20 +115,21 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "id": "c0d280def897"
    },
    "source": [
-    "Import and set up the JAX-level device API following [Distributed arrays and automatic parallelization](https://jax.readthedocs.io/en/latest/notebooks/Distributed_arrays_and_automatic_parallelization.html):\n",
+    "The code below shows how to import and set up the JAX-level device API, following JAX's [Distributed arrays and automatic parallelization](https://jax.readthedocs.io/en/latest/notebooks/Distributed_arrays_and_automatic_parallelization.html) guide:\n",
     "\n",
-    "1. Start a 2x4 device `mesh` (8 devices)—this is the same as the layout of [TPU v3-8](https://cloud.google.com/tpu/docs/system-architecture-tpu-vm#single_tpu_board).\n",
+    "1. Start a 2x4 device `mesh` (8 devices) using JAX's `mesh_utils.create_device_mesh`. This layout is the same as the one of a [TPU v3-8](https://cloud.google.com/tpu/docs/system-architecture-tpu-vm#single_tpu_board).\n",
     "\n",
-    "2. Annotate each axis with a name. A typical way to annotate axis names is `('data', 'model')`, where:\n",
+    "2. Annotate each axis with a name using the `axis_names` parameter in `jax.sharding.Mesh`. A typical way to annotate axis names is `axis_name=('data', 'model')`, where:\n",
     "  * `'data'`: the mesh dimension used for data-parallel sharding of the batch dimension of inputs and activations.\n",
     "  * `'model'`: the mesh dimension used for sharding parameters of the model across devices.\n",
     "  \n",
-    "3. Make a simple util `mesh_sharding` to generate a sharding object from the mesh and any layout."
+    "3. Make a simple utility function `mesh_sharding` for generating a sharding object from the mesh and any layout."
    ]
   },
   {
@@ -141,7 +148,9 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "metadata": {},
+   "metadata": {
+    "id": "4589d7a6d4bb"
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -163,7 +172,7 @@
     "print(mesh)\n",
     "\n",
     "def mesh_sharding(pspec: PartitionSpec) -> NamedSharding:\n",
-    "    return NamedSharding(mesh, pspec)"
+    "  return NamedSharding(mesh, pspec)"
    ]
   },
   {
@@ -175,13 +184,13 @@
    "source": [
     "## Define a layer\n",
     "\n",
-    "Before defining a model, create an example layer called `DotReluDot` (by subclassing `flax.linen.Module`), which creates two parameters `W1` and `W2` for dot product multiplication, and uses the `jax.nn.relu` (ReLU) activation function in-between.\n",
+    "Before defining a simple model, create an example layer called `DotReluDot` (by subclassing `flax.linen.Module`). The layer creates two parameters `W1` and `W2` for dot product multiplication, and uses the `jax.nn.relu` (ReLU) activation function in-between.\n",
     "\n",
     "To shard the parameters efficiently, apply the following APIs to annotate the parameters and intermediate variables:\n",
     "\n",
     "1. Use [`flax.linen.with_partitioning`](https://flax.readthedocs.io/en/latest/api_reference/_autosummary/flax.linen.with_partitioning.html#flax.linen.with_partitioning) to decorate the initializer function when creating sub-layers or raw parameters.\n",
     "\n",
-    "2. Apply [`jax.lax.with_sharding_constraint`](https://github.com/google/jax/blob/main/jax/_src/pjit.py#L1516) to annotate intermediate variables like `y` and `z` to force a particular sharding pattern when the ideal constraint is known.\n",
+    "2. Apply [`jax.lax.with_sharding_constraint`](https://github.com/google/jax/blob/main/jax/_src/pjit.py#L1516) (formerly, `pjit.with_sharding_constraint`) to annotate intermediate variables like `y` and `z` to force a particular sharding pattern when the ideal constraint is known.\n",
     "\n",
     "  * This step is optional, but can sometimes help auto-SPMD to partition efficiently. In the example below, the call is not required, because XLA will figure out the same sharding layout for `y` and `z` regardless."
    ]
@@ -223,12 +232,13 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "id": "cbac5321c08e"
    },
    "source": [
-    "Note that device axis names like `'data'`, `'model'` or `None` are passed into both `flax.linen.with_partitioning` and `with_sharding_constraint` API calls. This refers to how each dimension of this data should be sharded — either across one of the device mesh dimensions, or not sharded at all.\n",
+    "Note that device axis names like `'data'`, `'model'` or `None` are passed into both [`flax.linen.with_partitioning`](https://flax.readthedocs.io/en/latest/api_reference/_autosummary/flax.linen.with_partitioning.html) and [`jax.lax.with_sharding_constraint`](https://github.com/google/jax/blob/main/jax/_src/pjit.py#L1516) API calls. This refers to how each dimension of this data should be sharded — either across one of the device mesh dimensions, or not sharded at all.\n",
     "\n",
     "For example:\n",
     "\n",
@@ -244,6 +254,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "id": "b8389c11af79"
@@ -251,14 +262,14 @@
    "source": [
     "## Define a model with `flax.linen.scan` lifted transformation\n",
     "\n",
-    "Having created `DotReluDot`, define the `MLP` model (by subclassing `flax.linen.Module`) as multiple layers of `DotReluDot`.\n",
+    "Having created `DotReluDot`, you can now define the `MLP` model (by subclassing [`flax.linen.Module`](https://flax.readthedocs.io/en/latest/api_reference/flax.linen.html#flax.linen.Module)) as multiple layers of `DotReluDot`.\n",
     "\n",
-    "To replicate identical layers, you can either use `flax.linen.scan`, or a for-loop:\n",
+    "To replicate identical layers, you can either use [`flax.linen.scan`](https://flax.readthedocs.io/en/latest/api_reference/_autosummary/flax.linen.scan.html), or a for-loop:\n",
     "\n",
-    "* `flax.linen.scan` can offer faster compilation times.\n",
+    "* `flax.linen.scan` can provide faster compilation times.\n",
     "* The for-loop can be faster on runtime.\n",
     "\n",
-    "The code below shows how to apply both methods, and default with the for-loop, so that all the parameters are two-dimentional and we can visualize their sharding. \n",
+    "The code below shows how to apply both methods, and default with the for-loop, so that all the parameters are two-dimensional and you can visualize their sharding. \n",
     "\n",
     "The `flax.linen.scan` code is just to show that this API works with [Flax lifted transforms](https://flax.readthedocs.io/en/latest/developer_notes/lift.html#supported-transformations)."
    ]
@@ -290,16 +301,21 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "id": "44395b62561d"
+   },
    "source": [
-    "Now we make a `model` instance, and a sample input `x`."
+    "Now, create a `model` instance, and a sample input `x`."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 45,
-   "metadata": {},
+   "metadata": {
+    "id": "5686299b4839"
+   },
    "outputs": [],
    "source": [
     "# MLP hyperparameters.\n",
@@ -316,6 +332,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "id": "5b3abfef359d"
@@ -323,11 +340,11 @@
    "source": [
     "## Specify sharding\n",
     "\n",
-    "Next, we need to tell `jax.jit` how to share our data across devices.\n",
+    "Next, you need to tell `jax.jit` how to shard our data across devices.\n",
     "\n",
-    "### Input's sharding\n",
+    "### The input's sharding\n",
     "\n",
-    "For data parallelism, we shard the batched _input_ `x` across the `data` axis by denoting the batch axis as `data`. Then, use `jax.device_put` to place it into the correct devices."
+    "For data parallelism, you can shard the batched _input_ `x` across the `data` axis by denoting the batch axis as `'data'`. Then, use [`jax.device_put`](https://jax.readthedocs.io/en/latest/_autosummary/jax.device_put.html) to place it onto the correct `device`s."
    ]
   },
   {
@@ -378,27 +395,30 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "id": "06d134795ae1"
    },
    "source": [
-    "### Output's sharding\n",
+    "### The output's sharding\n",
     "\n",
-    "We want to compile `model.init()`, and its output is a pytree of parameters. Sometimes we even wrap it with a `flax.training.train_state` to track other variables like optimizer states, and that makes the output an even more complex pytree.\n",
+    "You need to compile `model.init()` (that is, [`flax.linen.Module.init()`](https://flax.readthedocs.io/en/latest/api_reference/flax.linen.html#flax.linen.Module.init)), and its output as a pytree of parameters. Additionally, you may sometimes need wrap it with a [`flax.training.train_state`](https://flax.readthedocs.io/en/latest/api_reference/flax.training.html#flax.training.train_state.TrainState) to track other variables, such as optimizer states, and that would make the output an even more complex pytree.\n",
     "\n",
-    "Luckily we don't have to hardcode the output's sharding by hand. We do:\n",
+    "To achieve this, luckily, you don't have to hardcode the output's sharding by hand. Instead, you can:\n",
     "\n",
     "1. Evaluate `model.init` (in this case, a wrapper of it) abstractly using [`jax.eval_shape`](https://jax.readthedocs.io/en/latest/_autosummary/jax.eval_shape.html).\n",
     "\n",
     "1. Use [`flax.linen.get_sharding`](https://flax.readthedocs.io/en/latest/api_reference/_autosummary/flax.linen.get_sharding.html) to automatically generate the `jax.sharding.NamedSharding`.\n",
-    "   * This steps utilizes the `nn.with_partitioning` annotations in earlier definition to genereate the correct sharding for the params."
+    "   * This step utilizes the [`flax.linen.with_partitioning`](https://flax.readthedocs.io/en/latest/api_reference/_autosummary/flax.linen.with_partitioning.html) annotations in the earlier definition to generate the correct sharding for the parameters."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 47,
-   "metadata": {},
+   "metadata": {
+    "id": "19094ec63385"
+   },
    "outputs": [],
    "source": [
     "def init_fn(k, x, model, optimizer):\n",
@@ -413,7 +433,9 @@
   {
    "cell_type": "code",
    "execution_count": 48,
-   "metadata": {},
+   "metadata": {
+    "id": "e49264a3c78e"
+   },
    "outputs": [
     {
      "data": {
@@ -508,7 +530,7 @@
    ],
    "source": [
     "# Create an abstract closure to wrap the function before feeding it in\n",
-    "# because `jax.eval_shape` only takes pytrees as arguments`.\n",
+    "# because `jax.eval_shape` only takes pytrees as arguments.\n",
     "abstract_variables = jax.eval_shape(\n",
     "    functools.partial(init_fn, model=model, optimizer=optimizer), k, x)\n",
     "\n",
@@ -534,7 +556,9 @@
   {
    "cell_type": "code",
    "execution_count": 49,
-   "metadata": {},
+   "metadata": {
+    "id": "5b6e699df733"
+   },
    "outputs": [
     {
      "data": {
@@ -652,7 +676,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "id": "2beee7d27bdb"
+   },
    "source": [
     "You can also check the underlying [`jax.sharding`](https://jax.readthedocs.io/en/latest/jax.sharding.html) of each parameter, which is now more internal than `NamedSharding`. Note that numbers like `initialized_state.step` are replicated across all devices."
    ]
@@ -682,7 +708,9 @@
   {
    "cell_type": "code",
    "execution_count": 16,
-   "metadata": {},
+   "metadata": {
+    "id": "d7cf0baa334b"
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -749,6 +777,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "id": "f7e1ccb14c6b"
@@ -756,7 +785,7 @@
    "source": [
     "## Compile the train step and inference \n",
     "\n",
-    "Now, you create a `jit`ted training step:"
+    "Create a `jit`ted training step as follows:"
    ]
   },
   {
@@ -786,7 +815,9 @@
   {
    "cell_type": "code",
    "execution_count": 19,
-   "metadata": {},
+   "metadata": {
+    "id": "91c6c2662c12"
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -873,12 +904,13 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "id": "2bae79e2e71b"
    },
    "source": [
-    "And a compiled inference step. Note that the output is also sharded along `(data, None)`."
+    "Then, create a compiled inference step. Note that the output is also sharded along `(data, None)`."
    ]
   },
   {
@@ -983,6 +1015,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "id": "51420b514d53"
@@ -990,13 +1023,13 @@
    "source": [
     "## Logical axis annotation\n",
     "\n",
-    "JAX auto SPMD encourages users to explore different sharding layouts to find the optimal one. To this end, in Flax you actually can annotate the dimensions of any data with more descriptive axis names (not just device mesh axis names like `'data'` and `'model'`). \n",
+    "JAX's automatic SPMD encourages users to explore different sharding layouts to find the optimal one. To this end, in Flax you actually can annotate the dimensions of any data with more descriptive axis names (not just device mesh axis names like `'data'` and `'model'`). \n",
     "\n",
     "The `LogicalDotReluDot` and `LogicalMLP` Module definition below are similar to the Modules you created earlier, except for the following:\n",
     "\n",
     "1. All axes are annotated with more concrete, meaningful names, such as `'embed'`, `'hidden'`, `'batch'` and `'layer'`. These names are referred to as _logical axis names_ in Flax. They make the dimensional changes inside model definitions more readable.\n",
     "\n",
-    "2. `nn.with_logical_partitioning` replaces `nn.with_partitioning`; and `nn.with_logical_constraint` replaces `jax.lax.with_sharding_constraint`, to recognize the logical axis names."
+    "2. [`flax.linen.with_logical_partitioning`](https://flax.readthedocs.io/en/latest/api_reference/_autosummary/flax.linen.with_logical_partitioning.html) replaces `flax.linen.with_partitioning`; and [`flax.linen.with_logical_constraint`](https://flax.readthedocs.io/en/latest/api_reference/_autosummary/flax.linen.with_logical_constraint.html#flax-linen-with-logical-constraint) replaces `jax.lax.with_sharding_constraint`, to recognize the logical axis names."
    ]
   },
   {
@@ -1050,14 +1083,15 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "id": "0de93ec6cbd6"
    },
    "source": [
-    "Now initiate a model and try to figure out what sharding its `state` should have.\n",
+    "Now, initiate a model and try to figure out what sharding its `state` should have.\n",
     "\n",
-    "To allow the device mesh to take your model correctly, you need to decide which of these logical axis names are mapped to the device axis `'data'` or `'model'`. This rule is a list of (`logical_axis_name`, `device_axis_name`) tuples, and `nn.logical_to_mesh_sharding` will convert them to the sharding that the device mesh understands.\n",
+    "To allow the device mesh to take your model correctly, you need to decide which of these logical axis names are mapped to the device axis `'data'` or `'model'`. This rule is a list of (`logical_axis_name`, `device_axis_name`) tuples, and [`flax.linen.logical_to_mesh_sharding`](https://flax.readthedocs.io/en/latest/api_reference/_autosummary/flax.linen.logical_to_mesh_sharding.html#flax-linen-logical-to-mesh-sharding) will convert them to the kind of sharding that the device mesh can understand.\n",
     "\n",
     "This allows you to change the rules and try out new partition layouts without modifying the model definition."
    ]
@@ -1097,12 +1131,13 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "id": "58475fffb2de"
    },
    "source": [
-    "You can verify that the `logical_state_spec` here has the same content as `state_spec` in the previous (\"non-logical\") example. This allows you to `jax.jit` your module's `init` and `apply`, same as above."
+    "You can verify that the `logical_state_spec` here has the same content as `state_spec` in the previous (\"non-logical\") example. This allows you to `jax.jit` your Module's [`flax.linen.Module.init`](https://flax.readthedocs.io/en/latest/api_reference/flax.linen.html#flax.linen.Module.init) and [`flax.linen.Module.apply`](https://flax.readthedocs.io/en/latest/api_reference/flax.linen.html#flax.linen.Module.apply) the same way in the above above."
    ]
   },
   {
@@ -1145,7 +1180,9 @@
   {
    "cell_type": "code",
    "execution_count": 54,
-   "metadata": {},
+   "metadata": {
+    "id": "fb53bc20e0f9"
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -1232,6 +1269,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "id": "ae1754a3031d"
@@ -1239,16 +1277,17 @@
    "source": [
     "## When to use device axis / logical axis\n",
     "\n",
-    "Choosing when to use a device or logical axis depends on how much you want to control the partitioning of your model.\n",
+    "Choosing when to use a device or logical axis depends on how much you want to control the partitioning of your model:\n",
     "\n",
-    "If you want a very simple model, or you are very confident of your way of partitioning, defining it with __device mesh axis__ can potentially save you a few extra lines of code of converting the logical naming back to the device naming.\n",
+    "* **Device mesh axis**: If you want a very simple model, or you are very confident of your way of partitioning, defining it with __device mesh axis__ can potentially save you a few extra lines of code of converting the logical naming back to the device naming.\n",
     "\n",
-    "On the other hand, the __logical naming__ helpers are useful for exploring different sharding layouts. Use this if you want to experiment around and find the most optimal partition layout for your model.\n",
+    "* **logical naming**: On the other hand, the __logical naming__ helpers can be useful for exploring different sharding layouts. Use this if you want to experiment around and find the most optimal partition layout for your model.\n",
     "\n",
-    "In really advanced use cases, you may have more complicated sharding patterns that require annotating *activation* dimension names differently from *parameter* dimension names. When people wish to have more fine-grained control on manual mesh assignments, directly using __device axis names__ could be more helpful."
+    "* **Device axis names**: In really advanced use cases, you may have more complicated sharding patterns that require annotating *activation* dimension names differently from *parameter* dimension names. If you wish to have more fine-grained control on manual mesh assignments, directly using __device axis names__ could be more helpful."
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "id": "576bdd5cd782"
@@ -1256,29 +1295,17 @@
    "source": [
     "## Save the data\n",
     "\n",
-    "You can use [`flax.training.checkpoints`](https://flax.readthedocs.io/en/latest/_modules/flax/training/checkpoints.html) to save the cross-device array, as shown in the [Save and load checkpoints guide - Multi-host/multi-process checkpointing](https://flax.readthedocs.io/en/latest/guides/use_checkpointing.html#multi-host-multi-process-checkpointing). This is especially required if you are running on a multi-host environment (for example, a TPU pod).\n",
+    "To save the cross-device array, you can use [`flax.training.checkpoints`](https://flax.readthedocs.io/en/latest/_modules/flax/training/checkpoints.html), as shown in the [Save and load checkpoints guide - Multi-host/multi-process checkpointing](https://flax.readthedocs.io/en/latest/guides/use_checkpointing.html#multi-host-multi-process-checkpointing). This is especially required if you are running on a multi-host environment (for example, a TPU pod).\n",
     "\n",
-    "Keep in mind that to restore the arrays to the desired partition, you need to provide a sample `target` pytree that has the same structure and has the desired `jax.sharding.Sharding` in place for each JAX array. The sharding you use to restore the array doesn't necessarily need to be the same as the ones you used to store the array."
+    "Keep in mind that to restore the arrays to the desired partition, you need to provide a sample `target` pytree that has the same structure and has the desired [`jax.sharding.Sharding`](https://jax.readthedocs.io/en/latest/jax.sharding.html#jax.sharding.Sharding) in place for each JAX array. The sharding you use to restore the array doesn't necessarily need to be the same as the ones you used to store the array."
    ]
   }
  ],
  "metadata": {
   "jupytext": {
    "formats": "ipynb,md:myst"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.9.15"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 0
 }

--- a/docs/guides/flax_on_pjit.ipynb
+++ b/docs/guides/flax_on_pjit.ipynb
@@ -1,57 +1,31 @@
 {
  "cells": [
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "id": "2a9f78765c0c"
    },
    "source": [
-    "# Scale up Flax Modules on multiple devices with `pjit`\n",
+    "# Scale up Flax Modules on multiple devices\n",
     "\n",
-    "This guide shows how to scale up [Flax Modules](https://flax.readthedocs.io/en/latest/developer_notes/module_lifecycle.html) on multiple devices and hosts using JAX's [`pjit`](https://jax.readthedocs.io/en/latest/jax.experimental.pjit.html#module-jax.experimental.pjit) and [`flax.linen.spmd`](https://flax.readthedocs.io/en/latest/api_reference/flax.linen.html#module-flax.linen.spmd).\n",
-    "\n",
-    "## Flax and `pjit`\n",
-    "\n",
-    "[`jax.experimental.pjit`](https://jax.readthedocs.io/en/latest/jax.experimental.pjit.html) provides a way to automatically compile and scale up JAX computations. `pjit` has the following benefits:\n",
-    "\n",
-    "* `pjit` has the similar interface of [`jax.jit`](https://jax.readthedocs.io/en/latest/jax-101/02-jitting.html) and works as a decorator on a function that needs to be compiled.\n",
-    "* When using `pjit`, you can write code as if it runs on a single device, and `pjit` will automatically compile and run it on multiple devices using the [Single Program Multi Data (SPMD)](https://jax.readthedocs.io/en/latest/glossary.html#term-SPMD) paradigm. \n",
-    "* With `pjit` you can state how the input and output of your code is partitioned across devices, and the compiler will figure out how to: 1) partition everything inside; and 2) compile inter-device communications.\n",
-    "\n",
-    "To learn more, refer to [JAX-101 pjit tutorial](https://jax.readthedocs.io/en/latest/jax-101/08-pjit.html) and [JAX in multi-process environments](https://jax.readthedocs.io/en/latest/multi_process.html).\n",
-    "\n",
-    "Flax provides several functionalities that can help you use `pjit` on [Flax Modules](https://flax.readthedocs.io/en/latest/developer_notes/module_lifecycle.html), including:\n",
-    "\n",
-    "1. An interface to specify partitions of your data when defining [`flax.linen.Module`](https://flax.readthedocs.io/en/latest/api_reference/flax.linen.html#module).\n",
-    "2. Utility functions to generate the partition information that `pjit` requires to run.\n",
-    "3. An interface to customize your axis names called \"logical axis annotations\" to decouple both your Module code and partition plan to experiment with different partition layouts more easily."
+    "This guide shows how to scale up [Flax Modules](https://flax.readthedocs.io/en/latest/developer_notes/module_lifecycle.html) on multiple devices and hosts using [`jax.jit`](https://jax.readthedocs.io/en/latest/jax-101/02-jitting.html) (formerly [`experimental.pjit`](https://jax.readthedocs.io/en/latest/jax.experimental.pjit.html#module-jax.experimental.pjit)) and [`flax.linen`](https://flax.readthedocs.io/en/latest/api_reference/flax.linen.html)."
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "0fa8ccbf573a"
-   },
+   "metadata": {},
    "source": [
-    "## Setup\n",
+    "## Flax and `jax.jit` scaled up\n",
     "\n",
-    "Install Flax from HEAD:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 15,
-   "metadata": {
-    "id": "867203db3bef",
-    "tags": [
-     "skip-execution"
-    ]
-   },
-   "outputs": [],
-   "source": [
-    "# Once Flax v0.6.4 is released, use `pip3 install flax`.\n",
-    "! pip3 install -qq \"git+https://github.com/google/flax.git@main#egg=flax\""
+    "`jax.jit` follows the [Single Program Multi Data (SPMD)](https://jax.readthedocs.io/en/latest/glossary.html#term-SPMD) paradigm and automatically compiles your code to run it on multiple devices. You need to only specify how you want the input and output of your code to be partitioned, and the compiler will figure out how to: 1) partition everything inside; and 2) compile inter-device communications.\n",
+    "\n",
+    "To learn more about `jax.jit` APIs for scaling-up, refer to [JAX in multi-process environments](https://jax.readthedocs.io/en/latest/multi_process.html) and [Distributed arrays and automatic parallelization](https://jax.readthedocs.io/en/latest/notebooks/Distributed_arrays_and_automatic_parallelization.html).\n",
+    "\n",
+    "Flax provides several functionalities that can help you use auto-SPMD on [Flax Modules](https://flax.readthedocs.io/en/latest/developer_notes/module_lifecycle.html), including:\n",
+    "\n",
+    "1. An interface to specify partitions of your data when defining [`flax.linen.Module`](https://flax.readthedocs.io/en/latest/api_reference/flax.linen.html#module).\n",
+    "2. Utility functions to generate the sharding information that `jax.jit` requires to run.\n",
+    "3. An interface to customize your axis names called \"logical axis annotations\" to decouple both your Module code and partition plan to experiment with different partition layouts more easily."
    ]
   },
   {
@@ -60,16 +34,31 @@
     "id": "a9601432b448"
    },
    "source": [
-    "## Imports\n",
+    "## Setup\n",
     "\n",
     "Import some necessary dependencies.\n",
     "\n",
-    "**Note:** This guide uses the `--xla_force_host_platform_device_count=8` flag to emulate multiple devices in a CPU environment in a Google Colab/Jupyter Notebook. Check out the [JAX-101 pjit tutorial](https://jax.readthedocs.io/en/latest/jax-101/08-pjit.html#setup) to learn more about emulating a multi-device TPU environment (in which case you should ignore running `os.environ`)."
+    "**Note:** This guide uses the `--xla_force_host_platform_device_count=8` flag to emulate multiple devices in a CPU environment in a Google Colab/Jupyter Notebook. You don't need this if you are already running on a multi-device TPU environment."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 1,
+   "metadata": {
+    "id": "867203db3bef",
+    "tags": [
+     "skip-execution"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "# Once Flax v0.6.10 is released, no need to do this.\n",
+    "# ! pip3 install -qq \"git+https://github.com/google/flax.git@main#egg=flax\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
    "metadata": {
     "id": "f8f42d1174e5"
    },
@@ -81,25 +70,42 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 42,
    "metadata": {
     "id": "b8da40732f0b"
    },
    "outputs": [],
    "source": [
     "import functools\n",
+    "from typing import Optional, Callable\n",
+    "\n",
     "import numpy as np\n",
     "import jax\n",
-    "\n",
     "from jax import lax, random, numpy as jnp\n",
     "\n",
     "import flax\n",
     "from flax import struct, traverse_util, linen as nn\n",
-    "from flax.linen import spmd # Flax Linen SPMD.\n",
     "from flax.core import freeze, unfreeze\n",
     "from flax.training import train_state, checkpoints\n",
     "\n",
     "import optax # Optax for common losses and optimizers. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "We have 8 fake JAX devices now: [CpuDevice(id=0), CpuDevice(id=1), CpuDevice(id=2), CpuDevice(id=3), CpuDevice(id=4), CpuDevice(id=5), CpuDevice(id=6), CpuDevice(id=7)]\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(f'We have 8 fake JAX devices now: {jax.devices()}')"
    ]
   },
   {
@@ -108,57 +114,60 @@
     "id": "c0d280def897"
    },
    "source": [
-    "Next, import all the `pjit`-related libraries.\n",
+    "Import and set up the JAX-level device API following [Distributed arrays and automatic parallelization](https://jax.readthedocs.io/en/latest/notebooks/Distributed_arrays_and_automatic_parallelization.html):\n",
     "\n",
-    "> **Note:** [`jax.experimental.pjit`](https://jax.readthedocs.io/en/latest/jax.experimental.pjit.html) is still in the experimental package of JAX, so there may be changes in the API in future.\n",
+    "1. Start a 2x4 device `mesh` (8 devices)—this is the same as the layout of [TPU v3-8](https://cloud.google.com/tpu/docs/system-architecture-tpu-vm#single_tpu_board).\n",
     "\n",
-    "1. Start a 2x4 device mesh (8 devices)—this is the same as the layout of [TPU v3-8](https://cloud.google.com/tpu/docs/system-architecture-tpu-vm#single_tpu_board).\n",
     "2. Annotate each axis with a name. A typical way to annotate axis names is `('data', 'model')`, where:\n",
     "  * `'data'`: the mesh dimension used for data-parallel sharding of the batch dimension of inputs and activations.\n",
-    "  * `'model'`: the mesh dimension used for sharding parameters of the model across devices."
+    "  * `'model'`: the mesh dimension used for sharding parameters of the model across devices.\n",
+    "  \n",
+    "3. Make a simple util `mesh_sharding` to generate a sharding object from the mesh and any layout."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 5,
    "metadata": {
     "id": "684fe9fe13a0"
    },
+   "outputs": [],
+   "source": [
+    "from jax.sharding import Mesh, PartitionSpec, NamedSharding\n",
+    "from jax.lax import with_sharding_constraint\n",
+    "from jax.experimental import mesh_utils"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
       "[[CpuDevice(id=0) CpuDevice(id=1) CpuDevice(id=2) CpuDevice(id=3)]\n",
-      " [CpuDevice(id=4) CpuDevice(id=5) CpuDevice(id=6) CpuDevice(id=7)]]\n"
+      " [CpuDevice(id=4) CpuDevice(id=5) CpuDevice(id=6) CpuDevice(id=7)]]\n",
+      "Mesh(device_ids=array([[0, 1, 2, 3],\n",
+      "       [4, 5, 6, 7]]), axis_names=('data', 'model'))\n"
      ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "Mesh(device_ids=array([[0, 1, 2, 3],\n",
-       "       [4, 5, 6, 7]]), axis_names=('data', 'model'))"
-      ]
-     },
-     "execution_count": 18,
-     "metadata": {},
-     "output_type": "execute_result"
     }
    ],
    "source": [
-    "from jax.experimental.pjit import pjit, with_sharding_constraint\n",
-    "from jax.sharding import Mesh, PartitionSpec\n",
-    "from jax.experimental import mesh_utils\n",
-    "\n",
-    "# Start a device mesh.\n",
+    "# Create a mesh and annotate each axis with a name.\n",
     "device_mesh = mesh_utils.create_device_mesh((2, 4))\n",
     "print(device_mesh)\n",
-    "# Annotate each axis with a name.\n",
+    "\n",
     "mesh = Mesh(devices=device_mesh, axis_names=('data', 'model'))\n",
-    "mesh"
+    "print(mesh)\n",
+    "\n",
+    "def mesh_sharding(pspec: PartitionSpec) -> NamedSharding:\n",
+    "    return NamedSharding(mesh, pspec)"
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "id": "307d39db6d94"
@@ -168,18 +177,18 @@
     "\n",
     "Before defining a model, create an example layer called `DotReluDot` (by subclassing `flax.linen.Module`), which creates two parameters `W1` and `W2` for dot product multiplication, and uses the `jax.nn.relu` (ReLU) activation function in-between.\n",
     "\n",
-    "To use this layer in `pjit` efficiently, apply the following APIs to annotate the parameters and intermediate variables correctly:\n",
+    "To shard the parameters efficiently, apply the following APIs to annotate the parameters and intermediate variables:\n",
     "\n",
-    "1. Use [`flax.linen.with_partitioning`](https://flax.readthedocs.io/en/latest/api_reference/_autosummary/flax.linen.with_partitioning.html#flax.linen.with_partitioning) to decorate the initializer function when creating parameters `W1` and `W2`.\n",
+    "1. Use [`flax.linen.with_partitioning`](https://flax.readthedocs.io/en/latest/api_reference/_autosummary/flax.linen.with_partitioning.html#flax.linen.with_partitioning) to decorate the initializer function when creating sub-layers or raw parameters.\n",
     "\n",
-    "2. Apply [`pjit.with_sharding_constraint`](https://github.com/google/jax/blob/main/jax/_src/pjit.py#L1516) to annotate intermediate variables like `y` and `z` to force a particular sharding pattern under `pjit` when the ideal constraint is known.\n",
+    "2. Apply [`jax.lax.with_sharding_constraint`](https://github.com/google/jax/blob/main/jax/_src/pjit.py#L1516) to annotate intermediate variables like `y` and `z` to force a particular sharding pattern when the ideal constraint is known.\n",
     "\n",
-    "  * This step is optional, but can sometimes help auto-SPMD to partition efficiently. In the example below, the call is not required, because `pjit` will figure out the same sharding layout for `y` and `z` regardless."
+    "  * This step is optional, but can sometimes help auto-SPMD to partition efficiently. In the example below, the call is not required, because XLA will figure out the same sharding layout for `y` and `z` regardless."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 43,
    "metadata": {
     "id": "b74c049968dc"
    },
@@ -187,25 +196,27 @@
    "source": [
     "class DotReluDot(nn.Module):\n",
     "  depth: int\n",
+    "  dense_init: Callable = nn.initializers.xavier_normal()\n",
     "  @nn.compact\n",
     "  def __call__(self, x):\n",
-    "    W1 = self.param(\n",
-    "        'W1', \n",
-    "        nn.with_partitioning(nn.initializers.xavier_normal(), (None, 'model')),\n",
-    "        (x.shape[-1], self.depth))\n",
+    "    \n",
+    "    y = nn.Dense(self.depth, \n",
+    "                 kernel_init=nn.with_partitioning(self.dense_init, (None, 'model')),\n",
+    "                 use_bias=False,  # or overwrite with `bias_init`\n",
+    "                 )(x)\n",
     "\n",
-    "    y = jax.nn.relu(jnp.dot(x, W1))\n",
+    "    y = jax.nn.relu(y)\n",
     "    # Force a local sharding annotation.\n",
-    "    y = with_sharding_constraint(y, PartitionSpec('data', 'model'))\n",
+    "    y = with_sharding_constraint(y, mesh_sharding(PartitionSpec('data', 'model')))\n",
     "\n",
     "    W2 = self.param(\n",
     "        'W2', \n",
-    "        nn.with_partitioning(nn.initializers.xavier_normal(), ('model', None)),\n",
+    "        nn.with_partitioning(self.dense_init, ('model', None)),\n",
     "        (self.depth, x.shape[-1]))\n",
-    "\n",
+    "    \n",
     "    z = jnp.dot(y, W2)\n",
     "    # Force a local sharding annotation.\n",
-    "    z = with_sharding_constraint(z, PartitionSpec('data', None))\n",
+    "    z = with_sharding_constraint(z, mesh_sharding(PartitionSpec('data', None)))\n",
     "\n",
     "    # Return a tuple to conform with the API `flax.linen.scan` as shown in the cell below.\n",
     "    return z, None"
@@ -217,7 +228,7 @@
     "id": "cbac5321c08e"
    },
    "source": [
-    "Note that device axis names like `'data'`, `'model'` or `None` are passed into both `flax.linen.with_partitioning` and `pjit_with_sharding_constraint` API calls. This refers to how each dimension of this data should be sharded — either across one of the device mesh dimensions, or not sharded at all.\n",
+    "Note that device axis names like `'data'`, `'model'` or `None` are passed into both `flax.linen.with_partitioning` and `with_sharding_constraint` API calls. This refers to how each dimension of this data should be sharded — either across one of the device mesh dimensions, or not sharded at all.\n",
     "\n",
     "For example:\n",
     "\n",
@@ -233,15 +244,12 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "id": "b8389c11af79"
    },
    "source": [
     "## Define a model with `flax.linen.scan` lifted transformation\n",
-    "\n",
-    "This guide uses `flax.linen.scan` to demonstrate how [Flax lifted transforms](https://flax.readthedocs.io/en/latest/developer_notes/lift.html#supported-transformations), such as `scan`, can work together with [JAX `pjit`](https://jax.readthedocs.io/en/latest/jax.experimental.pjit.html).\n",
     "\n",
     "Having created `DotReluDot`, define the `MLP` model (by subclassing `flax.linen.Module`) as multiple layers of `DotReluDot`.\n",
     "\n",
@@ -250,14 +258,14 @@
     "* `flax.linen.scan` can offer faster compilation times.\n",
     "* The for-loop can be faster on runtime.\n",
     "\n",
-    "The code below shows how to apply both methods.\n",
+    "The code below shows how to apply both methods, and default with the for-loop, so that all the parameters are two-dimentional and we can visualize their sharding. \n",
     "\n",
-    "**Note:** `flax.linen.scan` has another dimension for the parameters (the dimension over which `scan` is applied). You need to use the [`metadata_params`](https://flax.readthedocs.io/en/latest/api_reference/_autosummary/flax.linen.scan.html#flax.linen.scan) argument to annotate the partition of this dimension. Since the parameters inside your `DotReluDot` (a sub-`Module`) are already sharded along the `model` axis, you don't need to partition multiple layers across the `model` dimension here, and therefore you should denote it as `None`."
+    "The `flax.linen.scan` code is just to show that this API works with [Flax lifted transforms](https://flax.readthedocs.io/en/latest/developer_notes/lift.html#supported-transformations)."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 44,
    "metadata": {
     "id": "a0ea0dcccbc3"
    },
@@ -283,102 +291,19 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "5b3abfef359d"
-   },
+   "metadata": {},
    "source": [
-    "## Specify sharding (includes initialization and `TrainState` creation)\n",
-    "\n",
-    "Next, generate the [`jax.sharding.PartitionSpec`](https://jax.readthedocs.io/en/latest/jax-101/08-pjit.html?#more-information-on-partitionspec) that `pjit` should receive as annotations of _input_ and _output_ data. `PartitionSpec` is a tuple of 2 axes (in a 2x4 mesh). To learn more, refer to [JAX-101: Introduction to `pjit`](https://jax.readthedocs.io/en/latest/jax-101/08-pjit.html).\n",
-    "\n",
-    "### Specify the input\n",
-    "\n",
-    "For data parallelism, you can shard the batched _input_ `x` across the `data` axis by denoting the batch axis as `data`:"
+    "Now we make a `model` instance, and a sample input `x`."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
-   "metadata": {
-    "id": "4b8472d462f2"
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "PartitionSpec('data', None)"
-      ]
-     },
-     "execution_count": 21,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "x_spec = PartitionSpec('data', None)  # dimensions: (batch, length)\n",
-    "x_spec"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "06d134795ae1"
-   },
-   "source": [
-    "### Generate a `PartitionSpec` for the output\n",
-    "\n",
-    "Next, generate a [`PartitionSpec`](https://jax.readthedocs.io/en/latest/jax-101/08-pjit.html?#more-information-on-partitionspec) for the _output_, you need to use some actual output as a reference.\n",
-    "\n",
-    "1. Instantiate a model.\n",
-    "2. Evaluate `model.init` abstractly using [`jax.eval_shape`](https://jax.readthedocs.io/en/latest/_autosummary/jax.eval_shape.html).\n",
-    "3. Use [`flax.linen.get_partition_spec`](https://flax.readthedocs.io/en/latest/api_reference/_autosummary/flax.linen.get_partition_spec.html) to automatically generate the `PartitionSpec`.\n",
-    "\n",
-    "The code below shows how to get the output spec if you use `flax.training.train_state` to carry out your initialization and training steps, in which case your `pjit`ted function will output a `TrainState`. \n",
-    "\n",
-    "(In a simpler case, people might choose the variable dict as in `variables = model.init(k, x)` as their `pjit`ted function's output. That works too.)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 22,
-   "metadata": {
-    "id": "8b913a2e57d3"
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "TrainState(step=None, apply_fn=<bound method Module.apply of MLP(\n",
-       "    # attributes\n",
-       "    num_layers = 4\n",
-       "    depth = 1024\n",
-       "    use_scan = True\n",
-       ")>, params=FrozenDict({\n",
-       "    ScanDotReluDot_0: {\n",
-       "        W1: PartitionSpec(None, None, 'model'),\n",
-       "        W2: PartitionSpec(None, 'model', None),\n",
-       "    },\n",
-       "}), tx=GradientTransformation(init=<function chain.<locals>.init_fn at 0x14f96c1f0>, update=<function chain.<locals>.update_fn at 0x14f96c160>), opt_state=(ScaleByAdamState(count=None, mu=FrozenDict({\n",
-       "    ScanDotReluDot_0: {\n",
-       "        W1: PartitionSpec(None, None, 'model'),\n",
-       "        W2: PartitionSpec(None, 'model', None),\n",
-       "    },\n",
-       "}), nu=FrozenDict({\n",
-       "    ScanDotReluDot_0: {\n",
-       "        W1: PartitionSpec(None, None, 'model'),\n",
-       "        W2: PartitionSpec(None, 'model', None),\n",
-       "    },\n",
-       "})), EmptyState()))"
-      ]
-     },
-     "execution_count": 22,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "execution_count": 45,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "# MLP hyperparameters.\n",
-    "BATCH, LAYERS, DEPTH, USE_SCAN = 8, 4, 1024, True\n",
+    "BATCH, LAYERS, DEPTH, USE_SCAN = 8, 4, 1024, False\n",
     "# Create fake inputs.\n",
     "x = jnp.ones((BATCH, DEPTH))\n",
     "# Initialize a PRNG key.\n",
@@ -387,26 +312,210 @@
     "# Create an Optax optimizer.\n",
     "optimizer = optax.adam(learning_rate=0.001)\n",
     "# Instantiate the model.\n",
-    "model = MLP(LAYERS, DEPTH, USE_SCAN)\n",
+    "model = MLP(LAYERS, DEPTH, USE_SCAN)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "5b3abfef359d"
+   },
+   "source": [
+    "## Specify sharding\n",
     "\n",
-    "# A functional way of model initialization.\n",
+    "Next, we need to tell `jax.jit` how to share our data across devices.\n",
+    "\n",
+    "### Input's sharding\n",
+    "\n",
+    "For data parallelism, we shard the batched _input_ `x` across the `data` axis by denoting the batch axis as `data`. Then, use `jax.device_put` to place it into the correct devices."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 46,
+   "metadata": {
+    "id": "8b913a2e57d3"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">┌──────────────────────────────────────────────────────────────────────────────┐\n",
+       "│                                                                              │\n",
+       "│                                 CPU <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">0</span>,<span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">1</span>,<span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">2</span>,<span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">3</span>                                  │\n",
+       "│                                                                              │\n",
+       "│                                                                              │\n",
+       "├──────────────────────────────────────────────────────────────────────────────┤\n",
+       "│                                                                              │\n",
+       "│                                 CPU <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">4</span>,<span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">5</span>,<span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">6</span>,<span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">7</span>                                  │\n",
+       "│                                                                              │\n",
+       "│                                                                              │\n",
+       "└──────────────────────────────────────────────────────────────────────────────┘\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "┌──────────────────────────────────────────────────────────────────────────────┐\n",
+       "│                                                                              │\n",
+       "│                                 CPU \u001b[1;36m0\u001b[0m,\u001b[1;36m1\u001b[0m,\u001b[1;36m2\u001b[0m,\u001b[1;36m3\u001b[0m                                  │\n",
+       "│                                                                              │\n",
+       "│                                                                              │\n",
+       "├──────────────────────────────────────────────────────────────────────────────┤\n",
+       "│                                                                              │\n",
+       "│                                 CPU \u001b[1;36m4\u001b[0m,\u001b[1;36m5\u001b[0m,\u001b[1;36m6\u001b[0m,\u001b[1;36m7\u001b[0m                                  │\n",
+       "│                                                                              │\n",
+       "│                                                                              │\n",
+       "└──────────────────────────────────────────────────────────────────────────────┘\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "x_sharding = mesh_sharding(PartitionSpec('data', None)) # dimensions: (batch, length)\n",
+    "x = jax.device_put(x, x_sharding)\n",
+    "jax.debug.visualize_array_sharding(x)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "06d134795ae1"
+   },
+   "source": [
+    "### Output's sharding\n",
+    "\n",
+    "We want to compile `model.init()`, and its output is a pytree of parameters. Sometimes we even wrap it with a `flax.training.train_state` to track other variables like optimizer states, and that makes the output an even more complex pytree.\n",
+    "\n",
+    "Luckily we don't have to hardcode the output's sharding by hand. We do:\n",
+    "\n",
+    "1. Evaluate `model.init` (in this case, a wrapper of it) abstractly using [`jax.eval_shape`](https://jax.readthedocs.io/en/latest/_autosummary/jax.eval_shape.html).\n",
+    "\n",
+    "1. Use [`flax.linen.get_sharding`](https://flax.readthedocs.io/en/latest/api_reference/_autosummary/flax.linen.get_sharding.html) to automatically generate the `jax.sharding.NamedSharding`.\n",
+    "   * This steps utilizes the `nn.with_partitioning` annotations in earlier definition to genereate the correct sharding for the params."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 47,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "def init_fn(k, x, model, optimizer):\n",
     "  variables = model.init(k, x) # Initialize the model.\n",
     "  state = train_state.TrainState.create( # Create a `TrainState`.\n",
     "    apply_fn=model.apply,\n",
     "    params=variables['params'],\n",
     "    tx=optimizer)\n",
-    "  return state\n",
+    "  return state"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 48,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "TrainState(step=NamedSharding(mesh={'data': 2, 'model': 4}, spec=PartitionSpec()), apply_fn=<bound method Module.apply of MLP(\n",
+       "    # attributes\n",
+       "    num_layers = 4\n",
+       "    depth = 1024\n",
+       "    use_scan = False\n",
+       ")>, params=FrozenDict({\n",
+       "    DotReluDot_0: {\n",
+       "        Dense_0: {\n",
+       "            kernel: NamedSharding(mesh={'data': 2, 'model': 4}, spec=PartitionSpec(None, 'model')),\n",
+       "        },\n",
+       "        W2: NamedSharding(mesh={'data': 2, 'model': 4}, spec=PartitionSpec('model', None)),\n",
+       "    },\n",
+       "    DotReluDot_1: {\n",
+       "        Dense_0: {\n",
+       "            kernel: NamedSharding(mesh={'data': 2, 'model': 4}, spec=PartitionSpec(None, 'model')),\n",
+       "        },\n",
+       "        W2: NamedSharding(mesh={'data': 2, 'model': 4}, spec=PartitionSpec('model', None)),\n",
+       "    },\n",
+       "    DotReluDot_2: {\n",
+       "        Dense_0: {\n",
+       "            kernel: NamedSharding(mesh={'data': 2, 'model': 4}, spec=PartitionSpec(None, 'model')),\n",
+       "        },\n",
+       "        W2: NamedSharding(mesh={'data': 2, 'model': 4}, spec=PartitionSpec('model', None)),\n",
+       "    },\n",
+       "    DotReluDot_3: {\n",
+       "        Dense_0: {\n",
+       "            kernel: NamedSharding(mesh={'data': 2, 'model': 4}, spec=PartitionSpec(None, 'model')),\n",
+       "        },\n",
+       "        W2: NamedSharding(mesh={'data': 2, 'model': 4}, spec=PartitionSpec('model', None)),\n",
+       "    },\n",
+       "}), tx=GradientTransformation(init=<function chain.<locals>.init_fn at 0x140ac9e50>, update=<function chain.<locals>.update_fn at 0x140adb3a0>), opt_state=(ScaleByAdamState(count=NamedSharding(mesh={'data': 2, 'model': 4}, spec=PartitionSpec()), mu=FrozenDict({\n",
+       "    DotReluDot_0: {\n",
+       "        Dense_0: {\n",
+       "            kernel: NamedSharding(mesh={'data': 2, 'model': 4}, spec=PartitionSpec(None, 'model')),\n",
+       "        },\n",
+       "        W2: NamedSharding(mesh={'data': 2, 'model': 4}, spec=PartitionSpec('model', None)),\n",
+       "    },\n",
+       "    DotReluDot_1: {\n",
+       "        Dense_0: {\n",
+       "            kernel: NamedSharding(mesh={'data': 2, 'model': 4}, spec=PartitionSpec(None, 'model')),\n",
+       "        },\n",
+       "        W2: NamedSharding(mesh={'data': 2, 'model': 4}, spec=PartitionSpec('model', None)),\n",
+       "    },\n",
+       "    DotReluDot_2: {\n",
+       "        Dense_0: {\n",
+       "            kernel: NamedSharding(mesh={'data': 2, 'model': 4}, spec=PartitionSpec(None, 'model')),\n",
+       "        },\n",
+       "        W2: NamedSharding(mesh={'data': 2, 'model': 4}, spec=PartitionSpec('model', None)),\n",
+       "    },\n",
+       "    DotReluDot_3: {\n",
+       "        Dense_0: {\n",
+       "            kernel: NamedSharding(mesh={'data': 2, 'model': 4}, spec=PartitionSpec(None, 'model')),\n",
+       "        },\n",
+       "        W2: NamedSharding(mesh={'data': 2, 'model': 4}, spec=PartitionSpec('model', None)),\n",
+       "    },\n",
+       "}), nu=FrozenDict({\n",
+       "    DotReluDot_0: {\n",
+       "        Dense_0: {\n",
+       "            kernel: NamedSharding(mesh={'data': 2, 'model': 4}, spec=PartitionSpec(None, 'model')),\n",
+       "        },\n",
+       "        W2: NamedSharding(mesh={'data': 2, 'model': 4}, spec=PartitionSpec('model', None)),\n",
+       "    },\n",
+       "    DotReluDot_1: {\n",
+       "        Dense_0: {\n",
+       "            kernel: NamedSharding(mesh={'data': 2, 'model': 4}, spec=PartitionSpec(None, 'model')),\n",
+       "        },\n",
+       "        W2: NamedSharding(mesh={'data': 2, 'model': 4}, spec=PartitionSpec('model', None)),\n",
+       "    },\n",
+       "    DotReluDot_2: {\n",
+       "        Dense_0: {\n",
+       "            kernel: NamedSharding(mesh={'data': 2, 'model': 4}, spec=PartitionSpec(None, 'model')),\n",
+       "        },\n",
+       "        W2: NamedSharding(mesh={'data': 2, 'model': 4}, spec=PartitionSpec('model', None)),\n",
+       "    },\n",
+       "    DotReluDot_3: {\n",
+       "        Dense_0: {\n",
+       "            kernel: NamedSharding(mesh={'data': 2, 'model': 4}, spec=PartitionSpec(None, 'model')),\n",
+       "        },\n",
+       "        W2: NamedSharding(mesh={'data': 2, 'model': 4}, spec=PartitionSpec('model', None)),\n",
+       "    },\n",
+       "})), EmptyState()))"
+      ]
+     },
+     "execution_count": 48,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Create an abstract closure to wrap the function before feeding it in\n",
+    "# because `jax.eval_shape` only takes pytrees as arguments`.\n",
+    "abstract_variables = jax.eval_shape(\n",
+    "    functools.partial(init_fn, model=model, optimizer=optimizer), k, x)\n",
     "\n",
-    "with mesh:\n",
-    "  # Create an abstract closure to wrap the function before feeding it in\n",
-    "  # because `jax.eval_shape` only takes pytrees as arguments`.\n",
-    "  abstract_variables = jax.eval_shape(\n",
-    "      functools.partial(init_fn, model=model, optimizer=optimizer), k, x)\n",
-    "# This `state_spec` has the same pytree structure as the output\n",
+    "# This `state_sharding` has the same pytree structure as `state`, the output\n",
     "# of the `init_fn`.\n",
-    "state_spec = nn.get_partition_spec(abstract_variables)\n",
-    "state_spec"
+    "state_sharding = nn.get_sharding(abstract_variables, mesh)\n",
+    "state_sharding"
    ]
   },
   {
@@ -415,60 +524,92 @@
     "id": "2ec24614050b"
    },
    "source": [
-    "## Apply `pjit` to compile the code\n",
+    "## Compile the code\n",
     "\n",
-    "Now you can apply JAX [`pjit`](https://jax.readthedocs.io/en/latest/jax.experimental.pjit.html#module-jax.experimental.pjit) to your `init_fn` in a similar fashion as [`jax.jit`](https://jax.readthedocs.io/en/latest/jax-101/02-jitting.html) but with two extra arguments: `in_axis_resources` and `out_axis_resources`.\n",
+    "Now you can apply [`jax.jit`](https://jax.readthedocs.io/en/latest/jax-101/02-jitting.html) to your `init_fn`, but with two extra arguments: `in_shardings` and `out_shardings`.\n",
     "\n",
-    "You need to add a `with mesh:` context when running a `pjit`ted function, so that it can refer to `mesh` (an instance of `jax.sharding.Mesh`) to allocate data on devices correctly."
+    "Run it to get the `initialized_state`, in which parameters are sharded exactly as instructed:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
-   "metadata": {
-    "id": "a298c5d03c0d"
-   },
+   "execution_count": 49,
+   "metadata": {},
    "outputs": [
     {
      "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">┌───────┬───────┬───────┬───────┐\n",
+       "│       │       │       │       │\n",
+       "│       │       │       │       │\n",
+       "│       │       │       │       │\n",
+       "│       │       │       │       │\n",
+       "│CPU <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">0</span>,<span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">4</span>│CPU <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">1</span>,<span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">5</span>│CPU <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">2</span>,<span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">6</span>│CPU <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">3</span>,<span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">7</span>│\n",
+       "│       │       │       │       │\n",
+       "│       │       │       │       │\n",
+       "│       │       │       │       │\n",
+       "│       │       │       │       │\n",
+       "└───────┴───────┴───────┴───────┘\n",
+       "</pre>\n"
+      ],
       "text/plain": [
-       "TrainState(step=(), apply_fn=<bound method Module.apply of MLP(\n",
-       "    # attributes\n",
-       "    num_layers = 4\n",
-       "    depth = 1024\n",
-       "    use_scan = True\n",
-       ")>, params=FrozenDict({\n",
-       "    ScanDotReluDot_0: {\n",
-       "        W1: Partitioned(value=(4, 1024, 1024), names=(None, None, 'model')),\n",
-       "        W2: Partitioned(value=(4, 1024, 1024), names=(None, 'model', None)),\n",
-       "    },\n",
-       "}), tx=GradientTransformation(init=<function chain.<locals>.init_fn at 0x14f96c1f0>, update=<function chain.<locals>.update_fn at 0x14f96c160>), opt_state=(ScaleByAdamState(count=(), mu=FrozenDict({\n",
-       "    ScanDotReluDot_0: {\n",
-       "        W1: Partitioned(value=(4, 1024, 1024), names=(None, None, 'model')),\n",
-       "        W2: Partitioned(value=(4, 1024, 1024), names=(None, 'model', None)),\n",
-       "    },\n",
-       "}), nu=FrozenDict({\n",
-       "    ScanDotReluDot_0: {\n",
-       "        W1: Partitioned(value=(4, 1024, 1024), names=(None, None, 'model')),\n",
-       "        W2: Partitioned(value=(4, 1024, 1024), names=(None, 'model', None)),\n",
-       "    },\n",
-       "})), EmptyState()))"
+       "┌───────┬───────┬───────┬───────┐\n",
+       "│       │       │       │       │\n",
+       "│       │       │       │       │\n",
+       "│       │       │       │       │\n",
+       "│       │       │       │       │\n",
+       "│CPU \u001b[1;36m0\u001b[0m,\u001b[1;36m4\u001b[0m│CPU \u001b[1;36m1\u001b[0m,\u001b[1;36m5\u001b[0m│CPU \u001b[1;36m2\u001b[0m,\u001b[1;36m6\u001b[0m│CPU \u001b[1;36m3\u001b[0m,\u001b[1;36m7\u001b[0m│\n",
+       "│       │       │       │       │\n",
+       "│       │       │       │       │\n",
+       "│       │       │       │       │\n",
+       "│       │       │       │       │\n",
+       "└───────┴───────┴───────┴───────┘\n"
       ]
      },
-     "execution_count": 23,
      "metadata": {},
-     "output_type": "execute_result"
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">┌───────────────────────┐\n",
+       "│        CPU <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">0</span>,<span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">4</span>        │\n",
+       "├───────────────────────┤\n",
+       "│        CPU <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">1</span>,<span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">5</span>        │\n",
+       "├───────────────────────┤\n",
+       "│        CPU <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">2</span>,<span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">6</span>        │\n",
+       "├───────────────────────┤\n",
+       "│        CPU <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">3</span>,<span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">7</span>        │\n",
+       "└───────────────────────┘\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "┌───────────────────────┐\n",
+       "│        CPU \u001b[1;36m0\u001b[0m,\u001b[1;36m4\u001b[0m        │\n",
+       "├───────────────────────┤\n",
+       "│        CPU \u001b[1;36m1\u001b[0m,\u001b[1;36m5\u001b[0m        │\n",
+       "├───────────────────────┤\n",
+       "│        CPU \u001b[1;36m2\u001b[0m,\u001b[1;36m6\u001b[0m        │\n",
+       "├───────────────────────┤\n",
+       "│        CPU \u001b[1;36m3\u001b[0m,\u001b[1;36m7\u001b[0m        │\n",
+       "└───────────────────────┘\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
     }
    ],
    "source": [
-    "pjit_init_fn = pjit(init_fn,\n",
-    "                    static_argnums=(2, 3),\n",
-    "                    in_axis_resources=(PartitionSpec(None), x_spec),  # PRNG key and x\n",
-    "                    out_axis_resources=state_spec\n",
-    "                    )\n",
-    "with mesh:\n",
-    "  initialized_state = pjit_init_fn(k, x, model, optimizer)\n",
-    "jax.tree_map(jnp.shape, initialized_state)"
+    "jit_init_fn = jax.jit(init_fn, static_argnums=(2, 3),\n",
+    "                      in_shardings=(mesh_sharding(None), x_sharding),  # PRNG key and x\n",
+    "                      out_shardings=state_sharding)\n",
+    "\n",
+    "initialized_state = jit_init_fn(k, x, model, optimizer)\n",
+    "\n",
+    "# for weight, partitioned in initialized_state.params['DotReluDot_0'].items():\n",
+    "#     print(f'Sharding of {weight}: {partitioned.names}')\n",
+    "jax.debug.visualize_array_sharding(initialized_state.params['DotReluDot_0']['Dense_0']['kernel'].value)\n",
+    "jax.debug.visualize_array_sharding(initialized_state.params['DotReluDot_0']['W2'].value)"
    ]
   },
   {
@@ -479,14 +620,14 @@
    "source": [
     "## Inspect the Module output\n",
     "\n",
-    "Note that in the output of `initialized_state`, the `params` `W1` and `W2` are of type [`flax.linen.Partitioned`](https://flax.readthedocs.io/en/latest/api_reference/_autosummary/flax.linen.Partitioned.html). This is a wrapper around the actual `jax.Array` that allows Flax to record metadata associated with it. You can access the raw `jax.Array` by adding `.value` or running `.unbox()`.\n",
+    "Note that in the output of `initialized_state`, the `params` `W1` and `W2` are of type [`flax.linen.Partitioned`](https://flax.readthedocs.io/en/latest/api_reference/_autosummary/flax.linen.Partitioned.html). This is a wrapper around the actual `jax.Array` that allows Flax to record the axis names associated with it. \n",
     "\n",
-    "You can also check the underlying [`jax.sharding`](https://jax.readthedocs.io/en/latest/jax.sharding.html) of the JAX array, which gives a hint on the way it is partitioned."
+    "You can access the raw `jax.Array` by adding `.value` when outside `jit`, or by `.unbox()` when inside."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 14,
    "metadata": {
     "id": "19243982c892"
    },
@@ -496,34 +637,74 @@
      "output_type": "stream",
      "text": [
       "<class 'flax.core.meta.Partitioned'>\n",
-      "<class 'jaxlib.xla_extension.Array'>\n",
-      "(4, 1024, 1024)\n"
+      "<class 'jaxlib.xla_extension.ArrayImpl'>\n",
+      "(None, 'model')\n",
+      "(1024, 1024)\n"
      ]
     }
    ],
    "source": [
-    "print(type(initialized_state.params['ScanDotReluDot_0']['W1']))\n",
-    "print(type(initialized_state.params['ScanDotReluDot_0']['W1'].value))\n",
-    "print(initialized_state.params['ScanDotReluDot_0']['W1'].value.shape)"
+    "print(type(initialized_state.params['DotReluDot_0']['Dense_0']['kernel']))\n",
+    "print(type(initialized_state.params['DotReluDot_0']['Dense_0']['kernel'].value))\n",
+    "print(initialized_state.params['DotReluDot_0']['Dense_0']['kernel'].names)\n",
+    "print(initialized_state.params['DotReluDot_0']['Dense_0']['kernel'].value.shape)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can also check the underlying [`jax.sharding`](https://jax.readthedocs.io/en/latest/jax.sharding.html) of each parameter, which is now more internal than `NamedSharding`. Note that numbers like `initialized_state.step` are replicated across all devices."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 15,
    "metadata": {
     "id": "2067c419a826"
    },
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "OpShardingSharding({devices=[1,1,4,2]0,4,1,5,2,6,3,7 last_tile_dim_replicate})\n"
-     ]
+     "data": {
+      "text/plain": [
+       "GSPMDSharding({devices=[1,4,2]0,4,1,5,2,6,3,7 last_tile_dim_replicate})"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
     }
    ],
    "source": [
-    "print(initialized_state.params['ScanDotReluDot_0']['W1'].value.sharding)"
+    "initialized_state.params['DotReluDot_0']['Dense_0']['kernel'].value.sharding"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "GSPMDSharding({replicated})"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "print(initialized_state.step)\n",
+    "initialized_state.step.sharding"
    ]
   },
   {
@@ -537,7 +718,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 17,
    "metadata": {
     "id": "29b3dae156a2"
    },
@@ -547,20 +728,22 @@
      "output_type": "stream",
      "text": [
       "FrozenDict({\n",
-      "    W1: Partitioned(value=(4, 1024, 1024), names=(None, None, 'model')),\n",
-      "    W2: Partitioned(value=(4, 1024, 1024), names=(None, 'model', None)),\n",
+      "    Dense_0: {\n",
+      "        kernel: Partitioned(value=(1024, 1024), names=('model', None), mesh=None),\n",
+      "    },\n",
+      "    W1: Partitioned(value=(1024, 1024), names=(None, 'model'), mesh=None),\n",
       "})\n",
-      "<class 'jaxlib.xla_extension.Array'>\n",
-      "(4, 1024, 1024)\n"
+      "<class 'jaxlib.xla_extension.ArrayImpl'>\n",
+      "(1024, 1024)\n"
      ]
     }
    ],
    "source": [
     "diff = jax.tree_map(\n",
     "    lambda a, b: a - b, \n",
-    "    initialized_state.params['ScanDotReluDot_0'], initialized_state.params['ScanDotReluDot_0'])\n",
+    "    initialized_state.params['DotReluDot_0'], initialized_state.params['DotReluDot_0'])\n",
     "print(jax.tree_map(jnp.shape, diff))\n",
-    "diff_array = diff['W1'].unbox()\n",
+    "diff_array = diff['Dense_0']['kernel'].value\n",
     "print(type(diff_array))\n",
     "print(diff_array.shape)"
    ]
@@ -571,19 +754,21 @@
     "id": "f7e1ccb14c6b"
    },
    "source": [
-    "## Apply `pjit` to the train step and inference \n",
+    "## Compile the train step and inference \n",
     "\n",
-    "Now, you create a `pjit`ted training step:"
+    "Now, you create a `jit`ted training step:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 18,
    "metadata": {
     "id": "4e3cc300cfee"
    },
    "outputs": [],
    "source": [
+    "@functools.partial(jax.jit, in_shardings=(state_sharding, x_sharding), \n",
+    "                   out_shardings=state_sharding)\n",
     "def train_step(state, x):\n",
     "  # A fake loss function.\n",
     "  def loss_unrolled(params):\n",
@@ -594,12 +779,97 @@
     "  state = state.apply_gradients(grads=grads)\n",
     "  return state\n",
     "\n",
-    "pjit_step_fn = pjit(train_step,\n",
-    "                    in_axis_resources=(state_spec, x_spec),  # input annotations\n",
-    "                    out_axis_resources=state_spec,           # output annotations\n",
-    "                    )\n",
     "with mesh:\n",
-    "  new_state = pjit_step_fn(initialized_state, x)"
+    "  new_state = train_step(initialized_state, x)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Sharding of Weight 1:\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">┌───────┬───────┬───────┬───────┐\n",
+       "│       │       │       │       │\n",
+       "│       │       │       │       │\n",
+       "│       │       │       │       │\n",
+       "│       │       │       │       │\n",
+       "│CPU <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">0</span>,<span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">4</span>│CPU <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">1</span>,<span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">5</span>│CPU <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">2</span>,<span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">6</span>│CPU <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">3</span>,<span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">7</span>│\n",
+       "│       │       │       │       │\n",
+       "│       │       │       │       │\n",
+       "│       │       │       │       │\n",
+       "│       │       │       │       │\n",
+       "└───────┴───────┴───────┴───────┘\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "┌───────┬───────┬───────┬───────┐\n",
+       "│       │       │       │       │\n",
+       "│       │       │       │       │\n",
+       "│       │       │       │       │\n",
+       "│       │       │       │       │\n",
+       "│CPU \u001b[1;36m0\u001b[0m,\u001b[1;36m4\u001b[0m│CPU \u001b[1;36m1\u001b[0m,\u001b[1;36m5\u001b[0m│CPU \u001b[1;36m2\u001b[0m,\u001b[1;36m6\u001b[0m│CPU \u001b[1;36m3\u001b[0m,\u001b[1;36m7\u001b[0m│\n",
+       "│       │       │       │       │\n",
+       "│       │       │       │       │\n",
+       "│       │       │       │       │\n",
+       "│       │       │       │       │\n",
+       "└───────┴───────┴───────┴───────┘\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Sharding of Weight 2:\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">┌───────────────────────┐\n",
+       "│        CPU <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">0</span>,<span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">4</span>        │\n",
+       "├───────────────────────┤\n",
+       "│        CPU <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">1</span>,<span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">5</span>        │\n",
+       "├───────────────────────┤\n",
+       "│        CPU <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">2</span>,<span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">6</span>        │\n",
+       "├───────────────────────┤\n",
+       "│        CPU <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">3</span>,<span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">7</span>        │\n",
+       "└───────────────────────┘\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "┌───────────────────────┐\n",
+       "│        CPU \u001b[1;36m0\u001b[0m,\u001b[1;36m4\u001b[0m        │\n",
+       "├───────────────────────┤\n",
+       "│        CPU \u001b[1;36m1\u001b[0m,\u001b[1;36m5\u001b[0m        │\n",
+       "├───────────────────────┤\n",
+       "│        CPU \u001b[1;36m2\u001b[0m,\u001b[1;36m6\u001b[0m        │\n",
+       "├───────────────────────┤\n",
+       "│        CPU \u001b[1;36m3\u001b[0m,\u001b[1;36m7\u001b[0m        │\n",
+       "└───────────────────────┘\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "print(f'Sharding of Weight 1:')\n",
+    "jax.debug.visualize_array_sharding(initialized_state.params['DotReluDot_0']['Dense_0']['kernel'].value)\n",
+    "print(f'Sharding of Weight 2:')\n",
+    "jax.debug.visualize_array_sharding(initialized_state.params['DotReluDot_0']['W2'].value)"
    ]
   },
   {
@@ -608,12 +878,12 @@
     "id": "2bae79e2e71b"
    },
    "source": [
-    "Apply `pjit` to inference. Note that, similar to `jax.jit`, you can use a decorator like `@functools.partial(pjit, ...)` to directly compile your function."
+    "And a compiled inference step. Note that the output is also sharded along `(data, None)`."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 20,
    "metadata": {
     "id": "c9264a48b9ee"
    },
@@ -622,22 +892,57 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "<class 'jaxlib.xla_extension.Array'>\n",
+      "<class 'jaxlib.xla_extension.ArrayImpl'>\n",
       "float32\n",
       "(8, 1024)\n"
      ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">┌──────────────────────────────────────────────────────────────────────────────┐\n",
+       "│                                                                              │\n",
+       "│                                 CPU <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">0</span>,<span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">1</span>,<span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">2</span>,<span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">3</span>                                  │\n",
+       "│                                                                              │\n",
+       "│                                                                              │\n",
+       "├──────────────────────────────────────────────────────────────────────────────┤\n",
+       "│                                                                              │\n",
+       "│                                 CPU <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">4</span>,<span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">5</span>,<span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">6</span>,<span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">7</span>                                  │\n",
+       "│                                                                              │\n",
+       "│                                                                              │\n",
+       "└──────────────────────────────────────────────────────────────────────────────┘\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "┌──────────────────────────────────────────────────────────────────────────────┐\n",
+       "│                                                                              │\n",
+       "│                                 CPU \u001b[1;36m0\u001b[0m,\u001b[1;36m1\u001b[0m,\u001b[1;36m2\u001b[0m,\u001b[1;36m3\u001b[0m                                  │\n",
+       "│                                                                              │\n",
+       "│                                                                              │\n",
+       "├──────────────────────────────────────────────────────────────────────────────┤\n",
+       "│                                                                              │\n",
+       "│                                 CPU \u001b[1;36m4\u001b[0m,\u001b[1;36m5\u001b[0m,\u001b[1;36m6\u001b[0m,\u001b[1;36m7\u001b[0m                                  │\n",
+       "│                                                                              │\n",
+       "│                                                                              │\n",
+       "└──────────────────────────────────────────────────────────────────────────────┘\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
     }
    ],
    "source": [
-    "@functools.partial(pjit, in_axis_resources=(state_spec, x_spec), out_axis_resources=x_spec)\n",
-    "def pjit_apply_fn(state, x):\n",
+    "@functools.partial(jax.jit, in_shardings=(state_sharding, x_sharding), \n",
+    "                   out_shardings=x_sharding)\n",
+    "def apply_fn(state, x):\n",
     "  return state.apply_fn({'params': state.params}, x)\n",
     "\n",
     "with mesh:\n",
-    "  y = pjit_apply_fn(new_state, x)\n",
+    "  y = apply_fn(new_state, x)\n",
     "print(type(y))\n",
     "print(y.dtype)\n",
-    "print(y.shape)"
+    "print(y.shape)\n",
+    "jax.debug.visualize_array_sharding(y)"
    ]
   },
   {
@@ -653,7 +958,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 21,
    "metadata": {
     "id": "a68d7cb2eb89"
    },
@@ -662,7 +967,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "166 ms ± 5.72 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
+      "132 ms ± 6.21 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
      ]
     }
    ],
@@ -674,7 +979,7 @@
     "  return xs\n",
     "\n",
     "with mesh:\n",
-    "  new_state = block_all(pjit_step_fn(initialized_state, x))"
+    "  new_state = block_all(train_step(initialized_state, x))"
    ]
   },
   {
@@ -691,12 +996,12 @@
     "\n",
     "1. All axes are annotated with more concrete, meaningful names, such as `'embed'`, `'hidden'`, `'batch'` and `'layer'`. These names are referred to as _logical axis names_ in Flax. They make the dimensional changes inside model definitions more readable.\n",
     "\n",
-    "2. `flax.linen.spmd.with_logical_partitioning` replaces `flax.linen.with_partitioning`; and `flax.linen.spmd.with_logical_constraint` replaces `pjit.with_sharding_constraint`, to recognize the logical axis names."
+    "2. `nn.with_logical_partitioning` replaces `nn.with_partitioning`; and `nn.with_logical_constraint` replaces `jax.lax.with_sharding_constraint`, to recognize the logical axis names."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 50,
    "metadata": {
     "id": "a26f85a9e772"
    },
@@ -704,25 +1009,26 @@
    "source": [
     "class LogicalDotReluDot(nn.Module):\n",
     "  depth: int\n",
+    "  dense_init: Callable = nn.initializers.xavier_normal()\n",
     "  @nn.compact\n",
-    "  def __call__(self, x):\n",
-    "    W1 = self.param(\n",
-    "        'W1', \n",
-    "        spmd.with_logical_partitioning(nn.initializers.xavier_normal(), ('embed', 'hidden')),\n",
-    "        (x.shape[-1], self.depth)) \n",
+    "  def __call__(self, x):    \n",
+    "    y = nn.Dense(self.depth, \n",
+    "                 kernel_init=nn.with_partitioning(self.dense_init, ('embed', 'hidden')),\n",
+    "                 use_bias=False,  # or overwrite with `bias_init`\n",
+    "                 )(x)\n",
     "\n",
-    "    y = jax.nn.relu(jnp.dot(x, W1))\n",
+    "    y = jax.nn.relu(y)\n",
     "    # Force a local sharding annotation.\n",
-    "    y = spmd.with_logical_constraint(y, ('batch', 'hidden'))\n",
+    "    y = with_sharding_constraint(y, mesh_sharding(PartitionSpec('data', 'model')))\n",
     "\n",
     "    W2 = self.param(\n",
     "        'W2', \n",
-    "        spmd.with_logical_partitioning(nn.initializers.xavier_normal(), ('hidden', 'embed')),\n",
+    "        nn.with_partitioning(self.dense_init, ('hidden', 'embed')),\n",
     "        (self.depth, x.shape[-1]))\n",
     "\n",
     "    z = jnp.dot(y, W2)\n",
     "    # Force a local sharding annotation.\n",
-    "    z = spmd.with_logical_constraint(z, ('batch', 'embed'))\n",
+    "    z = nn.with_logical_constraint(z, ('batch', 'embed'))\n",
     "    return z, None\n",
     "\n",
     "class LogicalMLP(nn.Module):\n",
@@ -739,7 +1045,7 @@
     "                    )(self.depth)(x)\n",
     "    else:\n",
     "      for i in range(self.num_layers):\n",
-    "        x, _ = DotReluDot(self.depth)(x)\n",
+    "        x, _ = LogicalDotReluDot(self.depth)(x)\n",
     "    return x"
    ]
   },
@@ -749,104 +1055,27 @@
     "id": "0de93ec6cbd6"
    },
    "source": [
-    "The `LogicalMLP` model definition generates a set of `PartitionSpec` with logical axis names.\n",
+    "Now initiate a model and try to figure out what sharding its `state` should have.\n",
     "\n",
-    "Repeat the steps from earlier: instantiate a model, evaluate the `init_fn` abstractly, and use `flax.linen.get_partition_spec` to automatically generate the `PartitionSpec`:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 35,
-   "metadata": {
-    "id": "14db7a1e30fd"
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "TrainState(step=None, apply_fn=<bound method Module.apply of LogicalMLP(\n",
-       "    # attributes\n",
-       "    num_layers = 4\n",
-       "    depth = 1024\n",
-       "    use_scan = True\n",
-       ")>, params=FrozenDict({\n",
-       "    ScanLogicalDotReluDot_0: {\n",
-       "        W1: PartitionSpec('layer', 'embed', 'hidden'),\n",
-       "        W2: PartitionSpec('layer', 'hidden', 'embed'),\n",
-       "    },\n",
-       "}), tx=GradientTransformation(init=<function chain.<locals>.init_fn at 0x14f96c1f0>, update=<function chain.<locals>.update_fn at 0x14f96c160>), opt_state=(ScaleByAdamState(count=None, mu=FrozenDict({\n",
-       "    ScanLogicalDotReluDot_0: {\n",
-       "        W1: PartitionSpec('layer', 'embed', 'hidden'),\n",
-       "        W2: PartitionSpec('layer', 'hidden', 'embed'),\n",
-       "    },\n",
-       "}), nu=FrozenDict({\n",
-       "    ScanLogicalDotReluDot_0: {\n",
-       "        W1: PartitionSpec('layer', 'embed', 'hidden'),\n",
-       "        W2: PartitionSpec('layer', 'hidden', 'embed'),\n",
-       "    },\n",
-       "})), EmptyState()))"
-      ]
-     },
-     "execution_count": 35,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "logical_model = LogicalMLP(LAYERS, DEPTH, USE_SCAN)\n",
-    "logical_abstract_variables = jax.eval_shape(\n",
-    "    functools.partial(init_fn, model=logical_model, optimizer=optimizer), k, x)\n",
-    "logical_output_spec = nn.get_partition_spec(logical_abstract_variables)\n",
-    "logical_output_spec"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "d1c9b74e50b9"
-   },
-   "source": [
-    "To allow the device mesh to take your model correctly, you need to decide which of these logical axis names are mapped to the device axis `'data'` or `'model'`. This rule is a list of (`logical_axis_name`, `device_axis_name`) tuples, and `jax.linen.spmd.logical_to_mesh` will convert them to the spec that `pjit` accepts.\n",
+    "To allow the device mesh to take your model correctly, you need to decide which of these logical axis names are mapped to the device axis `'data'` or `'model'`. This rule is a list of (`logical_axis_name`, `device_axis_name`) tuples, and `nn.logical_to_mesh_sharding` will convert them to the sharding that the device mesh understands.\n",
     "\n",
     "This allows you to change the rules and try out new partition layouts without modifying the model definition."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 51,
    "metadata": {
-    "id": "711cb4bde093"
+    "id": "14db7a1e30fd"
    },
    "outputs": [
     {
-     "data": {
-      "text/plain": [
-       "TrainState(step=None, apply_fn=<bound method Module.apply of LogicalMLP(\n",
-       "    # attributes\n",
-       "    num_layers = 4\n",
-       "    depth = 1024\n",
-       "    use_scan = True\n",
-       ")>, params=FrozenDict({\n",
-       "    ScanLogicalDotReluDot_0: {\n",
-       "        W1: PartitionSpec(None, None, 'model'),\n",
-       "        W2: PartitionSpec(None, 'model', None),\n",
-       "    },\n",
-       "}), tx=GradientTransformation(init=<function chain.<locals>.init_fn at 0x14f96c1f0>, update=<function chain.<locals>.update_fn at 0x14f96c160>), opt_state=(ScaleByAdamState(count=None, mu=FrozenDict({\n",
-       "    ScanLogicalDotReluDot_0: {\n",
-       "        W1: PartitionSpec(None, None, 'model'),\n",
-       "        W2: PartitionSpec(None, 'model', None),\n",
-       "    },\n",
-       "}), nu=FrozenDict({\n",
-       "    ScanLogicalDotReluDot_0: {\n",
-       "        W1: PartitionSpec(None, None, 'model'),\n",
-       "        W2: PartitionSpec(None, 'model', None),\n",
-       "    },\n",
-       "})), EmptyState()))"
-      ]
-     },
-     "execution_count": 32,
-     "metadata": {},
-     "output_type": "execute_result"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "annotations are logical, not mesh-specific:  PartitionSpec('embed', 'hidden')\n",
+      "sharding annotations are mesh-specific:  PartitionSpec(None, 'model')\n"
+     ]
     }
    ],
    "source": [
@@ -854,8 +1083,17 @@
     "rules = (('batch', 'data'),\n",
     "         ('hidden', 'model'))\n",
     "\n",
-    "logical_state_spec = spmd.logical_to_mesh(logical_output_spec, rules)\n",
-    "logical_state_spec"
+    "logical_model = LogicalMLP(LAYERS, DEPTH, USE_SCAN)\n",
+    "\n",
+    "logical_abstract_variables = jax.eval_shape(\n",
+    "    functools.partial(init_fn, model=logical_model, optimizer=optimizer), k, x)\n",
+    "logical_state_spec = nn.get_partition_spec(logical_abstract_variables)\n",
+    "print('annotations are logical, not mesh-specific: ', \n",
+    "      logical_state_spec.params['LogicalDotReluDot_0']['Dense_0']['kernel'])\n",
+    "\n",
+    "logical_state_sharding = nn.logical_to_mesh_sharding(logical_state_spec, mesh, rules)\n",
+    "print('sharding annotations are mesh-specific: ', \n",
+    "      logical_state_sharding.params['LogicalDotReluDot_0']['Dense_0']['kernel'].spec)"
    ]
   },
   {
@@ -864,12 +1102,12 @@
     "id": "58475fffb2de"
    },
    "source": [
-    "You can verify that the `logical_state_spec` here has the same content as `state_spec` in the previous (\"non-logical\") example. This will be the `out_axis_resources` you specify when creating `pjit`ted functions."
+    "You can verify that the `logical_state_spec` here has the same content as `state_spec` in the previous (\"non-logical\") example. This allows you to `jax.jit` your module's `init` and `apply`, same as above."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 52,
    "metadata": {
     "id": "589ff774bb4c"
    },
@@ -880,62 +1118,117 @@
        "True"
       ]
      },
-     "execution_count": 33,
+     "execution_count": 52,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "state_spec.params['ScanDotReluDot_0'] == logical_state_spec.params['ScanLogicalDotReluDot_0']"
+    "state_sharding.params['DotReluDot_0'] == logical_state_sharding.params['LogicalDotReluDot_0']"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 53,
    "metadata": {
     "id": "77e07a0ab309"
    },
+   "outputs": [],
+   "source": [
+    "logical_jit_init_fn = jax.jit(init_fn, static_argnums=(2, 3),\n",
+    "                      in_shardings=(mesh_sharding(None), x_sharding),  # PRNG key and x\n",
+    "                      out_shardings=logical_state_sharding)\n",
+    "\n",
+    "logical_initialized_state = logical_jit_init_fn(k, x, logical_model, optimizer)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 54,
+   "metadata": {},
    "outputs": [
     {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Sharding of Weight 1:\n"
+     ]
+    },
+    {
      "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">┌───────┬───────┬───────┬───────┐\n",
+       "│       │       │       │       │\n",
+       "│       │       │       │       │\n",
+       "│       │       │       │       │\n",
+       "│       │       │       │       │\n",
+       "│CPU <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">0</span>,<span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">4</span>│CPU <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">1</span>,<span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">5</span>│CPU <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">2</span>,<span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">6</span>│CPU <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">3</span>,<span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">7</span>│\n",
+       "│       │       │       │       │\n",
+       "│       │       │       │       │\n",
+       "│       │       │       │       │\n",
+       "│       │       │       │       │\n",
+       "└───────┴───────┴───────┴───────┘\n",
+       "</pre>\n"
+      ],
       "text/plain": [
-       "TrainState(step=(), apply_fn=<bound method Module.apply of LogicalMLP(\n",
-       "    # attributes\n",
-       "    num_layers = 4\n",
-       "    depth = 1024\n",
-       "    use_scan = True\n",
-       ")>, params=FrozenDict({\n",
-       "    ScanLogicalDotReluDot_0: {\n",
-       "        W1: LogicallyPartitioned(value=(4, 1024, 1024), names=('layer', 'embed', 'hidden')),\n",
-       "        W2: LogicallyPartitioned(value=(4, 1024, 1024), names=('layer', 'hidden', 'embed')),\n",
-       "    },\n",
-       "}), tx=GradientTransformation(init=<function chain.<locals>.init_fn at 0x14f96c1f0>, update=<function chain.<locals>.update_fn at 0x14f96c160>), opt_state=(ScaleByAdamState(count=(), mu=FrozenDict({\n",
-       "    ScanLogicalDotReluDot_0: {\n",
-       "        W1: LogicallyPartitioned(value=(4, 1024, 1024), names=('layer', 'embed', 'hidden')),\n",
-       "        W2: LogicallyPartitioned(value=(4, 1024, 1024), names=('layer', 'hidden', 'embed')),\n",
-       "    },\n",
-       "}), nu=FrozenDict({\n",
-       "    ScanLogicalDotReluDot_0: {\n",
-       "        W1: LogicallyPartitioned(value=(4, 1024, 1024), names=('layer', 'embed', 'hidden')),\n",
-       "        W2: LogicallyPartitioned(value=(4, 1024, 1024), names=('layer', 'hidden', 'embed')),\n",
-       "    },\n",
-       "})), EmptyState()))"
+       "┌───────┬───────┬───────┬───────┐\n",
+       "│       │       │       │       │\n",
+       "│       │       │       │       │\n",
+       "│       │       │       │       │\n",
+       "│       │       │       │       │\n",
+       "│CPU \u001b[1;36m0\u001b[0m,\u001b[1;36m4\u001b[0m│CPU \u001b[1;36m1\u001b[0m,\u001b[1;36m5\u001b[0m│CPU \u001b[1;36m2\u001b[0m,\u001b[1;36m6\u001b[0m│CPU \u001b[1;36m3\u001b[0m,\u001b[1;36m7\u001b[0m│\n",
+       "│       │       │       │       │\n",
+       "│       │       │       │       │\n",
+       "│       │       │       │       │\n",
+       "│       │       │       │       │\n",
+       "└───────┴───────┴───────┴───────┘\n"
       ]
      },
-     "execution_count": 34,
      "metadata": {},
-     "output_type": "execute_result"
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Sharding of Weight 2:\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">┌───────────────────────┐\n",
+       "│        CPU <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">0</span>,<span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">4</span>        │\n",
+       "├───────────────────────┤\n",
+       "│        CPU <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">1</span>,<span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">5</span>        │\n",
+       "├───────────────────────┤\n",
+       "│        CPU <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">2</span>,<span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">6</span>        │\n",
+       "├───────────────────────┤\n",
+       "│        CPU <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">3</span>,<span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">7</span>        │\n",
+       "└───────────────────────┘\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "┌───────────────────────┐\n",
+       "│        CPU \u001b[1;36m0\u001b[0m,\u001b[1;36m4\u001b[0m        │\n",
+       "├───────────────────────┤\n",
+       "│        CPU \u001b[1;36m1\u001b[0m,\u001b[1;36m5\u001b[0m        │\n",
+       "├───────────────────────┤\n",
+       "│        CPU \u001b[1;36m2\u001b[0m,\u001b[1;36m6\u001b[0m        │\n",
+       "├───────────────────────┤\n",
+       "│        CPU \u001b[1;36m3\u001b[0m,\u001b[1;36m7\u001b[0m        │\n",
+       "└───────────────────────┘\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
     }
    ],
    "source": [
-    "logical_pjit_init_fn = pjit(init_fn,\n",
-    "                            static_argnums=(2, 3),\n",
-    "                            in_axis_resources=(PartitionSpec(None), x_spec),  # RNG key and x\n",
-    "                            out_axis_resources=logical_state_spec\n",
-    "                            )\n",
-    "with mesh:\n",
-    "  logical_initialized_state = logical_pjit_init_fn(k, x, logical_model, optimizer)\n",
-    "jax.tree_map(jnp.shape, logical_initialized_state)"
+    "print(f'Sharding of Weight 1:')\n",
+    "jax.debug.visualize_array_sharding(logical_initialized_state.params['LogicalDotReluDot_0']['Dense_0']['kernel'].value)\n",
+    "print(f'Sharding of Weight 2:')\n",
+    "jax.debug.visualize_array_sharding(logical_initialized_state.params['LogicalDotReluDot_0']['W2'].value)"
    ]
   },
   {
@@ -965,7 +1258,7 @@
     "\n",
     "You can use [`flax.training.checkpoints`](https://flax.readthedocs.io/en/latest/_modules/flax/training/checkpoints.html) to save the cross-device array, as shown in the [Save and load checkpoints guide - Multi-host/multi-process checkpointing](https://flax.readthedocs.io/en/latest/guides/use_checkpointing.html#multi-host-multi-process-checkpointing). This is especially required if you are running on a multi-host environment (for example, a TPU pod).\n",
     "\n",
-    "Keep in mind that to restore the arrays to the desired partition, you need to provide a sample `target` pytree that has the same structure and has the desired `PartitionSpec` in place for each JAX array. The `PartitionSpec` you use to restore the array doesn't necessarily need to be the same as the ones you used to store the array."
+    "Keep in mind that to restore the arrays to the desired partition, you need to provide a sample `target` pytree that has the same structure and has the desired `jax.sharding.Sharding` in place for each JAX array. The sharding you use to restore the array doesn't necessarily need to be the same as the ones you used to store the array."
    ]
   }
  ],
@@ -983,7 +1276,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.10"
+   "version": "3.9.15"
   }
  },
  "nbformat": 4,

--- a/docs/guides/flax_on_pjit.md
+++ b/docs/guides/flax_on_pjit.md
@@ -10,47 +10,39 @@ jupytext:
 
 +++ {"id": "2a9f78765c0c"}
 
-# Scale up Flax Modules on multiple devices with `pjit`
+# Scale up Flax Modules on multiple devices
 
-This guide shows how to scale up [Flax Modules](https://flax.readthedocs.io/en/latest/developer_notes/module_lifecycle.html) on multiple devices and hosts using JAX's [`pjit`](https://jax.readthedocs.io/en/latest/jax.experimental.pjit.html#module-jax.experimental.pjit) and [`flax.linen.spmd`](https://flax.readthedocs.io/en/latest/api_reference/flax.linen.html#module-flax.linen.spmd).
+This guide shows how to scale up [Flax Modules](https://flax.readthedocs.io/en/latest/developer_notes/module_lifecycle.html) on multiple devices and hosts using [`jax.jit`](https://jax.readthedocs.io/en/latest/jax-101/02-jitting.html) (formerly [`experimental.pjit`](https://jax.readthedocs.io/en/latest/jax.experimental.pjit.html#module-jax.experimental.pjit)) and [`flax.linen`](https://flax.readthedocs.io/en/latest/api_reference/flax.linen.html).
 
-## Flax and `pjit`
++++
 
-[`jax.experimental.pjit`](https://jax.readthedocs.io/en/latest/jax.experimental.pjit.html) provides a way to automatically compile and scale up JAX computations. `pjit` has the following benefits:
+## Flax and `jax.jit` scaled up
 
-* `pjit` has the similar interface of [`jax.jit`](https://jax.readthedocs.io/en/latest/jax-101/02-jitting.html) and works as a decorator on a function that needs to be compiled.
-* When using `pjit`, you can write code as if it runs on a single device, and `pjit` will automatically compile and run it on multiple devices using the [Single Program Multi Data (SPMD)](https://jax.readthedocs.io/en/latest/glossary.html#term-SPMD) paradigm. 
-* With `pjit` you can state how the input and output of your code is partitioned across devices, and the compiler will figure out how to: 1) partition everything inside; and 2) compile inter-device communications.
+`jax.jit` follows the [Single Program Multi Data (SPMD)](https://jax.readthedocs.io/en/latest/glossary.html#term-SPMD) paradigm and automatically compiles your code to run it on multiple devices. You need to only specify how you want the input and output of your code to be partitioned, and the compiler will figure out how to: 1) partition everything inside; and 2) compile inter-device communications.
 
-To learn more, refer to [JAX-101 pjit tutorial](https://jax.readthedocs.io/en/latest/jax-101/08-pjit.html) and [JAX in multi-process environments](https://jax.readthedocs.io/en/latest/multi_process.html).
+To learn more about `jax.jit` APIs for scaling-up, refer to [JAX in multi-process environments](https://jax.readthedocs.io/en/latest/multi_process.html) and [Distributed arrays and automatic parallelization](https://jax.readthedocs.io/en/latest/notebooks/Distributed_arrays_and_automatic_parallelization.html).
 
-Flax provides several functionalities that can help you use `pjit` on [Flax Modules](https://flax.readthedocs.io/en/latest/developer_notes/module_lifecycle.html), including:
+Flax provides several functionalities that can help you use auto-SPMD on [Flax Modules](https://flax.readthedocs.io/en/latest/developer_notes/module_lifecycle.html), including:
 
 1. An interface to specify partitions of your data when defining [`flax.linen.Module`](https://flax.readthedocs.io/en/latest/api_reference/flax.linen.html#module).
-2. Utility functions to generate the partition information that `pjit` requires to run.
+2. Utility functions to generate the sharding information that `jax.jit` requires to run.
 3. An interface to customize your axis names called "logical axis annotations" to decouple both your Module code and partition plan to experiment with different partition layouts more easily.
 
-+++ {"id": "0fa8ccbf573a"}
++++ {"id": "a9601432b448"}
 
 ## Setup
 
-Install Flax from HEAD:
+Import some necessary dependencies.
+
+**Note:** This guide uses the `--xla_force_host_platform_device_count=8` flag to emulate multiple devices in a CPU environment in a Google Colab/Jupyter Notebook. You don't need this if you are already running on a multi-device TPU environment.
 
 ```{code-cell} ipython3
 :id: 867203db3bef
 :tags: [skip-execution]
 
-# Once Flax v0.6.4 is released, use `pip3 install flax`.
-! pip3 install -qq "git+https://github.com/google/flax.git@main#egg=flax"
+# Once Flax v0.6.10 is released, no need to do this.
+# ! pip3 install -qq "git+https://github.com/google/flax.git@main#egg=flax"
 ```
-
-+++ {"id": "a9601432b448"}
-
-## Imports
-
-Import some necessary dependencies.
-
-**Note:** This guide uses the `--xla_force_host_platform_device_count=8` flag to emulate multiple devices in a CPU environment in a Google Colab/Jupyter Notebook. Check out the [JAX-101 pjit tutorial](https://jax.readthedocs.io/en/latest/jax-101/08-pjit.html#setup) to learn more about emulating a multi-device TPU environment (in which case you should ignore running `os.environ`).
 
 ```{code-cell} ipython3
 :id: f8f42d1174e5
@@ -63,44 +55,54 @@ os.environ["XLA_FLAGS"] = '--xla_force_host_platform_device_count=8'
 :id: b8da40732f0b
 
 import functools
+from typing import Optional, Callable
+
 import numpy as np
 import jax
-
 from jax import lax, random, numpy as jnp
 
 import flax
 from flax import struct, traverse_util, linen as nn
-from flax.linen import spmd # Flax Linen SPMD.
 from flax.core import freeze, unfreeze
 from flax.training import train_state, checkpoints
 
 import optax # Optax for common losses and optimizers. 
 ```
 
+```{code-cell} ipython3
+print(f'We have 8 fake JAX devices now: {jax.devices()}')
+```
+
 +++ {"id": "c0d280def897"}
 
-Next, import all the `pjit`-related libraries.
+Import and set up the JAX-level device API following [Distributed arrays and automatic parallelization](https://jax.readthedocs.io/en/latest/notebooks/Distributed_arrays_and_automatic_parallelization.html):
 
-> **Note:** [`jax.experimental.pjit`](https://jax.readthedocs.io/en/latest/jax.experimental.pjit.html) is still in the experimental package of JAX, so there may be changes in the API in future.
+1. Start a 2x4 device `mesh` (8 devices)—this is the same as the layout of [TPU v3-8](https://cloud.google.com/tpu/docs/system-architecture-tpu-vm#single_tpu_board).
 
-1. Start a 2x4 device mesh (8 devices)—this is the same as the layout of [TPU v3-8](https://cloud.google.com/tpu/docs/system-architecture-tpu-vm#single_tpu_board).
 2. Annotate each axis with a name. A typical way to annotate axis names is `('data', 'model')`, where:
   * `'data'`: the mesh dimension used for data-parallel sharding of the batch dimension of inputs and activations.
   * `'model'`: the mesh dimension used for sharding parameters of the model across devices.
+  
+3. Make a simple util `mesh_sharding` to generate a sharding object from the mesh and any layout.
 
 ```{code-cell} ipython3
 :id: 684fe9fe13a0
 
-from jax.experimental.pjit import pjit, with_sharding_constraint
-from jax.sharding import Mesh, PartitionSpec
+from jax.sharding import Mesh, PartitionSpec, NamedSharding
+from jax.lax import with_sharding_constraint
 from jax.experimental import mesh_utils
+```
 
-# Start a device mesh.
+```{code-cell} ipython3
+# Create a mesh and annotate each axis with a name.
 device_mesh = mesh_utils.create_device_mesh((2, 4))
 print(device_mesh)
-# Annotate each axis with a name.
+
 mesh = Mesh(devices=device_mesh, axis_names=('data', 'model'))
-mesh
+print(mesh)
+
+def mesh_sharding(pspec: PartitionSpec) -> NamedSharding:
+    return NamedSharding(mesh, pspec)
 ```
 
 +++ {"id": "307d39db6d94"}
@@ -109,38 +111,40 @@ mesh
 
 Before defining a model, create an example layer called `DotReluDot` (by subclassing `flax.linen.Module`), which creates two parameters `W1` and `W2` for dot product multiplication, and uses the `jax.nn.relu` (ReLU) activation function in-between.
 
-To use this layer in `pjit` efficiently, apply the following APIs to annotate the parameters and intermediate variables correctly:
+To shard the parameters efficiently, apply the following APIs to annotate the parameters and intermediate variables:
 
-1. Use [`flax.linen.with_partitioning`](https://flax.readthedocs.io/en/latest/api_reference/_autosummary/flax.linen.with_partitioning.html#flax.linen.with_partitioning) to decorate the initializer function when creating parameters `W1` and `W2`.
+1. Use [`flax.linen.with_partitioning`](https://flax.readthedocs.io/en/latest/api_reference/_autosummary/flax.linen.with_partitioning.html#flax.linen.with_partitioning) to decorate the initializer function when creating sub-layers or raw parameters.
 
-2. Apply [`pjit.with_sharding_constraint`](https://github.com/google/jax/blob/main/jax/_src/pjit.py#L1516) to annotate intermediate variables like `y` and `z` to force a particular sharding pattern under `pjit` when the ideal constraint is known.
+2. Apply [`jax.lax.with_sharding_constraint`](https://github.com/google/jax/blob/main/jax/_src/pjit.py#L1516) to annotate intermediate variables like `y` and `z` to force a particular sharding pattern when the ideal constraint is known.
 
-  * This step is optional, but can sometimes help auto-SPMD to partition efficiently. In the example below, the call is not required, because `pjit` will figure out the same sharding layout for `y` and `z` regardless.
+  * This step is optional, but can sometimes help auto-SPMD to partition efficiently. In the example below, the call is not required, because XLA will figure out the same sharding layout for `y` and `z` regardless.
 
 ```{code-cell} ipython3
 :id: b74c049968dc
 
 class DotReluDot(nn.Module):
   depth: int
+  dense_init: Callable = nn.initializers.xavier_normal()
   @nn.compact
   def __call__(self, x):
-    W1 = self.param(
-        'W1', 
-        nn.with_partitioning(nn.initializers.xavier_normal(), (None, 'model')),
-        (x.shape[-1], self.depth))
+    
+    y = nn.Dense(self.depth, 
+                 kernel_init=nn.with_partitioning(self.dense_init, (None, 'model')),
+                 use_bias=False,  # or overwrite with `bias_init`
+                 )(x)
 
-    y = jax.nn.relu(jnp.dot(x, W1))
+    y = jax.nn.relu(y)
     # Force a local sharding annotation.
-    y = with_sharding_constraint(y, PartitionSpec('data', 'model'))
+    y = with_sharding_constraint(y, mesh_sharding(PartitionSpec('data', 'model')))
 
     W2 = self.param(
         'W2', 
-        nn.with_partitioning(nn.initializers.xavier_normal(), ('model', None)),
+        nn.with_partitioning(self.dense_init, ('model', None)),
         (self.depth, x.shape[-1]))
-
+    
     z = jnp.dot(y, W2)
     # Force a local sharding annotation.
-    z = with_sharding_constraint(z, PartitionSpec('data', None))
+    z = with_sharding_constraint(z, mesh_sharding(PartitionSpec('data', None)))
 
     # Return a tuple to conform with the API `flax.linen.scan` as shown in the cell below.
     return z, None
@@ -148,7 +152,7 @@ class DotReluDot(nn.Module):
 
 +++ {"id": "cbac5321c08e"}
 
-Note that device axis names like `'data'`, `'model'` or `None` are passed into both `flax.linen.with_partitioning` and `pjit_with_sharding_constraint` API calls. This refers to how each dimension of this data should be sharded — either across one of the device mesh dimensions, or not sharded at all.
+Note that device axis names like `'data'`, `'model'` or `None` are passed into both `flax.linen.with_partitioning` and `with_sharding_constraint` API calls. This refers to how each dimension of this data should be sharded — either across one of the device mesh dimensions, or not sharded at all.
 
 For example:
 
@@ -166,8 +170,6 @@ For example:
 
 ## Define a model with `flax.linen.scan` lifted transformation
 
-This guide uses `flax.linen.scan` to demonstrate how [Flax lifted transforms](https://flax.readthedocs.io/en/latest/developer_notes/lift.html#supported-transformations), such as `scan`, can work together with [JAX `pjit`](https://jax.readthedocs.io/en/latest/jax.experimental.pjit.html).
-
 Having created `DotReluDot`, define the `MLP` model (by subclassing `flax.linen.Module`) as multiple layers of `DotReluDot`.
 
 To replicate identical layers, you can either use `flax.linen.scan`, or a for-loop:
@@ -175,9 +177,9 @@ To replicate identical layers, you can either use `flax.linen.scan`, or a for-lo
 * `flax.linen.scan` can offer faster compilation times.
 * The for-loop can be faster on runtime.
 
-The code below shows how to apply both methods.
+The code below shows how to apply both methods, and default with the for-loop, so that all the parameters are two-dimentional and we can visualize their sharding. 
 
-**Note:** `flax.linen.scan` has another dimension for the parameters (the dimension over which `scan` is applied). You need to use the [`metadata_params`](https://flax.readthedocs.io/en/latest/api_reference/_autosummary/flax.linen.scan.html#flax.linen.scan) argument to annotate the partition of this dimension. Since the parameters inside your `DotReluDot` (a sub-`Module`) are already sharded along the `model` axis, you don't need to partition multiple layers across the `model` dimension here, and therefore you should denote it as `None`.
+The `flax.linen.scan` code is just to show that this API works with [Flax lifted transforms](https://flax.readthedocs.io/en/latest/developer_notes/lift.html#supported-transformations).
 
 ```{code-cell} ipython3
 :id: a0ea0dcccbc3
@@ -200,42 +202,11 @@ class MLP(nn.Module):
     return x
 ```
 
-+++ {"id": "5b3abfef359d"}
-
-## Specify sharding (includes initialization and `TrainState` creation)
-
-Next, generate the [`jax.sharding.PartitionSpec`](https://jax.readthedocs.io/en/latest/jax-101/08-pjit.html?#more-information-on-partitionspec) that `pjit` should receive as annotations of _input_ and _output_ data. `PartitionSpec` is a tuple of 2 axes (in a 2x4 mesh). To learn more, refer to [JAX-101: Introduction to `pjit`](https://jax.readthedocs.io/en/latest/jax-101/08-pjit.html).
-
-### Specify the input
-
-For data parallelism, you can shard the batched _input_ `x` across the `data` axis by denoting the batch axis as `data`:
+Now we make a `model` instance, and a sample input `x`.
 
 ```{code-cell} ipython3
-:id: 4b8472d462f2
-
-x_spec = PartitionSpec('data', None)  # dimensions: (batch, length)
-x_spec
-```
-
-+++ {"id": "06d134795ae1"}
-
-### Generate a `PartitionSpec` for the output
-
-Next, generate a [`PartitionSpec`](https://jax.readthedocs.io/en/latest/jax-101/08-pjit.html?#more-information-on-partitionspec) for the _output_, you need to use some actual output as a reference.
-
-1. Instantiate a model.
-2. Evaluate `model.init` abstractly using [`jax.eval_shape`](https://jax.readthedocs.io/en/latest/_autosummary/jax.eval_shape.html).
-3. Use [`flax.linen.get_partition_spec`](https://flax.readthedocs.io/en/latest/api_reference/_autosummary/flax.linen.get_partition_spec.html) to automatically generate the `PartitionSpec`.
-
-The code below shows how to get the output spec if you use `flax.training.train_state` to carry out your initialization and training steps, in which case your `pjit`ted function will output a `TrainState`. 
-
-(In a simpler case, people might choose the variable dict as in `variables = model.init(k, x)` as their `pjit`ted function's output. That works too.)
-
-```{code-cell} ipython3
-:id: 8b913a2e57d3
-
 # MLP hyperparameters.
-BATCH, LAYERS, DEPTH, USE_SCAN = 8, 4, 1024, True
+BATCH, LAYERS, DEPTH, USE_SCAN = 8, 4, 1024, False
 # Create fake inputs.
 x = jnp.ones((BATCH, DEPTH))
 # Initialize a PRNG key.
@@ -245,8 +216,40 @@ k = random.PRNGKey(0)
 optimizer = optax.adam(learning_rate=0.001)
 # Instantiate the model.
 model = MLP(LAYERS, DEPTH, USE_SCAN)
+```
 
-# A functional way of model initialization.
++++ {"id": "5b3abfef359d"}
+
+## Specify sharding
+
+Next, we need to tell `jax.jit` how to share our data across devices.
+
+### Input's sharding
+
+For data parallelism, we shard the batched _input_ `x` across the `data` axis by denoting the batch axis as `data`. Then, use `jax.device_put` to place it into the correct devices.
+
+```{code-cell} ipython3
+:id: 8b913a2e57d3
+
+x_sharding = mesh_sharding(PartitionSpec('data', None)) # dimensions: (batch, length)
+x = jax.device_put(x, x_sharding)
+jax.debug.visualize_array_sharding(x)
+```
+
++++ {"id": "06d134795ae1"}
+
+### Output's sharding
+
+We want to compile `model.init()`, and its output is a pytree of parameters. Sometimes we even wrap it with a `flax.training.train_state` to track other variables like optimizer states, and that makes the output an even more complex pytree.
+
+Luckily we don't have to hardcode the output's sharding by hand. We do:
+
+1. Evaluate `model.init` (in this case, a wrapper of it) abstractly using [`jax.eval_shape`](https://jax.readthedocs.io/en/latest/_autosummary/jax.eval_shape.html).
+
+1. Use [`flax.linen.get_sharding`](https://flax.readthedocs.io/en/latest/api_reference/_autosummary/flax.linen.get_sharding.html) to automatically generate the `jax.sharding.NamedSharding`.
+   * This steps utilizes the `nn.with_partitioning` annotations in earlier definition to genereate the correct sharding for the params.
+
+```{code-cell} ipython3
 def init_fn(k, x, model, optimizer):
   variables = model.init(k, x) # Initialize the model.
   state = train_state.TrainState.create( # Create a `TrainState`.
@@ -254,59 +257,69 @@ def init_fn(k, x, model, optimizer):
     params=variables['params'],
     tx=optimizer)
   return state
+```
 
-with mesh:
-  # Create an abstract closure to wrap the function before feeding it in
-  # because `jax.eval_shape` only takes pytrees as arguments`.
-  abstract_variables = jax.eval_shape(
-      functools.partial(init_fn, model=model, optimizer=optimizer), k, x)
-# This `state_spec` has the same pytree structure as the output
+```{code-cell} ipython3
+# Create an abstract closure to wrap the function before feeding it in
+# because `jax.eval_shape` only takes pytrees as arguments`.
+abstract_variables = jax.eval_shape(
+    functools.partial(init_fn, model=model, optimizer=optimizer), k, x)
+
+# This `state_sharding` has the same pytree structure as `state`, the output
 # of the `init_fn`.
-state_spec = nn.get_partition_spec(abstract_variables)
-state_spec
+state_sharding = nn.get_sharding(abstract_variables, mesh)
+state_sharding
 ```
 
 +++ {"id": "2ec24614050b"}
 
-## Apply `pjit` to compile the code
+## Compile the code
 
-Now you can apply JAX [`pjit`](https://jax.readthedocs.io/en/latest/jax.experimental.pjit.html#module-jax.experimental.pjit) to your `init_fn` in a similar fashion as [`jax.jit`](https://jax.readthedocs.io/en/latest/jax-101/02-jitting.html) but with two extra arguments: `in_axis_resources` and `out_axis_resources`.
+Now you can apply [`jax.jit`](https://jax.readthedocs.io/en/latest/jax-101/02-jitting.html) to your `init_fn`, but with two extra arguments: `in_shardings` and `out_shardings`.
 
-You need to add a `with mesh:` context when running a `pjit`ted function, so that it can refer to `mesh` (an instance of `jax.sharding.Mesh`) to allocate data on devices correctly.
+Run it to get the `initialized_state`, in which parameters are sharded exactly as instructed:
 
 ```{code-cell} ipython3
-:id: a298c5d03c0d
+jit_init_fn = jax.jit(init_fn, static_argnums=(2, 3),
+                      in_shardings=(mesh_sharding(None), x_sharding),  # PRNG key and x
+                      out_shardings=state_sharding)
 
-pjit_init_fn = pjit(init_fn,
-                    static_argnums=(2, 3),
-                    in_axis_resources=(PartitionSpec(None), x_spec),  # PRNG key and x
-                    out_axis_resources=state_spec
-                    )
-with mesh:
-  initialized_state = pjit_init_fn(k, x, model, optimizer)
-jax.tree_map(jnp.shape, initialized_state)
+initialized_state = jit_init_fn(k, x, model, optimizer)
+
+# for weight, partitioned in initialized_state.params['DotReluDot_0'].items():
+#     print(f'Sharding of {weight}: {partitioned.names}')
+jax.debug.visualize_array_sharding(initialized_state.params['DotReluDot_0']['Dense_0']['kernel'].value)
+jax.debug.visualize_array_sharding(initialized_state.params['DotReluDot_0']['W2'].value)
 ```
 
 +++ {"id": "8f74b009f11f"}
 
 ## Inspect the Module output
 
-Note that in the output of `initialized_state`, the `params` `W1` and `W2` are of type [`flax.linen.Partitioned`](https://flax.readthedocs.io/en/latest/api_reference/_autosummary/flax.linen.Partitioned.html). This is a wrapper around the actual `jax.Array` that allows Flax to record metadata associated with it. You can access the raw `jax.Array` by adding `.value` or running `.unbox()`.
+Note that in the output of `initialized_state`, the `params` `W1` and `W2` are of type [`flax.linen.Partitioned`](https://flax.readthedocs.io/en/latest/api_reference/_autosummary/flax.linen.Partitioned.html). This is a wrapper around the actual `jax.Array` that allows Flax to record the axis names associated with it. 
 
-You can also check the underlying [`jax.sharding`](https://jax.readthedocs.io/en/latest/jax.sharding.html) of the JAX array, which gives a hint on the way it is partitioned.
+You can access the raw `jax.Array` by adding `.value` when outside `jit`, or by `.unbox()` when inside.
 
 ```{code-cell} ipython3
 :id: 19243982c892
 
-print(type(initialized_state.params['ScanDotReluDot_0']['W1']))
-print(type(initialized_state.params['ScanDotReluDot_0']['W1'].value))
-print(initialized_state.params['ScanDotReluDot_0']['W1'].value.shape)
+print(type(initialized_state.params['DotReluDot_0']['Dense_0']['kernel']))
+print(type(initialized_state.params['DotReluDot_0']['Dense_0']['kernel'].value))
+print(initialized_state.params['DotReluDot_0']['Dense_0']['kernel'].names)
+print(initialized_state.params['DotReluDot_0']['Dense_0']['kernel'].value.shape)
 ```
+
+You can also check the underlying [`jax.sharding`](https://jax.readthedocs.io/en/latest/jax.sharding.html) of each parameter, which is now more internal than `NamedSharding`. Note that numbers like `initialized_state.step` are replicated across all devices.
 
 ```{code-cell} ipython3
 :id: 2067c419a826
 
-print(initialized_state.params['ScanDotReluDot_0']['W1'].value.sharding)
+initialized_state.params['DotReluDot_0']['Dense_0']['kernel'].value.sharding
+```
+
+```{code-cell} ipython3
+print(initialized_state.step)
+initialized_state.step.sharding
 ```
 
 +++ {"id": "273547d3ab89"}
@@ -318,22 +331,24 @@ You can use [`jax.tree_map`](https://jax.readthedocs.io/en/latest/_autosummary/j
 
 diff = jax.tree_map(
     lambda a, b: a - b, 
-    initialized_state.params['ScanDotReluDot_0'], initialized_state.params['ScanDotReluDot_0'])
+    initialized_state.params['DotReluDot_0'], initialized_state.params['DotReluDot_0'])
 print(jax.tree_map(jnp.shape, diff))
-diff_array = diff['W1'].unbox()
+diff_array = diff['Dense_0']['kernel'].value
 print(type(diff_array))
 print(diff_array.shape)
 ```
 
 +++ {"id": "f7e1ccb14c6b"}
 
-## Apply `pjit` to the train step and inference 
+## Compile the train step and inference 
 
-Now, you create a `pjit`ted training step:
+Now, you create a `jit`ted training step:
 
 ```{code-cell} ipython3
 :id: 4e3cc300cfee
 
+@functools.partial(jax.jit, in_shardings=(state_sharding, x_sharding), 
+                   out_shardings=state_sharding)
 def train_step(state, x):
   # A fake loss function.
   def loss_unrolled(params):
@@ -344,30 +359,35 @@ def train_step(state, x):
   state = state.apply_gradients(grads=grads)
   return state
 
-pjit_step_fn = pjit(train_step,
-                    in_axis_resources=(state_spec, x_spec),  # input annotations
-                    out_axis_resources=state_spec,           # output annotations
-                    )
 with mesh:
-  new_state = pjit_step_fn(initialized_state, x)
+  new_state = train_step(initialized_state, x)
+```
+
+```{code-cell} ipython3
+print(f'Sharding of Weight 1:')
+jax.debug.visualize_array_sharding(initialized_state.params['DotReluDot_0']['Dense_0']['kernel'].value)
+print(f'Sharding of Weight 2:')
+jax.debug.visualize_array_sharding(initialized_state.params['DotReluDot_0']['W2'].value)
 ```
 
 +++ {"id": "2bae79e2e71b"}
 
-Apply `pjit` to inference. Note that, similar to `jax.jit`, you can use a decorator like `@functools.partial(pjit, ...)` to directly compile your function.
+And a compiled inference step. Note that the output is also sharded along `(data, None)`.
 
 ```{code-cell} ipython3
 :id: c9264a48b9ee
 
-@functools.partial(pjit, in_axis_resources=(state_spec, x_spec), out_axis_resources=x_spec)
-def pjit_apply_fn(state, x):
+@functools.partial(jax.jit, in_shardings=(state_sharding, x_sharding), 
+                   out_shardings=x_sharding)
+def apply_fn(state, x):
   return state.apply_fn({'params': state.params}, x)
 
 with mesh:
-  y = pjit_apply_fn(new_state, x)
+  y = apply_fn(new_state, x)
 print(type(y))
 print(y.dtype)
 print(y.shape)
+jax.debug.visualize_array_sharding(y)
 ```
 
 +++ {"id": "7daa9e6e6eb4"}
@@ -386,7 +406,7 @@ def block_all(xs):
   return xs
 
 with mesh:
-  new_state = block_all(pjit_step_fn(initialized_state, x))
+  new_state = block_all(train_step(initialized_state, x))
 ```
 
 +++ {"id": "51420b514d53"}
@@ -399,32 +419,33 @@ The `LogicalDotReluDot` and `LogicalMLP` Module definition below are similar to 
 
 1. All axes are annotated with more concrete, meaningful names, such as `'embed'`, `'hidden'`, `'batch'` and `'layer'`. These names are referred to as _logical axis names_ in Flax. They make the dimensional changes inside model definitions more readable.
 
-2. `flax.linen.spmd.with_logical_partitioning` replaces `flax.linen.with_partitioning`; and `flax.linen.spmd.with_logical_constraint` replaces `pjit.with_sharding_constraint`, to recognize the logical axis names.
+2. `nn.with_logical_partitioning` replaces `nn.with_partitioning`; and `nn.with_logical_constraint` replaces `jax.lax.with_sharding_constraint`, to recognize the logical axis names.
 
 ```{code-cell} ipython3
 :id: a26f85a9e772
 
 class LogicalDotReluDot(nn.Module):
   depth: int
+  dense_init: Callable = nn.initializers.xavier_normal()
   @nn.compact
-  def __call__(self, x):
-    W1 = self.param(
-        'W1', 
-        spmd.with_logical_partitioning(nn.initializers.xavier_normal(), ('embed', 'hidden')),
-        (x.shape[-1], self.depth)) 
+  def __call__(self, x):    
+    y = nn.Dense(self.depth, 
+                 kernel_init=nn.with_partitioning(self.dense_init, ('embed', 'hidden')),
+                 use_bias=False,  # or overwrite with `bias_init`
+                 )(x)
 
-    y = jax.nn.relu(jnp.dot(x, W1))
+    y = jax.nn.relu(y)
     # Force a local sharding annotation.
-    y = spmd.with_logical_constraint(y, ('batch', 'hidden'))
+    y = with_sharding_constraint(y, mesh_sharding(PartitionSpec('data', 'model')))
 
     W2 = self.param(
         'W2', 
-        spmd.with_logical_partitioning(nn.initializers.xavier_normal(), ('hidden', 'embed')),
+        nn.with_partitioning(self.dense_init, ('hidden', 'embed')),
         (self.depth, x.shape[-1]))
 
     z = jnp.dot(y, W2)
     # Force a local sharding annotation.
-    z = spmd.with_logical_constraint(z, ('batch', 'embed'))
+    z = nn.with_logical_constraint(z, ('batch', 'embed'))
     return z, None
 
 class LogicalMLP(nn.Module):
@@ -441,64 +462,63 @@ class LogicalMLP(nn.Module):
                     )(self.depth)(x)
     else:
       for i in range(self.num_layers):
-        x, _ = DotReluDot(self.depth)(x)
+        x, _ = LogicalDotReluDot(self.depth)(x)
     return x
 ```
 
 +++ {"id": "0de93ec6cbd6"}
 
-The `LogicalMLP` model definition generates a set of `PartitionSpec` with logical axis names.
+Now initiate a model and try to figure out what sharding its `state` should have.
 
-Repeat the steps from earlier: instantiate a model, evaluate the `init_fn` abstractly, and use `flax.linen.get_partition_spec` to automatically generate the `PartitionSpec`:
-
-```{code-cell} ipython3
-:id: 14db7a1e30fd
-
-logical_model = LogicalMLP(LAYERS, DEPTH, USE_SCAN)
-logical_abstract_variables = jax.eval_shape(
-    functools.partial(init_fn, model=logical_model, optimizer=optimizer), k, x)
-logical_output_spec = nn.get_partition_spec(logical_abstract_variables)
-logical_output_spec
-```
-
-+++ {"id": "d1c9b74e50b9"}
-
-To allow the device mesh to take your model correctly, you need to decide which of these logical axis names are mapped to the device axis `'data'` or `'model'`. This rule is a list of (`logical_axis_name`, `device_axis_name`) tuples, and `jax.linen.spmd.logical_to_mesh` will convert them to the spec that `pjit` accepts.
+To allow the device mesh to take your model correctly, you need to decide which of these logical axis names are mapped to the device axis `'data'` or `'model'`. This rule is a list of (`logical_axis_name`, `device_axis_name`) tuples, and `nn.logical_to_mesh_sharding` will convert them to the sharding that the device mesh understands.
 
 This allows you to change the rules and try out new partition layouts without modifying the model definition.
 
 ```{code-cell} ipython3
-:id: 711cb4bde093
+:id: 14db7a1e30fd
 
 # Unspecified rule means unsharded by default, so no need to specify `('embed', None)` and `('layer', None)`.
 rules = (('batch', 'data'),
          ('hidden', 'model'))
 
-logical_state_spec = spmd.logical_to_mesh(logical_output_spec, rules)
-logical_state_spec
+logical_model = LogicalMLP(LAYERS, DEPTH, USE_SCAN)
+
+logical_abstract_variables = jax.eval_shape(
+    functools.partial(init_fn, model=logical_model, optimizer=optimizer), k, x)
+logical_state_spec = nn.get_partition_spec(logical_abstract_variables)
+print('annotations are logical, not mesh-specific: ', 
+      logical_state_spec.params['LogicalDotReluDot_0']['Dense_0']['kernel'])
+
+logical_state_sharding = nn.logical_to_mesh_sharding(logical_state_spec, mesh, rules)
+print('sharding annotations are mesh-specific: ', 
+      logical_state_sharding.params['LogicalDotReluDot_0']['Dense_0']['kernel'].spec)
 ```
 
 +++ {"id": "58475fffb2de"}
 
-You can verify that the `logical_state_spec` here has the same content as `state_spec` in the previous ("non-logical") example. This will be the `out_axis_resources` you specify when creating `pjit`ted functions.
+You can verify that the `logical_state_spec` here has the same content as `state_spec` in the previous ("non-logical") example. This allows you to `jax.jit` your module's `init` and `apply`, same as above.
 
 ```{code-cell} ipython3
 :id: 589ff774bb4c
 
-state_spec.params['ScanDotReluDot_0'] == logical_state_spec.params['ScanLogicalDotReluDot_0']
+state_sharding.params['DotReluDot_0'] == logical_state_sharding.params['LogicalDotReluDot_0']
 ```
 
 ```{code-cell} ipython3
 :id: 77e07a0ab309
 
-logical_pjit_init_fn = pjit(init_fn,
-                            static_argnums=(2, 3),
-                            in_axis_resources=(PartitionSpec(None), x_spec),  # RNG key and x
-                            out_axis_resources=logical_state_spec
-                            )
-with mesh:
-  logical_initialized_state = logical_pjit_init_fn(k, x, logical_model, optimizer)
-jax.tree_map(jnp.shape, logical_initialized_state)
+logical_jit_init_fn = jax.jit(init_fn, static_argnums=(2, 3),
+                      in_shardings=(mesh_sharding(None), x_sharding),  # PRNG key and x
+                      out_shardings=logical_state_sharding)
+
+logical_initialized_state = logical_jit_init_fn(k, x, logical_model, optimizer)
+```
+
+```{code-cell} ipython3
+print(f'Sharding of Weight 1:')
+jax.debug.visualize_array_sharding(logical_initialized_state.params['LogicalDotReluDot_0']['Dense_0']['kernel'].value)
+print(f'Sharding of Weight 2:')
+jax.debug.visualize_array_sharding(logical_initialized_state.params['LogicalDotReluDot_0']['W2'].value)
 ```
 
 +++ {"id": "ae1754a3031d"}
@@ -519,4 +539,4 @@ In really advanced use cases, you may have more complicated sharding patterns th
 
 You can use [`flax.training.checkpoints`](https://flax.readthedocs.io/en/latest/_modules/flax/training/checkpoints.html) to save the cross-device array, as shown in the [Save and load checkpoints guide - Multi-host/multi-process checkpointing](https://flax.readthedocs.io/en/latest/guides/use_checkpointing.html#multi-host-multi-process-checkpointing). This is especially required if you are running on a multi-host environment (for example, a TPU pod).
 
-Keep in mind that to restore the arrays to the desired partition, you need to provide a sample `target` pytree that has the same structure and has the desired `PartitionSpec` in place for each JAX array. The `PartitionSpec` you use to restore the array doesn't necessarily need to be the same as the ones you used to store the array.
+Keep in mind that to restore the arrays to the desired partition, you need to provide a sample `target` pytree that has the same structure and has the desired `jax.sharding.Sharding` in place for each JAX array. The sharding you use to restore the array doesn't necessarily need to be the same as the ones you used to store the array.


### PR DESCRIPTION
Fixes #2755:

* Use `jax.jit` in place of `pjit`, and adjust explanations
* Use `jax.sharding` instead of `PartitionSpec` wherever possible, in light of JAX's [deprecation plan](https://github.com/google/jax/blob/main/jax/_src/pjit.py#L1944)
* Showcase how to use the API on existed layers (surprising that it wasn't showcased earlier...)
