### PR TITLE
Make Flax Basics visible

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -315,6 +315,7 @@ Notable examples in Flax include:
    :maxdepth: 2
 
    Quick start <getting_started>
+   guides/flax_basics
    guides/index
    examples
    glossary


### PR DESCRIPTION
Adds Flax Basics to the main ToC view, as it's not easy to find. @chiamp @cgarciae @IvyZX 