### PR TITLE
updated lm1b example with jit

### DIFF
--- a/examples/lm1b/requirements.txt
+++ b/examples/lm1b/requirements.txt
@@ -1,13 +1,13 @@
-absl-py==1.0.0
-clu==0.0.6
-flax==0.4.1
-jax==0.3.4
+absl-py==1.4.0
+clu==0.0.9
+flax==0.6.11
+jax==0.4.13
 --find-links https://storage.googleapis.com/jax-releases/jax_releases.html
-jaxlib==0.3.2+cuda11.cudnn82  # Make sure CUDA version matches the base image.
-ml-collections==0.1.0
-numpy==1.22.0
-optax==0.1.0
-sentencepiece==0.1.96
-tensorflow==2.11.1
-tensorflow-datasets==4.4.0
-tensorflow-text==2.8.1
+jaxlib==0.4.13+cuda11.cudnn82  # Make sure CUDA version matches the base image.
+ml-collections==0.1.1
+numpy==1.24.3
+optax==0.1.5
+sentencepiece==0.1.99
+tensorflow==2.13.0
+tensorflow-datasets==4.9.2
+tensorflow-text==2.13.0

--- a/examples/lm1b/temperature_sampler_test.py
+++ b/examples/lm1b/temperature_sampler_test.py
@@ -28,7 +28,7 @@ class TestTemperatureSampler(absltest.TestCase):
   def test_temperature_sampler(self):
     tokens = jnp.array([[5, 0, 0, 0]], dtype=jnp.int32)
     cache = None
-    key = jax.random.key(0)
+    key = jax.random.PRNGKey(0)
 
     def tokens_to_logits(tokens, cache):
       jax.debug.print('tokens: {}', tokens)

--- a/examples/lm1b/utils.py
+++ b/examples/lm1b/utils.py
@@ -1,0 +1,168 @@
+# Copied over from MaxText (https://github.com/google/maxtext/blob/main/MaxText/max_utils.py).
+
+import functools
+import logging
+
+import numpy as np
+import flax.linen as nn
+from flax.linen import partitioning as nn_partitioning
+from flax.training import train_state
+import jax
+import jax.numpy as jnp
+from jax.experimental import mesh_utils
+
+
+# Mesh utils.
+# -----------------------------------------------------------------------------
+
+
+def create_device_mesh(config):
+  """Creates a device mesh with each slice in its own data parallel group. If there is only one slice, uses two replicas."""
+  devices = jax.devices()
+  num_devices = len(devices)
+  try:
+    num_slices = 1 + max([d.slice_index for d in devices])
+  except:
+    num_slices = 1
+  num_devices_per_slice = num_devices // num_slices
+  logging.info(f"Devices: {devices}")
+  logging.info(f"Number of devices: {num_devices}")
+
+  multi_slice_env = hasattr(jax.devices()[0], "slice_index")
+
+  dcn_parallelism = [
+      config.dcn_data_parallelism,
+      config.dcn_fsdp_parallelism,
+      config.dcn_tensor_parallelism,
+  ]
+  ici_parallelism = [
+      config.ici_data_parallelism,
+      config.ici_fsdp_parallelism,
+      config.ici_tensor_parallelism,
+  ]
+
+  # Find possible unspecified parallelisms
+  dcn_parallelism = fill_unspecified_mesh_axes(
+      dcn_parallelism, num_slices, "DCN"
+  )
+  ici_parallelism = fill_unspecified_mesh_axes(
+      ici_parallelism, num_devices_per_slice, "ICI"
+  )
+
+  if multi_slice_env:
+    mesh = mesh_utils.create_hybrid_device_mesh(
+        ici_parallelism, dcn_parallelism
+    )
+  else:
+    mesh = mesh_utils.create_device_mesh(ici_parallelism)
+
+  logging.info(f"Decided on mesh: {mesh}")
+  logging.info(f"Mesh shape: {mesh.shape}")
+
+  return mesh
+
+
+def fill_unspecified_mesh_axes(
+    parallelism_vals, target_product, parallelism_type
+):
+  """Evaluates unspecified DCN/ICI parallelism values"""
+  if -1 in parallelism_vals:
+    assert parallelism_vals.count(-1) == 1, (
+        f"Found unspecified values (-1) for more than one {parallelism_type}   "
+        "   parallelism axis. At most one axis can be unspecified."
+    )
+
+    determined_val = target_product / np.product(parallelism_vals) * -1
+
+    assert determined_val >= 1 and determined_val.is_integer, (
+        "Unspecified value unable to be determined with the given     "
+        f" {parallelism_type} parallelism values"
+    )
+
+    parallelism_vals[parallelism_vals.index(-1)] = int(determined_val)
+
+  target_type = "slices" if parallelism_type == "DCN" else "devices per slice"
+
+  assert np.product(parallelism_vals) == target_product, (
+      f"Number of {target_type} {target_product} does not match    the product"
+      f" of the {parallelism_type} parallelism {np.product(parallelism_vals)}"
+  )
+
+  return parallelism_vals
+
+
+# State initialization utils.
+# -----------------------------------------------------------------------------
+
+
+def unbox_logicallypartioned_trainstate(
+    boxed_train_state: train_state.TrainState,
+):
+  """Unboxes the flax.LogicallyPartitioned pieces in a train state.
+
+  Args:
+    boxed_train_state: a train state that includes LogicallyPartitioned
+      leaves.
+  Returns:
+    a TrainState where all all LogicallyPartitioned leaves have been unboxed.
+  """
+  return jax.tree_util.tree_map(
+      lambda x: x.unbox() if isinstance(x, nn.spmd.LogicallyPartitioned) else x,
+      boxed_train_state,
+      is_leaf=lambda k: isinstance(k, nn.spmd.LogicallyPartitioned),
+  )
+
+
+def init_train_state(model, tx, config, key):
+  """
+  We pass in "static" objects like model, tx, config as JAX compares them by
+  object hash, and instantiating them inside causes pjit top-level annotations
+  to fail to match as pytree prefixes if we re-instantiate.
+
+  Args: model, tx, config, key
+  """
+  input_shape = (config.per_device_batch_size, config.max_target_length)
+  initial_variables = jax.jit(model.init)(
+      key, jnp.ones(input_shape, jnp.float32)
+  )
+
+  state = train_state.TrainState.create(
+      apply_fn=model.apply, params=initial_variables["params"], tx=tx
+  )
+  return state
+
+
+def setup_initial_state(model, tx, config, rng, mesh):
+  """We initialize the model and optimizer state, and optionally load from a
+  checkpoint as necessary.
+
+  Args:
+    model: the flax model to initialize
+    tx: the optax.GradientTransformation
+    config: config object
+    rng: jax.prng key
+    mesh: jax.devices() mesh
+
+  Returns:
+    state: the initialized train state
+    state_mesh_annotations: the mesh annotations for the train state
+  """
+  init_train_state_partial = functools.partial(
+      init_train_state, model, tx, config
+  )
+  abstract_state = jax.eval_shape(init_train_state_partial, rng)
+  state_logical_annotations = nn.get_partition_spec(abstract_state)
+
+  # Initialization
+  with mesh, nn_partitioning.axis_rules(config.logical_axis_rules):
+    state_mesh_annotations = nn.logical_to_mesh_sharding(
+        state_logical_annotations, mesh, config.logical_axis_rules
+    )
+    state = jax.jit(
+        init_train_state_partial,
+        in_shardings=None,  # type: ignore
+        out_shardings=state_mesh_annotations,
+    )(rng)
+
+  state = unbox_logicallypartioned_trainstate(state)
+  return state, state_mesh_annotations


### PR DESCRIPTION
Updated lm1b example to use jit instead of pmap.
lm1b now uses both data and model parallelism instead of just data parallelism.