### PR TITLE
Remove string from checkpointing example and unbreak doctest in head

### DIFF
--- a/docs/guides/use_checkpointing.ipynb
+++ b/docs/guides/use_checkpointing.ipynb
@@ -68,7 +68,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 1,
    "id": "ArKLnsyGRxGv",
    "metadata": {
     "id": "ArKLnsyGRxGv"
@@ -81,7 +81,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 2,
    "id": "SJT9DTxTytjn",
    "metadata": {
     "id": "SJT9DTxTytjn"
@@ -106,7 +106,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 3,
    "id": "afd6db30",
    "metadata": {},
    "outputs": [],
@@ -133,7 +133,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 4,
    "id": "56dec3f6",
    "metadata": {
     "id": "56dec3f6",
@@ -153,19 +153,16 @@
        "     kernel_init = init\n",
        "     bias_init = zeros\n",
        "     dot_general = dot_general\n",
-       " )>, params=FrozenDict({\n",
-       "     bias: Array([-0.001, -0.001, -0.001], dtype=float32),\n",
-       "     kernel: Array([[ 0.26048955, -0.61399287, -0.23458514],\n",
-       "            [ 0.11050402, -0.8765793 ,  0.9800635 ],\n",
-       "            [ 0.36260957,  0.18276349, -0.6856061 ],\n",
-       "            [-0.8519373 , -0.6416717 , -0.4818122 ],\n",
-       "            [-0.6886102 , -0.33987316, -0.05898903]], dtype=float32),\n",
-       " }), tx=GradientTransformation(init=<function chain.<locals>.init_fn at 0x158e7cd30>, update=<function chain.<locals>.update_fn at 0x158eaa670>), opt_state=(EmptyState(), EmptyState())),\n",
-       " 'config': {'dimensions': array([5, 3]), 'name': 'dense'},\n",
+       " )>, params={'bias': Array([-0.001, -0.001, -0.001], dtype=float32), 'kernel': Array([[ 0.26048955, -0.61399287, -0.23458514],\n",
+       "        [ 0.11050402, -0.8765793 ,  0.9800635 ],\n",
+       "        [ 0.36260957,  0.18276349, -0.6856061 ],\n",
+       "        [-0.8519373 , -0.6416717 , -0.4818122 ],\n",
+       "        [-0.6886102 , -0.33987316, -0.05898903]], dtype=float32)}, tx=GradientTransformationExtraArgs(init=<function chain.<locals>.init_fn at 0x1564f1280>, update=<function chain.<locals>.update_fn at 0x1564f1ca0>), opt_state=(EmptyState(), EmptyState())),\n",
+       " 'config': {'dimensions': array([5, 3])},\n",
        " 'data': [Array([0.59902626, 0.2172144 , 2.4202902 , 0.03266738, 1.2164948 ],      dtype=float32)]}"
       ]
      },
-     "execution_count": 5,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -187,8 +184,8 @@
     "# Perform a simple gradient update similar to the one during a normal training workflow.\n",
     "state = state.apply_gradients(grads=jax.tree_map(jnp.ones_like, state.params))\n",
     "\n",
-    "# Some arbitrary nested pytree with a dictionary, a string, and a NumPy array.\n",
-    "config = {'dimensions': np.array([5, 3]), 'name': 'dense'}\n",
+    "# Some arbitrary nested pytree with a dictionary and a NumPy array.\n",
+    "config = {'dimensions': np.array([5, 3])}\n",
     "\n",
     "# Bundle everything together.\n",
     "ckpt = {'model': state, 'config': config, 'data': [x1]}\n",
@@ -217,7 +214,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 5,
    "id": "61b12da2",
    "metadata": {
     "id": "0pp4QtEqW9k7"
@@ -245,7 +242,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 6,
    "id": "d3686ea5",
    "metadata": {
     "id": "T6T8V4UBXB1R",
@@ -258,7 +255,7 @@
        "['4', '3']"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -290,7 +287,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 7,
    "id": "4cdb35ef",
    "metadata": {
     "id": "4cdb35ef",
@@ -303,7 +300,7 @@
        "'tmp/flax-checkpointing/checkpoint_0'"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -335,7 +332,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 8,
    "id": "a807a9c1",
    "metadata": {
     "id": "WgRJj3wjXIaN",
@@ -345,7 +342,7 @@
     {
      "data": {
       "text/plain": [
-       "{'config': {'dimensions': array([5, 3]), 'name': 'dense'},\n",
+       "{'config': {'dimensions': array([5, 3])},\n",
        " 'data': [array([0.59902626, 0.2172144 , 2.4202902 , 0.03266738, 1.2164948 ],\n",
        "        dtype=float32)],\n",
        " 'model': {'opt_state': [None, None],\n",
@@ -358,7 +355,7 @@
        "  'step': 1}}"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -378,14 +375,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 9,
    "id": "251d7085",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "{'config': {'dimensions': array([5, 3]), 'name': 'dense'},\n",
+       "{'config': {'dimensions': array([5, 3])},\n",
        " 'data': [array([0.59902626, 0.2172144 , 2.4202902 , 0.03266738, 1.2164948 ],\n",
        "        dtype=float32)],\n",
        " 'model': {'opt_state': [None, None],\n",
@@ -398,7 +395,7 @@
        "  'step': 1}}"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -424,7 +421,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 10,
    "id": "150b20a0",
    "metadata": {
     "id": "150b20a0",
@@ -434,7 +431,7 @@
     {
      "data": {
       "text/plain": [
-       "{'config': {'dimensions': array([5, 3]), 'name': 'dense'},\n",
+       "{'config': {'dimensions': array([5, 3])},\n",
        " 'data': {'0': array([0.59902626, 0.2172144 , 2.4202902 , 0.03266738, 1.2164948 ],\n",
        "        dtype=float32)},\n",
        " 'model': {'opt_state': {'0': None, '1': None},\n",
@@ -447,7 +444,7 @@
        "  'step': 1}}"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -479,7 +476,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 11,
    "id": "58f42513",
    "metadata": {
     "id": "58f42513",
@@ -489,7 +486,7 @@
     {
      "data": {
       "text/plain": [
-       "{'config': {'dimensions': array([5, 3]), 'name': 'dense'},\n",
+       "{'config': {'dimensions': array([5, 3])},\n",
        " 'data': [array([0.59902626, 0.2172144 , 2.4202902 , 0.03266738, 1.2164948 ],\n",
        "        dtype=float32)],\n",
        " 'model': TrainState(step=1, apply_fn=<bound method Module.apply of Dense(\n",
@@ -502,17 +499,14 @@
        "     kernel_init = init\n",
        "     bias_init = zeros\n",
        "     dot_general = dot_general\n",
-       " )>, params=FrozenDict({\n",
-       "     bias: array([-0.001, -0.001, -0.001], dtype=float32),\n",
-       "     kernel: array([[ 0.26048955, -0.61399287, -0.23458514],\n",
-       "            [ 0.11050402, -0.8765793 ,  0.9800635 ],\n",
-       "            [ 0.36260957,  0.18276349, -0.6856061 ],\n",
-       "            [-0.8519373 , -0.6416717 , -0.4818122 ],\n",
-       "            [-0.6886102 , -0.33987316, -0.05898903]], dtype=float32),\n",
-       " }), tx=GradientTransformation(init=<function chain.<locals>.init_fn at 0x158e7cd30>, update=<function chain.<locals>.update_fn at 0x158eaa670>), opt_state=(EmptyState(), EmptyState()))}"
+       " )>, params={'bias': array([-0.001, -0.001, -0.001], dtype=float32), 'kernel': array([[ 0.26048955, -0.61399287, -0.23458514],\n",
+       "        [ 0.11050402, -0.8765793 ,  0.9800635 ],\n",
+       "        [ 0.36260957,  0.18276349, -0.6856061 ],\n",
+       "        [-0.8519373 , -0.6416717 , -0.4818122 ],\n",
+       "        [-0.6886102 , -0.33987316, -0.05898903]], dtype=float32)}, tx=GradientTransformationExtraArgs(init=<function chain.<locals>.init_fn at 0x1564f1280>, update=<function chain.<locals>.update_fn at 0x1564f1ca0>), opt_state=(EmptyState(), EmptyState()))}"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -523,7 +517,7 @@
     "    params=jax.tree_map(np.zeros_like, variables['params']),  # values of the tree leaf doesn't matter\n",
     "    tx=tx,\n",
     ")\n",
-    "empty_config = {'dimensions': np.array([0, 0]), 'name': ''}\n",
+    "empty_config = {'dimensions': np.array([0, 0])}\n",
     "target = {'model': empty_state, 'config': empty_config, 'data': [jnp.zeros_like(x1)]}\n",
     "state_restored = orbax_checkpointer.restore('tmp/orbax/single_save', item=target)\n",
     "state_restored"
@@ -541,14 +535,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 12,
    "id": "a61e9a66",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "{'config': {'dimensions': array([5, 3]), 'name': 'dense'},\n",
+       "{'config': {'dimensions': array([5, 3])},\n",
        " 'data': [array([0.59902626, 0.2172144 , 2.4202902 , 0.03266738, 1.2164948 ],\n",
        "        dtype=float32)],\n",
        " 'model': TrainState(step=1, apply_fn=<bound method Module.apply of Dense(\n",
@@ -561,17 +555,14 @@
        "     kernel_init = init\n",
        "     bias_init = zeros\n",
        "     dot_general = dot_general\n",
-       " )>, params=FrozenDict({\n",
-       "     bias: array([-0.001, -0.001, -0.001], dtype=float32),\n",
-       "     kernel: array([[ 0.26048955, -0.61399287, -0.23458514],\n",
-       "            [ 0.11050402, -0.8765793 ,  0.9800635 ],\n",
-       "            [ 0.36260957,  0.18276349, -0.6856061 ],\n",
-       "            [-0.8519373 , -0.6416717 , -0.4818122 ],\n",
-       "            [-0.6886102 , -0.33987316, -0.05898903]], dtype=float32),\n",
-       " }), tx=GradientTransformation(init=<function chain.<locals>.init_fn at 0x158e7cd30>, update=<function chain.<locals>.update_fn at 0x158eaa670>), opt_state=(EmptyState(), EmptyState()))}"
+       " )>, params={'bias': array([-0.001, -0.001, -0.001], dtype=float32), 'kernel': array([[ 0.26048955, -0.61399287, -0.23458514],\n",
+       "        [ 0.11050402, -0.8765793 ,  0.9800635 ],\n",
+       "        [ 0.36260957,  0.18276349, -0.6856061 ],\n",
+       "        [-0.8519373 , -0.6416717 , -0.4818122 ],\n",
+       "        [-0.6886102 , -0.33987316, -0.05898903]], dtype=float32)}, tx=GradientTransformationExtraArgs(init=<function chain.<locals>.init_fn at 0x1564f1280>, update=<function chain.<locals>.update_fn at 0x1564f1ca0>), opt_state=(EmptyState(), EmptyState()))}"
       ]
      },
-     "execution_count": 13,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -582,7 +573,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 13,
    "id": "412af50e",
    "metadata": {},
    "outputs": [
@@ -599,20 +590,16 @@
        "     kernel_init = init\n",
        "     bias_init = zeros\n",
        "     dot_general = dot_general\n",
-       " )>, params=FrozenDict({\n",
-       "     bias: array([-0.001, -0.001, -0.001], dtype=float32),\n",
-       "     kernel: array([[ 0.26048955, -0.61399287, -0.23458514],\n",
-       "            [ 0.11050402, -0.8765793 ,  0.9800635 ],\n",
-       "            [ 0.36260957,  0.18276349, -0.6856061 ],\n",
-       "            [-0.8519373 , -0.6416717 , -0.4818122 ],\n",
-       "            [-0.6886102 , -0.33987316, -0.05898903]], dtype=float32),\n",
-       " }), tx=GradientTransformation(init=<function chain.<locals>.init_fn at 0x158e7cd30>, update=<function chain.<locals>.update_fn at 0x158eaa670>), opt_state=(EmptyState(), EmptyState())),\n",
-       " 'config': {'dimensions': array([5, 3]), 'name': 'dense'},\n",
-       " 'data': [array([0.59902626, 0.2172144 , 2.4202902 , 0.03266738, 1.2164948 ],\n",
-       "        dtype=float32)]}"
+       " )>, params={'bias': array([-0.001, -0.001, -0.001], dtype=float32), 'kernel': array([[ 0.26048955, -0.61399287, -0.23458514],\n",
+       "        [ 0.11050402, -0.8765793 ,  0.9800635 ],\n",
+       "        [ 0.36260957,  0.18276349, -0.6856061 ],\n",
+       "        [-0.8519373 , -0.6416717 , -0.4818122 ],\n",
+       "        [-0.6886102 , -0.33987316, -0.05898903]], dtype=float32)}, tx=GradientTransformationExtraArgs(init=<function chain.<locals>.init_fn at 0x1564f1280>, update=<function chain.<locals>.update_fn at 0x1564f1ca0>), opt_state=(EmptyState(), EmptyState())),\n",
+       " 'config': {'dimensions': array([5, 3])},\n",
+       " 'data': [Array([0.59902626, 0.2172144 , 2.4202902 , 0.03266738, 1.2164948 ],      dtype=float32)]}"
       ]
      },
-     "execution_count": 14,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -650,7 +637,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 14,
    "id": "be65d4af",
    "metadata": {
     "id": "be65d4af",
@@ -663,7 +650,7 @@
        "True"
       ]
      },
-     "execution_count": 15,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -717,14 +704,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 15,
    "id": "68828029",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "{'config': {'dimensions': array([5, 3]), 'name': 'dense'},\n",
+       "{'config': {'dimensions': array([5, 3])},\n",
        " 'data': [array([0.59902626, 0.2172144 , 2.4202902 , 0.03266738, 1.2164948 ],\n",
        "        dtype=float32)],\n",
        " 'model': TrainState(step=0, apply_fn=<bound method Module.apply of Dense(\n",
@@ -737,17 +724,14 @@
        "     kernel_init = init\n",
        "     bias_init = zeros\n",
        "     dot_general = dot_general\n",
-       " )>, params=FrozenDict({\n",
-       "     bias: array([-0.001, -0.001, -0.001], dtype=float32),\n",
-       "     kernel: array([[ 0.26048955, -0.61399287, -0.23458514],\n",
-       "            [ 0.11050402, -0.8765793 ,  0.9800635 ],\n",
-       "            [ 0.36260957,  0.18276349, -0.6856061 ],\n",
-       "            [-0.8519373 , -0.6416717 , -0.4818122 ],\n",
-       "            [-0.6886102 , -0.33987316, -0.05898903]], dtype=float32),\n",
-       " }), tx=GradientTransformation(init=<function chain.<locals>.init_fn at 0x158e7cd30>, update=<function chain.<locals>.update_fn at 0x158eaa670>), opt_state=(EmptyState(), EmptyState()))}"
+       " )>, params={'bias': array([-0.001, -0.001, -0.001], dtype=float32), 'kernel': array([[ 0.26048955, -0.61399287, -0.23458514],\n",
+       "        [ 0.11050402, -0.8765793 ,  0.9800635 ],\n",
+       "        [ 0.36260957,  0.18276349, -0.6856061 ],\n",
+       "        [-0.8519373 , -0.6416717 , -0.4818122 ],\n",
+       "        [-0.6886102 , -0.33987316, -0.05898903]], dtype=float32)}, tx=GradientTransformationExtraArgs(init=<function chain.<locals>.init_fn at 0x1564f1280>, update=<function chain.<locals>.update_fn at 0x1564f1ca0>), opt_state=(EmptyState(), EmptyState()))}"
       ]
      },
-     "execution_count": 16,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -776,7 +760,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 16,
    "id": "a5d14c9f",
    "metadata": {},
    "outputs": [
@@ -792,8 +776,7 @@
      "data": {
       "text/plain": [
        "{'config': None,\n",
-       " 'data': [array([0.59902626, 0.2172144 , 2.4202902 , 0.03266738, 1.2164948 ],\n",
-       "        dtype=float32)],\n",
+       " 'data': [Array([0.59902626, 0.2172144 , 2.4202902 , 0.03266738, 1.2164948 ],      dtype=float32)],\n",
        " 'model': CustomTrainState(step=1, apply_fn=<bound method Module.apply of Dense(\n",
        "     # attributes\n",
        "     features = 3\n",
@@ -804,17 +787,14 @@
        "     kernel_init = init\n",
        "     bias_init = zeros\n",
        "     dot_general = dot_general\n",
-       " )>, params=FrozenDict({\n",
-       "     bias: array([-0.001, -0.001, -0.001], dtype=float32),\n",
-       "     kernel: array([[ 0.26048955, -0.61399287, -0.23458514],\n",
-       "            [ 0.11050402, -0.8765793 ,  0.9800635 ],\n",
-       "            [ 0.36260957,  0.18276349, -0.6856061 ],\n",
-       "            [-0.8519373 , -0.6416717 , -0.4818122 ],\n",
-       "            [-0.6886102 , -0.33987316, -0.05898903]], dtype=float32),\n",
-       " }), tx=GradientTransformation(init=<function chain.<locals>.init_fn at 0x158e7cd30>, update=<function chain.<locals>.update_fn at 0x158eaa670>), opt_state=(EmptyState(), EmptyState()), batch_stats=array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]))}"
+       " )>, params={'bias': Array([-0.001, -0.001, -0.001], dtype=float32), 'kernel': Array([[ 0.26048955, -0.61399287, -0.23458514],\n",
+       "        [ 0.11050402, -0.8765793 ,  0.9800635 ],\n",
+       "        [ 0.36260957,  0.18276349, -0.6856061 ],\n",
+       "        [-0.8519373 , -0.6416717 , -0.4818122 ],\n",
+       "        [-0.6886102 , -0.33987316, -0.05898903]], dtype=float32)}, tx=GradientTransformationExtraArgs(init=<function chain.<locals>.init_fn at 0x1564f1280>, update=<function chain.<locals>.update_fn at 0x1564f1ca0>), opt_state=(EmptyState(), EmptyState()), batch_stats=array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]))}"
       ]
      },
-     "execution_count": 20,
+     "execution_count": 16,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -848,7 +828,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 17,
    "id": "29fd1e33",
    "metadata": {
     "id": "29fd1e33",
@@ -868,20 +848,16 @@
        "     kernel_init = init\n",
        "     bias_init = zeros\n",
        "     dot_general = dot_general\n",
-       " )>, params=FrozenDict({\n",
-       "     bias: array([-0.001, -0.001, -0.001], dtype=float32),\n",
-       "     kernel: array([[ 0.26048955, -0.61399287, -0.23458514],\n",
-       "            [ 0.11050402, -0.8765793 ,  0.9800635 ],\n",
-       "            [ 0.36260957,  0.18276349, -0.6856061 ],\n",
-       "            [-0.8519373 , -0.6416717 , -0.4818122 ],\n",
-       "            [-0.6886102 , -0.33987316, -0.05898903]], dtype=float32),\n",
-       " }), tx=GradientTransformation(init=<function chain.<locals>.init_fn at 0x158e7cd30>, update=<function chain.<locals>.update_fn at 0x158eaa670>), opt_state=(EmptyState(), EmptyState()), batch_stats=array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])),\n",
+       " )>, params={'bias': Array([-0.001, -0.001, -0.001], dtype=float32), 'kernel': Array([[ 0.26048955, -0.61399287, -0.23458514],\n",
+       "        [ 0.11050402, -0.8765793 ,  0.9800635 ],\n",
+       "        [ 0.36260957,  0.18276349, -0.6856061 ],\n",
+       "        [-0.8519373 , -0.6416717 , -0.4818122 ],\n",
+       "        [-0.6886102 , -0.33987316, -0.05898903]], dtype=float32)}, tx=GradientTransformationExtraArgs(init=<function chain.<locals>.init_fn at 0x1564f1280>, update=<function chain.<locals>.update_fn at 0x1564f1ca0>), opt_state=(EmptyState(), EmptyState()), batch_stats=array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])),\n",
        " 'config': None,\n",
-       " 'data': [array([0.59902626, 0.2172144 , 2.4202902 , 0.03266738, 1.2164948 ],\n",
-       "        dtype=float32)]}"
+       " 'data': [Array([0.59902626, 0.2172144 , 2.4202902 , 0.03266738, 1.2164948 ],      dtype=float32)]}"
       ]
      },
-     "execution_count": 21,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -913,7 +889,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 18,
    "id": "051e7a16",
    "metadata": {},
    "outputs": [
@@ -930,20 +906,17 @@
        "     kernel_init = init\n",
        "     bias_init = zeros\n",
        "     dot_general = dot_general\n",
-       " )>, params=FrozenDict({\n",
-       "     bias: array([-0.001, -0.001, -0.001], dtype=float32),\n",
-       "     kernel: array([[ 0.26048955, -0.61399287, -0.23458514],\n",
-       "            [ 0.11050402, -0.8765793 ,  0.9800635 ],\n",
-       "            [ 0.36260957,  0.18276349, -0.6856061 ],\n",
-       "            [-0.8519373 , -0.6416717 , -0.4818122 ],\n",
-       "            [-0.6886102 , -0.33987316, -0.05898903]], dtype=float32),\n",
-       " }), tx=GradientTransformation(init=<function chain.<locals>.init_fn at 0x158e7cd30>, update=<function chain.<locals>.update_fn at 0x158eaa670>), opt_state=(EmptyState(), EmptyState()), batch_stats=array([9, 8, 7, 6, 5, 4, 3, 2, 1, 0])),\n",
-       " 'config': {'dimensions': array([5, 3]), 'name': 'dense'},\n",
+       " )>, params={'bias': array([-0.001, -0.001, -0.001], dtype=float32), 'kernel': array([[ 0.26048955, -0.61399287, -0.23458514],\n",
+       "        [ 0.11050402, -0.8765793 ,  0.9800635 ],\n",
+       "        [ 0.36260957,  0.18276349, -0.6856061 ],\n",
+       "        [-0.8519373 , -0.6416717 , -0.4818122 ],\n",
+       "        [-0.6886102 , -0.33987316, -0.05898903]], dtype=float32)}, tx=GradientTransformationExtraArgs(init=<function chain.<locals>.init_fn at 0x1564f1280>, update=<function chain.<locals>.update_fn at 0x1564f1ca0>), opt_state=(EmptyState(), EmptyState()), batch_stats=array([9, 8, 7, 6, 5, 4, 3, 2, 1, 0])),\n",
+       " 'config': {'dimensions': array([5, 3])},\n",
        " 'data': [array([0.59902626, 0.2172144 , 2.4202902 , 0.03266738, 1.2164948 ],\n",
        "        dtype=float32)]}"
       ]
      },
-     "execution_count": 22,
+     "execution_count": 18,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -985,7 +958,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 19,
    "id": "85be68a6",
    "metadata": {
     "id": "85be68a6",
@@ -995,7 +968,7 @@
     {
      "data": {
       "text/plain": [
-       "{'config': {'dimensions': array([5, 3]), 'name': 'dense'},\n",
+       "{'config': {'dimensions': array([5, 3])},\n",
        " 'data': [array([0.59902626, 0.2172144 , 2.4202902 , 0.03266738, 1.2164948 ],\n",
        "        dtype=float32)],\n",
        " 'model': TrainState(step=1, apply_fn=<bound method Module.apply of Dense(\n",
@@ -1008,17 +981,14 @@
        "     kernel_init = init\n",
        "     bias_init = zeros\n",
        "     dot_general = dot_general\n",
-       " )>, params=FrozenDict({\n",
-       "     bias: array([-0.001, -0.001, -0.001], dtype=float32),\n",
-       "     kernel: array([[ 0.26048955, -0.61399287, -0.23458514],\n",
-       "            [ 0.11050402, -0.8765793 ,  0.9800635 ],\n",
-       "            [ 0.36260957,  0.18276349, -0.6856061 ],\n",
-       "            [-0.8519373 , -0.6416717 , -0.4818122 ],\n",
-       "            [-0.6886102 , -0.33987316, -0.05898903]], dtype=float32),\n",
-       " }), tx=GradientTransformation(init=<function chain.<locals>.init_fn at 0x158e7cd30>, update=<function chain.<locals>.update_fn at 0x158eaa670>), opt_state=(EmptyState(), EmptyState()))}"
+       " )>, params={'bias': array([-0.001, -0.001, -0.001], dtype=float32), 'kernel': array([[ 0.26048955, -0.61399287, -0.23458514],\n",
+       "        [ 0.11050402, -0.8765793 ,  0.9800635 ],\n",
+       "        [ 0.36260957,  0.18276349, -0.6856061 ],\n",
+       "        [-0.8519373 , -0.6416717 , -0.4818122 ],\n",
+       "        [-0.6886102 , -0.33987316, -0.05898903]], dtype=float32)}, tx=GradientTransformationExtraArgs(init=<function chain.<locals>.init_fn at 0x1564f1280>, update=<function chain.<locals>.update_fn at 0x1564f1ca0>), opt_state=(EmptyState(), EmptyState()))}"
       ]
      },
-     "execution_count": 23,
+     "execution_count": 19,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1055,7 +1025,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 20,
    "id": "af33b138",
    "metadata": {},
    "outputs": [],
@@ -1083,7 +1053,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 21,
    "id": "ubdUvyMrhD-1",
    "metadata": {
     "id": "ubdUvyMrhD-1"
@@ -1106,7 +1076,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 22,
    "id": "a669bc05",
    "metadata": {},
    "outputs": [],
@@ -1131,20 +1101,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 23,
    "id": "b8e7daaa",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "{'model': Array([[0, 1],\n",
-       "        [2, 3],\n",
-       "        [4, 5],\n",
-       "        [6, 7]], dtype=int32)}"
+       "{'model': Array([[ 0,  1],\n",
+       "        [ 2,  3],\n",
+       "        [ 4,  5],\n",
+       "        [ 6,  7],\n",
+       "        [ 8,  9],\n",
+       "        [10, 11],\n",
+       "        [12, 13],\n",
+       "        [14, 15]], dtype=int32)}"
       ]
      },
-     "execution_count": 27,
+     "execution_count": 23,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1177,7 +1151,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 24,
    "id": "5d10039b",
    "metadata": {
     "id": "5d10039b",
@@ -1190,7 +1164,7 @@
        "'tmp/checkpoint_3'"
       ]
      },
-     "execution_count": 28,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1207,7 +1181,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 25,
    "id": "a9f9724c",
    "metadata": {
     "id": "a9f9724c",
@@ -1217,13 +1191,17 @@
     {
      "data": {
       "text/plain": [
-       "{'model': Array([[0, 1],\n",
-       "        [2, 3],\n",
-       "        [4, 5],\n",
-       "        [6, 7]], dtype=int32)}"
+       "{'model': Array([[ 0,  1],\n",
+       "        [ 2,  3],\n",
+       "        [ 4,  5],\n",
+       "        [ 6,  7],\n",
+       "        [ 8,  9],\n",
+       "        [10, 11],\n",
+       "        [12, 13],\n",
+       "        [14, 15]], dtype=int32)}"
       ]
      },
-     "execution_count": 29,
+     "execution_count": 25,
      "metadata": {},
      "output_type": "execute_result"
     }

--- a/docs/guides/use_checkpointing.md
+++ b/docs/guides/use_checkpointing.md
@@ -111,8 +111,8 @@ state = train_state.TrainState.create(
 # Perform a simple gradient update similar to the one during a normal training workflow.
 state = state.apply_gradients(grads=jax.tree_map(jnp.ones_like, state.params))
 
-# Some arbitrary nested pytree with a dictionary, a string, and a NumPy array.
-config = {'dimensions': np.array([5, 3]), 'name': 'dense'}
+# Some arbitrary nested pytree with a dictionary and a NumPy array.
+config = {'dimensions': np.array([5, 3])}
 
 # Bundle everything together.
 ckpt = {'model': state, 'config': config, 'data': [x1]}
@@ -224,7 +224,7 @@ empty_state = train_state.TrainState.create(
     params=jax.tree_map(np.zeros_like, variables['params']),  # values of the tree leaf doesn't matter
     tx=tx,
 )
-empty_config = {'dimensions': np.array([0, 0]), 'name': ''}
+empty_config = {'dimensions': np.array([0, 0])}
 target = {'model': empty_state, 'config': empty_config, 'data': [jnp.zeros_like(x1)]}
 state_restored = orbax_checkpointer.restore('tmp/orbax/single_save', item=target)
 state_restored

--- a/flax/linen/spmd.py
+++ b/flax/linen/spmd.py
@@ -345,7 +345,7 @@ def with_logical_partitioning(
   @functools.wraps(fn)
   def wrapper(*args, **kwargs):
     return LogicallyPartitioned(
-        fn(*args, **kwargs), names, rules=rules, mesh=mesh
-    )
+        fn(*args, **kwargs), names, mesh=mesh, rules=rules
+    )  # pytype: disable=wrong-keyword-args
 
   return wrapper


### PR DESCRIPTION
Orbax `construct_restore_args` doesn't work for strings. This should be fixed on the next release. Removing the string from checkpointing example for now.