### PR TITLE
Add MaxText open source LLM to index.rst

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -274,6 +274,18 @@ Notable examples in Flax include:
    .. grid-item::
       :columns: 6 6 6 4
 
+      .. card:: `MaxText <https://github.com/google/maxtext>`__
+         :class-card: sd-border-0
+         :shadow: none
+         :class-title: sd-text-center sd-fs-5
+
+         .. div:: sd-text-center sd-font-italic
+
+            Open source high performance LLM
+
+   .. grid-item::
+      :columns: 6 6 6 4
+
       .. card:: `T5x <https://github.com/google-research/t5x>`__
          :class-card: sd-border-0
          :shadow: none
@@ -281,7 +293,7 @@ Notable examples in Flax include:
 
          .. div:: sd-text-center sd-font-italic
 
-            Large Language Models
+            Large language models
 
    .. grid-item::
       :columns: 6 6 6 4


### PR DESCRIPTION
This PR adds the MaxText open source LLM to the Flax ReadTheDocs main page as an example.

[MaxText](https://github.com/google/maxtext) is built with JAX and Flax Linen.