### PR TITLE
Allow apply's method argument to accept submodules

### DIFF
--- a/flax/linen/module.py
+++ b/flax/linen/module.py
@@ -1910,6 +1910,12 @@ class Module(ModuleBase):
             f"'{class_name}.{attribute_name}' must be a callable, got"
             f' {type(method)}.'
         )
+      # if the `method` string is a submodule, we create a lambda function
+      # that calls the submodule, forwarding all arguments.
+      if isinstance(method, Module):
+        method = lambda self, *args, **kwargs: getattr(self, attribute_name)(
+            *args, **kwargs
+        )
     elif method is None:
       method = self.__call__
     method = _get_unbound_fn(method)

--- a/tests/linen/linen_module_test.py
+++ b/tests/linen/linen_module_test.py
@@ -890,6 +890,19 @@ class ModuleTest(absltest.TestCase):
       # test same for init.
       Foo().init({}, method='not_callable')
 
+  def test_module_apply_method_submodule(self):
+    class Foo(nn.Module):
+      bar: nn.Module
+
+      @nn.compact
+      def __call__(self, x):
+        return self.bar(x)
+
+    foo = Foo(nn.Dense(3))
+    variables = foo.init(jax.random.PRNGKey(0), jnp.zeros(3))
+
+    foo.apply(variables, jnp.zeros(3), method='bar')
+
   def test_call_unbound_compact_module_methods(self):
     dense = Dense(3)
     msg = r'Can\'t call compact methods on unbound modules'


### PR DESCRIPTION
# What does this PR do?

Related to #3279. Improve apply's support string arguments to method by allowing submodules to be accepted as well.