### PR TITLE
BugFix 836e0e4 PR #3293 - TypeError: 'type' object is not subscriptable

### DIFF
--- a/flax/linen/kw_only_dataclasses.py
+++ b/flax/linen/kw_only_dataclasses.py
@@ -54,7 +54,7 @@ import dataclasses
 import inspect
 import functools
 from types import MappingProxyType
-from typing import Any, TypeVar
+from typing import Any, Type, TypeVar
 from typing_extensions import dataclass_transform
 import flax
 
@@ -123,7 +123,7 @@ def dataclass(cls=None, extra_fields=None, **kwargs):
   return wrap if cls is None else wrap(cls)
 
 
-def _process_class(cls: type[M], extra_fields=None, **kwargs):
+def _process_class(cls: Type[M], extra_fields=None, **kwargs):
   """Transforms `cls` into a dataclass that supports kw_only fields."""
   if '__annotations__' not in cls.__dict__:
     cls.__annotations__ = {}
@@ -205,7 +205,7 @@ def _process_class(cls: type[M], extra_fields=None, **kwargs):
   create_init = '__init__' not in vars(cls) and kwargs.get('init', True)
 
   # Apply the dataclass transform.
-  transformed_cls: type[M] = dataclasses.dataclass(cls, **kwargs)
+  transformed_cls: Type[M] = dataclasses.dataclass(cls, **kwargs)
 
   # Restore the base classes' __dataclass_fields__.
   for _cls, fields in base_dataclass_fields.items():


### PR DESCRIPTION
 Fixing Bug introduced in 836e0e439bc3dc6f9fe91446a1e50bc3efe89e70 @cgarciae - PR #3293 (reviewer: @superbobry)

```bash
$ python --version
Python 3.8.10

$ pip freeze | grep jax
jax==0.4.13
jaxlib==0.4.13

$ pip freeze | grep flax
flax==0.7.3
```

```python
>>> from flax.core.frozen_dict import FrozenDict
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/user/.local/lib/python3.8/site-packages/flax/__init__.py", line 25, in <module>
    from . import linen
  File "/home/user/.local/lib/python3.8/site-packages/flax/linen/__init__.py", line 34, in <module>
    from .activation import (
  File "/home/user/.local/lib/python3.8/site-packages/flax/linen/activation.py", line 21, in <module>
    from flax.linen.module import compact
  File "/home/user/.local/lib/python3.8/site-packages/flax/linen/module.py", line 68, in <module>
    from flax.linen import kw_only_dataclasses
  File "/home/user/.local/lib/python3.8/site-packages/flax/linen/kw_only_dataclasses.py", line 126, in <module>
    def _process_class(cls: type[M], extra_fields=None, **kwargs):
TypeError: 'type' object is not subscriptable
```

Small bug though fairly wide implications, it's breaking a whole lot of code with the new release `0.7.3`


***Note:***
It might be linked to a minimum version of python 3.9 for JAX for the most recent releases. Though I would argue that it's an improper assumptions given that the dependency game might install FLAX `0.7.3` with an older version of JAX (which does support python 3.8). And nothing really prevents FLAX to be compatible with older versions of python. 
Given the super narrow impact of such a change, (and that other places of FLAX also use `typing.Type` -> example: https://github.com/google/flax/blob/main/flax/linen/transforms.py#L88) I am of the opinion that it's a zero impact change for FLAX and help FLAX customers/users and the ecosystem.