### PR TITLE
Fix setup trigger issue under sharing and transforms.

### DIFF
--- a/flax/linen/module.py
+++ b/flax/linen/module.py
@@ -1112,7 +1112,8 @@ class Module(ModuleBase):
           self._validate_setup()
       finally:
         self._state.in_setup = False
-        self._state.setup_called = SetupState.DONE
+        if not shallow:
+          self._state.setup_called = SetupState.DONE
 
   def _validate_setup(self) -> None:
     """Abstractly evaluates setup only to run static checks."""


### PR DESCRIPTION
There was a subtle bug in the case of using a shared module that defined a setup() method that was called first at one location under a transform (like remat or jit) and at another location without the transform.

In the latter case the "outside" instance of the submodule had had a "shallow" _try_setup call pre-transform and was then marked as having had setup called, but the setup method had not in fact been called. This requires a one-line logic fix in _try_setup().

