### PR TITLE
fixed bind-unbind bug

### DIFF
--- a/flax/core/scope.py
+++ b/flax/core/scope.py
@@ -1006,7 +1006,7 @@ def _unfreeze_variables(variables, mutable):
     if in_filter(mutable, key):
       new_variables[key] = unfreeze(value)
     else:
-      new_variables[key] = freeze(value)
+      new_variables[key] = value
   return new_variables
 
 


### PR DESCRIPTION
Resolves #3305.

The error is caused by unbounded submodules containing a non-null value for its `parent` and `name` attributes even after calling `.unbind`. This is fixed by [deep](https://github.com/google/flax/pull/3365/files#diff-b604a3c3fbfb859c1f293c2305d80cff5802eb29ec3b0dd6d21a82f8a31aceacR1834) [cloning](https://github.com/google/flax/pull/3365/files#diff-b604a3c3fbfb859c1f293c2305d80cff5802eb29ec3b0dd6d21a82f8a31aceacR1480-R1483) the module when calling `.unbind` and overwriting the `name` attribute to a null value.

This PR also removes the `freeze` call in [`_unfreeze_variables`](https://github.com/google/flax/pull/3365/files#diff-d53cff3509f30c883e4991afdf992b5b5ef97ae3070d28b50812b8fe1fb3f728R1009) because it currently returns a partially frozen variable dict when calling `.bind` and then `.unbind`. E.g.:
```
class A(nn.Module):
  @nn.compact
  def __call__(self, x):
    return nn.Dense(2)(x)
a = A()
v = a.init(jax.random.PRNGKey(0), np.ones((1, 3)))
print(v)
```
```
{'params': {'Dense_0': {'kernel': Array([[-0.31948987,  0.97000796],
       [-1.1898962 , -0.02842528],
       [ 0.05931677,  0.38352993]], dtype=float32), 'bias': Array([0., 0.], dtype=float32)}}}
```
```
new_a, new_v = a.bind(v).unbind()
print(new_v)
```
```
{'params': FrozenDict({
    Dense_0: {
        kernel: Array([[-0.31948987,  0.97000796],
               [-1.1898962 , -0.02842528],
               [ 0.05931677,  0.38352993]], dtype=float32),
        bias: Array([0., 0.], dtype=float32),
    },
})}
```