### PR TITLE
fixed mypy errors at HEAD

### DIFF
--- a/flax/linen/fp8_ops.py
+++ b/flax/linen/fp8_ops.py
@@ -174,7 +174,7 @@ class Fp8DotGeneralOp(module.Module):
     k_qdq = in_qdq(
         comp_dtype, k, self.kernel_scale.value, self.kernel_amax_history.value
     )
-    y_qdq = lax.dot_general(x_qdq, k_qdq, dimension_numbers, precision)
+    y_qdq = lax.dot_general(x_qdq, k_qdq, dimension_numbers, precision) # type: ignore
     y = out_qdq(
         comp_dtype,
         y_qdq,
@@ -182,5 +182,5 @@ class Fp8DotGeneralOp(module.Module):
         self.output_grad_amax_history.value
     )
 
-    return y
+    return y # type: ignore
 


### PR DESCRIPTION
fixed mypy [errors](https://github.com/google/flax/actions/runs/6633647201/job/18063731667#step:9:56) at HEAD:
```
flax/linen/fp8_ops.py:177: error: Argument 1 to "dot_general" has incompatible type "ReturnValue"; expected "Array | ndarray[Any, Any] | bool_ | number[Any] | bool | int | float | complex"  [arg-type]
flax/linen/fp8_ops.py:177: error: Argument 2 to "dot_general" has incompatible type "ReturnValue"; expected "Array | ndarray[Any, Any] | bool_ | number[Any] | bool | int | float | complex"  [arg-type]
flax/linen/fp8_ops.py:185: error: Incompatible return value type (got "ReturnValue", expected "Array")  [return-value]
```
The cause of the error is because [`customvjp`](https://github.com/google/flax/pull/3440/files#diff-06017f1d3c34fb3901ed1c1748b278b2febf1337ac520724de0916395c96cdcaR82) is applied to `in_qdq`, causing it to have a return type of [`TypeVar('ReturnValue')`](https://github.com/google/jax/blob/main/jax/_src/custom_derivatives.py#L586), which causes mypy to throw errors.