### PR TITLE
make flax.core.copy `add_or_replace` optional

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ build/
 .vscode/*
 /.devcontainer
 docs/**/tmp
+
+# used by direnv
+.envrc

--- a/flax/core/frozen_dict.py
+++ b/flax/core/frozen_dict.py
@@ -112,10 +112,8 @@ class FrozenDict(Mapping[K, V]):
     return self._hash
 
   def copy(
-      self, add_or_replace: Optional[Mapping[K, V]] = None
+      self, add_or_replace: Mapping[K, V] = MappingProxyType({})
   ) -> 'FrozenDict[K, V]':
-    if add_or_replace is None:
-      add_or_replace = {}
     """Create a new FrozenDict with additional or replaced entries."""
     return type(self)({**self, **unfreeze(add_or_replace)})  # type: ignore[arg-type]
 
@@ -227,7 +225,7 @@ def unfreeze(x: Union[FrozenDict, Dict[str, Any]]) -> Dict[Any, Any]:
 
 def copy(
     x: Union[FrozenDict, Dict[str, Any]],
-    add_or_replace: Optional[Union[FrozenDict, Dict[str, Any]]] = None,
+    add_or_replace: Union[FrozenDict[str, Any], Dict[str, Any]] = FrozenDict({}),
 ) -> Union[FrozenDict, Dict[str, Any]]:
   """Create a new dict with additional and/or replaced entries. This is a utility
   function that can act on either a FrozenDict or regular dict and mimics the

--- a/flax/core/frozen_dict.py
+++ b/flax/core/frozen_dict.py
@@ -16,6 +16,7 @@
 
 import collections
 from typing import Any, Dict, Hashable, Optional, Mapping, Tuple, TypeVar, Union
+from types import MappingProxyType
 
 from flax import serialization
 import jax
@@ -225,7 +226,9 @@ def unfreeze(x: Union[FrozenDict, Dict[str, Any]]) -> Dict[Any, Any]:
 
 def copy(
     x: Union[FrozenDict, Dict[str, Any]],
-    add_or_replace: Union[FrozenDict[str, Any], Dict[str, Any]] = FrozenDict({}),
+    add_or_replace: Union[FrozenDict[str, Any], Dict[str, Any]] = FrozenDict(
+        {}
+    ),
 ) -> Union[FrozenDict, Dict[str, Any]]:
   """Create a new dict with additional and/or replaced entries. This is a utility
   function that can act on either a FrozenDict or regular dict and mimics the
@@ -246,8 +249,7 @@ def copy(
     return x.copy(add_or_replace)
   elif isinstance(x, dict):
     new_dict = jax.tree_map(lambda x: x, x)  # make a deep copy of dict x
-    if add_or_replace is not None:
-      new_dict.update(add_or_replace)
+    new_dict.update(add_or_replace)
     return new_dict
   raise TypeError(f'Expected FrozenDict or dict, got {type(x)}')
 

--- a/flax/core/frozen_dict.py
+++ b/flax/core/frozen_dict.py
@@ -15,7 +15,7 @@
 """Frozen Dictionary."""
 
 import collections
-from typing import Any, TypeVar, Mapping, Dict, Tuple, Union, Hashable
+from typing import Any, Dict, Hashable, Optional, Mapping, Tuple, TypeVar, Union
 
 from flax import serialization
 import jax
@@ -111,7 +111,11 @@ class FrozenDict(Mapping[K, V]):
       self._hash = h
     return self._hash
 
-  def copy(self, add_or_replace: Mapping[K, V]) -> 'FrozenDict[K, V]':
+  def copy(
+      self, add_or_replace: Optional[Mapping[K, V]] = None
+  ) -> 'FrozenDict[K, V]':
+    if add_or_replace is None:
+      add_or_replace = {}
     """Create a new FrozenDict with additional or replaced entries."""
     return type(self)({**self, **unfreeze(add_or_replace)})  # type: ignore[arg-type]
 

--- a/flax/core/frozen_dict.py
+++ b/flax/core/frozen_dict.py
@@ -227,7 +227,7 @@ def unfreeze(x: Union[FrozenDict, Dict[str, Any]]) -> Dict[Any, Any]:
 
 def copy(
     x: Union[FrozenDict, Dict[str, Any]],
-    add_or_replace: Union[FrozenDict, Dict[str, Any]],
+    add_or_replace: Optional[Union[FrozenDict, Dict[str, Any]]] = None,
 ) -> Union[FrozenDict, Dict[str, Any]]:
   """Create a new dict with additional and/or replaced entries. This is a utility
   function that can act on either a FrozenDict or regular dict and mimics the
@@ -248,7 +248,8 @@ def copy(
     return x.copy(add_or_replace)
   elif isinstance(x, dict):
     new_dict = jax.tree_map(lambda x: x, x)  # make a deep copy of dict x
-    new_dict.update(add_or_replace)
+    if add_or_replace is not None:
+      new_dict.update(add_or_replace)
     return new_dict
   raise TypeError(f'Expected FrozenDict or dict, got {type(x)}')
 

--- a/tests/core/core_frozen_dict_test.py
+++ b/tests/core/core_frozen_dict_test.py
@@ -124,6 +124,18 @@ class FrozenDictTest(parameterized.TestCase):
   @parameterized.parameters(
       {
           'x': {'a': 1, 'b': {'c': 2}},
+      },
+      {
+          'x': FrozenDict({'a': 1, 'b': {'c': 2}}),
+      },
+  )
+  def test_utility_copy_singlearg(self, x):
+    new_x = copy(x)
+    self.assertTrue(new_x == x and isinstance(new_x, type(x)))
+
+  @parameterized.parameters(
+      {
+          'x': {'a': 1, 'b': {'c': 2}},
           'pretty_str': '{\n    a: 1,\n    b: {\n        c: 2,\n    },\n}',
       },
       {


### PR DESCRIPTION
It makes the API easier to use when you just want to have a copy of a dictionary.