### PR TITLE
Allow manually specifying the rng key for Dropout

### DIFF
--- a/flax/configurations.py
+++ b/flax/configurations.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Global configuration options for Flax.
+r"""Global configuration options for Flax.
 
 Now a wrapper over jax.config, in which all config vars have a 'flax\_' prefix.
 

--- a/flax/linen/module.py
+++ b/flax/linen/module.py
@@ -49,8 +49,8 @@ from flax.linen import kw_only_dataclasses
 
 traceback_util.register_exclusion(__file__)
 
-PRNGKey = Any  # pylint: disable=invalid-name
-RNGSequences = Dict[str, PRNGKey]
+KeyArray = Union[jax.Array, jax.random.KeyArray]  # pylint: disable=invalid-name
+RNGSequences = Dict[str, KeyArray]
 Array = Any    # pylint: disable=invalid-name
 
 
@@ -1270,7 +1270,7 @@ class Module(ModuleBase):
       raise ValueError("Can't query for RNGs on unbound modules")
     return self.scope.has_rng(name)
 
-  def make_rng(self, name: str) -> PRNGKey:
+  def make_rng(self, name: str) -> KeyArray:
     """Returns a new RNG key from a given RNG sequence for this Module.
 
     The new RNG key is split from the previous one. Thus, every call to
@@ -1494,7 +1494,7 @@ class Module(ModuleBase):
 
   @traceback_util.api_boundary
   def init_with_output(self,
-                       rngs: Union[PRNGKey, RNGSequences],
+                       rngs: Union[KeyArray, RNGSequences],
                        *args,
                        method: Union[Callable[..., Any], str, None] = None,
                        mutable: CollectionFilter = DenyList('intermediates'),
@@ -1551,7 +1551,7 @@ class Module(ModuleBase):
 
   @traceback_util.api_boundary
   def init(self,
-           rngs: Union[PRNGKey, RNGSequences],
+           rngs: Union[KeyArray, RNGSequences],
            *args,
            method: Union[Callable[..., Any], str, None] = None,
            mutable: CollectionFilter = DenyList('intermediates'),
@@ -1648,7 +1648,7 @@ class Module(ModuleBase):
 
   @traceback_util.api_boundary
   def lazy_init(self,
-           rngs: Union[PRNGKey, RNGSequences],
+           rngs: Union[KeyArray, RNGSequences],
            *args,
            method: Optional[Callable[..., Any]] = None,
            mutable: CollectionFilter = DenyList('intermediates'),
@@ -1875,7 +1875,7 @@ class Module(ModuleBase):
 
   def tabulate(
     self,
-    rngs: Union[PRNGKey, RNGSequences],
+    rngs: Union[KeyArray, RNGSequences],
     *args,
     depth: Optional[int] = None,
     show_repeated: bool = False,


### PR DESCRIPTION
# What does this PR do?

Fixes #3115. 

* Adds an optional `rng` argument to `Dropout.__call__` so users can manually specify a `PRNGKey` if more fine grained control is required.
* Improves typing for `PRNGKey` type alias (renamed to `KeyArray` to match JAX naming).