### PR TITLE
remove pdf target

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -18,7 +18,7 @@ sphinx:
 formats:
   - htmlzip
   - epub
-  - pdf
+  # - pdf
 
 # Optionally set the version of Python and requirements required to build your docs
 python:


### PR DESCRIPTION
# What does this PR do?

Temporarily remove the `pdf` target from ReadTheDocs to fix build.