### PR TITLE
Fix doctoring of `linen.Module.bind`

### DIFF
--- a/flax/linen/module.py
+++ b/flax/linen/module.py
@@ -1382,9 +1382,9 @@ class Module(ModuleBase):
       rngs: a dict of PRNGKeys to initialize the PRNG sequences.
       mutable: Can be bool, str, or list. Specifies which collections should be
         treated as mutable:
-          ``bool``: all/no collections are mutable.
-          ``str``: The name of a single mutable collection.
-          ``list``: A list of names of mutable collections.
+        *  ``bool``: all/no collections are mutable.
+        *  ``str``: The name of a single mutable collection.
+        *  ``list``: A list of names of mutable collections.
 
     Returns:
       A copy of this instance with bound variables and RNGs.


### PR DESCRIPTION
Sphinx used to raise an error, which is annoying for packages with classes inheriting from flax `linen.Module` as we see those errors as well.

 besides, the documentation was also broken and this fixes it

Current behaviour:

<!--
<img width="587" alt="Screenshot 2023-07-04 at 01 41 11" src="https://github.com/google/flax/assets/2407108/4bebb7f8-3483-43e6-887b-b836b52d0bb3">

Fixed behaviour:
(to add a screenshot from readthedocs)