### PR TITLE
fixed typo

### DIFF
--- a/docs/api_reference/flax.errors.rst
+++ b/docs/api_reference/flax.errors.rst
@@ -1,5 +1,5 @@
 
-flax.error package
+flax.errors package
 ===================
 
 Flax has the following classes of errors.


### PR DESCRIPTION
fixed typo from `flax.error` to `flax.errors`