### PR TITLE
fixed quickstart

### DIFF
--- a/docs/getting_started.ipynb
+++ b/docs/getting_started.ipynb
@@ -41,7 +41,7 @@
    },
    "outputs": [],
    "source": [
-    "!pip install -q flax"
+    "!pip install -q flax>=0.7.5"
    ]
   },
   {

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -30,7 +30,7 @@ the network for image classification on the MNIST dataset.
 :id: bb81587e
 :tags: [skip-execution]
 
-!pip install -q flax
+!pip install -q flax>=0.7.5
 ```
 
 +++ {"id": "b529fbef"}


### PR DESCRIPTION
A user got an error trying to run our [Quickstart guide](https://flax.readthedocs.io/en/latest/getting_started.html): `TypeError: CNN.__call__() got an unexpected keyword argument 'compute_flops'`. 

The issue is because the colab installs Flax `0.7.4`, whereas the PR that adds the compute_flops arg is in `0.7.5`. This PR fixes this by installing a Flax version that's >= `0.7.5`.