### PR TITLE
switch to jax.extend

### DIFF
--- a/flax/core/axes_scan.py
+++ b/flax/core/axes_scan.py
@@ -19,7 +19,7 @@ from typing import Any, Callable, Optional
 import jax
 from jax import core
 from jax import lax
-from jax import linear_util as lu
+from jax.extend import linear_util as lu
 from jax.interpreters import partial_eval as pe
 import jax.numpy as jnp
 import numpy as np

--- a/flax/core/partial_eval.py
+++ b/flax/core/partial_eval.py
@@ -18,7 +18,7 @@ import functools
 
 import jax
 from jax import core
-from jax import linear_util as lu
+from jax.extend import linear_util as lu
 from jax.interpreters import partial_eval as pe
 
 from flax import errors

--- a/flax/jax_utils.py
+++ b/flax/jax_utils.py
@@ -22,7 +22,7 @@ import warnings
 import jax
 from jax import core
 from jax import lax
-from jax import linear_util as lu
+from jax.extend import linear_util as lu
 from jax.interpreters import partial_eval as pe
 import jax.numpy as jnp
 import numpy as np


### PR DESCRIPTION
Flax is using `jax.linear_util.wrap_init`, which is a deprecated API:
```
DeprecationWarning: jax.linear_util.wrap_init is deprecated. Use jax.extend.linear_util.wrap_init instead.
```
This PR will switch to `jax.extend`.