### PR TITLE
Removed `with mesh` context manager from Flax jit guide, since it doesn't do anything with jax.jit

### DIFF
--- a/docs/guides/flax_on_pjit.ipynb
+++ b/docs/guides/flax_on_pjit.ipynb
@@ -808,8 +808,7 @@
     "  state = state.apply_gradients(grads=grads)\n",
     "  return state\n",
     "\n",
-    "with mesh:\n",
-    "  new_state = train_step(initialized_state, x)"
+    "new_state = train_step(initialized_state, x)"
    ]
   },
   {
@@ -969,8 +968,7 @@
     "def apply_fn(state, x):\n",
     "  return state.apply_fn({'params': state.params}, x)\n",
     "\n",
-    "with mesh:\n",
-    "  y = apply_fn(new_state, x)\n",
+    "y = apply_fn(new_state, x)\n",
     "print(type(y))\n",
     "print(y.dtype)\n",
     "print(y.shape)\n",
@@ -1010,8 +1008,7 @@
     "  jax.tree_map(lambda x: x.block_until_ready(), xs)\n",
     "  return xs\n",
     "\n",
-    "with mesh:\n",
-    "  new_state = block_all(train_step(initialized_state, x))"
+    "new_state = block_all(train_step(initialized_state, x))"
    ]
   },
   {

--- a/docs/guides/flax_on_pjit.md
+++ b/docs/guides/flax_on_pjit.md
@@ -377,8 +377,7 @@ def train_step(state, x):
   state = state.apply_gradients(grads=grads)
   return state
 
-with mesh:
-  new_state = train_step(initialized_state, x)
+new_state = train_step(initialized_state, x)
 ```
 
 ```{code-cell}
@@ -402,8 +401,7 @@ Then, create a compiled inference step. Note that the output is also sharded alo
 def apply_fn(state, x):
   return state.apply_fn({'params': state.params}, x)
 
-with mesh:
-  y = apply_fn(new_state, x)
+y = apply_fn(new_state, x)
 print(type(y))
 print(y.dtype)
 print(y.shape)
@@ -425,8 +423,7 @@ def block_all(xs):
   jax.tree_map(lambda x: x.block_until_ready(), xs)
   return xs
 
-with mesh:
-  new_state = block_all(train_step(initialized_state, x))
+new_state = block_all(train_step(initialized_state, x))
 ```
 
 +++ {"id": "51420b514d53"}


### PR DESCRIPTION
Removed `with mesh` context manager from [Flax jit guide](https://flax--3303.org.readthedocs.build/en/3303/guides/flax_on_pjit.html#compile-the-train-step-and-inference), since it doesn't do anything with jax.jit