### PR TITLE
update doctest requirements to use recentish jax minver

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,7 +1,7 @@
 sphinx>=3.3.1
 sphinx-book-theme
 Pygments>=2.6.1
-jax>=0.3
+jax>=0.4
 jaxlib
 ipykernel
 myst_nb


### PR DESCRIPTION
We were getting an odd CI error from doctests and I noticed that they were setting the jax minimum version too old, try to update it to see if that resolves the odd pypi import hash issue we saw.