### PR TITLE
fix stackoverflow when loading pickled module

### DIFF
--- a/flax/linen/module.py
+++ b/flax/linen/module.py
@@ -862,6 +862,8 @@ def create_descriptor_wrapper(descriptor: Descriptor):
         self.wrapped.__set_name__(*args, **kwargs)
 
     def __getattr__(self, name):
+      if 'wrapped' not in vars(self):
+        raise AttributeError()
       return getattr(self.wrapped, name)
 
   return _DescriptorWrapper(descriptor)


### PR DESCRIPTION
# What does this PR do?

Fixes #3283. Raises `AttributeError` in `_DescriptorWrapper.__getattr__` if `wrapped` attribute is not present to avoid stackoverlfow.