### PR TITLE
Allow for fast accumulation selection for FP8 GEMM

### DIFF
--- a/flax/linen/fp8_ops.py
+++ b/flax/linen/fp8_ops.py
@@ -135,6 +135,7 @@ def dot_general_with_precision(
     lhs, rhs, dimension_numbers, precision=lax.Precision.DEFAULT
   )
 
+
 @dot_general_with_precision.defjvp
 def dot_general_with_precision_jvp(
   dimension_numbers, precision, preferred_element_type, primals, tangents

--- a/flax/linen/fp8_ops.py
+++ b/flax/linen/fp8_ops.py
@@ -135,7 +135,7 @@ def dot_general_with_precision(
     lhs, rhs, dimension_numbers, precision=lax.Precision.DEFAULT
   )
 
-
+@dot_general_with_precision.defjvp
 def dot_general_with_precision_jvp(
   dimension_numbers, precision, preferred_element_type, primals, tangents
 ):


### PR DESCRIPTION
In this PR, issue#[6168 ](https://github.com/openxla/xla/issues/6168) is addressed by introducing a custom gradients(forward mode autodiff) for fp8 dot_general. This PR is closely related to FLAX PR-[6599](https://github.com/openxla/xla/pull/6599)@reedwm @kaixih @burmako