### PR TITLE
Checkpoint fixes to unbreak head

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     "jax>=0.4.2",
     "msgpack",
     "optax",
-    "orbax-checkpoint",
+    "orbax",
     "tensorstore",
     "rich>=11.1",
     "typing_extensions>=4.1.1",
@@ -127,8 +127,6 @@ filterwarnings = [
     "ignore:jax.experimental.maps.Mesh is deprecated. Use jax.sharding.Mesh.*:DeprecationWarning",
     # Deprecated legacy checkpoint - just want to keep the tests running for a while
     "ignore:Flax Checkpointing will soon be deprecated in favor of Orbax.*:DeprecationWarning",
-    # Future warning from jax
-    "ignore:jax.tree_util.register_keypaths is deprecated.*:FutureWarning",
     # Some Tensorflow IO error on 3/27/2023
     "ignore:file system plugins are not loaded.*:UserWarning",
     "ignore:unable to load libtensorflow_io_plugins.so.*:UserWarning",

--- a/tests/checkpoints_test.py
+++ b/tests/checkpoints_test.py
@@ -120,8 +120,6 @@ class CheckpointsTest(parameterized.TestCase):
     new_object = checkpoints.restore_checkpoint(
         tmp_dir, test_object0, prefix='test_')
     check_eq(new_object, test_object0)
-    # Create leftover temporary checkpoint, which should be ignored.
-    io.GFile(os.path.join(tmp_dir, 'test_tmp'), 'w')
     checkpoints.save_checkpoint(
         tmp_dir, test_object1, 0, prefix='test_', keep=1)
     self.assertIn('test_0', os.listdir(tmp_dir))
@@ -225,8 +223,6 @@ class CheckpointsTest(parameterized.TestCase):
                     'b': np.array([1, 1, 1], np.int32)}
     test_object2 = {'a': np.array([4, 5, 6], np.int32),
                     'b': np.array([2, 2, 2], np.int32)}
-    # Create leftover temporary checkpoint, which should be ignored.
-    io.GFile(os.path.join(tmp_dir, 'test_tmp'), 'w')
     checkpoints.save_checkpoint(
         tmp_dir, test_object1, 0.0, prefix='test_', keep=1)
     self.assertIn('test_0.0', os.listdir(tmp_dir))


### PR DESCRIPTION
* Make the dependency `orbax` instead of `orbax-checkpoint`, to unbreak from issue https://github.com/google/orbax/issues/289

* Fixed behavior of `checkpoints_test.py` as postfix logic subtly changed with Orbax

* Removed some test filters no longer needed