### PR TITLE
Fix carry slice logic

### DIFF
--- a/flax/linen/recurrent.py
+++ b/flax/linen/recurrent.py
@@ -818,6 +818,7 @@ class RNN(Module):
     # return_carry is True we slice the carry history and select the last valid
     # carry for each sequence. Otherwise we just use the last carry.
     if slice_carry:
+      assert seq_lengths is not None
       _, (carries, outputs) = scan_output
       # seq_lengths[None] expands the shape of the mask to match the
       # number of dimensions of the carry.

--- a/flax/linen/recurrent.py
+++ b/flax/linen/recurrent.py
@@ -786,6 +786,8 @@ class RNN(Module):
     else:
       carry = initial_carry
 
+    slice_carry = seq_lengths is not None and return_carry
+
     def scan_fn(
       cell: RNNCellBase, carry: Carry, x: Array
     ) -> Union[Tuple[Carry, Array], Tuple[Carry, Tuple[Carry, Array]]]:
@@ -794,7 +796,7 @@ class RNN(Module):
       # so that we can select the last carry for each sequence later.
       # This uses more memory but is faster than using jnp.where at each
       # iteration. As a small optimization do this when we really need it.
-      if seq_lengths is not None and return_carry:
+      if slice_carry:
         return carry, (carry, y)
       else:
         return carry, y
@@ -802,7 +804,7 @@ class RNN(Module):
     scan = transforms.scan(
       scan_fn,
       in_axes=time_axis,
-      out_axes=time_axis if seq_lengths is None else (0, time_axis),
+      out_axes=(0, time_axis) if slice_carry else time_axis,
       unroll=self.unroll,
       variable_axes=self.variable_axes,
       variable_broadcast=self.variable_broadcast,
@@ -815,7 +817,7 @@ class RNN(Module):
     # Next we select the final carry. If a segmentation mask was provided and
     # return_carry is True we slice the carry history and select the last valid
     # carry for each sequence. Otherwise we just use the last carry.
-    if seq_lengths is not None and return_carry:
+    if slice_carry:
       _, (carries, outputs) = scan_output
       # seq_lengths[None] expands the shape of the mask to match the
       # number of dimensions of the carry.

--- a/tests/linen/linen_recurrent_test.py
+++ b/tests/linen/linen_recurrent_test.py
@@ -369,6 +369,14 @@ class RNNTest(absltest.TestCase):
     np.testing.assert_allclose(flipped[:4, 0], x[:4, 0][::-1])
     np.testing.assert_allclose(flipped[:2, 1], x[:2, 1][::-1])
 
+  def test_basic_seq_lengths(self):
+
+    x = jnp.ones((2, 10, 6))
+    lstm = nn.RNN(nn.LSTMCell(265))
+    variables = lstm.init(jax.random.PRNGKey(0), x)
+    y = lstm.apply(variables, x, seq_lengths=jnp.array([5, 5]))
+
+
 class BidirectionalTest(absltest.TestCase):
 
   def test_bidirectional(self):


### PR DESCRIPTION
# What does this PR do?

Fixes #3208.

Properly handles carry slicing logic. Refactors logic that checks if carry should be sliced into a `slice_carry` variable.