### PR TITLE
added cursor api

### DIFF
--- a/docs/api_reference/flax.cursor.rst
+++ b/docs/api_reference/flax.cursor.rst
@@ -1,0 +1,60 @@
+
+flax.cursor package
+=============================
+
+The Cursor API allows for mutability of pytrees. This API provides a more
+ergonomic solution to making partial-updates of deeply nested immutable
+data structures, compared to making many nested ``dataclasses.replace`` calls.
+
+To illustrate, consider the example below::
+
+  from flax.cursor import cursor
+  import dataclasses
+  from typing import Any
+
+  @dataclasses.dataclass
+  class A:
+    x: Any
+
+  a = A(A(A(A(A(A(A(0)))))))
+
+To replace the int 0 using ``dataclasses.replace``, we would have to write many nested calls::
+
+  a2 = dataclasses.replace(
+    a,
+    x=dataclasses.replace(
+      a.x,
+      x=dataclasses.replace(
+        a.x.x,
+        x=dataclasses.replace(
+          a.x.x.x,
+          x=dataclasses.replace(
+            a.x.x.x.x,
+            x=dataclasses.replace(
+              a.x.x.x.x.x,
+              x=dataclasses.replace(a.x.x.x.x.x.x, x=1),
+            ),
+          ),
+        ),
+      ),
+    ),
+  )
+
+The equivalent can be achieved much more simply using the Cursor API::
+
+  a3 = cursor(a).x.x.x.x.x.x.x.set(1)
+  assert a2 == a3
+
+The Cursor object keeps tracks of changes made to it and when ``.build`` is called,
+generates a new object with the accumulated changes. Basic usage involves
+wrapping the object in a Cursor, making changes to the Cursor object and
+generating a new copy of the original object with the accumulated changes.
+
+.. currentmodule:: flax.cursor
+
+.. autofunction:: cursor
+
+.. autoclass:: Cursor
+  :members: build, set, apply_update
+
+

--- a/docs/api_reference/index.rst
+++ b/docs/api_reference/index.rst
@@ -6,6 +6,7 @@ API Reference
 
    flax.config
    flax.core.frozen_dict
+   flax.cursor
    flax.errors
    flax.jax_utils
    flax.linen/index

--- a/flax/cursor.py
+++ b/flax/cursor.py
@@ -1,0 +1,392 @@
+import enum
+from typing import Any, Callable, Dict, Generator, Generic, Mapping, Optional, Protocol, Tuple, TypeVar, Union, runtime_checkable
+from flax.core import FrozenDict
+import dataclasses
+
+
+A = TypeVar('A')
+Key = Any
+
+
+@runtime_checkable
+class Indexable(Protocol):
+
+  def __getitem__(self, key) -> Any:
+    ...
+
+
+@dataclasses.dataclass
+class ParentKey(Generic[A]):
+  parent: 'Cursor[A]'
+  key: Any
+
+
+class AccessType(enum.Enum):
+  GETITEM = enum.auto()
+  GETATTR = enum.auto()
+
+
+def is_named_tuple(obj):
+  return (
+      isinstance(obj, tuple)
+      and hasattr(obj, '_fields')
+      and hasattr(obj, '_asdict')
+      and hasattr(obj, '_replace')
+  )
+
+
+def _get_changes(path, obj, update_fn):
+  """Helper function for ``Cursor.apply_update``. Returns a generator of
+  Tuple[Tuple[Union[str, int], Any], ...], where the first element is a
+  tuple key path where the change was applied from the ``update_fn``, and
+  the second element is the newly modified value. If the generator is
+  non-empty, then the tuple key path will always be non-empty as well."""
+  if path:
+    str_path = '/'.join(str(key) for key, _ in path)
+    new_obj = update_fn(str_path, obj)
+    if new_obj is not obj:
+      yield path, new_obj
+      return
+
+  if isinstance(obj, (FrozenDict, dict)):
+    items = obj.items()
+    access_type = AccessType.GETITEM
+  elif is_named_tuple(obj):
+    items = ((name, getattr(obj, name)) for name in obj._fields)  # type: ignore
+    access_type = AccessType.GETATTR
+  elif isinstance(obj, (list, tuple)):
+    items = enumerate(obj)
+    access_type = AccessType.GETITEM
+  elif dataclasses.is_dataclass(obj):
+    items = (
+        (f.name, getattr(obj, f.name))
+        for f in dataclasses.fields(obj)
+        if f.init
+    )
+    access_type = AccessType.GETATTR
+  else:
+    yield from ()  # empty generator
+    return
+
+  for key, value in items:
+    yield from _get_changes(path + ((key, access_type),), value, update_fn)
+
+
+class Cursor(Generic[A]):
+  obj: A
+  parent_key: Optional[ParentKey[A]]
+  changes: Dict[Any, Union[Any, 'Cursor[A]']]
+
+  def __init__(self, obj: A, parent_key: Optional[ParentKey[A]]):
+    # NOTE: we use `vars` here to avoid calling `__setattr__`
+    # vars(self) = self.__dict__
+    vars(self)['obj'] = obj
+    vars(self)['parent_key'] = parent_key
+    vars(self)['changes'] = {}
+
+  @property
+  def root(self) -> 'Cursor[A]':
+    if self.parent_key is None:
+      return self
+    else:
+      return self.parent_key.parent.root  # type: ignore
+
+  def __getitem__(self, key) -> 'Cursor[A]':
+    if key in self.changes:
+      return self.changes[key]
+
+    if not isinstance(self.obj, Indexable):
+      raise TypeError(f'Cannot index into {self.obj}')
+
+    if isinstance(self.obj, Mapping) and key not in self.obj:
+      raise KeyError(f'Key {key} not found in {self.obj}')
+
+    if is_named_tuple(self.obj):
+      return getattr(self, self.obj._fields[key])  # type: ignore
+
+    child = Cursor(self.obj[key], ParentKey(self, key))
+    self.changes[key] = child
+    return child
+
+  def __getattr__(self, name) -> 'Cursor[A]':
+    if name in self.changes:
+      return self.changes[name]
+
+    if not hasattr(self.obj, name):
+      raise AttributeError(f'Attribute {name} not found in {self.obj}')
+
+    child = Cursor(getattr(self.obj, name), ParentKey(self, name))
+    self.changes[name] = child
+    return child
+
+  def __setitem__(self, key, value):
+    if is_named_tuple(self.obj):
+      return setattr(self, self.obj._fields[key], value)  # type: ignore
+    self.changes[key] = Cursor(value, ParentKey(self, key))
+
+  def __setattr__(self, name, value):
+    self.changes[name] = Cursor(value, ParentKey(self, name))
+
+  def set(self, value) -> A:
+    """Set a new value for an attribute, property, element or entry
+    in the Cursor object and return a copy of the original object,
+    containing the new set value.
+
+    Example::
+
+      from flax.cursor import cursor
+      from flax.training import train_state
+      import optax
+
+      dict_obj = {'a': 1, 'b': (2, 3), 'c': [4, 5]}
+      modified_dict_obj = cursor(dict_obj)['b'][0].set(10)
+      assert modified_dict_obj == {'a': 1, 'b': (10, 3), 'c': [4, 5]}
+
+      state = train_state.TrainState.create(
+          apply_fn=lambda x: x,
+          params=dict_obj,
+          tx=optax.adam(1e-3),
+      )
+      modified_state = cursor(state).params['b'][1].set(10)
+      assert modified_state.params == {'a': 1, 'b': (2, 10), 'c': [4, 5]}
+
+    Args:
+      value: the value used to set an attribute, property, element or entry in the Cursor object
+    Returns:
+      A copy of the original object with the new set value.
+    """
+    if self.parent_key is None:
+      return value
+    parent, key = self.parent_key.parent, self.parent_key.key  # type: ignore
+    parent.changes[key] = value
+    return parent.root.build()
+
+  def build(self) -> A:
+    """Create and return a copy of the original object with accumulated changes.
+    This method is to be called after making changes to the Cursor object.
+
+    NOTE: The new object is built bottom-up, the changes will be first applied
+    to the leaf nodes, and then its parent, all the way up to the root.
+
+    Example::
+
+      from flax.cursor import cursor
+      from flax.training import train_state
+      import optax
+
+      dict_obj = {'a': 1, 'b': (2, 3), 'c': [4, 5]}
+      c = cursor(dict_obj)
+      c['b'][0] = 10
+      c['a'] = (100, 200)
+      modified_dict_obj = c.build()
+      assert modified_dict_obj == {'a': (100, 200), 'b': (10, 3), 'c': [4, 5]}
+
+      state = train_state.TrainState.create(
+          apply_fn=lambda x: x,
+          params=dict_obj,
+          tx=optax.adam(1e-3),
+      )
+      new_fn = lambda x: x + 1
+      c = cursor(state)
+      c.params['b'][1] = 10
+      c.apply_fn = new_fn
+      modified_state = c.build()
+      assert modified_state.params == {'a': 1, 'b': (2, 10), 'c': [4, 5]}
+      assert modified_state.apply_fn == new_fn
+
+    Returns:
+      A copy of the original object with the accumulated changes.
+    """
+    changes = {
+        key: child.build() if isinstance(child, Cursor) else child
+        for key, child in self.changes.items()
+    }
+    if isinstance(self.obj, FrozenDict):
+      obj = self.obj.copy(changes)  # type: ignore
+    elif isinstance(self.obj, (dict, list)):
+      obj = self.obj.copy()  # type: ignore
+      for key, value in changes.items():
+        obj[key] = value
+    elif is_named_tuple(self.obj):
+      obj = self.obj._replace(**changes)  # type: ignore
+    elif isinstance(self.obj, tuple):
+      obj = list(self.obj)  # type: ignore
+      for key, value in changes.items():
+        obj[key] = value
+      obj = tuple(obj)  # type: ignore
+    elif dataclasses.is_dataclass(self.obj):
+      obj = dataclasses.replace(self.obj, **changes)  # type: ignore
+    else:
+      obj = self.obj  # type: ignore
+
+      # NOTE: There is a way to try to do a general replace for pytrees, but it requires
+      # the key of `changes` to store the type of access (getattr, getitem, etc.)
+      # in order to access those value from the original object and try to replace them
+      # with the new value. For simplicity, this is not implemented for now.
+      # ----------------------
+      # changed_values = tuple(changes.values())
+      # result = flatten_until_found(self.obj, changed_values)
+
+      # if result is None:
+      #   raise ValueError('Cannot find object in parent')
+
+      # leaves, treedef = result
+      # leaves = [leaf if leaf is not self.obj else value for leaf in leaves]
+      # obj = jax.tree_util.tree_unflatten(treedef, leaves)
+
+    return obj  # type: ignore
+
+  def apply_update(
+      self,
+      update_fn: Callable[[str, Any], Any],
+  ) -> 'Cursor[A]':
+    """Traverse the Cursor object and apply conditional changes recursively via an ``update_fn``.
+    The ``update_fn`` has a function signature of ``(str, Any) -> Any``:
+
+    - The input arguments are the current key path (in the form of a string delimited
+      by '/') and value at that current key path
+    - The output is the new value (either modified by the ``update_fn`` or same as the
+      input value if the condition wasn't fulfilled)
+
+    To generate a copy of the original object with the accumulated changes, call the ``.build`` method.
+
+    NOTES:
+
+    - If the ``update_fn`` returns a modified value, this function will not recurse any further
+      down that branch to apply changes. For example, if we intend to replace an attribute that points
+      to a dictionary with an int, we don't need to look for further changes inside the dictionary,
+      since the dictionary will be replaced anyways.
+    - The ``is`` operator is used to determine whether the return value is modified (by comparing it
+      to the input value). Therefore if the ``update_fn`` modifies a mutable container (e.g. lists,
+      dicts, etc.) and returns the same container, ``.apply_update`` will treat the returned value as
+      unmodified as it contains the same ``id``. To avoid this, return a copy of the modified value.
+    - The ``.apply_update`` WILL NOT apply the ``update_fn`` to the value at the top-most level of
+      the pytree (i.e. the root node). The ``update_fn`` will be applied recursively, starting at the
+      root node's children.
+
+    Example::
+
+      import flax.linen as nn
+      from flax.cursor import cursor
+      import jax
+      import jax.numpy as jnp
+
+      class Model(nn.Module):
+        @nn.compact
+        def __call__(self, x):
+          x = nn.Dense(3)(x)
+          x = nn.relu(x)
+          x = nn.Dense(3)(x)
+          x = nn.relu(x)
+          x = nn.Dense(3)(x)
+          x = nn.relu(x)
+          return x
+
+      params = Model().init(jax.random.PRNGKey(0), jnp.empty((1, 2)))['params']
+
+      def update_fn(path, value):
+        '''Multiply all dense kernel params by 2 and add 1.
+        Subtract the Dense_1 bias param by 1.'''
+        if 'kernel' in path:
+          return value * 2 + 1
+        elif 'Dense_1' in path and 'bias' in path:
+          return value - 1
+        return value
+
+      c = cursor(params)
+      new_params = c.apply_update(update_fn).build()
+      for layer in ('Dense_0', 'Dense_1', 'Dense_2'):
+        assert (new_params[layer]['kernel'] == 2 * params[layer]['kernel'] + 1).all()
+        if layer == 'Dense_1':
+          assert (new_params[layer]['bias'] == jnp.array([-1, -1, -1])).all()
+        else:
+          assert (new_params[layer]['bias'] == params[layer]['bias']).all()
+
+      assert jax.tree_util.tree_all(
+            jax.tree_util.tree_map(
+                lambda x, y: (x == y).all(),
+                params,
+                Model().init(jax.random.PRNGKey(0), jnp.empty((1, 2)))[
+                    'params'
+                ],
+            )
+        ) # make sure original params are unchanged
+
+    Args:
+      update_fn: the function that will conditionally apply changes to the Cursor object
+    Returns:
+      The current Cursor object with the updates applied by the ``update_fn``.
+    """
+    for path, value in _get_changes((), self.obj, update_fn):
+      child = self
+      for key, access_type in path[:-1]:
+        if access_type is AccessType.GETITEM:
+          child = child[key]
+        else:  # access_type is AccessType.GETATTR
+          child = getattr(child, key)
+      key, access_type = path[-1]
+      if access_type is AccessType.GETITEM:
+        child[key] = value
+      else:  # access_type is AccessType.GETATTR
+        setattr(child, key, value)
+
+    return self
+
+
+def cursor(obj: A) -> Cursor[A]:
+  """Wrap Cursor over obj and return it.
+  Changes can then be applied to the Cursor object in the following ways:
+
+  - single-line change via the ``.set`` method
+  - multiple changes, and then calling the ``.build`` method
+  - multiple changes conditioned on the tree path and node value, via the ``.apply_update`` method
+
+  ``.set`` example::
+
+    from flax.cursor import cursor
+
+    dict_obj = {'a': 1, 'b': (2, 3), 'c': [4, 5]}
+    modified_dict_obj = cursor(dict_obj)['b'][0].set(10)
+    assert modified_dict_obj == {'a': 1, 'b': (10, 3), 'c': [4, 5]}
+
+  ``.build`` example::
+
+    from flax.cursor import cursor
+
+    dict_obj = {'a': 1, 'b': (2, 3), 'c': [4, 5]}
+    c = cursor(dict_obj)
+    c['b'][0] = 10
+    c['a'] = (100, 200)
+    modified_dict_obj = c.build()
+    assert modified_dict_obj == {'a': (100, 200), 'b': (10, 3), 'c': [4, 5]}
+
+  ``.apply_update`` example::
+
+    from flax.cursor import cursor
+    from flax.training import train_state
+    import optax
+
+    def update_fn(path, value):
+      '''Replace params with empty dictionary.'''
+      if 'params' in path:
+        return {}
+      return value
+
+    state = train_state.TrainState.create(
+        apply_fn=lambda x: x,
+        params={'a': 1, 'b': 2},
+        tx=optax.adam(1e-3),
+    )
+    c = cursor(state)
+    state2 = c.apply_update(update_fn).build()
+    assert state2.params == {}
+    assert state.params == {'a': 1, 'b': 2} # make sure original params are unchanged
+
+  View the docstrings for each method to see more examples of their usage.
+
+  Args:
+    obj: the object you want to wrap the Cursor in
+  Returns:
+    A Cursor object wrapped around obj.
+  """
+  return Cursor(obj, None)

--- a/tests/cursor_test.py
+++ b/tests/cursor_test.py
@@ -1,0 +1,332 @@
+# Copyright 2023 The Flax Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for flax.struct."""
+
+
+from absl.testing import absltest
+import jax
+import jax.numpy as jnp
+import optax
+from typing import Any, Generic, NamedTuple
+
+import flax.linen as nn
+from flax.core import freeze
+from flax.cursor import cursor
+from flax.training import train_state
+
+# Parse absl flags test_srcdir and test_tmpdir.
+jax.config.parse_flags_with_absl()
+
+
+class GenericTuple(NamedTuple):
+  x: Any
+  y: Any = None
+
+
+class CursorTest(absltest.TestCase):
+
+  def test_set_and_build(self):
+    # test regular dict and FrozenDict
+    dict_obj = {'a': 1, 'b': (2, 3), 'c': [4, 5]}
+    for d, freeze_wrap in ((dict_obj, lambda x: x), (freeze(dict_obj), freeze)):
+      # set API
+      self.assertEqual(
+          cursor(d)['b'][0].set(10),
+          freeze_wrap({'a': 1, 'b': (10, 3), 'c': [4, 5]}),
+      )
+      # build API
+      c = cursor(d)
+      c['b'][0] = 20
+      c['a'] = (100, 200)
+      d2 = c.build()
+      self.assertEqual(
+          d2, freeze_wrap({'a': (100, 200), 'b': (20, 3), 'c': [4, 5]})
+      )
+    self.assertEqual(
+        dict_obj, {'a': 1, 'b': (2, 3), 'c': [4, 5]}
+    )  # make sure original object is unchanged
+
+    # test list and tuple
+    list_obj = [0, dict_obj, (1, 2), [3, 4, 5]]
+    for l, tuple_wrap in ((list_obj, lambda x: x), (tuple(list_obj), tuple)):
+      # set API
+      self.assertEqual(
+          cursor(l)[1]['b'][0].set(10),
+          tuple_wrap(
+              [0, {'a': 1, 'b': (10, 3), 'c': [4, 5]}, (1, 2), [3, 4, 5]]
+          ),
+      )
+      # build API
+      c = cursor(l)
+      c[1]['b'][0] = 20
+      c[2] = (100, 200)
+      l2 = c.build()
+      self.assertEqual(
+          l2,
+          tuple_wrap(
+              [0, {'a': 1, 'b': (20, 3), 'c': [4, 5]}, (100, 200), [3, 4, 5]]
+          ),
+      )
+    self.assertEqual(
+        list_obj, [0, {'a': 1, 'b': (2, 3), 'c': [4, 5]}, (1, 2), [3, 4, 5]]
+    )  # make sure original object is unchanged
+
+    # test TrainState
+    state = train_state.TrainState.create(
+        apply_fn=lambda x: x,
+        params=dict_obj,
+        tx=optax.adam(1e-3),
+    )
+    # set API
+    self.assertEqual(
+        cursor(state).params['b'][0].set(10).params,
+        {'a': 1, 'b': (10, 3), 'c': [4, 5]},
+    )
+    # build API
+    new_fn = lambda x: x + 1
+    c = cursor(state)
+    c.apply_fn = new_fn
+    c.params['b'][0] = 20
+    c.params['a'] = (100, 200)
+    state2 = c.build()
+    self.assertEqual(state2.apply_fn, new_fn)
+    self.assertEqual(
+        state2.params, {'a': (100, 200), 'b': (20, 3), 'c': [4, 5]}
+    )
+
+    self.assertEqual(
+        dict_obj, {'a': 1, 'b': (2, 3), 'c': [4, 5]}
+    )  # make sure original object is unchanged
+
+    # test NamedTuple
+    # set API
+    t = GenericTuple(GenericTuple(0))
+    self.assertEqual(cursor(t).x.x.set(1), GenericTuple(GenericTuple(1)))
+
+    # build API
+    c = cursor(t)
+    c.x.x = 2
+    c.x.y = 3
+    c.y = 4
+    t2 = c.build()
+    self.assertEqual(t2, GenericTuple(GenericTuple(2, 3), 4))
+
+    self.assertEqual(
+        t, GenericTuple(GenericTuple(0))
+    )  # make sure original object is unchanged
+
+  def test_apply_update(self):
+    # test list and tuple
+    def update_fn(path, value):
+      """Multiply the first element of all leaf nodes of the pytree by -1."""
+      if path[-1] == '0' and isinstance(value, int):
+        return value * -1
+      return value
+
+    for tuple_wrap in (lambda x: x, tuple):
+      l = tuple_wrap([tuple_wrap([1, 2]), tuple_wrap([3, 4])])
+      c = cursor(l)
+      l2 = c.apply_update(update_fn).build()
+      self.assertEqual(
+          l2, tuple_wrap([tuple_wrap([-1, 2]), tuple_wrap([-3, 4])])
+      )
+      self.assertEqual(
+          l, tuple_wrap([tuple_wrap([1, 2]), tuple_wrap([3, 4])])
+      )  # make sure the original object is unchanged
+
+    # test regular dict and FrozenDict
+    def update_fn(path, value):
+      """Multiply all dense kernel params by 2 and add 1.
+      Subtract the Dense_1 bias param by 1."""
+      if 'kernel' in path:
+        return value * 2 + 1
+      elif 'Dense_1' in path and 'bias' in path:
+        return value - 1
+      return value
+
+    class Model(nn.Module):
+
+      @nn.compact
+      def __call__(self, x):
+        x = nn.Dense(3)(x)
+        x = nn.relu(x)
+        x = nn.Dense(3)(x)
+        x = nn.relu(x)
+        x = nn.Dense(3)(x)
+        x = nn.relu(x)
+        return x
+
+    for freeze_wrap in (lambda x: x, freeze):
+      params = freeze_wrap(
+          Model().init(jax.random.PRNGKey(0), jnp.empty((1, 2)))['params']
+      )
+
+      c = cursor(params)
+      params2 = c.apply_update(update_fn).build()
+      for layer in ('Dense_0', 'Dense_1', 'Dense_2'):
+        self.assertTrue(
+            (params2[layer]['kernel'] == 2 * params[layer]['kernel'] + 1).all()
+        )
+        if layer == 'Dense_1':
+          self.assertTrue(
+              (params2[layer]['bias'] == jnp.array([-1, -1, -1])).all()
+          )
+        else:
+          self.assertTrue(
+              (params2[layer]['bias'] == params[layer]['bias']).all()
+          )
+      self.assertTrue(
+          jax.tree_util.tree_all(
+              jax.tree_util.tree_map(
+                  lambda x, y: (x == y).all(),
+                  params,
+                  freeze_wrap(
+                      Model().init(jax.random.PRNGKey(0), jnp.empty((1, 2)))[
+                          'params'
+                      ]
+                  ),
+              )
+          )
+      )  # make sure original params are unchanged
+
+    # test TrainState
+    def update_fn(path, value):
+      """Replace params with empty dictionary."""
+      if 'params' in path:
+        return {}
+      return value
+
+    state = train_state.TrainState.create(
+        apply_fn=lambda x: x,
+        params={'a': 1, 'b': 2},
+        tx=optax.adam(1e-3),
+    )
+    c = cursor(state)
+    state2 = c.apply_update(update_fn).build()
+    self.assertEqual(state2.params, {})
+    self.assertEqual(
+        state.params, {'a': 1, 'b': 2}
+    )  # make sure original params are unchanged
+
+    # test NamedTuple
+    def update_fn(path, value):
+      """Add 5 to all x-attribute values that are ints"""
+      if path[-1] == 'x' and isinstance(value, int):
+        return value + 5
+      return value
+
+    t = GenericTuple(GenericTuple(0, 1), GenericTuple(2, 3))
+    c = cursor(t)
+    t2 = c.apply_update(update_fn).build()
+    self.assertEqual(t2, GenericTuple(GenericTuple(5, 1), GenericTuple(7, 3)))
+    self.assertEqual(
+        t, GenericTuple(GenericTuple(0, 1), GenericTuple(2, 3))
+    )  # make sure original object is unchanged
+
+  def test_apply_update_root_node_unmodified(self):
+    def update_fn(path, value):
+      if isinstance(value, list):
+        value = value.copy()
+        value.append(-1)
+      return value
+
+    l = [[1, 2], [3, 4], 5]
+    l2 = cursor(l).apply_update(update_fn).build()
+    self.assertEqual(l2, [[1, 2, -1], [3, 4, -1], 5])
+
+  def test_multi_modify(self):
+    d = {'a': 1, 'b': (2, 3), 'c': [4, 5]}
+    c = cursor(d)
+    # test multiple changes on same element
+    c['b'][0] = 6
+    c['b'][0] = 7
+    d2 = c.build()
+    self.assertEqual(d2, {'a': 1, 'b': (7, 3), 'c': [4, 5]})
+    # test nested changes
+    c['a'] = (100, 200)
+    c['a'][1] = -1
+    d3 = c.build()
+    self.assertEqual(d3, {'a': (100, -1), 'b': (7, 3), 'c': [4, 5]})
+
+  def test_hidden_change(self):
+    # test list
+    l = [1, 2]
+    c = cursor(l)
+    c[0] = 100
+    l[1] = -1
+    l2 = c.build()
+    self.assertEqual(
+        l2, [100, -1]
+    )  # change in l affects l2 (this is expected behavior)
+    self.assertEqual(l, [1, -1])
+
+    # test regular dict
+    d = {'a': 1, 'b': 2}
+    c = cursor(d)
+    c['a'] = 100
+    d['b'] = -1
+    d2 = c.build()
+    self.assertEqual(
+        d2, {'a': 100, 'b': -1}
+    )  # change in d affects d2 (this is expected behavior)
+    self.assertEqual(d, {'a': 1, 'b': -1})
+
+    # test TrainState
+    params = {'a': 1, 'b': 2}
+    state = train_state.TrainState.create(
+        apply_fn=lambda x: x,
+        params=params,
+        tx=optax.adam(1e-3),
+    )
+    c = cursor(state)
+    c.params['a'] = 100
+    params['b'] = -1
+    state2 = c.build()
+    self.assertEqual(
+        state2.params, {'a': 100, 'b': -1}
+    )  # change in state affects state2 (this is expected behavior)
+    self.assertEqual(state.params, {'a': 1, 'b': -1})
+
+  def test_named_tuple_multi_access(self):
+    t = GenericTuple(GenericTuple(0, 1), GenericTuple(2, 3))
+    c = cursor(t)
+    c.x.x = 4
+    c[0].y = 5
+    c.y.x = 6
+    c.y[1] = 7
+    self.assertEqual(
+        c.build(), GenericTuple(GenericTuple(4, 5), GenericTuple(6, 7))
+    )
+
+    c[0][1] = -5
+    self.assertEqual(
+        c.build(), GenericTuple(GenericTuple(4, -5), GenericTuple(6, 7))
+    )
+    c.x[1] = -6
+    self.assertEqual(
+        c.build(), GenericTuple(GenericTuple(4, -6), GenericTuple(6, 7))
+    )
+    c.x.y = -7
+    self.assertEqual(
+        c.build(), GenericTuple(GenericTuple(4, -7), GenericTuple(6, 7))
+    )
+    c[0].y = -8
+    self.assertEqual(
+        c.build(), GenericTuple(GenericTuple(4, -8), GenericTuple(6, 7))
+    )
+
+
+if __name__ == '__main__':
+  absltest.main()


### PR DESCRIPTION
Continuing from #3236.

Added the [Cursor API](https://flax--3246.org.readthedocs.build/en/3246/api_reference/flax.cursor.html), which allows for mutability of pytrees. This API provides a more ergonomic solution to making partial-updates of deeply nested immutable data structures, compared to making many nested `dataclasses.replace` calls.

To illustrate, consider the example below:
```
from flax.cursor import cursor
import dataclasses
from typing import Any

@dataclasses.dataclass
class A:
  x: Any

a = A(A(A(A(A(A(A(0)))))))
```
To replace the int 0 using ``dataclasses.replace``, we would have to write many nested calls:
```
a2 = dataclasses.replace(
  a,
  x=dataclasses.replace(
    a.x,
    x=dataclasses.replace(
      a.x.x,
      x=dataclasses.replace(
        a.x.x.x,
        x=dataclasses.replace(
          a.x.x.x.x,
          x=dataclasses.replace(
            a.x.x.x.x.x,
            x=dataclasses.replace(a.x.x.x.x.x.x, x=1),
          ),
        ),
      ),
    ),
  ),
)
```
The equivalent can be achieved much more simply using the Cursor API:
```
a3 = cursor(a).x.x.x.x.x.x.x.set(1)
assert a2 == a3
```
The Cursor object keeps tracks of changes made to it and when `.build` is called, generates a new object with the accumulated changes. Basic usage involves wrapping the object in a Cursor, making changes to the Cursor object and generating a new copy of the original object with the accumulated changes.

There are three ways to use the Cursor API:
* multiple changes using the `.build` method
* single line change using the `.set` method
* multiple conditional changes using the `.apply_update` method

Once you wrap the object in a Cursor and make changes to it, calling the `.build` method will generate a new object with the accumulated changes. For example:
```
from flax.cursor import cursor
from flax.training import train_state
import optax

dict_obj = {'a': 1, 'b': (2, 3), 'c': [4, 5]}
c = cursor(dict_obj)          # wrap the object in a Cursor
c['b'][0] = 10                # change 1
c['a'] = (100, 200)           # change 2
modified_dict_obj = c.build() # generate new object with the above changes
assert modified_dict_obj == {'a': (100, 200), 'b': (10, 3), 'c': [4, 5]}

state = train_state.TrainState.create(
    apply_fn=lambda x: x,
    params=dict_obj,
    tx=optax.adam(1e-3),
)
new_fn = lambda x: x + 1
c = cursor(state)          # wrap the object in a Cursor
c.params['b'][1] = 10      # change 1
c.apply_fn = new_fn        # change 2
modified_state = c.build() # generate new object with the above changes
assert modified_state.params == {'a': 1, 'b': (2, 10), 'c': [4, 5]}
assert modified_state.apply_fn == new_fn
```
Calling the `.set` method will apply a single-line change and call `.build` immediately after. Therefore, you don't need to manually call `.build` after `.set`. For example:
```
from flax.cursor import cursor
from flax.training import train_state
import optax

dict_obj = {'a': 1, 'b': (2, 3), 'c': [4, 5]}
modified_dict_obj = cursor(dict_obj)['b'][0].set(10) # apply change and generate new object with the change
assert modified_dict_obj == {'a': 1, 'b': (10, 3), 'c': [4, 5]}

state = train_state.TrainState.create(
    apply_fn=lambda x: x,
    params=dict_obj,
    tx=optax.adam(1e-3),
)
modified_state = cursor(state).params['b'][1].set(10) # apply change and generate new object with the change
assert modified_state.params == {'a': 1, 'b': (2, 10), 'c': [4, 5]}
```
Calling `.apply_update` will traverse the Cursor object and apply conditional changes recursively via a filter function. 
The filter function has a function signature of `(str, Any) -> Any`:
- The input arguments are the current key path (in the form of a string delimited by ‘/’) and value at that current key path
- The output is the new value (either modified by the `update_fn` or same as the input value if the condition wasn’t fulfilled)

To generate a copy of the original object with the accumulated changes, call the `.build` method. For example:
```
import flax.linen as nn
from flax.cursor import cursor
import jax
import jax.numpy as jnp

class Model(nn.Module):
  @nn.compact
  def __call__(self, x):
    x = nn.Dense(3)(x)
    x = nn.relu(x)
    x = nn.Dense(3)(x)
    x = nn.relu(x)
    x = nn.Dense(3)(x)
    x = nn.relu(x)
    return x

params = Model().init(jax.random.PRNGKey(0), jnp.empty((1, 2)))['params']

def update_fn(path, value):
  '''Multiply all dense kernel params by 2 and add 1.
  Subtract the Dense_1 bias param by 1.'''
  if 'kernel' in path:
    return value * 2 + 1
  elif 'Dense_1' in path and 'bias' in path:
    return value - 1
  return value

c = cursor(params)
new_params = c.apply_update(update_fn).build()
for layer in ('Dense_0', 'Dense_1', 'Dense_2'):
  assert (new_params[layer]['kernel'] == 2 * params[layer]['kernel'] + 1).all()
  if layer == 'Dense_1':
    assert (new_params[layer]['bias'] == jnp.array([-1, -1, -1])).all()
  else:
    assert (new_params[layer]['bias'] == params[layer]['bias']).all()
```