### PR TITLE
Disable pyink

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,10 +13,11 @@ repos:
   hooks:
   - id: jupytext
     args: [--sync]
-- repo: https://github.com/google/pyink
-  rev: 23.5.0
-  hooks:
-    - id: pyink
+# diable pyink for now
+# - repo: https://github.com/google/pyink
+#   rev: 23.5.0
+#   hooks:
+#     - id: pyink
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v4.3.0
   hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ testing = [
     "torch",
     "nbstripout",
     "black[jupyter]==23.7.0",
-    "pyink==23.5.0",
+    # "pyink==23.5.0", # disabling pyink fow now
 ]
 
 [project.urls]


### PR DESCRIPTION
# What does this PR do?

Given the discrepancy between `pyink` and Google's internal formatter, it has become difficult to make both formatters happy so we are disabling `pyink` on CI until Google fixes the issue.