### PR TITLE
Minor fix to jax_utils.prefect_to_device

### DIFF
--- a/flax/jax_utils.py
+++ b/flax/jax_utils.py
@@ -132,7 +132,7 @@ def prefetch_to_device(iterator, size, devices=None):
     the specified devices.
   """
   queue = collections.deque()
-  devices = devices or _pmap_device_order()
+  devices = _pmap_device_order() if devices is None else devices
 
   def _prefetch(xs):
     return jax.device_put_sharded(list(xs), devices)


### PR DESCRIPTION
Check if devices is None, as it can be a numpy array which cannot be cast to a boolean.

# What does this PR do?

Minor fix to jax_utils.prefect_to_device.

Check if devices is None, as it can be a numpy array which cannot be cast to a boolean.


Great, you are contributing to Flax!

But... please read the following carefully so we can make sure your PR is merged
easily.

Replace this text block with a description of the change and which issue it
fixes (if applicable). Please also include relevant motivation/context.

Once you're done, someone in the Flax team will review your PR shortly. They may
suggest changes to make the code even better. If no one reviewed your PR after a
week has passed, don't hesitate to post a new comment @-mentioning the same
persons (sometimes notifications get lost).
-->

Fixes # (issue)

## Checklist
- [x] This PR fixes a minor issue (e.g.: typo or small bug) or improves the docs (you can dismiss the other
      checks if that's the case).
- [ ] This change is discussed in a Github issue/
      [discussion](https://github.com/google/flax/discussions) (please add a
      link).
- [ ] The documentation and docstrings adhere to the
      [documentation guidelines](https://github.com/google/flax/blob/main/docs/README.md#how-to-write-code-documentation).
- [ ] This change includes necessary high-coverage tests.
      (No quality testing = no merge!)
