### PR TITLE
0.6.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,24 +5,27 @@ vNext
 ------
 (Add your change to a random empty line to avoid merge conflicts)
 -
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+
+0.6.10
+-----
 - Rudimentary quantization support: some layers can be parametrized with custom dot_general and conv_general_dilated.
--
--
--
--
--
--
--
--
--
--
--
--
--
--
--
--
--
 
 0.6.9
 -----

--- a/flax/version.py
+++ b/flax/version.py
@@ -13,5 +13,5 @@
 # limitations under the License.
 
 """Current Flax version at head on Github."""
-__version__ = "0.6.9"
+__version__ = "0.6.10"
 


### PR DESCRIPTION
# What does this PR do?

Updates to version `0.6.10`

Fixes #3087 and fixes #3075.
