### PR TITLE
Remove transformers dependency from docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -133,6 +133,7 @@ myst_enable_extensions = ['dollarmath']
 nb_execution_excludepatterns = [
     'getting_started.ipynb',  # <-- times out
     'optax_update_guide.ipynb',  # <-- requires flax<=0.5.3
+    'transfer_learning.ipynb',  # <-- transformers requires flax<=0.7.0
 ]
 # raise exceptions on execution so CI can catch errors
 nb_execution_allow_errors = False

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -32,4 +32,3 @@ tensorflow_text>=2.11.0 # WMT example
 
 # notebooks
 einops
-transformers[flax]


### PR DESCRIPTION
# Changes

`transformers` has a `flax<=0.7.0` constraint that is currently making installation of the docs impossible. To get around this, this PR removes the `transformers`dependency from `docs/requirements.txt` and excludes the `transfer_learning.ipynb` notebook from running on CI.