### PR TITLE
fixed broken coverage link

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # Flax: A neural network library and ecosystem for JAX designed for flexibility
 
-![Build](https://github.com/google/flax/workflows/Build/badge.svg?branch=main) [![coverage](https://badgen.net/codecov/c/github/google/flax)](https://codecov.io/github/google/flax)
+![Build](https://github.com/google/flax/workflows/Build/badge.svg?branch=main) [![coverage](https://badgen.net/codecov/c/gh/google/flax)](https://codecov.io/gh/google/flax)
 
 
 [**Overview**](#overview)


### PR DESCRIPTION
Clicking the coverage button on the front page README leads to an improperly rendered page:
<img width="909" alt="Screenshot 2023-04-25 at 4 47 30 PM" src="https://user-images.githubusercontent.com/19753743/234431794-6b3be5de-6ead-41a5-94d8-3a28bdd4338d.png">
<img width="798" alt="Screenshot 2023-04-25 at 4 49 41 PM" src="https://user-images.githubusercontent.com/19753743/234431887-48222a33-91a1-4c86-860e-034705e8dc0f.png">

This PR fixes the URL link. Test the new coverage button URL [here](https://github.com/chiamp/flax/tree/readme#flax-a-neural-network-library-and-ecosystem-for-jax-designed-for-flexibility).