### PR TITLE
Improve kw_only_dataclass

### DIFF
--- a/tests/linen/kw_only_dataclasses_test.py
+++ b/tests/linen/kw_only_dataclasses_test.py
@@ -62,7 +62,7 @@ class KwOnlyDataclassesTest(absltest.TestCase):
     v1 = Child(4)
     self.assertDictEqual(dataclasses.asdict(v1), dict(a=2, b=4))
 
-    v2 = Child(4, 5)  # pylint: disable=too-many-function-args
+    v2 = Child(4, a=5)  # pylint: disable=too-many-function-args
     self.assertDictEqual(dataclasses.asdict(v2), dict(a=5, b=4))
 
   def test_subclass_overrides_base(self):

--- a/tests/linen/linen_module_test.py
+++ b/tests/linen/linen_module_test.py
@@ -2214,6 +2214,18 @@ class ModuleTest(absltest.TestCase):
       # take positional arg. It takes BaseLayer's default kwargs though.
       np.testing.assert_equal(ChildLayer(8)(np.ones(10)), -8 * np.ones(10))
 
+  def test_positional_cannot_be_kw_only(self):
+    class Foo(nn.Module):
+      a: int
+
+    Foo(1)  # ok
+    Foo(a=1)  # ok
+    with self.assertRaisesRegex(
+        TypeError, r'takes 2 positional arguments but 3 were'
+    ):
+      Foo(1, None)
+    Foo(a=1, parent=None)  # type: ignore[call-arg]
+
   def test_intercept_methods(self):
     mod = IdentityModule(parent=None)
     x = jnp.ones([])

--- a/tests/linen/linen_transforms_test.py
+++ b/tests/linen/linen_transforms_test.py
@@ -414,8 +414,8 @@ class TransformTest(absltest.TestCase):
 
     x = jnp.ones((10, 10))
     rngs = random.PRNGKey(0)
-    init_vars = Test(None).init(rngs, x)
-    _, new_vars = Test(None).apply(init_vars, x, mutable=['counter'])
+    init_vars = Test(parent=None).init(rngs, x)
+    _, new_vars = Test(parent=None).apply(init_vars, x, mutable=['counter'])
     self.assertEqual(
         init_vars['counter']['outer']['cntr']['foo'], jnp.array([2], jnp.int32)
     )
@@ -462,8 +462,8 @@ class TransformTest(absltest.TestCase):
 
     x = jnp.ones((1, 1))
     rngs = random.PRNGKey(0)
-    init_vars = Test(None).init(rngs, x)
-    _, new_vars = Test(None).apply(init_vars, x, mutable=['counter'])
+    init_vars = Test(parent=None).init(rngs, x)
+    _, new_vars = Test(parent=None).apply(init_vars, x, mutable=['counter'])
     self.assertEqual(
         init_vars['counter']['outer']['cntr']['foo'], jnp.array([2], jnp.int32)
     )
@@ -508,8 +508,8 @@ class TransformTest(absltest.TestCase):
 
     x = jnp.ones((1, 1))
     rngs = random.PRNGKey(0)
-    init_vars = Test(None).init(rngs, x)
-    _, new_vars = Test(None).apply(init_vars, x, mutable=['counter'])
+    init_vars = Test(parent=None).init(rngs, x)
+    _, new_vars = Test(parent=None).apply(init_vars, x, mutable=['counter'])
     self.assertEqual(
         init_vars['counter']['outer1']['cntr']['foo'], jnp.array([2], jnp.int32)
     )
@@ -563,8 +563,8 @@ class TransformTest(absltest.TestCase):
 
     x = jnp.ones((1, 1))
     rngs = random.PRNGKey(0)
-    init_vars = Test(None).init(rngs, x)
-    _, new_vars = Test(None).apply(init_vars, x, mutable=['counter'])
+    init_vars = Test(parent=None).init(rngs, x)
+    _, new_vars = Test(parent=None).apply(init_vars, x, mutable=['counter'])
     self.assertEqual(
         init_vars['counter']['outer1']['cntr']['foo'], jnp.array([2], jnp.int32)
     )
@@ -619,8 +619,8 @@ class TransformTest(absltest.TestCase):
 
     x = jnp.ones((1, 1))
     rngs = random.PRNGKey(0)
-    init_vars = Test(None).init(rngs, x)
-    _, new_vars = Test(None).apply(init_vars, x, mutable=['counter'])
+    init_vars = Test(parent=None).init(rngs, x)
+    _, new_vars = Test(parent=None).apply(init_vars, x, mutable=['counter'])
     self.assertEqual(
         init_vars['counter']['outer']['cntr']['foo'], jnp.array([2], jnp.int32)
     )
@@ -662,8 +662,8 @@ class TransformTest(absltest.TestCase):
 
     x = jnp.ones((3, 1, 2))
     rngs = random.PRNGKey(0)
-    init_vars = Test(None).init(rngs, x)
-    y = Test(None).apply(init_vars, x)
+    init_vars = Test(parent=None).init(rngs, x)
+    y = Test(parent=None).apply(init_vars, x)
     self.assertEqual(
         init_vars['params']['outer']['Dense_0']['kernel'].shape, (3, 2, 5)
     )


### PR DESCRIPTION
# What does this PR do?

* Checks the number of positional arguments on `__init__` to prevent assigning `kw_only` arguments.
* Fixes existing tests that leverage positional leaking into kw_only.
* Fixes mypy erros