### PR TITLE
Fix Documentation Typo

### DIFF
--- a/docs/guides/dropout.rst
+++ b/docs/guides/dropout.rst
@@ -23,7 +23,7 @@ Split the PRNG key
 
 Since dropout is a random operation, it requires a pseudorandom number generator
 (PRNG) state. Flax uses JAX's (splittable) PRNG keys, which have a number of
-desirable properties for neutral networks. To learn more, refer to the
+desirable properties for neural networks. To learn more, refer to the
 `Pseudorandom numbers in JAX tutorial <https://jax.readthedocs.io/en/latest/jax-101/05-random-numbers.html>`__.
 
 **Note:** Recall that JAX has an explicit way of giving you PRNG keys:


### PR DESCRIPTION
# What does this PR do?

This pull request fixes a documentation typo in the following [guide](https://flax.readthedocs.io/en/latest/guides/dropout.html). In particular, it replaces the typo "neutral network" with "neural network".

## Checklist
- [x] This PR fixes a minor issue (e.g.: typo or small bug) or improves the docs (you can dismiss the other
      checks if that's the case).
- [ ] This change is discussed in a Github issue/
      [discussion](https://github.com/google/flax/discussions) (please add a
      link).
- [ ] The documentation and docstrings adhere to the
      [documentation guidelines](https://github.com/google/flax/blob/main/docs/README.md#how-to-write-code-documentation).
- [ ] This change includes necessary high-coverage tests.
      (No quality testing = no merge!)
