### PR TITLE
updated docs

### DIFF
--- a/docs/api_reference/flax.cursor.rst
+++ b/docs/api_reference/flax.cursor.rst
@@ -12,7 +12,7 @@ To illustrate, consider the example below::
   import dataclasses
   from typing import Any
 
-  @dataclasses.dataclass
+  @dataclasses.dataclass(frozen=True)
   class A:
     x: Any
 

--- a/docs/examples_community_examples.rst
+++ b/docs/examples_community_examples.rst
@@ -56,10 +56,6 @@ Examples
       - `@vasudevgupta7 <https://github.com/vasudevgupta7>`__
       - Question-Answering
       - https://arxiv.org/abs/2007.14062
-    * - `Bayesian Networks with BlackJAX <https://blackjax-devs.github.io/blackjax/examples/SGMCMC.html>`__
-      - `@rlouf <https://github.com/rlouf>`__
-      - Bayesian Inference, SGMCMC
-      - https://arxiv.org/abs/1402.4102
     * - `DCGAN <https://github.com/bkkaggle/jax-dcgan>`__
       - `@bkkaggle <https://github.com/bkkaggle>`__
       - Image Synthesis

--- a/docs/guides/flax_on_pjit.ipynb
+++ b/docs/guides/flax_on_pjit.ipynb
@@ -190,7 +190,7 @@
     "\n",
     "1. Use [`flax.linen.with_partitioning`](https://flax.readthedocs.io/en/latest/api_reference/_autosummary/flax.linen.with_partitioning.html#flax.linen.with_partitioning) to decorate the initializer function when creating sub-layers or raw parameters.\n",
     "\n",
-    "2. Apply [`jax.lax.with_sharding_constraint`](https://github.com/google/jax/blob/main/jax/_src/pjit.py#L1516) (formerly, `pjit.with_sharding_constraint`) to annotate intermediate variables like `y` and `z` to force a particular sharding pattern when the ideal constraint is known.\n",
+    "2. Apply [`jax.lax.with_sharding_constraint`](https://jax.readthedocs.io/en/latest/_autosummary/jax.lax.with_sharding_constraint.html) (formerly, `pjit.with_sharding_constraint`) to annotate intermediate variables like `y` and `z` to force a particular sharding pattern when the ideal constraint is known.\n",
     "\n",
     "  * This step is optional, but can sometimes help auto-SPMD to partition efficiently. In the example below, the call is not required, because XLA will figure out the same sharding layout for `y` and `z` regardless."
    ]
@@ -1281,7 +1281,7 @@
     "\n",
     "* **Device mesh axis**: If you want a very simple model, or you are very confident of your way of partitioning, defining it with __device mesh axis__ can potentially save you a few extra lines of code of converting the logical naming back to the device naming.\n",
     "\n",
-    "* **logical naming**: On the other hand, the __logical naming__ helpers can be useful for exploring different sharding layouts. Use this if you want to experiment around and find the most optimal partition layout for your model.\n",
+    "* **Logical naming**: On the other hand, the __logical naming__ helpers can be useful for exploring different sharding layouts. Use this if you want to experiment around and find the most optimal partition layout for your model.\n",
     "\n",
     "* **Device axis names**: In really advanced use cases, you may have more complicated sharding patterns that require annotating *activation* dimension names differently from *parameter* dimension names. If you wish to have more fine-grained control on manual mesh assignments, directly using __device axis names__ could be more helpful."
    ]

--- a/docs/guides/flax_on_pjit.md
+++ b/docs/guides/flax_on_pjit.md
@@ -119,7 +119,7 @@ To shard the parameters efficiently, apply the following APIs to annotate the pa
 
 1. Use [`flax.linen.with_partitioning`](https://flax.readthedocs.io/en/latest/api_reference/_autosummary/flax.linen.with_partitioning.html#flax.linen.with_partitioning) to decorate the initializer function when creating sub-layers or raw parameters.
 
-2. Apply [`jax.lax.with_sharding_constraint`](https://github.com/google/jax/blob/main/jax/_src/pjit.py#L1516) (formerly, `pjit.with_sharding_constraint`) to annotate intermediate variables like `y` and `z` to force a particular sharding pattern when the ideal constraint is known.
+2. Apply [`jax.lax.with_sharding_constraint`](https://jax.readthedocs.io/en/latest/_autosummary/jax.lax.with_sharding_constraint.html) (formerly, `pjit.with_sharding_constraint`) to annotate intermediate variables like `y` and `z` to force a particular sharding pattern when the ideal constraint is known.
 
   * This step is optional, but can sometimes help auto-SPMD to partition efficiently. In the example below, the call is not required, because XLA will figure out the same sharding layout for `y` and `z` regardless.
 
@@ -551,7 +551,7 @@ Choosing when to use a device or logical axis depends on how much you want to co
 
 * **Device mesh axis**: If you want a very simple model, or you are very confident of your way of partitioning, defining it with __device mesh axis__ can potentially save you a few extra lines of code of converting the logical naming back to the device naming.
 
-* **logical naming**: On the other hand, the __logical naming__ helpers can be useful for exploring different sharding layouts. Use this if you want to experiment around and find the most optimal partition layout for your model.
+* **Logical naming**: On the other hand, the __logical naming__ helpers can be useful for exploring different sharding layouts. Use this if you want to experiment around and find the most optimal partition layout for your model.
 
 * **Device axis names**: In really advanced use cases, you may have more complicated sharding patterns that require annotating *activation* dimension names differently from *parameter* dimension names. If you wish to have more fine-grained control on manual mesh assignments, directly using __device axis names__ could be more helpful.
 

--- a/docs/guides/regular_dict_upgrade_guide.rst
+++ b/docs/guides/regular_dict_upgrade_guide.rst
@@ -120,9 +120,11 @@ Alternatively, the environment variable ``flax_return_frozendict``
 (found `here <https://github.com/google/flax/blob/main/flax/configurations.py>`__) can be directly modified in the Flax source code.
 
 
-Migration plan
+Migration status
 --------------
 
-Currently ``flax_return_frozendict`` is set to True, meaning Flax will default to returning ``FrozenDicts``.
-In the future this flag will be flipped to False, and Flax will instead default to returning regular dicts.
-Eventually this feature flag will be removed once the migration is complete.
+As of July 19th, 2023, ``flax_return_frozendict`` is set to ``False`` (see
+`#3193 <https://github.com/google/flax/pull/3193>`__), meaning Flax will default to
+returning regular dicts from version `0.7.1 <https://github.com/google/flax/releases/tag/v0.7.1>`__
+onward. This flag can be flipped to ``True`` temporarily to have Flax return
+``Frozendicts``. However this feature flag will eventually be removed in the future.

--- a/docs/guides/transfer_learning.ipynb
+++ b/docs/guides/transfer_learning.ipynb
@@ -165,7 +165,7 @@
    "metadata": {},
    "source": [
     "## Transfering the parameters\n",
-    "Since `params` are currently random, the pretrained parameters from `vision_model_vars` have to be transfered to the `params` structure at the appropriate location. This can be done by unfreezing `params`, updating the `backbone` parameters, and freezing the `params` again:"
+    "Since `params` are currently random, the pretrained parameters from `vision_model_vars` have to be transfered to the `params` structure at the appropriate location (i.e. the `backbone`):"
    ]
   },
   {
@@ -174,11 +174,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import flax\n",
-    "\n",
-    "params = flax.core.unfreeze(params)\n",
-    "params['backbone'] = vision_model_vars['params']\n",
-    "params = flax.core.freeze(params)"
+    "params['backbone'] = vision_model_vars['params']"
    ]
   },
   {
@@ -247,13 +243,13 @@
     "import optax\n",
     "\n",
     "partition_optimizers = {'trainable': optax.adam(5e-3), 'frozen': optax.set_to_zero()}\n",
-    "param_partitions = flax.core.freeze(traverse_util.path_aware_map(\n",
-    "  lambda path, v: 'frozen' if 'backbone' in path else 'trainable', params))\n",
+    "param_partitions = traverse_util.path_aware_map(\n",
+    "  lambda path, v: 'frozen' if 'backbone' in path else 'trainable', params)\n",
     "tx = optax.multi_transform(partition_optimizers, param_partitions)\n",
     "\n",
     "# visualize a subset of the param_partitions structure\n",
     "flat = list(traverse_util.flatten_dict(param_partitions).items())\n",
-    "flax.core.freeze(traverse_util.unflatten_dict(dict(flat[:2] + flat[-2:])))"
+    "traverse_util.unflatten_dict(dict(flat[:2] + flat[-2:]))"
    ]
   },
   {

--- a/flax/core/meta.py
+++ b/flax/core/meta.py
@@ -206,7 +206,7 @@ class Partitioned(struct.PyTreeNode, AxisMetadata[A]):
     mlp = MLP(4096)
     x = jnp.ones((8 * 1024, 1024))
     # use eval_shape to get the Partitioned instances for the variables.
-    # this way we can determinte the PartitionSpecs for the init variables
+    # this way we can determine the PartitionSpecs for the init variables
     # before we call the init fn.
     var_spec = nn.get_partition_spec(
         jax.eval_shape(mlp.init, random.key(0), x))

--- a/flax/linen/stochastic.py
+++ b/flax/linen/stochastic.py
@@ -32,10 +32,19 @@ class Dropout(Module):
   """Create a dropout layer.
 
   Note: When using :meth:`Module.apply() <flax.linen.Module.apply>`, make sure
-  to include an RNG seed named `'dropout'`. For example::
+  to include an RNG seed named `'dropout'`. Dropout isn't necessary for
+  variable initialization. Example::
 
-    model.apply({'params': params}, inputs=inputs, train=True, rngs={'dropout':
-    dropout_rng})`
+    class MLP(nn.Module):
+      @nn.compact
+      def __call__(self, x, train):
+        x = nn.Dense(4)(x)
+        x = nn.Dropout(0.5, deterministic=not train)(x)
+        return x
+    model = MLP()
+    x = jnp.ones((1, 3))
+    variables = model.init(jax.random.key(0), x, train=False) # don't use dropout
+    model.apply(variables, x, train=True, rngs={'dropout': jax.random.key(1)}) # use dropout
 
   Attributes:
     rate: the dropout probability.  (_not_ the keep rate!)


### PR DESCRIPTION
Updated docs.

A couple highlights:
* [Removed](https://github.com/google/flax/pull/3370/files#diff-dce016d0e4f8a6b6c5bda025db3ab4fea095d2bf2843db45f1dab22a1cb226bdL59-L62) BlackJax example since the link is broken and it seems like the [current codebase](https://github.com/blackjax-devs/blackjax) doesn't use Flax (although it is listed as a [required dependency](https://github.com/blackjax-devs/blackjax/blob/main/requirements-doc.txt))
* Added a more detailed [example](https://github.com/google/flax/pull/3370/files#diff-9401b9f921c0646d40ec072c53d29fea7051e47410b0a30340e54c3012c86a0fR38-R47) in the docstring of `Dropout`, since a new user may find it unclear what the `train=True` argument is for in the original code snippet:
```
model.apply({'params': params}, inputs=inputs, train=True, rngs={'dropout': dropout_rng})
```