### PR TITLE
added weightnorm layer

### DIFF
--- a/docs/api_reference/flax.linen/layers.rst
+++ b/docs/api_reference/flax.linen/layers.rst
@@ -60,6 +60,10 @@ Normalization
   :module: flax.linen
   :class: SpectralNorm
 
+.. flax_module::
+  :module: flax.linen
+  :class: WeightNorm
+
 
 Combinators
 ------------------------
@@ -136,6 +140,7 @@ Recurrent
   GroupNorm
   RMSNorm
   SpectralNorm
+  WeightNorm
   Sequential
   Dropout
   SelfAttention

--- a/flax/linen/__init__.py
+++ b/flax/linen/__init__.py
@@ -108,6 +108,7 @@ from .normalization import (
     LayerNorm as LayerNorm,
     RMSNorm as RMSNorm,
     SpectralNorm as SpectralNorm,
+    WeightNorm as WeightNorm
 )
 from .pooling import (avg_pool as avg_pool, max_pool as max_pool, pool as pool)
 from .recurrent import (


### PR DESCRIPTION
Resolves #3400.

Implemented `nn.WeightNorm` as a layer wrapper. Check out the API documentation [here](https://flax--3405.org.readthedocs.build/en/3405/api_reference/flax.linen/layers.html#flax.linen.WeightNorm).

Example usage:
```
class Baz(nn.Module):
  @nn.compact
  def __call__(self, x):
    return nn.Dense(2)(x)

class Bar(nn.Module):
  @nn.compact
  def __call__(self, x):
    x = Baz()(x)
    x = nn.Dense(3)(x)
    x = Baz()(x)
    x = nn.Dense(3)(x)
    return x

class Foo(nn.Module):
  @nn.compact
  def __call__(self, x):
    x = nn.Dense(3)(x)
    # l2-normalize all params of the second Dense layer
    x = nn.WeightNorm(nn.Dense(4), variable_filter=None)(x)
    x = nn.Dense(5)(x)
    # l2-normalize all kernels in the Bar submodule and all params in the Baz submodule
    x = nn.WeightNorm(Bar(), variable_filter={'kernel', 'Baz'})(x)
    return x

# init
x = jnp.ones((1, 2))
y = jnp.ones((1, 5))
model = Foo()
variables = model.init(jax.random.key(0), x)
variables
```
```
{
  params: {
    ...
    WeightNorm_0: {
        Dense_1/bias/scale: Array([1., 1., 1., 1.], dtype=float32),
        Dense_1/kernel/scale: Array([1., 1., 1., 1.], dtype=float32),
    },
    ...
    WeightNorm_1: {
        Bar_0/Baz_0/Dense_0/bias/scale: Array([1., 1.], dtype=float32),
        Bar_0/Baz_0/Dense_0/kernel/scale: Array([1., 1.], dtype=float32),
        Bar_0/Baz_1/Dense_0/bias/scale: Array([1., 1.], dtype=float32),
        Bar_0/Baz_1/Dense_0/kernel/scale: Array([1., 1.], dtype=float32),
        Bar_0/Dense_0/kernel/scale: Array([1., 1., 1.], dtype=float32),
        Bar_0/Dense_1/kernel/scale: Array([1., 1., 1.], dtype=float32),
    },
    ...
  }
}
```