### PR TITLE
fix DeprecationWarnings

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -144,3 +144,9 @@ nb_execution_raise_on_error = True
 # Tell sphinx-autodoc-typehints to generate stub parameter annotations including
 # types, even if the parameters aren't explicitly documented.
 always_document_param_types = True
+
+# -- doctest configuration -------------------------------------------------
+doctest_global_setup = """
+import jax
+import jax.numpy as jnp
+"""

--- a/flax/core/axes_scan.py
+++ b/flax/core/axes_scan.py
@@ -19,7 +19,7 @@ from typing import Any, Callable, Optional
 import jax
 from jax import core
 from jax import lax
-from jax import linear_util as lu
+from jax.extend import linear_util as lu
 from jax.interpreters import partial_eval as pe
 import jax.numpy as jnp
 import numpy as np

--- a/flax/core/partial_eval.py
+++ b/flax/core/partial_eval.py
@@ -18,7 +18,7 @@ import functools
 
 import jax
 from jax import core
-from jax import linear_util as lu
+from jax.extend import linear_util as lu
 from jax.interpreters import partial_eval as pe
 
 from flax import errors

--- a/flax/jax_utils.py
+++ b/flax/jax_utils.py
@@ -22,7 +22,7 @@ import warnings
 import jax
 from jax import core
 from jax import lax
-from jax import linear_util as lu
+from jax.extend import linear_util as lu
 from jax.interpreters import partial_eval as pe
 import jax.numpy as jnp
 import numpy as np

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -142,6 +142,8 @@ filterwarnings = [
     "ignore:.*Deprecated call to `pkg_resources.declare_namespace.*:DeprecationWarning",
     # DeprecationWarning: module 'sre_constants' is deprecated
     "ignore:.*module 'sre_constants' is deprecated.*:DeprecationWarning",
+    # DeprecationWarning: jax.random.KeyArray is deprecated. Use jax.Array for annotations, and jax.dtypes.issubdtype(arr, jax.dtypes.prng_key) for runtime detection of typed prng keys.
+    "ignore:.*jax.random.KeyArray is deprecated.*:DeprecationWarning",
 ]
 
 [tool.coverage.report]


### PR DESCRIPTION
The following deprecation warning is thrown in `tests/jax_utils_test.py` due to a chex import error. This PR will add a rule to ignore this specific deprecation warning.

This is the traceback:
```
tests/jax_utils_test.py:19: in <module>
    import chex
venv/lib/python3.10/site-packages/chex/__init__.py:17: in <module>
    from chex._src.asserts import assert_axis_dimension
venv/lib/python3.10/site-packages/chex/_src/asserts.py:26: in <module>
    from chex._src import asserts_internal as _ai
venv/lib/python3.10/site-packages/chex/_src/asserts_internal.py:34: in <module>
    from chex._src import pytypes
venv/lib/python3.10/site-packages/chex/_src/pytypes.py:54: in <module>
    PRNGKey = jax.random.KeyArray
venv/lib/python3.10/site-packages/jax/_src/deprecations.py:51: in getattr
    warnings.warn(message, DeprecationWarning, stacklevel=2)
E   DeprecationWarning: jax.random.KeyArray is deprecated. Use jax.Array for annotations, and jax.dtypes.issubdtype(arr, jax.dtypes.prng_key) for runtime detection of typed prng keys.
```

Flax is using `jax.linear_util.wrap_init`, which is a deprecated API:
```
DeprecationWarning: jax.linear_util.wrap_init is deprecated. Use jax.extend.linear_util.wrap_init instead.
```
This PR will switch to `jax.extend`.