### PR TITLE
use jax.Array type for rng keys

### DIFF
--- a/docs/guides/dropout.rst
+++ b/docs/guides/dropout.rst
@@ -212,7 +212,7 @@ the training step function. Refer to the
   from flax.training import train_state
 
   class TrainState(train_state.TrainState): #!
-    key: jax.random.KeyArray #!
+    key: jax.Array #!
 
   state = TrainState.create( #!
     apply_fn=my_model.apply,

--- a/examples/seq2seq/models.py
+++ b/examples/seq2seq/models.py
@@ -26,7 +26,7 @@ import jax.numpy as jnp
 import numpy as np
 
 Array = jax.Array
-PRNGKey = jax.random.KeyArray
+PRNGKey = jax.Array
 LSTMCarry = Tuple[Array, Array]
 
 

--- a/flax/linen/module.py
+++ b/flax/linen/module.py
@@ -74,7 +74,7 @@ from typing_extensions import Protocol, dataclass_transform  # pytype: disable=n
 
 traceback_util.register_exclusion(__file__)
 
-KeyArray = Union[jax.Array, jax.random.KeyArray]  # pylint: disable=invalid-name
+KeyArray = jax.Array
 RNGSequences = Dict[str, KeyArray]
 Array = Any  # pylint: disable=invalid-name
 

--- a/flax/linen/recurrent.py
+++ b/flax/linen/recurrent.py
@@ -42,7 +42,7 @@ import numpy as np
 from typing_extensions import Protocol
 
 A = TypeVar('A')
-PRNGKey = jax.random.KeyArray
+PRNGKey = jax.Array
 Shape = Tuple[int, ...]
 Dtype = Any  # this could be a real type?
 Array = jax.Array
@@ -750,7 +750,7 @@ class RNN(Module):
       inputs: jax.Array,
       *,
       initial_carry: Optional[Carry] = None,
-      init_key: Optional[random.KeyArray] = None,
+      init_key: Optional[PRNGKey] = None,
       seq_lengths: Optional[Array] = None,
       return_carry: Optional[bool] = None,
       time_major: Optional[bool] = None,
@@ -976,7 +976,7 @@ class RNNBase(Protocol):
       inputs: jax.Array,
       *,
       initial_carry: Optional[Carry] = None,
-      init_key: Optional[random.KeyArray] = None,
+      init_key: Optional[PRNGKey] = None,
       seq_lengths: Optional[Array] = None,
       return_carry: Optional[bool] = None,
       time_major: Optional[bool] = None,
@@ -1000,7 +1000,7 @@ class Bidirectional(Module):
       inputs: jax.Array,
       *,
       initial_carry: Optional[Carry] = None,
-      init_key: Optional[random.KeyArray] = None,
+      init_key: Optional[PRNGKey] = None,
       seq_lengths: Optional[Array] = None,
       return_carry: Optional[bool] = None,
       time_major: Optional[bool] = None,

--- a/flax/linen/stochastic.py
+++ b/flax/linen/stochastic.py
@@ -25,7 +25,7 @@ from jax import lax
 from jax import random
 import jax.numpy as jnp
 
-KeyArray = Union[jax.Array, jax.random.KeyArray]
+KeyArray = jax.Array
 
 
 class Dropout(Module):


### PR DESCRIPTION
for more details, see [the Jax PR](https://github.com/google/jax/pull/17297) and [JEP 9263](https://jax--17297.org.readthedocs.build/en/17297/jep/9263-typed-keys.html)