### PR TITLE
fix: dev container

### DIFF
--- a/dev/.devcontainer/Dockerfile
+++ b/dev/.devcontainer/Dockerfile
@@ -3,7 +3,7 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 
-FROM python:3.7
+FROM python:3.11
 
 # Avoid warnings by switching to noninteractive
 ENV DEBIAN_FRONTEND=noninteractive
@@ -52,7 +52,7 @@ RUN apt-get update \
 RUN pip install numpy jaxlib tensorflow tensorflow-datasets matplotlib msgpack \
     jupyter pytest pytest-xdist \
     twine \
-    sphinx sphinx_rtd_theme ipykernel nbsphinx recommonmark sklearn
+    sphinx sphinx_rtd_theme ipykernel nbsphinx recommonmark scikit-learn
 
 # Switch back to dialog for any ad-hoc use of apt-get
 ENV DEBIAN_FRONTEND=dialog

--- a/dev/.devcontainer/devcontainer.json
+++ b/dev/.devcontainer/devcontainer.json
@@ -22,7 +22,7 @@
 	// Uncomment the next line to run commands after the container is created.
 	// "postCreateCommand": "pip install -r requirements.txt",
 	"runArgs": ["-v", "${env:HOME}${env:USERPROFILE}/.ssh:/root/.ssh-localhost:ro"],
-	"postCreateCommand": "sudo cp -r /root/.ssh-localhost ~/.ssh && sudo chown -R $(id -u):$(id -g) ~/.ssh && chmod 700 ~/.ssh && chmod 600 ~/.ssh/* && pip install -e ./flax",
+	"postCreateCommand": "sudo cp -r /root/.ssh-localhost ~/.ssh && sudo chown -R $(id -u):$(id -g) ~/.ssh && chmod 700 ~/.ssh && chmod 600 ~/.ssh/* && pip install -e .",
 
 	// Uncomment the next line to have VS Code connect as an existing non-root user in the container.
 	// On Linux, by default, the container user's UID/GID will be updated to match your local user. See

--- a/examples/ogbg_molpcba/requirements.txt
+++ b/examples/ogbg_molpcba/requirements.txt
@@ -8,6 +8,6 @@ jraph==0.0.2.dev0
 ml-collections==0.1.0
 numpy==1.22.0
 optax==0.1.0
-sklearn==0.0
+scikit-learn==1.3.1
 tensorflow==2.11.1
 tensorflow-datasets==4.4.0


### PR DESCRIPTION
Currently the dev container is broken, this PR fixes it by:

- Replacing deprecated `sklearn` package with `scikit-learn`
- Update docker container to run Python 3.11 (install fails due to dependency issues with Python 3.7)
- Fix pip install command for `flax` (was pointing to the wrong path)

## Checklist
- [x] This PR fixes a minor issue (e.g.: typo or small bug) or improves the docs (you can dismiss the other
      checks if that's the case).
- [ ] This change is discussed in a Github issue/
      [discussion](https://github.com/google/flax/discussions) (please add a
      link).
- [ ] The documentation and docstrings adhere to the
      [documentation guidelines](https://github.com/google/flax/blob/main/docs/README.md#how-to-write-code-documentation).
- [ ] This change includes necessary high-coverage tests.
      (No quality testing = no merge!)
