### PR TITLE
Don't propagate default args in Tabulate

### DIFF
--- a/flax/linen/module.py
+++ b/flax/linen/module.py
@@ -2357,7 +2357,7 @@ class Module(ModuleBase):
       *args,
       depth: Optional[int] = None,
       show_repeated: bool = False,
-      mutable: CollectionFilter = True,
+      mutable: CollectionFilter = DenyList('intermediates'),
       console_kwargs: Optional[Mapping[str, Any]] = None,
       table_kwargs: Mapping[str, Any] = MappingProxyType({}),
       column_kwargs: Mapping[str, Any] = MappingProxyType({}),

--- a/flax/linen/summary.py
+++ b/flax/linen/summary.py
@@ -251,12 +251,16 @@ def tabulate(
     (`method`) and returns a string with a tabular representation of the
     Modules.
   """
+  # add non-default arguments to kwargs, this prevents some issue we overloading init
+  # see: https://github.com/google/flax/issues/3299
+  if mutable != True:
+    kwargs['mutable'] = mutable
 
   def _tabulate_fn(*fn_args, **fn_kwargs):
     table_fn = _get_module_table(
         module, depth=depth, show_repeated=show_repeated
     )
-    table = table_fn(rngs, *fn_args, mutable=mutable, **fn_kwargs, **kwargs)
+    table = table_fn(rngs, *fn_args, **fn_kwargs, **kwargs)
     return _render_table(table, console_kwargs, table_kwargs, column_kwargs)
 
   return _tabulate_fn

--- a/flax/linen/summary.py
+++ b/flax/linen/summary.py
@@ -22,7 +22,7 @@ from flax.core import unfreeze
 
 import flax.linen.module as module_lib
 from flax.core import meta
-from flax.core.scope import CollectionFilter, FrozenVariableDict, MutableVariableDict
+from flax.core.scope import CollectionFilter, DenyList, FrozenVariableDict, MutableVariableDict
 import jax
 import jax.numpy as jnp
 import rich.console
@@ -156,7 +156,7 @@ def tabulate(
     rngs: Union[PRNGKey, RNGSequences],
     depth: Optional[int] = None,
     show_repeated: bool = False,
-    mutable: CollectionFilter = True,
+    mutable: CollectionFilter = DenyList('intermediates'),
     console_kwargs: Optional[Mapping[str, Any]] = None,
     table_kwargs: Mapping[str, Any] = MappingProxyType({}),
     column_kwargs: Mapping[str, Any] = MappingProxyType({}),
@@ -253,7 +253,7 @@ def tabulate(
   """
   # add non-default arguments to kwargs, this prevents some issue we overloading init
   # see: https://github.com/google/flax/issues/3299
-  if mutable != True:
+  if mutable != DenyList('intermediates'):
     kwargs['mutable'] = mutable
 
   def _tabulate_fn(*fn_args, **fn_kwargs):

--- a/tests/linen/summary_test.py
+++ b/tests/linen/summary_test.py
@@ -329,6 +329,7 @@ class SummaryTest(absltest.TestCase):
         {"dropout": random.key(0), "params": random.key(1)},
         x,
         training=True,
+        mutable=True,
         console_kwargs=CONSOLE_TEST_KWARGS,
     )
 


### PR DESCRIPTION
# Changes

Fixes #3299. Prevents the progatation of default args from `.tabulate` to `.init` when they have the default value e.g. `mutable=True`. This solves some issues when monkey-patching `init`.