### PR TITLE
Add `inputs_k` and `inputs_v` args to attention layer

### DIFF
--- a/examples/wmt/models.py
+++ b/examples/wmt/models.py
@@ -299,7 +299,7 @@ class EncoderDecoder1DBlock(nn.Module):
         broadcast_dropout=False,
         dropout_rate=config.attention_dropout_rate,
         deterministic=config.deterministic,
-    )(y, encoded, encoder_decoder_mask)
+    )(y, encoded, mask=encoder_decoder_mask)
 
     y = nn.Dropout(rate=config.dropout_rate)(
         y, deterministic=config.deterministic

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -147,6 +147,12 @@ filterwarnings = [
     "ignore:.*module 'sre_constants' is deprecated.*:DeprecationWarning",
     # DeprecationWarning: jax.random.KeyArray is deprecated.
     "ignore:.*jax.random.KeyArray is deprecated.*:DeprecationWarning",
+    # DeprecationWarning: SelfAttention will be deprecated soon.
+    "ignore:.*SelfAttention will be deprecated soon.*:DeprecationWarning",
+    # DeprecationWarning: The inputs_kv arg will be deprecated soon. Use inputs_k and inputs_v instead.
+    "ignore:.*The inputs_kv arg will be deprecated soon. Use inputs_k and inputs_v instead.*:DeprecationWarning",
+    # DeprecationWarning: the function signature of MultiHeadDotProductAttention's `__call__` method has changed
+    "ignore:.*the function signature of MultiHeadDotProductAttention's `__call__` method has changed.*:DeprecationWarning"
 ]
 
 [tool.coverage.report]


### PR DESCRIPTION
Currently, [`MultiHeadDotProductAttention`](https://flax.readthedocs.io/en/latest/api_reference/flax.linen/layers.html#flax.linen.MultiHeadDotProductAttention.__call__) layer's call method signature is `MultiHeadDotProductAttention.__call__(inputs_q, inputs_kv, mask=None, deterministic=None)`. As discussed in #1737, there are some cases where passing in separate values for the key and values is desired, which isn't possible with the current API. This PR adds two more arguments, `inputs_k` and `inputs_v` to the call method signature and sets the method signature to the following: `MultiHeadDotProductAttention.__call__(inputs_q, inputs_k=None, inputs_v=None, *, inputs_kv=None, mask=None, deterministic=None)`. Note that the `inputs_kv`, `mask` and `deterministic` args are now **keyword arguments**.

* if `inputs_k` and `inputs_v` are `None`, then they will both copy the value of `inputs_q` (i.e. self attention)
* if `inputs_v` is `None`, it will copy the value of `inputs_k` (same behavior as the previous API, i.e. `module.apply(inputs_q=query, inputs_k=key_value, ...)` is equivalent to `module.apply(inputs_q=query, inputs_kv=key_value, ...)`)
* if `inputs_kv` is **not** None, both `inputs_k` and `inputs_v` will copy the value of `inputs_kv`

Users can still use `inputs_kv` but a `DeprecationWarning` will be raised and **`inputs_kv` will be removed in the future**.
Since self attention can be done using this new API, the **`SelfAttention` layer will also raise a `DeprecationWarning` and will be removed in the future**.

Check out #3389 to see examples of how to port your code over to the new API.