### PR TITLE
add scan over layers section

### DIFF
--- a/docs/guides/haiku_migration_guide.rst
+++ b/docs/guides/haiku_migration_guide.rst
@@ -791,7 +791,7 @@ we are telling ``nn.scan`` create different parameters for each step and slice t
       return y
 
 Notice how in Flax we pass ``None`` as the second argument to ``ScanBlock`` and ignore
-its second output, these represent the inputs/outputs per-step but they are ``None``
+its second output. These represent the inputs/outputs per-step but they are ``None``
 because in this case we don't have any.
 
 Initializing each model is the same as in previous examples. In this case,

--- a/docs/guides/haiku_migration_guide.rst
+++ b/docs/guides/haiku_migration_guide.rst
@@ -719,7 +719,7 @@ Scan Over Layers
 ----------------
 One very important application of ``scan`` is apply a sequence of layers iteratively
 over an input, passing the output of each layer as the input to the next layer. This
-very useful to reduce compilation time for big models. As an example we will create
+is very useful to reduce compilation time for big models. As an example we will create
 a simple ``Block`` Module, and then use it inside an ``MLP`` Module that will apply
 the ``Block`` Module ``num_layers`` times.
 

--- a/docs/guides/haiku_migration_guide.rst
+++ b/docs/guides/haiku_migration_guide.rst
@@ -715,7 +715,7 @@ The only notable change with respect to the examples in the previous sections is
 this time around we used ``hk.without_apply_rng`` in Haiku so we didn't have to
 pass the ``rng`` argument as ``None`` to the ``apply`` method.
 
-Scan Over Layers
+Scan over layers
 ----------------
 One very important application of ``scan`` is apply a sequence of layers iteratively
 over an input, passing the output of each layer as the input to the next layer. This

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -9,6 +9,7 @@ recommonmark
 ipython_genutils
 sphinx-design
 jupytext==1.13.8
+dm-haiku
 
 # Need to pin docutils to 0.16 to make bulleted lists appear correctly on
 # ReadTheDocs: https://stackoverflow.com/a/68008428


### PR DESCRIPTION
# What does this PR do?

Adds a `Scan Over Layers` section to the Haiku Migration Guide.

Preview: https://flax--3195.org.readthedocs.build/en/3195/guides/haiku_migration_guide.html#scan-over-layers