### PR TITLE
Add fp8 custom op and unit test

### DIFF
--- a/flax/linen/__init__.py
+++ b/flax/linen/__init__.py
@@ -70,6 +70,7 @@ from .attention import (
 )
 from .combinators import Sequential as Sequential
 from .fp8_ops import (
+  compute_scale as fp8_compute_scale,
   quantize_dequantize as fp8_quantize_dequantize,
   Fp8DenseGeneralOp as Fp8DenseGeneralOp,
 )

--- a/flax/linen/__init__.py
+++ b/flax/linen/__init__.py
@@ -69,6 +69,10 @@ from .attention import (
     make_causal_mask as make_causal_mask,
 )
 from .combinators import Sequential as Sequential
+from .fp8_ops import (
+  quantize_dequantize as fp8_quantize_dequantize,
+  Fp8DenseGeneralOp as Fp8DenseGeneralOp,
+)
 from .initializers import (
     ones_init as ones_init,
     ones as ones,

--- a/flax/linen/fp8_ops.py
+++ b/flax/linen/fp8_ops.py
@@ -1,8 +1,6 @@
-from typing import Callable, Iterable, Union, Tuple
+from typing import Callable
 from functools import partial
 
-from flax import core
-from flax.core import scope as flax_scope
 from flax.linen import initializers
 from flax.linen.module import Module
 from flax.linen import partitioning as nn_partitioning
@@ -11,25 +9,13 @@ from jax import lax
 from jax import numpy as jnp
 from jax import random
 
-from fp8layers.jax_common.fp8 import fp8_dot_general
 
-param_with_axes = nn_partitioning.param_with_axes
 variable_with_axes = nn_partitioning.variable_with_axes
 
 # Type annotations
 Array = jnp.ndarray
 Dtype = jnp.dtype
 PRNGKey = jnp.ndarray
-Shape = Iterable[int]
-ActivationFn = Callable[..., Array]
-DotGeneralT = Callable[..., Array]
-PrecisionLike = Union[
-    None,
-    str,
-    lax.Precision,
-    Tuple[str, str],
-    Tuple[lax.Precision, lax.Precision],
-]
 
 class FP8Helper:
   FP8_COLLECTION_NAME: str = "fp8_params"

--- a/flax/linen/fp8_ops.py
+++ b/flax/linen/fp8_ops.py
@@ -3,14 +3,11 @@ from functools import partial
 
 from flax.linen import initializers
 from flax.linen.module import Module
-from flax.linen import partitioning as nn_partitioning
 from jax import custom_vjp
 from jax import lax
 from jax import numpy as jnp
 from jax import random
 
-
-variable_with_axes = nn_partitioning.variable_with_axes
 
 # Type annotations
 Array = jnp.ndarray
@@ -140,37 +137,31 @@ class Fp8DenseGeneralOp(Module):
         jnp.float32,
     )
 
-    self.input_amax_history = variable_with_axes(
+    self.input_amax_history = self.variable(
         FP8Helper.FP8_COLLECTION_NAME,
         'input_amax_history',
-        *amax_history_args,
-        axes=('fp8_meta',))
-    self.kernel_amax_history = variable_with_axes(
+        *amax_history_args)
+    self.kernel_amax_history = self.variable(
         FP8Helper.FP8_COLLECTION_NAME,
         'kernel_amax_history',
-        *amax_history_args,
-        axes=('fp8_meta',))
-    self.output_grad_amax_history = variable_with_axes(
+        *amax_history_args)
+    self.output_grad_amax_history = self.variable(
         FP8Helper.FP8_COLLECTION_NAME,
         'output_grad_amax_history',
-        *amax_history_args,
-        axes=('fp8_meta',))
+        *amax_history_args)
 
-    self.input_scale = variable_with_axes(
+    self.input_scale = self.variable(
         FP8Helper.FP8_COLLECTION_NAME,
         'input_scale',
-        *scale_args,
-        axes=('fp8_meta',))
-    self.kernel_scale = variable_with_axes(
+        *scale_args)
+    self.kernel_scale = self.variable(
         FP8Helper.FP8_COLLECTION_NAME,
         'kernel_scale',
-        *scale_args,
-        axes=('fp8_meta',))
-    self.output_grad_scale = variable_with_axes(
+        *scale_args)
+    self.output_grad_scale = self.variable(
         FP8Helper.FP8_COLLECTION_NAME,
         'output_grad_scale',
-        *scale_args,
-        axes=('fp8_meta',))
+        *scale_args)
 
 
   def __call__(self, *args, **kwargs) -> Array:

--- a/flax/linen/fp8_ops.py
+++ b/flax/linen/fp8_ops.py
@@ -1,0 +1,207 @@
+from typing import Callable, Iterable, Union, Tuple
+from functools import partial
+
+from flax import core
+from flax.core import scope as flax_scope
+from flax.linen import initializers
+from flax.linen.module import Module
+from flax.linen import partitioning as nn_partitioning
+from jax import custom_vjp
+from jax import lax
+from jax import numpy as jnp
+from jax import random
+
+from fp8layers.jax_common.fp8 import fp8_dot_general
+
+param_with_axes = nn_partitioning.param_with_axes
+variable_with_axes = nn_partitioning.variable_with_axes
+
+# Type annotations
+Array = jnp.ndarray
+Dtype = jnp.dtype
+PRNGKey = jnp.ndarray
+Shape = Iterable[int]
+ActivationFn = Callable[..., Array]
+DotGeneralT = Callable[..., Array]
+PrecisionLike = Union[
+    None,
+    str,
+    lax.Precision,
+    Tuple[str, str],
+    Tuple[lax.Precision, lax.Precision],
+]
+
+class FP8Helper:
+  FP8_COLLECTION_NAME: str = "fp8_params"
+
+def get_fp8_max(fp8_dtype, out_dtype):
+  assert fp8_dtype in (jnp.float8_e4m3fn, jnp.float8_e5m2)
+  return jnp.finfo(fp8_dtype).max.astype(out_dtype)
+
+def quantize(x, q_dtype, scale, compute_dtype):
+  # We need to explicitly cast the max value to compute_dtype, otherwise the jax
+  # dtype promotion will cast the scaled_x to fp32 in the following ops, which
+  # would violate the fp8-matmul pattern matching.
+  dtype_max = get_fp8_max(q_dtype, compute_dtype)
+
+  scaled_x = x / scale.astype(compute_dtype)
+
+  clipped_x = jnp.clip(scaled_x, -dtype_max, dtype_max)
+
+  return clipped_x.astype(q_dtype)
+
+def dequantize(x, dq_dtype, scale):
+  return x.astype(dq_dtype) * scale.astype(dq_dtype)
+
+def quantize_dequantize(x, q_dtype, scale, compute_dtype):
+  qx = quantize(x, q_dtype, scale, compute_dtype)
+  return dequantize(qx, x.dtype, scale)
+
+def compute_scale(amax, scale, fp8_max, margin=0):
+  """Default function to convert amax to scaling factor."""
+  # This function copied from the TransformerEngine is used to compute its
+  # `scale`. However, our scale matches its `scale_inv` concept. So, we apply
+  # the reciprocal operation at the entry and exit of the function.
+  scale = 1.0 / scale
+  exp = jnp.floor(jnp.log2(fp8_max / amax)) - margin
+  sf = jnp.round(lax.pow(2., jnp.abs(exp)))
+  sf = jnp.where(amax > 0.0, sf, scale)
+  sf = jnp.where(lax.is_finite(amax), sf, scale)
+  sf = jnp.where(exp < 0, 1.0 / sf, sf)
+  return 1.0 / sf
+
+def compute_scale_and_amax_history(x, q_dtype, scale, amax_history):
+  dtype_max = get_fp8_max(q_dtype, jnp.float32)
+
+  amax_update = jnp.max(jnp.abs(x)).astype(scale.dtype)
+  new_amax_history = \
+      jnp.roll(amax_history, shift=-1, axis=0).at[0].set(amax_update)
+
+  amax_from_history = jnp.max(new_amax_history, axis=0)
+  new_scale = compute_scale(amax_from_history, scale, dtype_max)
+  return new_scale, new_amax_history
+
+def qdq_and_return(x, q_dtype, scale, amax_history, compute_dtype):
+  qx = quantize_dequantize(x, q_dtype, scale, compute_dtype)
+  new_scale, new_amax_history = compute_scale_and_amax_history(
+      x, q_dtype, scale, amax_history)
+  return qx, new_scale, new_amax_history
+
+@partial(custom_vjp, nondiff_argnums=(0,))
+def in_qdq(compute_dtype, inp, scale, amax_history):
+  qin, _, _ = qdq_and_return(
+      inp, jnp.float8_e4m3fn, scale, amax_history, compute_dtype)
+  return qin
+
+def in_qdq_fwd(compute_dtype, inp, scale, amax_history):
+  qin, new_scale, new_amax_history = qdq_and_return(
+      inp, jnp.float8_e4m3fn, scale, amax_history, compute_dtype)
+  return qin, (new_scale, new_amax_history)
+
+def in_qdq_bwd(compute_dtype, res, g):
+  new_scale, new_amax_history = res
+  q_g = g
+  return q_g, new_scale, new_amax_history
+
+in_qdq.defvjp(in_qdq_fwd, in_qdq_bwd)
+
+
+@partial(custom_vjp, nondiff_argnums=(0,))
+def out_qdq(compute_dtype, out, scale, amax_history):
+  return out
+
+def out_qdq_fwd(compute_dtype, out, scale, amax_history):
+  return out, (scale, amax_history)
+
+def out_qdq_bwd(compute_dtype, res, g):
+  scale, amax_history = res
+  q_g, new_scale, new_amax_history = qdq_and_return(
+      g, jnp.float8_e5m2, scale, amax_history, compute_dtype)
+  return q_g, new_scale, new_amax_history
+  
+out_qdq.defvjp(out_qdq_fwd, out_qdq_bwd)
+
+def fp8_dot_general(lhs, rhs, dimension_numbers, precision, compute_dtype,
+                    lhs_scale, lhs_amax_history, rhs_scale, rhs_amax_history,
+                    dout_scale, dout_amax_history):
+  """Perform dot_general.  """
+  
+  lhs_qdq = in_qdq(compute_dtype, lhs, lhs_scale, lhs_amax_history)
+
+  rhs_qdq = in_qdq(compute_dtype, rhs, rhs_scale, rhs_amax_history)
+
+  output_qdq = lax.dot_general(lhs_qdq, rhs_qdq, dimension_numbers, precision)
+
+  out = out_qdq(compute_dtype, output_qdq, dout_scale, dout_amax_history)
+
+  return out
+
+
+class Fp8DenseGeneralOp(Module):
+  amax_history_length: int = 1024
+
+  def setup(self) -> None:
+    scale_args = (
+        initializers.ones_init(),
+        random.PRNGKey(0),
+        (1,),
+        jnp.float32,
+    )
+    amax_history_args = (
+        initializers.zeros_init(),
+        random.PRNGKey(0),
+        (self.amax_history_length,),
+        jnp.float32,
+    )
+
+    self.input_amax_history = variable_with_axes(
+        FP8Helper.FP8_COLLECTION_NAME,
+        'input_amax_history',
+        *amax_history_args,
+        axes=('fp8_meta',))
+    self.kernel_amax_history = variable_with_axes(
+        FP8Helper.FP8_COLLECTION_NAME,
+        'kernel_amax_history',
+        *amax_history_args,
+        axes=('fp8_meta',))
+    self.output_grad_amax_history = variable_with_axes(
+        FP8Helper.FP8_COLLECTION_NAME,
+        'output_grad_amax_history',
+        *amax_history_args,
+        axes=('fp8_meta',))
+
+    self.input_scale = variable_with_axes(
+        FP8Helper.FP8_COLLECTION_NAME,
+        'input_scale',
+        *scale_args,
+        axes=('fp8_meta',))
+    self.kernel_scale = variable_with_axes(
+        FP8Helper.FP8_COLLECTION_NAME,
+        'kernel_scale',
+        *scale_args,
+        axes=('fp8_meta',))
+    self.output_grad_scale = variable_with_axes(
+        FP8Helper.FP8_COLLECTION_NAME,
+        'output_grad_scale',
+        *scale_args,
+        axes=('fp8_meta',))
+
+
+  def __call__(self, *args, **kwargs) -> Array:
+
+    assert len(args) == 3
+    inputs = args[0]
+    kernel = args[1]
+    dimension_numbers = args[2]
+    precision = kwargs['precision']
+    comp_dtype = kernel.dtype
+    inputs = jnp.asarray(inputs, comp_dtype)
+    
+    out = fp8_dot_general(inputs, kernel, dimension_numbers, precision,
+                          comp_dtype, self.input_scale.value,
+                          self.input_amax_history.value,
+                          self.kernel_scale.value, self.kernel_amax_history.value,
+                          self.output_grad_scale.value,
+                          self.output_grad_amax_history.value)
+    return out
+

--- a/tests/linen/linen_linear_test.py
+++ b/tests/linen/linen_linear_test.py
@@ -21,7 +21,10 @@ from typing import Callable, Optional
 from absl.testing import absltest
 from absl.testing import parameterized
 
+import optax
+
 from flax import linen as nn
+from flax.training import train_state
 
 import jax
 from jax import random
@@ -1032,10 +1035,9 @@ class LinearTest(parameterized.TestCase):
     dy = jax.random.uniform(random_key, (16, 64))
     dy = cast_to_representable(dy, jnp.float8_e5m2)
     def run(fp8_injection, expected_shapes):
-      dg_args = {}
+      p = nn.DenseGeneral(features=64, name='dense')
       if fp8_injection:
-        dg_arg = {'dot_general_cls': nn.Fp8DenseGeneralOp}
-      p = nn.DenseGeneral(features=64, name='dense', **dg_args)
+        p.dot_general_cls=nn.Fp8DenseGeneralOp
       y, initial_vars = p.init_with_output(init_key, x)
       var_shapes = jax.tree_util.tree_map(jnp.shape, initial_vars)
       if 'fp8_params_axes' in var_shapes:
@@ -1051,26 +1053,110 @@ class LinearTest(parameterized.TestCase):
       return outputs, grads
 
     expected_shapes_original = {
-        'params': {'dense': {'kernel': (32, 64), 'bias': (64,)}},
+        'params': {'kernel': (32, 64), 'bias': (64,)},
     }
     expected_shapes_new = {
-        'params': {'dense': {'kernel': (32, 64), 'bias': (64,)}},
-        'fp8_params': {'dense': {'Fp8DenseGeneralOp_0': {'input_amax_history': (1024,),
-                                                         'kernel_amax_history': (1024,),
-                                                         'output_grad_amax_history': (1024,),
-                                                         'input_scale': (1,),
-                                                         'kernel_scale': (1,),
-                                                         'output_grad_scale': (1,), }}},
+        'params': {'kernel': (32, 64), 'bias': (64,)},
+        'fp8_params': {
+            'Fp8DenseGeneralOp_0': {'input_amax_history': (1024,),
+                                    'kernel_amax_history': (1024,),
+                                    'output_grad_amax_history': (1024,),
+                                    'input_scale': (1,),
+                                    'kernel_scale': (1,),
+                                    'output_grad_scale': (1,), }},
     }
 
     output1a, output1b = run(False, expected_shapes_original)
     output2a, output2b = run(True, expected_shapes_new)
-    dw1, dw2 = output1b[0]['params']['dense']['kernel'], output2b[0]['params']['dense']['kernel']
+    dw1, dw2 = output1b[0]['params']['kernel'], output2b[0]['params']['kernel']
     dx1, dx2 = output1b[1], output2b[1]
 
     np.testing.assert_allclose(output1a, output2a, atol=1e-02)
     np.testing.assert_allclose(dw1, dw2, atol=1e-04)
     np.testing.assert_allclose(dx1, dx2, atol=1e-04)
+
+  def test_fp8_with_train_state(self):
+    x = random.uniform(random.PRNGKey(1), (16, 16), dtype=jnp.float32)
+    dense = nn.DenseGeneral(features=32, use_bias=True,
+                            dot_general_cls=nn.Fp8DenseGeneralOp)
+    key = random.PRNGKey(0)
+    variables = dense.init(key, x)
+
+    opt = optax.adam(learning_rate=.1)
+    state = train_state.TrainState.create(params=variables, tx=opt,
+                                          apply_fn=dense.apply)
+    
+    def roll_and_update(amax_h, update):
+      return jnp.roll(amax_h, shift=-1, axis=0).at[0].set(update)
+
+    def _train_loss(state, x, dy):
+      def loss_fn(vars):
+        y = state.apply_fn(vars, x)
+        loss = y * dy.astype(y.dtype)
+        return jnp.sum(loss)
+
+      grad_fn = jax.grad(loss_fn)
+      grads = grad_fn(state.params)
+
+      state = state.apply_gradients(grads=grads)
+      return state
+
+    train_fn = jax.jit(_train_loss)
+
+    amax_history_x = jnp.zeros((1024, ))
+    amax_history_k = jnp.zeros((1024, ))
+    amax_history_dy = jnp.zeros((1024, ))
+    scale_x = jnp.ones(())
+    scale_k = jnp.ones(())
+    scale_dy = jnp.ones(())
+    fp8_e4m3_max = jnp.finfo(jnp.float8_e4m3fn).max.astype(jnp.float32)
+    fp8_e5m2_max = jnp.finfo(jnp.float8_e5m2).max.astype(jnp.float32)
+    for _ in range(5):
+      x = random.normal(random.PRNGKey(1), (16, 16), dtype=jnp.float32)
+      dy = random.normal(random.PRNGKey(1), (16, 32), dtype=jnp.float32)
+
+      amax_history_x = roll_and_update(amax_history_x, jnp.max(jnp.abs(x)))
+      amax_history_k = roll_and_update(
+          amax_history_k,
+          jnp.max(jnp.abs(state.params['params']['kernel'])))
+      amax_history_dy = roll_and_update(amax_history_dy, jnp.max(jnp.abs(dy)))
+
+      amax_from_history_x = jnp.max(amax_history_x, axis=0)
+      amax_from_history_k = jnp.max(amax_history_k, axis=0)
+      amax_from_history_dy = jnp.max(amax_history_dy, axis=0)
+      scale_x = nn.fp8_compute_scale(amax_from_history_x, scale_x,
+                                     fp8_e4m3_max)
+      scale_k = nn.fp8_compute_scale(amax_from_history_k, scale_k, fp8_e4m3_max)
+      scale_dy = nn.fp8_compute_scale(amax_from_history_dy, scale_dy,
+                                      fp8_e5m2_max)
+      
+      state = train_fn(state, x, dy)
+
+      rtol, atol = 0.001, 0.001
+      fp8_vars = state.params['fp8_params']
+      np.testing.assert_allclose(
+          fp8_vars['Fp8DenseGeneralOp_0']['input_amax_history'],
+          amax_history_x, rtol=rtol, atol=atol)
+      np.testing.assert_allclose(
+          fp8_vars['Fp8DenseGeneralOp_0']['kernel_amax_history'],
+          amax_history_k, rtol=rtol, atol=atol)
+      np.testing.assert_allclose(
+          fp8_vars['Fp8DenseGeneralOp_0']
+          ['output_grad_amax_history'],
+          amax_history_dy, rtol=rtol, atol=atol)
+
+      np.testing.assert_allclose(
+          fp8_vars['Fp8DenseGeneralOp_0']
+          ['input_scale'][0],
+          scale_x)
+      np.testing.assert_allclose(
+          fp8_vars['Fp8DenseGeneralOp_0']
+          ['kernel_scale'][0],
+          scale_k)
+      np.testing.assert_allclose(
+          fp8_vars['Fp8DenseGeneralOp_0']
+          ['output_grad_scale'][0],
+          scale_dy)
 
   def test_non_final_axes(self):
     class Foo(nn.Module):

--- a/tests/linen/linen_linear_test.py
+++ b/tests/linen/linen_linear_test.py
@@ -1081,8 +1081,8 @@ class LinearTest(parameterized.TestCase):
     variables = dense.init(key, x)
 
     opt = optax.adam(learning_rate=.1)
-    state = train_state.TrainState.create(params=variables, tx=opt,
-                                          apply_fn=dense.apply)
+    state = train_state.Fp8TrainState.create(params=variables, tx=opt,
+                                             apply_fn=dense.apply)
     
     def roll_and_update(amax_h, update):
       return jnp.roll(amax_h, shift=-1, axis=0).at[0].set(update)

--- a/tests/linen/linen_linear_test.py
+++ b/tests/linen/linen_linear_test.py
@@ -1040,8 +1040,6 @@ class LinearTest(parameterized.TestCase):
         p.dot_general_cls=nn.Fp8DenseGeneralOp
       y, initial_vars = p.init_with_output(init_key, x)
       var_shapes = jax.tree_util.tree_map(jnp.shape, initial_vars)
-      if 'fp8_params_axes' in var_shapes:
-          var_shapes.pop('fp8_params_axes')
       self.assertEqual(var_shapes, expected_shapes)
 
       def _train(variables, x):


### PR DESCRIPTION
In this PR, we add one custom op to utilize the fp8 gemms provided by the XLA to better utilize NVIDIA Hopper GPUs. Users can then code-inject this custom op like:
```
dense=nn.DenseGeneral(dot_general_cls=nn.Fp8EinsumOp)
```
The PR also provides unit tests for the injection and accuracy.

Reference:

[FP8 basics](https://docs.nvidia.com/deeplearning/transformer-engine/user-guide/examples/fp8_primer.html).

[Basics of QDQ process used in our custom op](https://github.com/NVIDIA/atex/blob/experimental-xla-fp8-layers/experimental/xla-fp8-layers/fp8-tutorial.md).

cc. @pjannaty @reedwm @kaixih @levskaya 