### PR TITLE
Use pyproject.toml as hash on CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -106,7 +106,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path: venv
-        key: pip-${{ steps.setup_python.outputs.python-version }}-${{ steps.date_key.outputs.DATE }}-${{ hashFiles('**/requirements.txt', 'setup.py') }}
+        key: pip-${{ steps.setup_python.outputs.python-version }}-${{ steps.date_key.outputs.DATE }}-${{ hashFiles('**/requirements.txt', 'pyproject.toml') }}
     - name: Install Dependencies for cache
       if: steps.venv_cache.outputs.cache-hit != 'true'
       run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     "jax>=0.4.2",
     "msgpack",
     "optax",
-    "orbax-checkpoint",
+    "orbax-checkpoint==0.2.3", # temporarily pin until orbax is fixed
     "tensorstore",
     "rich>=11.1",
     "typing_extensions>=4.1.1",


### PR DESCRIPTION
# What does this PR do?

Uses the `pyproject.toml` file instead of the old `setup.py` to cache the environment on CI.