### PR TITLE
Write version file with `setuptools-scm` 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "setuptools-scm"]
+requires = ["setuptools", "setuptools-scm[toml]"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -64,13 +64,15 @@ homepage = "https://github.com/google/flax"
 
 [tool.setuptools.dynamic]
 readme = {file = ["README.md"], content-type = "text/markdown"}
-version = {attr = "flax.version.__version__"}
 
 [tool.setuptools.packages.find]
 include = ["flax*"]
 
 [tool.setuptools.package-data]
 flax = ["*py.typed"]
+
+[tool.setuptools_scm]
+write_to = "flax/version.py"  # Will be deprecated in favor of version_file.
 
 [tool.yapf]
 based_on_style = "yapf"


### PR DESCRIPTION
Package version in `flax.version` is not updated properly on regular basis. This results in impossibility to make a wheel out out git repo (e.g. `SETUPTOOLS_SCM_PRETEND_VERSION=0.7.1 python -m build -nw .`). This commits enables `setuptools-scm` to read configuration from `pyproject.toml` and configure version file.

@chiamp Some packaging issues related to the latest release 0.7.1 are solved in this PR.