### PR TITLE
added warning filter for jax.random.KeyArray

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -142,6 +142,8 @@ filterwarnings = [
     "ignore:.*Deprecated call to `pkg_resources.declare_namespace.*:DeprecationWarning",
     # DeprecationWarning: module 'sre_constants' is deprecated
     "ignore:.*module 'sre_constants' is deprecated.*:DeprecationWarning",
+    # DeprecationWarning: jax.random.KeyArray is deprecated
+    "ignore:.*jax.random.KeyArray is deprecated.*:DeprecationWarning",
 ]
 
 [tool.coverage.report]


### PR DESCRIPTION
Warning is due to a [`chex`](https://github.com/google/flax/actions/runs/6407312853/job/17393862864?pr=3394#step:9:570) import from `tests/jax_utils_test.py`