### PR TITLE
Fix warning with random number generation

### DIFF
--- a/flax/core/scope.py
+++ b/flax/core/scope.py
@@ -954,9 +954,8 @@ class Scope:
     """
     self.reserve(name, 'params')
     if self.has_variable('params', name):
-      abs_rng = jax.ShapeDtypeStruct(
-          random.default_prng_impl().key_shape, jnp.uint32
-      )
+      # The seed is irrelevant since we only want to evaluate the shape.
+      abs_rng = random.key(0)
       value = self.get_variable('params', name)
       # Validate that the shape of the init_fn output is the same as the shape
       # of the existing parameter. This is to make sure that the hparams set up


### PR DESCRIPTION
This Flax function creates a dummy RNG key consisting of an empty uint32 array, and uses it as an RNG key.  Recent versions of Jax warn on using uint32 arrays as RNG keys.

To prevent the warning and simplify the code, just call jax.random.key(0).

# What does this PR do?

<!--

Great, you are contributing to Flax!

But... please read the following carefully so we can make sure your PR is merged
easily.

Replace this text block with a description of the change and which issue it
fixes (if applicable). Please also include relevant motivation/context.

Once you're done, someone in the Flax team will review your PR shortly. They may
suggest changes to make the code even better. If no one reviewed your PR after a
week has passed, don't hesitate to post a new comment @-mentioning the same
persons (sometimes notifications get lost).
-->

Fixes # (issue)

## Checklist
- [x] This PR fixes a minor issue (e.g.: typo or small bug) or improves the docs (you can dismiss the other
      checks if that's the case).
- [ ] This change is discussed in a Github issue/
      [discussion](https://github.com/google/flax/discussions) (please add a
      link).
- [ ] The documentation and docstrings adhere to the
      [documentation guidelines](https://github.com/google/flax/blob/main/docs/README.md#how-to-write-code-documentation).
- [ ] This change includes necessary high-coverage tests.
      (No quality testing = no merge!)
