### PR TITLE
fixed missing separator for rng fold in

### DIFF
--- a/docs/api_reference/flax.config.rst
+++ b/docs/api_reference/flax.config.rst
@@ -4,4 +4,4 @@ flax.config package
 
 .. automodule:: flax.configurations
     :members:
-    :exclude-members: use_regular_dict
+    :exclude-members: temp_flip_flag

--- a/flax/core/scope.py
+++ b/flax/core/scope.py
@@ -142,6 +142,9 @@ def _fold_in_static(rng: PRNGKey,
     return rng
   m = hashlib.sha1()
   for x in data:
+    if config.flax_fix_rng_separator:
+      # encode seperate to avoid collisions like for example: ("ab", "c") and ("a", "bc")
+      m.update(b'\00')
     if isinstance(x, str):
       m.update(x.encode('utf-8'))
     elif isinstance(x, int):

--- a/tests/core/core_lift_test.py
+++ b/tests/core/core_lift_test.py
@@ -15,7 +15,7 @@
 import operator
 from flax import errors
 from flax.core import Scope, init, apply, lift, nn, FrozenDict, unfreeze, copy
-from flax.configurations import use_regular_dict
+from flax.configurations import temp_flip_flag
 
 import jax
 from jax import random
@@ -164,7 +164,7 @@ class LiftTest(absltest.TestCase):
     self.assertEqual(vars['state'], {'true_count': 1, 'false_count': 1})
     np.testing.assert_allclose(y1, -y2)
 
-  @use_regular_dict()
+  @temp_flip_flag('return_frozendict', False)
   def test_switch(self):
     def f(scope, x, index):
       scope.variable('state', 'a_count', lambda: 0)

--- a/tests/core/core_scope_test.py
+++ b/tests/core/core_scope_test.py
@@ -16,6 +16,7 @@ import unittest
 from flax import errors
 from flax.core import Scope, scope, freeze, lazy_init, init, apply, nn
 from flax.core.scope import LazyRng
+from flax.configurations import temp_flip_flag
 
 import jax
 from jax import config as jax_config
@@ -234,6 +235,12 @@ class ScopeTest(absltest.TestCase):
     init_fn = lazy_init(f)
     with self.assertRaises(errors.LazyInitError):
       init_fn(random.PRNGKey(0), jax.ShapeDtypeStruct((8, 4), jnp.float32))
+
+  @temp_flip_flag('fix_rng_separator', True)
+  def test_fold_in_static_seperator(self):
+    x = LazyRng(random.PRNGKey(0), ("ab", "c"))
+    y = LazyRng(random.PRNGKey(0), ("a", "bc"))
+    self.assertFalse(np.all(x.as_jax_rng() == y.as_jax_rng()))
 
 if __name__ == '__main__':
   absltest.main()

--- a/tests/linen/linen_attention_test.py
+++ b/tests/linen/linen_attention_test.py
@@ -20,7 +20,7 @@ from absl.testing import parameterized
 from flax import linen as nn
 from flax import jax_utils
 from flax.core import pop
-from flax.configurations import use_regular_dict
+from flax.configurations import temp_flip_flag
 
 import jax
 from jax import lax
@@ -144,7 +144,7 @@ class AttentionTest(parameterized.TestCase):
     np.testing.assert_allclose(mask_1d, mask_1d_simple,)
 
   @parameterized.parameters([((5,), (1,)), ((6, 5), (2,))])
-  @use_regular_dict()
+  @temp_flip_flag('return_frozendict', False)
   def test_decoding(self, spatial_shape, attn_dims):
     bs = 2
     num_heads = 3

--- a/tests/linen/linen_module_test.py
+++ b/tests/linen/linen_module_test.py
@@ -32,7 +32,7 @@ from flax import linen as nn
 from flax import struct
 from flax.core import Scope, freeze, FrozenDict, tracers
 from flax.linen import compact
-from flax.configurations import use_regular_dict
+from flax.configurations import temp_flip_flag
 import jax
 from jax import random
 from jax.nn import initializers
@@ -1141,7 +1141,7 @@ class ModuleTest(absltest.TestCase):
     A().test()
     self.assertFalse(setup_called)
 
-  @use_regular_dict()
+  @temp_flip_flag('return_frozendict', False)
   def test_module_pass_as_attr(self):
 
     class A(nn.Module):
@@ -1172,7 +1172,7 @@ class ModuleTest(absltest.TestCase):
     }
     self.assertTrue(tree_equals(var_shapes, ref_var_shapes))
 
-  @use_regular_dict()
+  @temp_flip_flag('return_frozendict', False)
   def test_module_pass_in_closure(self):
     a = nn.Dense(2)
 
@@ -1197,7 +1197,7 @@ class ModuleTest(absltest.TestCase):
     self.assertTrue(tree_equals(var_shapes, ref_var_shapes))
     self.assertIsNone(a.name)
 
-  @use_regular_dict()
+  @temp_flip_flag('return_frozendict', False)
   def test_toplevel_submodule_adoption(self):
 
     class Encoder(nn.Module):
@@ -1253,7 +1253,7 @@ class ModuleTest(absltest.TestCase):
     }
     self.assertTrue(tree_equals(var_shapes, ref_var_shapes))
 
-  @use_regular_dict()
+  @temp_flip_flag('return_frozendict', False)
   def test_toplevel_submodule_adoption_pytree(self):
 
     class A(nn.Module):
@@ -1297,7 +1297,7 @@ class ModuleTest(absltest.TestCase):
                 lambda x, y: np.testing.assert_allclose(x, y, atol=1e-7),
                 counters, ref_counters)))
 
-  @use_regular_dict()
+  @temp_flip_flag('return_frozendict', False)
   def test_toplevel_submodule_adoption_sharing(self):
     dense = functools.partial(nn.Dense, use_bias=False)
 
@@ -1348,7 +1348,7 @@ class ModuleTest(absltest.TestCase):
     }
     self.assertTrue(tree_equals(var_shapes, ref_var_shapes))
 
-  @use_regular_dict()
+  @temp_flip_flag('return_frozendict', False)
   def test_toplevel_named_submodule_adoption(self):
     dense = functools.partial(nn.Dense, use_bias=False)
 
@@ -1403,7 +1403,7 @@ class ModuleTest(absltest.TestCase):
       }
     self.assertTrue(tree_equals(var_shapes, ref_var_shapes))
 
-  @use_regular_dict()
+  @temp_flip_flag('return_frozendict', False)
   def test_toplevel_submodule_pytree_adoption_sharing(self):
 
     class A(nn.Module):

--- a/tests/linen/linen_test.py
+++ b/tests/linen/linen_test.py
@@ -298,8 +298,8 @@ class StochasticTest(absltest.TestCase):
       all_counts = np.prod((100, 100, n_trials))
       frac = np.sum(nonzero_counts) / all_counts
       keep_rate = 1.0 - rate
-      # just check within 3 sigma.
-      delta = 3 * np.sqrt(rate * keep_rate) / np.sqrt(all_counts)
+      # just check within 4 sigma.
+      delta = 4 * np.sqrt(rate * keep_rate) / np.sqrt(all_counts)
       self.assertTrue(keep_rate - delta < frac < keep_rate + delta)
 
   def test_dropout_rate_limits(self):

--- a/tests/linen/linen_transforms_test.py
+++ b/tests/linen/linen_transforms_test.py
@@ -28,7 +28,7 @@ from flax import config
 from flax import errors
 from flax import linen as nn
 from flax.core import freeze, copy
-from flax.configurations import use_regular_dict
+from flax.configurations import temp_flip_flag
 
 # Parse absl flags test_srcdir and test_tmpdir.
 jax.config.parse_flags_with_absl()
@@ -278,7 +278,7 @@ class TransformTest(absltest.TestCase):
     y1 = normal_model.apply(init_variables, x2.reshape((-1, 4)), mutable=['batch_stats'])[0]
     y1 = y1.reshape((5, 4, 3))
     y2 = vmap_model.apply(init_variables, x2, mutable=['batch_stats'])[0]
-    np.testing.assert_allclose(y1, y2, atol=1e-6)
+    np.testing.assert_allclose(y1, y2, atol=1e-5)
 
   def test_scan(self):
     class SimpleScan(nn.Module):
@@ -807,7 +807,7 @@ class TransformTest(absltest.TestCase):
     y3 = Ctrafo(a2, b).apply(p2, x)
     np.testing.assert_allclose(y1, y3, atol=1e-7)
 
-  @use_regular_dict()
+  @temp_flip_flag('return_frozendict', False)
   def test_toplevel_submodule_adoption_pytree_transform(self):
     class A(nn.Module):
       @nn.compact
@@ -852,7 +852,7 @@ class TransformTest(absltest.TestCase):
             cntrs, ref_cntrs)
         ))
 
-  @use_regular_dict()
+  @temp_flip_flag('return_frozendict', False)
   def test_partially_applied_module_constructor_transform(self):
     k = random.PRNGKey(0)
     x = jnp.ones((3,4,4))
@@ -870,7 +870,7 @@ class TransformTest(absltest.TestCase):
     }
     self.assertTrue(tree_equals(init_vars_shapes, ref_var_shapes))
 
-  @use_regular_dict()
+  @temp_flip_flag('return_frozendict', False)
   def test_partial_module_method(self):
     k = random.PRNGKey(0)
     x = jnp.ones((3,4,4))
@@ -1510,7 +1510,7 @@ class TransformTest(absltest.TestCase):
 
         return nn.cond(pred, true_fn, false_fn, self, x)
 
-  @use_regular_dict()
+  @temp_flip_flag('return_frozendict', False)
   def test_switch(self):
     class Foo(nn.Module):
       @nn.compact
@@ -1545,7 +1545,7 @@ class TransformTest(absltest.TestCase):
     self.assertEqual(vars['state'], {'a_count': 1, 'b_count': 1, 'c_count': 1})
     np.testing.assert_allclose(y1, y3)
 
-  @use_regular_dict()
+  @temp_flip_flag('return_frozendict', False)
   def test_switch_multihead(self):
     class Foo(nn.Module):
       def setup(self) -> None:

--- a/tests/linen/summary_test.py
+++ b/tests/linen/summary_test.py
@@ -24,7 +24,7 @@ from flax import linen as nn
 from flax.core.scope import Array
 from flax.linen import summary
 from flax import struct
-from flax.configurations import use_regular_dict
+from flax.configurations import temp_flip_flag
 
 # Parse absl flags test_srcdir and test_tmpdir.
 jax.config.parse_flags_with_absl()
@@ -181,7 +181,7 @@ class SummaryTest(absltest.TestCase):
         row.counted_variables,
       )
 
-  @use_regular_dict()
+  @temp_flip_flag('return_frozendict', False)
   def test_module_summary_with_depth(self):
     """
     This test creates a Table using `module_summary` set the `depth` argument to `1`,
@@ -240,7 +240,7 @@ class SummaryTest(absltest.TestCase):
     self.assertEqual(table[3].module_variables, table[3].counted_variables)
 
 
-  @use_regular_dict()
+  @temp_flip_flag('return_frozendict', False)
   def test_tabulate(self):
     """
     This test creates a string representation of a Module using `Module.tabulate`
@@ -323,7 +323,7 @@ class SummaryTest(absltest.TestCase):
     self.assertIn("(block_method)", module_repr)
     self.assertIn("(cnn_method)", module_repr)
 
-  @use_regular_dict()
+  @temp_flip_flag('return_frozendict', False)
   def test_tabulate_function(self):
     """
     This test creates a string representation of a Module using `Module.tabulate`
@@ -370,7 +370,7 @@ class SummaryTest(absltest.TestCase):
     self.assertIn("79.4 KB", lines[-3])
 
 
-  @use_regular_dict()
+  @temp_flip_flag('return_frozendict', False)
   def test_lifted_transform(self):
     class LSTM(nn.Module):
       batch_size: int
@@ -407,7 +407,7 @@ class SummaryTest(absltest.TestCase):
     self.assertIn("ScanLSTM/ii", lines[13])
     self.assertIn("Dense", lines[13])
 
-  @use_regular_dict()
+  @temp_flip_flag('return_frozendict', False)
   def test_lifted_transform_no_rename(self):
     class LSTM(nn.Module):
       batch_size: int
@@ -444,7 +444,7 @@ class SummaryTest(absltest.TestCase):
     self.assertIn("ScanLSTMCell_0/ii", lines[13])
     self.assertIn("Dense", lines[13])
 
-  @use_regular_dict()
+  @temp_flip_flag('return_frozendict', False)
   def test_module_reuse(self):
     class ConvBlock(nn.Module):
       @nn.compact
@@ -526,7 +526,7 @@ class SummaryTest(absltest.TestCase):
     self.assertIn('x: 3.141592', lines[7])
     self.assertIn('4.141592', lines[7])
 
-  @use_regular_dict()
+  @temp_flip_flag('return_frozendict', False)
   def test_partitioned_params(self):
 
     class Classifier(nn.Module):


### PR DESCRIPTION
Adds the changes in #2159 as a feature flag.

Also replaced `use_regular_dict` decorator with more general `temp_flip_flag` decorator that can flip any flax config variable temporarily.