### PR TITLE
added pre-commit hook that sort imports and formats

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,6 +35,11 @@ repos:
         "metadata.kernelspec metadata.vscode metadata.colab cell.metadata.executionInfo.user cell.metadata.executionInfo.user_tz cell.metadata.colab",
       ]
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.0.292
+  # Ruff version.
+  rev: v0.1.3
   hooks:
+    # Run the Ruff linter.
     - id: ruff
+      args: [--fix, --exit-non-zero-on-fix]
+    # Run the Ruff formatter.
+    - id: ruff-format

--- a/dev/update_requirements.py
+++ b/dev/update_requirements.py
@@ -46,21 +46,19 @@ This will use the currently installed versions of all packages.
 import pathlib
 import re
 
-from absl import app
-from absl import flags
-
+from absl import app, flags
 
 FLAGS = flags.FLAGS
 
 flags.DEFINE_string(
-    'versions',
-    None,
-    'space-separated list of pkg-name-1.0.0 pairs. can be obtained from local '
-    'environment with '
-    '`--version="$(pip freeze | sed s/==/-/g) flax-0.3.6"` '
-    '(note the flax version "override") '
-    'or from the "install dependencies" step in the github build action '
-    'https://github.com/google/flax/actions/workflows/build.yml',
+  'versions',
+  None,
+  'space-separated list of pkg-name-1.0.0 pairs. can be obtained from local '
+  'environment with '
+  '`--version="$(pip freeze | sed s/==/-/g) flax-0.3.6"` '
+  '(note the flax version "override") '
+  'or from the "install dependencies" step in the github build action '
+  'https://github.com/google/flax/actions/workflows/build.yml',
 )
 flags.mark_flag_as_required('versions')
 flags.DEFINE_bool('verbose', False, 'enables verbose output.')
@@ -70,18 +68,18 @@ flags.DEFINE_list('ignore', ['jax'], 'packages not to add to requirements.')
 import_re = re.compile(r'(?:from|import)\s+(\w+)')
 # maps `import cv2` to `pip install opencv-python`
 pkg_map = {
-    'absl': 'absl-py',
-    'atari_py': 'atari-py',
-    'cv2': 'opencv-python',
-    'ml_collections': 'ml-collections',
-    'PIL': 'Pillow',
-    'tensorflow_datasets': 'tensorflow-datasets',
-    'tensorflow_text': 'tensorflow-text',
+  'absl': 'absl-py',
+  'atari_py': 'atari-py',
+  'cv2': 'opencv-python',
+  'ml_collections': 'ml-collections',
+  'PIL': 'Pillow',
+  'tensorflow_datasets': 'tensorflow-datasets',
+  'tensorflow_text': 'tensorflow-text',
 }
 standard_libs = set(
-    'codecs collections dataclasses datetime enum functools math'
-    ' multiprocessing itertools os pathlib random re sys tempfile time typing'
-    ' unicodedata warnings'.split(' ')
+  'codecs collections dataclasses datetime enum functools math'
+  ' multiprocessing itertools os pathlib random re sys tempfile time typing'
+  ' unicodedata warnings'.split(' ')
 )
 
 
@@ -89,11 +87,11 @@ def main(argv):
   del argv
 
   versions = {
-      pkg_version[: pkg_version.rindex('-')]: pkg_version[
-          pkg_version.rindex('-') + 1 :
-      ]
-      for pkg_version in FLAGS.versions.replace('\n', ' ').split(' ')
-      if '-' in pkg_version
+    pkg_version[: pkg_version.rindex('-')]: pkg_version[
+      pkg_version.rindex('-') + 1 :
+    ]
+    for pkg_version in FLAGS.versions.replace('\n', ' ').split(' ')
+    if '-' in pkg_version
   }
   if FLAGS.verbose:
     print('parsed versions:', sorted(versions.items()))

--- a/docs/_ext/codediff.py
+++ b/docs/_ext/codediff.py
@@ -28,32 +28,30 @@ In order to highlight a line of code, append "#!" to it.
 """
 from typing import List, Tuple
 
+import sphinx
 from docutils import nodes
 from docutils.parsers.rst import directives
 from docutils.statemachine import ViewList
-
-import sphinx
 from sphinx.util.docutils import SphinxDirective
 
 MISSING = object()
 
 
 class CodeDiffParser:
-
   def parse(
-      self,
-      lines,
-      title_left='Base',
-      title_right='Diff',
-      code_sep='---',
-      sync=MISSING,
+    self,
+    lines,
+    title_left='Base',
+    title_right='Diff',
+    code_sep='---',
+    sync=MISSING,
   ):
     sync = sync is not MISSING
 
     if code_sep not in lines:
       raise ValueError(
-          'Code separator not found! Code snippets should be '
-          f'separated by {code_sep}.'
+        'Code separator not found! Code snippets should be '
+        f'separated by {code_sep}.'
       )
     idx = lines.index(code_sep)
     code_left = self._code_block(lines[0:idx])
@@ -61,7 +59,7 @@ class CodeDiffParser:
     code_right = self._code_block(test_code)
 
     output = self._tabs(
-        (title_left, code_left), (title_right, code_right), sync=sync
+      (title_left, code_left), (title_right, code_right), sync=sync
     )
 
     return output, test_code
@@ -101,15 +99,15 @@ class CodeDiffParser:
 class CodeDiffDirective(SphinxDirective):
   has_content = True
   option_spec = {
-      'title_left': directives.unchanged,
-      'title_right': directives.unchanged,
-      'code_sep': directives.unchanged,
-      'sync': directives.flag,
+    'title_left': directives.unchanged,
+    'title_right': directives.unchanged,
+    'code_sep': directives.unchanged,
+    'sync': directives.flag,
   }
 
   def run(self):
     table_code, test_code = CodeDiffParser().parse(
-        list(self.content), **self.options
+      list(self.content), **self.options
     )
 
     # Create a test node as a comment node so it won't show up in the docs.
@@ -137,7 +135,7 @@ def setup(app):
   app.add_directive('codediff', CodeDiffDirective)
 
   return {
-      'version': sphinx.__display_version__,
-      'parallel_read_safe': True,
-      'parallel_write_safe': True,
+    'version': sphinx.__display_version__,
+    'parallel_read_safe': True,
+    'parallel_write_safe': True,
   }

--- a/docs/_ext/codediff_test.py
+++ b/docs/_ext/codediff_test.py
@@ -15,12 +15,10 @@
 """Tests for codediff Sphinx extension."""
 
 from absl.testing import absltest
-
 from codediff import CodeDiffParser
 
 
 class CodeDiffTest(absltest.TestCase):
-
   def test_parse(self):
     input_text = r"""@jax.jit #!
 def get_initial_params(key):   #!
@@ -59,9 +57,9 @@ def get_initial_params(key):
     title_right = 'Ensembling on multiple devices'
 
     actual_table, actual_testcode = CodeDiffParser().parse(
-        lines=input_text.split('\n'),
-        title_left=title_left,
-        title_right=title_right,
+      lines=input_text.split('\n'),
+      title_left=title_left,
+      title_right=title_right,
     )
     actual_table = '\n'.join(actual_table)
     actual_testcode = '\n'.join(actual_testcode)

--- a/docs/_ext/flax_module.py
+++ b/docs/_ext/flax_module.py
@@ -21,15 +21,16 @@ Use directive as follows:
   :class: Dense
 """
 
+import importlib
+
+import sphinx
+import sphinx.ext.autosummary.generate as ag
 from docutils import nodes
 from docutils.parsers.rst import directives
 from docutils.statemachine import ViewList
-
-import sphinx
 from sphinx.util.docutils import SphinxDirective
+
 from docs.conf_sphinx_patch import generate_autosummary_content
-import sphinx.ext.autosummary.generate as ag
-import importlib
 
 
 def render_module(modname: str, qualname: str, app):
@@ -41,30 +42,30 @@ def render_module(modname: str, qualname: str, app):
   recursive = False
   context = {}
   return generate_autosummary_content(
-      qualname,
-      obj,
-      parent,
-      template,
-      template_name,
-      imported_members,
-      app,
-      recursive,
-      context,
-      modname,
-      qualname,
+    qualname,
+    obj,
+    parent,
+    template,
+    template_name,
+    imported_members,
+    app,
+    recursive,
+    context,
+    modname,
+    qualname,
   )
 
 
 class FlaxModuleDirective(SphinxDirective):
   has_content = True
   option_spec = {
-      'module': directives.unchanged,
-      'class': directives.unchanged,
+    'module': directives.unchanged,
+    'class': directives.unchanged,
   }
 
   def run(self):
     module_template = render_module(
-        self.options['module'], self.options['class'], self.env.app
+      self.options['module'], self.options['class'], self.env.app
     )
     module_template = module_template.splitlines()
 
@@ -80,7 +81,7 @@ def setup(app):
   app.add_directive('flax_module', FlaxModuleDirective)
 
   return {
-      'version': sphinx.__display_version__,
-      'parallel_read_safe': True,
-      'parallel_write_safe': True,
+    'version': sphinx.__display_version__,
+    'parallel_read_safe': True,
+    'parallel_write_safe': True,
   }

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -50,18 +50,18 @@ author = 'The Flax authors'
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-    'sphinx.ext.autodoc',
-    'sphinx.ext.autosummary',
-    'sphinx.ext.autosectionlabel',
-    'sphinx.ext.doctest',
-    'sphinx.ext.intersphinx',
-    'sphinx.ext.mathjax',
-    'sphinx.ext.napoleon',
-    'sphinx.ext.viewcode',
-    'myst_nb',
-    'codediff',
-    'flax_module',
-    'sphinx_design',
+  'sphinx.ext.autodoc',
+  'sphinx.ext.autosummary',
+  'sphinx.ext.autosectionlabel',
+  'sphinx.ext.doctest',
+  'sphinx.ext.intersphinx',
+  'sphinx.ext.mathjax',
+  'sphinx.ext.napoleon',
+  'sphinx.ext.viewcode',
+  'myst_nb',
+  'codediff',
+  'flax_module',
+  'sphinx_design',
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -109,17 +109,17 @@ html_title = ''
 html_static_path = ['_static']
 
 html_theme_options = {
-    'repository_url': 'https://github.com/google/flax',
-    'use_repository_button': True,  # add a 'link to repository' button
-    'use_issues_button': False,  # add an 'Open an Issue' button
-    'path_to_docs': (
-        'docs'
-    ),  # used to compute the path to launch notebooks in colab
-    'launch_buttons': {
-        'colab_url': 'https://colab.research.google.com/',
-    },
-    'prev_next_buttons_location': None,
-    'show_navbar_depth': 1,
+  'repository_url': 'https://github.com/google/flax',
+  'use_repository_button': True,  # add a 'link to repository' button
+  'use_issues_button': False,  # add an 'Open an Issue' button
+  'path_to_docs': (
+    'docs'
+  ),  # used to compute the path to launch notebooks in colab
+  'launch_buttons': {
+    'colab_url': 'https://colab.research.google.com/',
+  },
+  'prev_next_buttons_location': None,
+  'show_navbar_depth': 1,
 }
 
 # -- Options for myst ----------------------------------------------
@@ -131,9 +131,9 @@ nb_execution_timeout = 100
 # files that will not be executed.
 myst_enable_extensions = ['dollarmath']
 nb_execution_excludepatterns = [
-    'getting_started.ipynb',  # <-- times out
-    'optax_update_guide.ipynb',  # <-- requires flax<=0.5.3
-    'transfer_learning.ipynb',  # <-- transformers requires flax<=0.7.0
+  'getting_started.ipynb',  # <-- times out
+  'optax_update_guide.ipynb',  # <-- requires flax<=0.5.3
+  'transfer_learning.ipynb',  # <-- transformers requires flax<=0.7.0
 ]
 # raise exceptions on execution so CI can catch errors
 nb_execution_allow_errors = False

--- a/docs/conf_sphinx_patch.py
+++ b/docs/conf_sphinx_patch.py
@@ -24,45 +24,46 @@
 # We should consider sending a PR to sphinx so we can get rid of this.
 # Original source: https://github.com/sphinx-doc/sphinx/blob/0aedcc9a916daa92d477226da67d33ce1831822e/sphinx/ext/autosummary/generate.py#L211-L351
 from typing import Any, Dict, List, Set, Tuple
-import sphinx.ext.autosummary.generate as ag
+
 import sphinx.ext.autodoc
+import sphinx.ext.autosummary.generate as ag
 
 
 def generate_autosummary_content(
-    name: str,
-    obj: Any,
-    parent: Any,
-    template: ag.AutosummaryRenderer,
-    template_name: str,
-    imported_members: bool,
-    app: Any,
-    recursive: bool,
-    context: Dict,
-    modname: str = None,
-    qualname: str = None,
+  name: str,
+  obj: Any,
+  parent: Any,
+  template: ag.AutosummaryRenderer,
+  template_name: str,
+  imported_members: bool,
+  app: Any,
+  recursive: bool,
+  context: Dict,
+  modname: str = None,
+  qualname: str = None,
 ) -> str:
   doc = ag.get_documenter(app, obj, parent)
 
   def skip_member(obj: Any, name: str, objtype: str) -> bool:
     try:
       return app.emit_firstresult(
-          'autodoc-skip-member', objtype, name, obj, False, {}
+        'autodoc-skip-member', objtype, name, obj, False, {}
       )
     except Exception as exc:
       ag.logger.warning(
-          __(
-              'autosummary: failed to determine %r to be documented, '
-              'the following exception was raised:\n%s'
-          ),
-          name,
-          exc,
-          type='autosummary',
+        __(
+          'autosummary: failed to determine %r to be documented, '
+          'the following exception was raised:\n%s'
+        ),
+        name,
+        exc,
+        type='autosummary',
       )
       return False
 
   def get_class_members(obj: Any) -> Dict[str, Any]:
     members = sphinx.ext.autodoc.get_class_members(
-        obj, [qualname], ag.safe_getattr
+      obj, [qualname], ag.safe_getattr
     )
     return {name: member.object for name, member in members.items()}
 
@@ -83,10 +84,10 @@ def generate_autosummary_content(
     return {}
 
   def get_members(
-      obj: Any,
-      types: Set[str],
-      include_public: List[str] = [],
-      imported: bool = True,
+    obj: Any,
+    types: Set[str],
+    include_public: List[str] = [],
+    imported: bool = True,
   ) -> Tuple[List[str], List[str]]:
     items: List[str] = []
     public: List[str] = []
@@ -148,13 +149,13 @@ def generate_autosummary_content(
     scanner = ag.ModuleScanner(app, obj)
     ns['members'] = scanner.scan(imported_members)
     ns['functions'], ns['all_functions'] = get_members(
-        obj, {'function'}, imported=imported_members
+      obj, {'function'}, imported=imported_members
     )
     ns['classes'], ns['all_classes'] = get_members(
-        obj, {'class'}, imported=imported_members
+      obj, {'class'}, imported=imported_members
     )
     ns['exceptions'], ns['all_exceptions'] = get_members(
-        obj, {'exception'}, imported=imported_members
+      obj, {'exception'}, imported=imported_members
     )
     ns['attributes'], ns['all_attributes'] = get_module_attrs(ns['members'])
     ispackage = hasattr(obj, '__path__')
@@ -164,10 +165,10 @@ def generate_autosummary_content(
     ns['members'] = dir(obj)
     ns['inherited_members'] = set(dir(obj)) - set(obj.__dict__.keys())
     ns['methods'], ns['all_methods'] = get_members(
-        obj, {'method'}, ['__init__']
+      obj, {'method'}, ['__init__']
     )
     ns['attributes'], ns['all_attributes'] = get_members(
-        obj, {'attribute', 'property'}
+      obj, {'attribute', 'property'}
     )
     ns['annotations'] = list(getattr(obj, '__annotations__', {}).keys())
 

--- a/flax/configurations.py
+++ b/flax/configurations.py
@@ -21,9 +21,9 @@ To modify a config value on run time, call:
 """
 
 import os
-from jax import config as jax_config
-
 from contextlib import contextmanager
+
+from jax import config as jax_config
 
 # Keep a wrapper at the flax namespace, in case we make our implementation
 # in the future.
@@ -65,7 +65,7 @@ def static_bool_env(varname: str, default: bool) -> bool:
     return False
   else:
     raise ValueError(
-        'invalid truth value {!r} for environment {!r}'.format(val, varname)
+      'invalid truth value {!r} for environment {!r}'.format(val, varname)
     )
 
 
@@ -91,41 +91,41 @@ def temp_flip_flag(var_name: str, var_value: bool):
 flax_lazy_rng = static_bool_env('FLAX_LAZY_RNG', True)
 
 flax_filter_frames = define_bool_state(
-    name='filter_frames',
-    default=True,
-    help='Whether to hide flax-internal stack frames from tracebacks.',
+  name='filter_frames',
+  default=True,
+  help='Whether to hide flax-internal stack frames from tracebacks.',
 )
 
 flax_profile = define_bool_state(
-    name='profile',
-    default=True,
-    help='Whether to run Module methods under jax.named_scope for profiles.',
+  name='profile',
+  default=True,
+  help='Whether to run Module methods under jax.named_scope for profiles.',
 )
 
 flax_use_orbax_checkpointing = define_bool_state(
-    name='use_orbax_checkpointing',
-    default=True,
-    help='Whether to use Orbax to save checkpoints.',
+  name='use_orbax_checkpointing',
+  default=True,
+  help='Whether to use Orbax to save checkpoints.',
 )
 
 flax_preserve_adopted_names = define_bool_state(
-    name='preserve_adopted_names',
-    default=False,
-    help="When adopting outside modules, don't clobber existing names.",
+  name='preserve_adopted_names',
+  default=False,
+  help="When adopting outside modules, don't clobber existing names.",
 )
 
 # TODO(marcuschiam): remove this feature flag once regular dict migration is complete
 flax_return_frozendict = define_bool_state(
-    name='return_frozendict',
-    default=False,
-    help='Whether to return FrozenDicts when calling init or apply.',
+  name='return_frozendict',
+  default=False,
+  help='Whether to return FrozenDicts when calling init or apply.',
 )
 
 flax_fix_rng = define_bool_state(
-    name='fix_rng_separator',
-    default=False,
-    help=(
-        'Whether to add separator characters when folding in static data into'
-        ' PRNG keys.'
-    ),
+  name='fix_rng_separator',
+  default=False,
+  help=(
+    'Whether to add separator characters when folding in static data into'
+    ' PRNG keys.'
+  ),
 )

--- a/flax/core/axes_scan.py
+++ b/flax/core/axes_scan.py
@@ -17,13 +17,11 @@ import functools
 from typing import Any, Callable, Optional
 
 import jax
-from jax import core
-from jax import lax
-from jax.extend import linear_util as lu
-from jax.interpreters import partial_eval as pe
 import jax.numpy as jnp
 import numpy as np
-
+from jax import core, lax
+from jax.extend import linear_util as lu
+from jax.interpreters import partial_eval as pe
 
 ScanAxis = Optional[int]
 
@@ -36,12 +34,12 @@ broadcast = _Broadcast()
 
 
 def scan(
-    fn: Callable[..., Any],
-    in_axes: Any,
-    out_axes: Any,
-    length: Optional[int] = None,
-    reverse: bool = False,
-    unroll: int = 1,
+  fn: Callable[..., Any],
+  in_axes: Any,
+  out_axes: Any,
+  length: Optional[int] = None,
+  reverse: bool = False,
+  unroll: int = 1,
 ):
   """A wrapper around `jax.lax.scan` with in_axes/out_axes api.
 
@@ -117,34 +115,34 @@ def scan(
     def body_fn(c, xs, init_mode=False):
       # inject constants
       xs = jax.tree_util.tree_map(
-          lambda ax, arg, x: (arg if ax is broadcast else x), in_axes, args, xs
+        lambda ax, arg, x: (arg if ax is broadcast else x), in_axes, args, xs
       )
       broadcast_out, c, ys = fn(broadcast_in, c, *xs)
 
       if init_mode:
         ys = jax.tree_util.tree_map(
-            lambda ax, y: (y if ax is broadcast else ()), out_axes, ys
+          lambda ax, y: (y if ax is broadcast else ()), out_axes, ys
         )
         return broadcast_out, ys
       else:
         ys = jax.tree_util.tree_map(
-            lambda ax, y: (() if ax is broadcast else y), out_axes, ys
+          lambda ax, y: (() if ax is broadcast else y), out_axes, ys
         )
         return c, ys
 
     broadcast_body = functools.partial(body_fn, init_mode=True)
 
     carry_avals = jax.tree_util.tree_map(
-        lambda x: core.ShapedArray(jnp.shape(x), jnp.result_type(x)), init
+      lambda x: core.ShapedArray(jnp.shape(x), jnp.result_type(x)), init
     )
     scan_avals = jax.tree_util.tree_map(
-        lambda x: core.ShapedArray(jnp.shape(x)[1:], jnp.result_type(x)), xs
+      lambda x: core.ShapedArray(jnp.shape(x)[1:], jnp.result_type(x)), xs
     )
     input_avals = (carry_avals, scan_avals)
 
     in_avals, in_tree = jax.tree_util.tree_flatten(input_avals)
     f_flat, out_tree = jax.api_util.flatten_fun_nokwargs(
-        lu.wrap_init(broadcast_body), in_tree
+      lu.wrap_init(broadcast_body), in_tree
     )
     in_pvals = list(map(pe.PartialVal.unknown, in_avals))
     _, out_pvals, _ = pe.trace_to_jaxpr_nounits(f_flat, in_pvals)
@@ -153,22 +151,22 @@ def scan(
     for pv, const in out_pvals:
       if pv is not None:
         raise ValueError(
-            'broadcasted variable has a data dependency on the scan body.'
+          'broadcasted variable has a data dependency on the scan body.'
         )
       out_flat.append(const)
     broadcast_in, constants_out = jax.tree_util.tree_unflatten(
-        out_tree(), out_flat
+      out_tree(), out_flat
     )
 
     c, ys = lax.scan(
-        body_fn, init, xs, length=length, reverse=reverse, unroll=unroll
+      body_fn, init, xs, length=length, reverse=reverse, unroll=unroll
     )
     ys = jax.tree_util.tree_map(transpose_from_front, out_axes, ys)
     ys = jax.tree_util.tree_map(
-        lambda ax, const, y: (const if ax is broadcast else y),
-        out_axes,
-        constants_out,
-        ys,
+      lambda ax, const, y: (const if ax is broadcast else y),
+      out_axes,
+      constants_out,
+      ys,
     )
     return broadcast_in, c, ys
 

--- a/flax/core/frozen_dict.py
+++ b/flax/core/frozen_dict.py
@@ -15,11 +15,12 @@
 """Frozen Dictionary."""
 
 import collections
-from typing import Any, Dict, Hashable, Mapping, Tuple, TypeVar, Union
 from types import MappingProxyType
+from typing import Any, Dict, Hashable, Mapping, Tuple, TypeVar, Union
+
+import jax
 
 from flax import serialization
-import jax
 
 
 class FrozenKeysView(collections.abc.KeysView):
@@ -113,7 +114,7 @@ class FrozenDict(Mapping[K, V]):
     return self._hash
 
   def copy(
-      self, add_or_replace: Mapping[K, V] = MappingProxyType({})
+    self, add_or_replace: Mapping[K, V] = MappingProxyType({})
   ) -> 'FrozenDict[K, V]':
     """Create a new FrozenDict with additional or replaced entries."""
     return type(self)({**self, **unfreeze(add_or_replace)})  # type: ignore[arg-type]
@@ -162,7 +163,7 @@ class FrozenDict(Mapping[K, V]):
     """
     sorted_keys = sorted(self._dict)
     return tuple(
-        [(jax.tree_util.DictKey(k), self._dict[k]) for k in sorted_keys]
+      [(jax.tree_util.DictKey(k), self._dict[k]) for k in sorted_keys]
     ), tuple(sorted_keys)
 
   @classmethod
@@ -225,10 +226,8 @@ def unfreeze(x: Union[FrozenDict, Dict[str, Any]]) -> Dict[Any, Any]:
 
 
 def copy(
-    x: Union[FrozenDict, Dict[str, Any]],
-    add_or_replace: Union[FrozenDict[str, Any], Dict[str, Any]] = FrozenDict(
-        {}
-    ),
+  x: Union[FrozenDict, Dict[str, Any]],
+  add_or_replace: Union[FrozenDict[str, Any], Dict[str, Any]] = FrozenDict({}),
 ) -> Union[FrozenDict, Dict[str, Any]]:
   """Create a new dict with additional and/or replaced entries. This is a utility
   function that can act on either a FrozenDict or regular dict and mimics the
@@ -255,7 +254,7 @@ def copy(
 
 
 def pop(
-    x: Union[FrozenDict, Dict[str, Any]], key: str
+  x: Union[FrozenDict, Dict[str, Any]], key: str
 ) -> Tuple[Union[FrozenDict, Dict[str, Any]], Any]:
   """Create a new dict where one entry is removed. This is a utility
   function that can act on either a FrozenDict or regular dict and
@@ -320,19 +319,19 @@ def _restore_frozen_dict(xs, states):
   diff = set(map(str, xs.keys())).difference(states.keys())
   if diff:
     raise ValueError(
-        'The target dict keys and state dict keys do not match, target dict'
-        f' contains keys {diff} which are not present in state dict at path'
-        f' {serialization.current_path()}'
+      'The target dict keys and state dict keys do not match, target dict'
+      f' contains keys {diff} which are not present in state dict at path'
+      f' {serialization.current_path()}'
     )
 
   return FrozenDict(
-      {
-          key: serialization.from_state_dict(value, states[key], name=key)
-          for key, value in xs.items()
-      }
+    {
+      key: serialization.from_state_dict(value, states[key], name=key)
+      for key, value in xs.items()
+    }
   )
 
 
 serialization.register_serialization_state(
-    FrozenDict, _frozen_dict_state_dict, _restore_frozen_dict
+  FrozenDict, _frozen_dict_state_dict, _restore_frozen_dict
 )

--- a/flax/core/meta.py
+++ b/flax/core/meta.py
@@ -25,11 +25,10 @@ import abc
 import functools
 from typing import Any, Callable, Dict, Generic, Optional, Tuple, TypeVar, Union
 
-from flax import errors
-from flax import struct
 import jax
 from jax.experimental import maps
 
+from flax import errors, struct
 
 A = TypeVar('A')
 B = TypeVar('B')
@@ -85,7 +84,7 @@ class AxisMetadata(Generic[A], metaclass=abc.ABCMeta):
 
   @abc.abstractmethod
   def add_axis(
-      self: TAxisMetadata, index: int, params: Dict[Any, Any]
+    self: TAxisMetadata, index: int, params: Dict[Any, Any]
   ) -> TAxisMetadata:
     """Adds a new axis to the axis metadata.
 
@@ -106,7 +105,7 @@ class AxisMetadata(Generic[A], metaclass=abc.ABCMeta):
 
   @abc.abstractmethod
   def remove_axis(
-      self: TAxisMetadata, index: int, params: Dict[Any, Any]
+    self: TAxisMetadata, index: int, params: Dict[Any, Any]
   ) -> TAxisMetadata:
     """Removes an axis from the axis metadata.
 
@@ -240,7 +239,7 @@ class Partitioned(struct.PyTreeNode, AxisMetadata[A]):
   value: Any
   names: LogicalNames = struct.field(pytree_node=False)
   mesh: Optional[jax.sharding.Mesh] = struct.field(
-      default=None, pytree_node=False
+    default=None, pytree_node=False
   )
 
   def unbox(self, apply_constraint=True) -> A:
@@ -286,9 +285,9 @@ class Partitioned(struct.PyTreeNode, AxisMetadata[A]):
 
 
 def with_partitioning(
-    fn: Callable[..., Any],
-    names: LogicalNames,
-    mesh: Optional[jax.sharding.Mesh] = None,
+  fn: Callable[..., Any],
+  names: LogicalNames,
+  mesh: Optional[jax.sharding.Mesh] = None,
 ) -> Callable[..., Partitioned[Any]]:
   """Wraps a function's return value with Partitioned.
 

--- a/flax/core/nn/normalization.py
+++ b/flax/core/nn/normalization.py
@@ -14,10 +14,11 @@
 
 """Normalization modules for Flax."""
 
+import jax.numpy as jnp
+from jax import lax
+
 from flax.core import Scope
 from flax.linen import initializers
-from jax import lax
-import jax.numpy as jnp
 
 
 def _absolute_dims(ndim, dims):
@@ -25,20 +26,20 @@ def _absolute_dims(ndim, dims):
 
 
 def batch_norm(
-    scope: Scope,
-    x,
-    use_running_average=False,
-    axis=-1,
-    momentum=0.99,
-    epsilon=1e-5,
-    dtype=jnp.float32,
-    bias=True,
-    scale=True,
-    bias_init=initializers.zeros_init(),
-    scale_init=initializers.ones_init(),
-    axis_name=None,
-    axis_index_groups=None,
-    kind='batch_stats',
+  scope: Scope,
+  x,
+  use_running_average=False,
+  axis=-1,
+  momentum=0.99,
+  epsilon=1e-5,
+  dtype=jnp.float32,
+  bias=True,
+  scale=True,
+  bias_init=initializers.zeros_init(),
+  scale_init=initializers.ones_init(),
+  axis_name=None,
+  axis_index_groups=None,
+  kind='batch_stats',
 ):
   x = jnp.asarray(x, jnp.float32)
   axis = axis if isinstance(axis, tuple) else (axis,)
@@ -74,7 +75,7 @@ def batch_norm(
   mul = lax.rsqrt(var + epsilon)
   if scale:
     mul = mul * scope.param('scale', scale_init, squeeze_shape).reshape(
-        mean.shape
+      mean.shape
     )
   y = y * mul
   if bias:
@@ -83,14 +84,14 @@ def batch_norm(
 
 
 def layer_norm(
-    scope: Scope,
-    x,
-    epsilon=1e-6,
-    dtype=jnp.float32,
-    bias=True,
-    scale=True,
-    bias_init=initializers.zeros_init(),
-    scale_init=initializers.ones_init(),
+  scope: Scope,
+  x,
+  epsilon=1e-6,
+  dtype=jnp.float32,
+  bias=True,
+  scale=True,
+  bias_init=initializers.zeros_init(),
+  scale_init=initializers.ones_init(),
 ):
   """Applies layer normalization on the input.
   It normalizes the activations of the layer for each given example in a
@@ -117,7 +118,7 @@ def layer_norm(
   mul = lax.rsqrt(var + epsilon)
   if scale:
     mul = mul * jnp.asarray(
-        scope.param('scale', scale_init, (features,)), dtype
+      scope.param('scale', scale_init, (features,)), dtype
     )
   y = (x - mean) * mul
   if bias:
@@ -126,16 +127,16 @@ def layer_norm(
 
 
 def group_norm(
-    scope,
-    x,
-    num_groups=32,
-    group_size=None,
-    epsilon=1e-6,
-    dtype=jnp.float32,
-    bias=True,
-    scale=True,
-    bias_init=initializers.zeros_init(),
-    scale_init=initializers.ones_init(),
+  scope,
+  x,
+  num_groups=32,
+  group_size=None,
+  epsilon=1e-6,
+  dtype=jnp.float32,
+  bias=True,
+  scale=True,
+  bias_init=initializers.zeros_init(),
+  scale_init=initializers.ones_init(),
 ):
   """Applies group normalization to the input (arxiv.org/abs/1803.08494).
   This op is similar to batch normalization, but statistics are shared across
@@ -164,19 +165,19 @@ def group_norm(
   """
   x = jnp.asarray(x, jnp.float32)
   if (num_groups is None and group_size is None) or (
-      num_groups is not None and group_size is not None
+    num_groups is not None and group_size is not None
   ):
     raise ValueError(
-        'Either `num_groups` or `group_size` should be '
-        'specified, but not both of them.'
+      'Either `num_groups` or `group_size` should be '
+      'specified, but not both of them.'
     )
 
   if group_size is not None:
     channels = x.shape[-1]
     if channels % group_size != 0:
       raise ValueError(
-          'Number of channels ({}) is not multiple of the '
-          'group size ({}).'.format(channels, group_size)
+        'Number of channels ({}) is not multiple of the '
+        'group size ({}).'.format(channels, group_size)
       )
     num_groups = channels // group_size
 

--- a/flax/core/nn/stochastic.py
+++ b/flax/core/nn/stochastic.py
@@ -14,9 +14,8 @@
 
 """Stochastic modules."""
 
-from jax import lax
-from jax import random
 import jax.numpy as jnp
+from jax import lax, random
 
 
 def dropout(scope, inputs, rate, deterministic=False, rng=None):

--- a/flax/core/partial_eval.py
+++ b/flax/core/partial_eval.py
@@ -12,9 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any
-
 import functools
+from typing import Any
 
 import jax
 from jax import core

--- a/flax/core/tracers.py
+++ b/flax/core/tracers.py
@@ -14,8 +14,9 @@
 
 """Functionality for inspecting jax tracers."""
 
-from .. import errors
 import jax
+
+from .. import errors
 
 
 def current_trace():

--- a/flax/cursor.py
+++ b/flax/cursor.py
@@ -12,12 +12,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import dataclasses
 import enum
-from typing import Any, Callable, Dict, Generator, Generic, Mapping, Optional, Protocol, TypeVar, runtime_checkable
+from typing import (
+  Any,
+  Callable,
+  Dict,
+  Generator,
+  Generic,
+  Mapping,
+  Optional,
+  Protocol,
+  TypeVar,
+  runtime_checkable,
+)
+
 from flax.core import FrozenDict
 from flax.errors import CursorFindError, TraverseTreeError
-import dataclasses
-
 
 A = TypeVar('A')
 Key = Any
@@ -25,7 +36,6 @@ Key = Any
 
 @runtime_checkable
 class Indexable(Protocol):
-
   def __getitem__(self, key) -> Any:
     ...
 
@@ -44,10 +54,10 @@ class ParentKey(Generic[A]):
 
 def is_named_tuple(obj):
   return (
-      isinstance(obj, tuple)
-      and hasattr(obj, '_fields')
-      and hasattr(obj, '_asdict')
-      and hasattr(obj, '_replace')
+    isinstance(obj, tuple)
+    and hasattr(obj, '_fields')
+    and hasattr(obj, '_asdict')
+    and hasattr(obj, '_replace')
   )
 
 
@@ -93,9 +103,7 @@ def _traverse_tree(path, obj, *, update_fn=None, cond_fn=None):
     access_type = AccessType.ITEM
   elif dataclasses.is_dataclass(obj):
     items = (
-        (f.name, getattr(obj, f.name))
-        for f in dataclasses.fields(obj)
-        if f.init
+      (f.name, getattr(obj, f.name)) for f in dataclasses.fields(obj) if f.init
     )
     access_type = AccessType.ATTR
   else:
@@ -104,12 +112,12 @@ def _traverse_tree(path, obj, *, update_fn=None, cond_fn=None):
   if update_fn:
     for key, value in items:
       yield from _traverse_tree(
-          path + ((key, access_type),), value, update_fn=update_fn
+        path + ((key, access_type),), value, update_fn=update_fn
       )
   else:
     for key, value in items:
       yield from _traverse_tree(
-          path + ((key, access_type),), value, cond_fn=cond_fn
+        path + ((key, access_type),), value, cond_fn=cond_fn
       )
 
 
@@ -170,7 +178,7 @@ class Cursor(Generic[A]):
       raise AttributeError(f'Attribute {name} not found in {self._obj}')
 
     child = Cursor(
-        getattr(self._obj, name), ParentKey(self, name, AccessType.ATTR)
+      getattr(self._obj, name), ParentKey(self, name, AccessType.ATTR)
     )
     self._changes[name] = child
     return child
@@ -254,8 +262,8 @@ class Cursor(Generic[A]):
       A copy of the original object with the accumulated changes.
     """
     changes = {
-        key: child.build() if isinstance(child, Cursor) else child
-        for key, child in self._changes.items()
+      key: child.build() if isinstance(child, Cursor) else child
+      for key, child in self._changes.items()
     }
     if isinstance(self._obj, FrozenDict):
       obj = self._obj.copy(changes)  # type: ignore
@@ -277,8 +285,8 @@ class Cursor(Generic[A]):
     return obj  # type: ignore
 
   def apply_update(
-      self,
-      update_fn: Callable[[str, Any], Any],
+    self,
+    update_fn: Callable[[str, Any], Any],
   ) -> 'Cursor[A]':
     """Traverse the Cursor object and record conditional changes recursively via an ``update_fn``.
     The changes are recorded in the Cursor object's ``._changes`` dictionary. To generate a copy
@@ -470,7 +478,7 @@ class Cursor(Generic[A]):
       return cursor
 
   def find_all(
-      self, cond_fn: Callable[[str, Any], bool]
+    self, cond_fn: Callable[[str, Any], bool]
   ) -> Generator['Cursor[A]', None, None]:
     """Traverse the Cursor object and return a generator of child Cursor objects that fulfill the
     conditions in the ``cond_fn``. The ``cond_fn`` has a function signature of ``(str, Any) -> bool``:
@@ -552,7 +560,7 @@ class Cursor(Generic[A]):
   def _pretty_repr(self, indent=2, _prefix_indent=0):
     s = 'Cursor(\n'
     obj_str = repr(self._obj).replace(
-        '\n', '\n' + ' ' * (_prefix_indent + indent)
+      '\n', '\n' + ' ' * (_prefix_indent + indent)
     )
     s += ' ' * (_prefix_indent + indent) + f'_obj={obj_str},\n'
     s += ' ' * (_prefix_indent + indent) + '_changes={'
@@ -562,14 +570,14 @@ class Cursor(Generic[A]):
         str_key = repr(key)
         prefix = ' ' * (_prefix_indent + 2 * indent) + str_key + ': '
         s += (
-            prefix
-            + self._changes[key]._pretty_repr(
-                indent=indent, _prefix_indent=len(prefix)
-            )
-            + ',\n'
+          prefix
+          + self._changes[key]._pretty_repr(
+            indent=indent, _prefix_indent=len(prefix)
+          )
+          + ',\n'
         )
       s = s[
-          :-2
+        :-2
       ]  # remove comma and newline character for last element in self._changes
       s += '\n' + ' ' * (_prefix_indent + indent) + '}\n'
     else:
@@ -585,8 +593,8 @@ class Cursor(Generic[A]):
       return (self[i] for i in range(len(self._obj)))
     else:
       raise NotImplementedError(
-          '__iter__ method only implemented for tuples and lists, not type'
-          f' {type(self._obj)}'
+        '__iter__ method only implemented for tuples and lists, not type'
+        f' {type(self._obj)}'
       )
 
   def __reversed__(self):
@@ -594,8 +602,8 @@ class Cursor(Generic[A]):
       return (self[i] for i in range(len(self._obj) - 1, -1, -1))
     else:
       raise NotImplementedError(
-          '__reversed__ method only implemented for tuples and lists, not type'
-          f' {type(self._obj)}'
+        '__reversed__ method only implemented for tuples and lists, not type'
+        f' {type(self._obj)}'
       )
 
   def __add__(self, other):

--- a/flax/errors.py
+++ b/flax/errors.py
@@ -50,10 +50,9 @@ class Template(FlaxError):
 
 
 class FlaxError(Exception):
-
   def __init__(self, message):
     error_page = (
-        'https://flax.readthedocs.io/en/latest/api_reference/flax.errors.html'
+      'https://flax.readthedocs.io/en/latest/api_reference/flax.errors.html'
     )
     module_name = self.__class__.__module__
     class_name = self.__class__.__name__
@@ -88,8 +87,8 @@ class LazyInitError(FlaxError):
 
   def __init__(self, partial_val):
     super().__init__(
-        'Lazy init encountered a value that could with '
-        f'the given inputs (shape: {partial_val}).'
+      'Lazy init encountered a value that could with '
+      f'the given inputs (shape: {partial_val}).'
     )
 
 
@@ -168,9 +167,9 @@ class ApplyScopeInvalidVariablesTypeError(FlaxError):
 
   def __init__(self):
     super().__init__(
-        'The first argument passed to an apply function should be '
-        'a dictionary of collections. Each collection should be a '
-        'dictionary with string keys.'
+      'The first argument passed to an apply function should be '
+      'a dictionary of collections. Each collection should be a '
+      'dictionary with string keys.'
     )
 
 
@@ -183,10 +182,10 @@ class ApplyScopeInvalidVariablesStructureError(FlaxError):
 
   def __init__(self, variables):
     super().__init__(
-        f'Expect the `variables` (first argument) passed to apply() '
-        f'to be a dict with the structure {{"params": ...}}, but got a dict '
-        f'with an extra params layer, i.e.  {{"params": {{"params": ... }} }}. '
-        f'You should instead pass in your dict\'s ["params"].'
+      f'Expect the `variables` (first argument) passed to apply() '
+      f'to be a dict with the structure {{"params": ...}}, but got a dict '
+      f'with an extra params layer, i.e.  {{"params": {{"params": ... }} }}. '
+      f'You should instead pass in your dict\'s ["params"].'
     )
 
 
@@ -215,8 +214,8 @@ class ScopeParamNotFoundError(FlaxError):
 
   def __init__(self, param_name, scope_path):
     super().__init__(
-        f'Could not find parameter named "{param_name}" in scope '
-        f'"{scope_path}".'
+      f'Could not find parameter named "{param_name}" in scope '
+      f'"{scope_path}".'
     )
 
 
@@ -235,8 +234,8 @@ class ScopeCollectionNotFound(FlaxError):
 
   def __init__(self, col_name, var_name, scope_path):
     super().__init__(
-        f'Tried to access "{var_name}" from collection "{col_name}" in '
-        f'"{scope_path}" but the collection is empty.'
+      f'Tried to access "{var_name}" from collection "{col_name}" in '
+      f'"{scope_path}" but the collection is empty.'
     )
 
 
@@ -270,9 +269,9 @@ class ScopeParamShapeError(FlaxError):
 
   def __init__(self, param_name, scope_path, value_shape, init_shape):
     super().__init__(
-        f'Initializer expected to generate shape {init_shape} '
-        f'but got shape {value_shape} instead for parameter '
-        f'"{param_name}" in "{scope_path}".'
+      f'Initializer expected to generate shape {init_shape} '
+      f'but got shape {value_shape} instead for parameter '
+      f'"{param_name}" in "{scope_path}".'
     )
 
 
@@ -286,8 +285,8 @@ class ScopeVariableNotFoundError(FlaxError):
 
   def __init__(self, name, col, scope_path):
     super().__init__(
-        f'No Variable named "{name}" for collection "{col}" '
-        f'exists in "{scope_path}".'
+      f'No Variable named "{name}" for collection "{col}" '
+      f'exists in "{scope_path}".'
     )
 
 
@@ -333,8 +332,8 @@ class ModifyScopeVariableError(FlaxError):
 
   def __init__(self, col, variable_name, scope_path):
     super().__init__(
-        f'Cannot update variable "{variable_name}" in '
-        f'"{scope_path}" because collection "{col}" is immutable.'
+      f'Cannot update variable "{variable_name}" in '
+      f'"{scope_path}" because collection "{col}" is immutable.'
     )
 
 
@@ -365,8 +364,8 @@ class PartitioningUnspecifiedError(FlaxError):
 
   def __init__(self, target):
     super().__init__(
-        'Trying to transform a Partitioned variable but "partition_name"'
-        f' is not specified in metadata_params: {target}'
+      'Trying to transform a Partitioned variable but "partition_name"'
+      f' is not specified in metadata_params: {target}'
     )
 
 
@@ -427,8 +426,8 @@ class NameInUseError(FlaxError):
   def __init__(self, key_type, value, module_name):
     # key_type is in {param, variable, submodule}.
     super().__init__(
-        f'Could not create {key_type} "{value}" in Module '
-        f'{module_name}: Name in use.'
+      f'Could not create {key_type} "{value}" in Module '
+      f'{module_name}: Name in use.'
     )
 
 
@@ -472,8 +471,8 @@ class AssignSubModuleError(FlaxError):
 
   def __init__(self, cls):
     super().__init__(
-        f'Submodule {cls} must be defined in `setup()` or in a '
-        'method wrapped in `@compact`'
+      f'Submodule {cls} must be defined in `setup()` or in a '
+      'method wrapped in `@compact`'
     )
 
 
@@ -546,9 +545,9 @@ class SetAttributeFrozenModuleError(FlaxError):
 
   def __init__(self, module_cls, attr_name, attr_val):
     super().__init__(
-        f"Can't set {attr_name}={attr_val} for Module of type "
-        f'{module_cls}: Module instance is frozen outside of '
-        'setup method.'
+      f"Can't set {attr_name}={attr_val} for Module of type "
+      f'{module_cls}: Module instance is frozen outside of '
+      'setup method.'
     )
 
 
@@ -581,7 +580,7 @@ class ReservedModuleAttributeError(FlaxError):
 
   def __init__(self, annotations):
     super().__init__(
-        f'properties `parent` and `name` are reserved: {annotations}'
+      f'properties `parent` and `name` are reserved: {annotations}'
     )
 
 
@@ -598,7 +597,7 @@ class ApplyModuleInvalidMethodError(FlaxError):
 
   def __init__(self, method):
     super().__init__(
-        f'Cannot call apply(): {method} is not a valid function for apply().'
+      f'Cannot call apply(): {method} is not a valid function for apply().'
     )
 
 
@@ -708,8 +707,8 @@ class InvalidInstanceModuleError(FlaxError):
 
   def __init__(self):
     super().__init__(
-        'Can only call init, init_with_output or apply methods on an instance'
-        ' of the Module class, not the Module class itself'
+      'Can only call init, init_with_output or apply methods on an instance'
+      ' of the Module class, not the Module class itself'
     )
 
 
@@ -736,7 +735,7 @@ class IncorrectPostInitOverrideError(FlaxError):
 
   def __init__(self):
     super().__init__(
-        'Overrode `.__post_init__()` without calling `super().__post_init__()`'
+      'Overrode `.__post_init__()` without calling `super().__post_init__()`'
     )
 
 
@@ -758,8 +757,8 @@ class DescriptorAttributeError(FlaxError):
 
   def __init__(self):
     super().__init__(
-        'Trying to access a property that is accessing a non-existent'
-        ' attribute.'
+      'Trying to access a property that is accessing a non-existent'
+      ' attribute.'
     )
 
 
@@ -774,8 +773,8 @@ class InvalidCheckpointError(FlaxError):
 
   def __init__(self, path, step):
     super().__init__(
-        f'Trying to save an outdated checkpoint at step: "{step}" and path:'
-        f' "{path}".'
+      f'Trying to save an outdated checkpoint at step: "{step}" and path:'
+      f' "{path}".'
     )
 
 
@@ -792,9 +791,9 @@ class MPACheckpointingRequiredError(FlaxError):
 
   def __init__(self, path, step):
     super().__init__(
-        f'Checkpoint failed at step: "{step}" and path: "{path}": Target '
-        'contains a multiprocess array should be saved/restored with a '
-        'GlobalAsyncCheckpointManager.'
+      f'Checkpoint failed at step: "{step}" and path: "{path}": Target '
+      'contains a multiprocess array should be saved/restored with a '
+      'GlobalAsyncCheckpointManager.'
     )
 
 
@@ -810,10 +809,10 @@ class MPARestoreTargetRequiredError(FlaxError):
 
   def __init__(self, path, step, key=None):
     error_msg = (
-        f'Restore checkpoint failed at step: "{step}" and path: "{path}": '
-        'Checkpoints containing a multiprocess array need to be restored with '
-        'a target with pre-created arrays. If you cannot provide a full valid '
-        'target, consider ``allow_partial_mpa_restoration=True``. '
+      f'Restore checkpoint failed at step: "{step}" and path: "{path}": '
+      'Checkpoints containing a multiprocess array need to be restored with '
+      'a target with pre-created arrays. If you cannot provide a full valid '
+      'target, consider ``allow_partial_mpa_restoration=True``. '
     )
     if key:
       error_msg += f'This error fired when trying to restore array at {key}.'
@@ -828,9 +827,9 @@ class MPARestoreDataCorruptedError(FlaxError):
 
   def __init__(self, step, path):
     super().__init__(
-        f'Restore checkpoint failed at step: "{step}" on multiprocess array at '
-        f' "{path}": No "commit_success.txt" found on this "_gda" directory. '
-        'Was its save halted before completion?'
+      f'Restore checkpoint failed at step: "{step}" on multiprocess array at '
+      f' "{path}": No "commit_success.txt" found on this "_gda" directory. '
+      'Was its save halted before completion?'
     )
 
 
@@ -844,7 +843,7 @@ class TransformedMethodReturnValueError(FlaxError):
 
   def __init__(self, name):
     super().__init__(
-        f'Transformed module method {name} cannot return Modules or Variables.'
+      f'Transformed module method {name} cannot return Modules or Variables.'
     )
 
 
@@ -875,9 +874,9 @@ class TransformTargetError(FlaxError):
 
   def __init__(self, target):
     super().__init__(
-        'Linen transformations must be applied to Modules classes or'
-        ' functions taking a Module instance as the first argument.'
-        f' The provided target is not a Module class or callable: {target}'
+      'Linen transformations must be applied to Modules classes or'
+      ' functions taking a Module instance as the first argument.'
+      f' The provided target is not a Module class or callable: {target}'
     )
 
 
@@ -912,9 +911,9 @@ class CursorFindError(FlaxError):
   def __init__(self, cursor=None, cursor2=None):
     if cursor and cursor2:
       super().__init__(
-          'More than one object found given the conditions of the cond_fn. '
-          'The first two objects found have the following paths: '
-          f'{cursor._path} and {cursor2._path}'
+        'More than one object found given the conditions of the cond_fn. '
+        'The first two objects found have the following paths: '
+        f'{cursor._path} and {cursor2._path}'
       )
     else:
       super().__init__('No object found given the conditions of the cond_fn.')
@@ -937,11 +936,11 @@ class TraverseTreeError(FlaxError):
   def __init__(self, update_fn, cond_fn):
     if update_fn is None and cond_fn is None:
       super().__init__(
-          'Both update_fn and cond_fn are None. Exactly one of them must be'
-          ' None.'
+        'Both update_fn and cond_fn are None. Exactly one of them must be'
+        ' None.'
       )
     else:
       super().__init__(
-          'Both update_fn and cond_fn are not None. Exactly one of them must be'
-          ' not None.'
+        'Both update_fn and cond_fn are not None. Exactly one of them must be'
+        ' not None.'
       )

--- a/flax/ids.py
+++ b/flax/ids.py
@@ -55,7 +55,7 @@ class FlaxId:
     return hash(self.id)
 
   def __repr__(self):
-    return f"FlaxId({self.id})"
+    return f'FlaxId({self.id})'
 
   def __deepcopy__(self, memo):
     del memo

--- a/flax/io.py
+++ b/flax/io.py
@@ -17,15 +17,15 @@ The sole purpose of this abstraction layer is to avoid requiring tensorflow
 as an open-source dependency solely for its tensorflow.io.gfile functions.
 """
 import contextlib
-from enum import Enum
 import glob as glob_module
 import importlib
 import os
 import shutil
+from enum import Enum
 
 from absl import logging
-from . import errors
 
+from . import errors
 
 # Global Modes and selective import of tensorflow.io gfile.
 
@@ -38,15 +38,15 @@ class BackendMode(Enum):
 io_mode = None
 gfile = None
 
-if importlib.util.find_spec("tensorflow"):
+if importlib.util.find_spec('tensorflow'):
   from tensorflow.io import gfile  # type: ignore
 
   io_mode = BackendMode.TF
 else:
   logging.warning(
-      "Tensorflow library not found, tensorflow.io.gfile "
-      "operations will use native shim calls. "
-      "GCS paths (i.e. 'gs://...') cannot be accessed."
+    'Tensorflow library not found, tensorflow.io.gfile '
+    'operations will use native shim calls. '
+    "GCS paths (i.e. 'gs://...') cannot be accessed."
   )
   io_mode = BackendMode.DEFAULT
 
@@ -96,14 +96,14 @@ def set_mode(override: BackendMode):
 
 def GFile(name, mode):  # pylint: disable=invalid-name
   if io_mode == BackendMode.DEFAULT:
-    if "b" in mode:
+    if 'b' in mode:
       return open(name, mode)  # pylint: disable=unspecified-encoding
     else:
-      return open(name, mode, encoding="utf-8")
+      return open(name, mode, encoding='utf-8')
   elif io_mode == BackendMode.TF:
     return gfile.GFile(name, mode)
   else:
-    raise ValueError("Unknown IO Backend Mode.")
+    raise ValueError('Unknown IO Backend Mode.')
 
 
 def listdir(path):
@@ -112,7 +112,7 @@ def listdir(path):
   elif io_mode == BackendMode.TF:
     return gfile.listdir(path=path)
   else:
-    raise ValueError("Unknown IO Backend Mode.")
+    raise ValueError('Unknown IO Backend Mode.')
 
 
 def isdir(path):
@@ -121,7 +121,7 @@ def isdir(path):
   elif io_mode == BackendMode.TF:
     return gfile.isdir(path)
   else:
-    raise ValueError("Unknown IO Backend Mode.")
+    raise ValueError('Unknown IO Backend Mode.')
 
 
 def copy(src, dst, overwrite=False):
@@ -133,7 +133,7 @@ def copy(src, dst, overwrite=False):
   elif io_mode == BackendMode.TF:
     return gfile.copy(src, dst, overwrite=overwrite)
   else:
-    raise ValueError("Unknown IO Backend Mode.")
+    raise ValueError('Unknown IO Backend Mode.')
 
 
 def rename(src, dst, overwrite=False):
@@ -144,7 +144,7 @@ def rename(src, dst, overwrite=False):
   elif io_mode == BackendMode.TF:
     return gfile.rename(src, dst, overwrite=overwrite)
   else:
-    raise ValueError("Unknown IO Backend Mode.")
+    raise ValueError('Unknown IO Backend Mode.')
 
 
 def exists(path):
@@ -153,7 +153,7 @@ def exists(path):
   elif io_mode == BackendMode.TF:
     return gfile.exists(path)
   else:
-    raise ValueError("Unknown IO Backend Mode.")
+    raise ValueError('Unknown IO Backend Mode.')
 
 
 def makedirs(path):
@@ -162,18 +162,18 @@ def makedirs(path):
   elif io_mode == BackendMode.TF:
     return gfile.makedirs(path)
   else:
-    raise ValueError("Unknown IO Backend Mode.")
+    raise ValueError('Unknown IO Backend Mode.')
 
 
 def glob(pattern):
   if io_mode == BackendMode.DEFAULT:
     return [
-        path.rstrip("/") for path in glob_module.glob(pattern, recursive=False)
+      path.rstrip('/') for path in glob_module.glob(pattern, recursive=False)
     ]
   elif io_mode == BackendMode.TF:
     return gfile.glob(pattern)
   else:
-    raise ValueError("Unknown IO Backend Mode.")
+    raise ValueError('Unknown IO Backend Mode.')
 
 
 def remove(path):
@@ -183,7 +183,7 @@ def remove(path):
   elif io_mode == BackendMode.TF:
     return gfile.remove(path)
   else:
-    raise ValueError("Unknown IO Backend Mode.")
+    raise ValueError('Unknown IO Backend Mode.')
 
 
 def rmtree(path):
@@ -193,7 +193,7 @@ def rmtree(path):
   elif io_mode == BackendMode.TF:
     return gfile.rmtree(path)
   else:
-    raise ValueError("Unknown IO Backend Mode.")
+    raise ValueError('Unknown IO Backend Mode.')
 
 
 def getsize(path):
@@ -203,4 +203,4 @@ def getsize(path):
   elif io_mode == BackendMode.TF:
     return gfile.stat(path).length
   else:
-    raise ValueError("Unknown IO Backend Mode.")
+    raise ValueError('Unknown IO Backend Mode.')

--- a/flax/jax_utils.py
+++ b/flax/jax_utils.py
@@ -15,17 +15,16 @@
 """Utilities we could consider upstreaming to Jax."""
 
 import collections
-from collections.abc import Iterable  # pylint: disable=g-importing-member
 import itertools
 import warnings
+from collections.abc import Iterable  # pylint: disable=g-importing-member
 
 import jax
-from jax import core
-from jax import lax
-from jax.extend import linear_util as lu
-from jax.interpreters import partial_eval as pe
 import jax.numpy as jnp
 import numpy as np
+from jax import core, lax
+from jax.extend import linear_util as lu
+from jax.interpreters import partial_eval as pe
 
 
 def _pmap_device_order():
@@ -52,7 +51,7 @@ def unreplicate(tree):
 
 
 def pmean(xs, axis_name):
-  warnings.warn("use jax.lax.pmean instead", DeprecationWarning)
+  warnings.warn('use jax.lax.pmean instead', DeprecationWarning)
   return lax.pmean(xs, axis_name)
 
 
@@ -82,13 +81,13 @@ def partial_eval_by_shape(fn, input_spec, *args, **kwargs):
   inputs_flat, in_tree = jax.tree_util.tree_flatten(input_structs)
   f_flat, out_tree = jax.api_util.flatten_fun_nokwargs(lu.wrap_init(f), in_tree)
   in_pvals = [
-      pe.PartialVal.unknown(core.ShapedArray(x.shape, x.dtype))
-      for x in inputs_flat
+    pe.PartialVal.unknown(core.ShapedArray(x.shape, x.dtype))
+    for x in inputs_flat
   ]
   _, out_pvals, _ = pe.trace_to_jaxpr_nounits(f_flat, in_pvals)
   out_flat = [
-      const if pv is None else jax.ShapeDtypeStruct(pv.shape, pv.dtype)
-      for pv, const in out_pvals
+    const if pv is None else jax.ShapeDtypeStruct(pv.shape, pv.dtype)
+    for pv, const in out_pvals
   ]
   return jax.tree_util.tree_unflatten(out_tree(), out_flat)
 
@@ -219,7 +218,7 @@ def scan_in_dim(body_fn, init, xs, axis=(0,), unroll=(1,), keepdims=False):
   def body_wrapper(c, xs):
     if keepdims:
       xs = jax.tree_util.tree_map(
-          lambda x: x.reshape((1,) * len(axis) + x.shape), xs
+        lambda x: x.reshape((1,) * len(axis) + x.shape), xs
       )
       xs = jax.tree_util.tree_map(transpose_out, xs)
     c, ys = body_fn(c, xs)
@@ -236,7 +235,7 @@ def scan_in_dim(body_fn, init, xs, axis=(0,), unroll=(1,), keepdims=False):
 
 # Copied from https://github.com/google-research/big_vision
 def pad_shard_unpad(
-    wrapped, static_argnums=(0,), static_argnames=(), static_return=False
+  wrapped, static_argnums=(0,), static_argnames=(), static_return=False
 ):
   """Wraps a function with code that pads, shards, then un-shards, un-pads.
 
@@ -281,7 +280,7 @@ def pad_shard_unpad(
     for k, v in kw.items():
       if k not in static_argnames:
         batch_sizes |= {t.shape[0] for t in jax.tree_util.tree_leaves(v)}
-    assert len(batch_sizes) == 1, f"Inconsistent batch-sizes: {batch_sizes}"
+    assert len(batch_sizes) == 1, f'Inconsistent batch-sizes: {batch_sizes}'
     b = batch_sizes.pop()
 
     def pad(x):
@@ -292,7 +291,7 @@ def pad_shard_unpad(
         db += 1
       if min_device_batch and db < min_device_batch:
         x = np.concatenate(
-            [x, np.zeros((d * (min_device_batch - db), *shape), x.dtype)]
+          [x, np.zeros((d * (min_device_batch - db), *shape), x.dtype)]
         )
         db = min_device_batch
       return x.reshape(d, db, *shape)

--- a/flax/linen/combinators.py
+++ b/flax/linen/combinators.py
@@ -75,13 +75,13 @@ class Sequential(Module):
   def __post_init__(self):
     if not isinstance(self.layers, Sequence):
       raise ValueError(
-          f"'layers' must be a sequence, got '{type(self.layers).__name__}'."
+        f"'layers' must be a sequence, got '{type(self.layers).__name__}'."
       )
     super().__post_init__()
 
   def __call__(self, *args, **kwargs):
     if not self.layers:
-      raise ValueError(f"Empty Sequential module {self.name}.")
+      raise ValueError(f'Empty Sequential module {self.name}.')
 
     outputs = self.layers[0](*args, **kwargs)
     for layer in self.layers[1:]:

--- a/flax/linen/dtypes.py
+++ b/flax/linen/dtypes.py
@@ -27,17 +27,16 @@
 # limitations under the License.
 """APIs for handling dtypes in Linen Modules."""
 
-from typing import Any, Optional, List
+from typing import Any, List, Optional
 
 from jax import numpy as jnp
-
 
 Dtype = Any
 Array = Any
 
 
 def canonicalize_dtype(
-    *args, dtype: Optional[Dtype] = None, inexact: bool = True
+  *args, dtype: Optional[Dtype] = None, inexact: bool = True
 ) -> Dtype:
   """Canonicalize an optional dtype to the definitive dtype.
 

--- a/flax/linen/initializers.py
+++ b/flax/linen/initializers.py
@@ -16,6 +16,7 @@
 
 # pylint: disable=unused-import
 # re-export initializer functions from jax.nn
+from jax.nn.initializers import Initializer as Initializer
 from jax.nn.initializers import constant as constant
 from jax.nn.initializers import delta_orthogonal as delta_orthogonal
 from jax.nn.initializers import glorot_normal as glorot_normal
@@ -27,15 +28,15 @@ from jax.nn.initializers import kaiming_uniform as kaiming_uniform
 from jax.nn.initializers import lecun_normal as lecun_normal
 from jax.nn.initializers import lecun_uniform as lecun_uniform
 from jax.nn.initializers import normal as normal
-from jax.nn.initializers import truncated_normal as truncated_normal
 from jax.nn.initializers import ones as ones
 from jax.nn.initializers import orthogonal as orthogonal
+from jax.nn.initializers import truncated_normal as truncated_normal
 from jax.nn.initializers import uniform as uniform
 from jax.nn.initializers import variance_scaling as variance_scaling
 from jax.nn.initializers import xavier_normal as xavier_normal
 from jax.nn.initializers import xavier_uniform as xavier_uniform
 from jax.nn.initializers import zeros as zeros
-from jax.nn.initializers import Initializer as Initializer
+
 # pylint: enable=unused-import
 
 

--- a/flax/linen/kw_only_dataclasses.py
+++ b/flax/linen/kw_only_dataclasses.py
@@ -51,11 +51,13 @@ end of the parameter list (after all non-keyword-only parameters).
 """
 
 import dataclasses
-import inspect
 import functools
+import inspect
 from types import MappingProxyType
 from typing import Any, TypeVar
+
 from typing_extensions import dataclass_transform
+
 import flax
 
 M = TypeVar('M', bound='flax.linen.Module')
@@ -88,9 +90,9 @@ def field(*, metadata=None, kw_only=dataclasses.MISSING, **kwargs):
   """
   if kw_only is not dataclasses.MISSING and kw_only:
     if (
-        kwargs.get('default', dataclasses.MISSING) is dataclasses.MISSING
-        and kwargs.get('default_factory', dataclasses.MISSING)
-        is dataclasses.MISSING
+      kwargs.get('default', dataclasses.MISSING) is dataclasses.MISSING
+      and kwargs.get('default_factory', dataclasses.MISSING)
+      is dataclasses.MISSING
     ):
       raise ValueError('Keyword-only fields with no default are not supported.')
     if metadata is None:
@@ -146,7 +148,7 @@ def _process_class(cls: type[M], extra_fields=None, **kwargs):
     elif kw_only_name is not None:
       if not hasattr(cls, name):
         raise ValueError(
-            'Keyword-only fields with no default are not supported.'
+          'Keyword-only fields with no default are not supported.'
         )
       default = getattr(cls, name)
       if isinstance(default, dataclasses.Field):
@@ -162,8 +164,8 @@ def _process_class(cls: type[M], extra_fields=None, **kwargs):
     for name, annotation, default in extra_fields:
       if not (isinstance(name, str) and isinstance(default, dataclasses.Field)):
         raise ValueError(
-            'Expected extra_fields to a be a list of '
-            '(name, type, Field) tuples.'
+          'Expected extra_fields to a be a list of '
+          '(name, type, Field) tuples.'
         )
       setattr(cls, name, default)
       cls.__annotations__[name] = annotation
@@ -174,14 +176,14 @@ def _process_class(cls: type[M], extra_fields=None, **kwargs):
       continue
     base_annotations = base.__dict__.get('__annotations__', {})
     base_dataclass_fields[base] = dict(
-        getattr(base, '__dataclass_fields__', {})
+      getattr(base, '__dataclass_fields__', {})
     )
     for base_field in list(dataclasses.fields(base)):
       field_name = base_field.name
       if base_field.metadata.get(KW_ONLY) or field_name in kw_only_fields:
         kw_only_fields[field_name] = (
-            base_annotations.get(field_name),
-            base_field,
+          base_annotations.get(field_name),
+          base_field,
         )
         del base.__dataclass_fields__[field_name]
 
@@ -190,7 +192,7 @@ def _process_class(cls: type[M], extra_fields=None, **kwargs):
   for name, annotation in list(cls_annotations.items()):
     value = getattr(cls, name, None)
     if (
-        isinstance(value, dataclasses.Field) and value.metadata.get(KW_ONLY)
+      isinstance(value, dataclasses.Field) and value.metadata.get(KW_ONLY)
     ) or name in kw_only_fields:
       del cls_annotations[name]
       kw_only_fields[name] = (annotation, value)
@@ -215,8 +217,8 @@ def _process_class(cls: type[M], extra_fields=None, **kwargs):
     dataclass_init = transformed_cls.__init__
     # use sum to count the number of init fields that are not keyword-only
     expected_num_args = sum(
-        f.init and not f.metadata.get(KW_ONLY, False)
-        for f in dataclasses.fields(transformed_cls)
+      f.init and not f.metadata.get(KW_ONLY, False)
+      for f in dataclasses.fields(transformed_cls)
     )
 
     @functools.wraps(dataclass_init)
@@ -226,8 +228,8 @@ def _process_class(cls: type[M], extra_fields=None, **kwargs):
         # we add + 1 to each to account for `self`, matching python's
         # default error message
         raise TypeError(
-            f'__init__() takes {expected_num_args + 1} positional '
-            f'arguments but {num_args + 1} were given'
+          f'__init__() takes {expected_num_args + 1} positional '
+          f'arguments but {num_args + 1} were given'
         )
 
       dataclass_init(self, *args, **kwargs)

--- a/flax/linen/module.py
+++ b/flax/linen/module.py
@@ -21,36 +21,52 @@ import functools
 import inspect
 import sys
 import threading
-from types import MappingProxyType
 import typing
-from typing import Any, Callable, Dict, Iterable, Iterator, List, Literal, Mapping, Optional, Tuple, Type, TypeVar, Union, overload
-from typing_extensions import Protocol, dataclass_transform
 import weakref
+from types import MappingProxyType
+from typing import (
+  Any,
+  Callable,
+  Dict,
+  Iterable,
+  Iterator,
+  List,
+  Literal,
+  Mapping,
+  Optional,
+  Tuple,
+  Type,
+  TypeVar,
+  Union,
+  overload,
+)
 
-import flax
-from flax import config
-from flax import core
-from flax import errors
-from flax import serialization
-from flax import traceback_util
-from flax import traverse_util
-from flax.core import meta
-from flax.core import partial_eval
-from flax.core import Scope
-from flax.core.frozen_dict import FrozenDict
-from flax.core.scope import CollectionFilter
-from flax.core.scope import DenyList
-from flax.core.scope import FrozenVariableDict
-from flax.core.scope import union_filters
-from flax.core.scope import Variable
-from flax.core.scope import VariableDict
-from flax.ids import FlaxId
-from flax.ids import uuid
-import flax.linen as nn
-from flax.linen import kw_only_dataclasses
 import jax
 import jax.numpy as jnp
+from typing_extensions import Protocol, dataclass_transform
 
+import flax
+import flax.linen as nn
+from flax import (
+  config,
+  core,
+  errors,
+  serialization,
+  traceback_util,
+  traverse_util,
+)
+from flax.core import Scope, meta, partial_eval
+from flax.core.frozen_dict import FrozenDict
+from flax.core.scope import (
+  CollectionFilter,
+  DenyList,
+  FrozenVariableDict,
+  Variable,
+  VariableDict,
+  union_filters,
+)
+from flax.ids import FlaxId, uuid
+from flax.linen import kw_only_dataclasses
 
 traceback_util.register_exclusion(__file__)
 
@@ -67,9 +83,9 @@ _CallableT = TypeVar('_CallableT', bound=Callable)
 
 # Used for abstractly testing module behavior.
 TestScope = type(
-    'TestScope',
-    (Scope,),
-    {'make_rng': lambda self, name: jax.random.key(0)},
+  'TestScope',
+  (Scope,),
+  {'make_rng': lambda self, name: jax.random.key(0)},
 )
 
 
@@ -90,8 +106,8 @@ def _indent(x: str, num_spaces: int):
 
 def _attr_repr(value: Any):
   if callable(value) and (
-      (isinstance(value, nn.Module) and value.__dict__.get('__name__', None))
-      or (not isinstance(value, nn.Module) and getattr(value, '__name__', None))
+    (isinstance(value, nn.Module) and value.__dict__.get('__name__', None))
+    or (not isinstance(value, nn.Module) and getattr(value, '__name__', None))
   ):
     value_rep = value.__name__
   else:
@@ -106,14 +122,14 @@ def _module_repr(module: 'Module', num_spaces: int = 4):
   rep = ''
 
   attributes = {
-      f.name: f.type
-      for f in dataclasses.fields(cls)
-      if f.name not in ('parent', 'name') and f.repr
+    f.name: f.type
+    for f in dataclasses.fields(cls)
+    if f.name not in ('parent', 'name') and f.repr
   }
   child_modules = {
-      k: v
-      for k, v in module._state.children.items()  # pytype: disable=attribute-error
-      if isinstance(v, Module)
+    k: v
+    for k, v in module._state.children.items()  # pytype: disable=attribute-error
+    if isinstance(v, Module)
   }
   if attributes:
     rep += '# attributes\n'
@@ -178,7 +194,7 @@ class _DynamicContext(threading.local):
 
   def __init__(self):
     self.module_stack = [
-        None,
+      None,
     ]
     self.capture_stack = []
     self.call_info_stack = []
@@ -189,7 +205,6 @@ _context = _DynamicContext()
 
 
 class _Sentinel:
-
   def __copy__(self):
     return self  # Do not copy singleton sentinel.
 
@@ -374,10 +389,10 @@ def intercept_methods(interceptor: Interceptor):
 
 
 def run_interceptors(
-    orig_method: Callable[..., Any],
-    module: 'Module',
-    *args,
-    **kwargs,
+  orig_method: Callable[..., Any],
+  module: 'Module',
+  *args,
+  **kwargs,
 ) -> Any:
   """Runs method interceptors."""
   method_name = _get_fn_name(orig_method)
@@ -410,7 +425,7 @@ def _sorted_items(x):
 
 
 def _get_suffix_value_pairs(
-    tree_or_leaf: Any,
+  tree_or_leaf: Any,
 ) -> List[Tuple[str, Type['Module']]]:
   """Helper for naming pytrees of submodules."""
   dict_or_leaf = serialization.to_state_dict(tree_or_leaf)
@@ -429,10 +444,10 @@ def _map_over_modules_in_tree(fn, tree_or_leaf):
   else:
     flat_dict = traverse_util.flatten_dict(dict_or_leaf, keep_empty_nodes=True)
     mapped_flat_dict = {
-        k: fn('_' + '_'.join(k), v) for k, v in _sorted_items(flat_dict)
+      k: fn('_' + '_'.join(k), v) for k, v in _sorted_items(flat_dict)
     }
     return serialization.from_state_dict(
-        tree_or_leaf, traverse_util.unflatten_dict(mapped_flat_dict)
+      tree_or_leaf, traverse_util.unflatten_dict(mapped_flat_dict)
     )
 
 
@@ -514,7 +529,7 @@ def nowrap(fun: _CallableT) -> _CallableT:
 
 
 def _get_local_method_names(
-    cls: Any, exclude: Iterable[str] = ()
+  cls: Any, exclude: Iterable[str] = ()
 ) -> Tuple[str, ...]:
   """Gets method names of a class, excluding class and static methods.
 
@@ -527,7 +542,9 @@ def _get_local_method_names(
   """
   true_methods = set()
   for m in cls.__dict__:
-    if callable(cls.__dict__[m]) and not inspect.isclass(cls.__dict__[m]):  # pytype: disable=not-supported-yet
+    if callable(cls.__dict__[m]) and not inspect.isclass(
+      cls.__dict__[m]
+    ):  # pytype: disable=not-supported-yet
       mtype = type(cls.__dict__[m])
       if mtype != staticmethod and mtype != classmethod:
         true_methods.add(m)
@@ -535,7 +552,7 @@ def _get_local_method_names(
 
 
 def _get_local_descriptor_names(
-    cls: Any, exclude: Iterable[str] = ()
+  cls: Any, exclude: Iterable[str] = ()
 ) -> Tuple[str, ...]:
   """Gets descriptor names of a class.
 
@@ -549,9 +566,9 @@ def _get_local_descriptor_names(
   true_properties = set()
   for m, attr in cls.__dict__.items():
     if not callable(attr) and (
-        hasattr(attr, '__get__')
-        or hasattr(attr, '__set__')
-        or hasattr(attr, '__delete__')
+      hasattr(attr, '__get__')
+      or hasattr(attr, '__set__')
+      or hasattr(attr, '__delete__')
     ):
       mtype = type(attr)
       if mtype != staticmethod and mtype != classmethod:
@@ -616,9 +633,9 @@ def _wrap_hash(hash_fn: Callable[..., Any]) -> Callable[..., Any]:
       hash_value = hash_fn(self)
     except TypeError as exc:
       raise TypeError(
-          'Failed to hash Flax Module.  '
-          'The module probably contains unhashable attributes.  '
-          f'Module={self}'
+        'Failed to hash Flax Module.  '
+        'The module probably contains unhashable attributes.  '
+        f'Module={self}'
       ) from exc
     return hash_value
 
@@ -639,15 +656,15 @@ def _get_unbound_fn(method_or_fn: Callable[..., Any]) -> Callable[..., Any]:
     An unbound version of input function.
   """
   if inspect.ismethod(method_or_fn) and isinstance(
-      method_or_fn.__self__, Module
+    method_or_fn.__self__, Module
   ):  # pytype: disable=attribute-error
     method_or_fn = method_or_fn.__func__  # pytype: disable=attribute-error
 
   # The method should be callable, and it should have at least one argument
   # representing the class that is passed in.
   if (
-      not callable(method_or_fn)
-      or len(inspect.signature(method_or_fn).parameters) < 1
+    not callable(method_or_fn)
+    or len(inspect.signature(method_or_fn).parameters) < 1
   ):
     raise errors.ApplyModuleInvalidMethodError(method_or_fn)
 
@@ -684,7 +701,7 @@ class _ModuleInternalState:
   is_initialized: bool = False
   autoname_cursor: Dict[str, int] = dataclasses.field(default_factory=dict)
   children: Dict[str, Union[str, 'Module']] = dataclasses.field(
-      default_factory=dict
+    default_factory=dict
   )
 
   def reset(self) -> None:
@@ -700,14 +717,14 @@ class _ModuleInternalState:
   def export(self) -> '_ModuleInternalState':
     """Exports transform-preserved state across transform boundary."""
     setup_state = (
-        SetupState.TRANSFORMED if self.setup_called else SetupState.NEW
+      SetupState.TRANSFORMED if self.setup_called else SetupState.NEW
     )
     cloned = _ModuleInternalState(
-        in_compact_method=self.in_compact_method,
-        in_setup=self.in_setup,
-        setup_called=setup_state,
-        is_initialized=self.is_initialized,
-        autoname_cursor=dict(self.autoname_cursor),
+      in_compact_method=self.in_compact_method,
+      in_setup=self.in_setup,
+      setup_called=setup_state,
+      is_initialized=self.is_initialized,
+      autoname_cursor=dict(self.autoname_cursor),
     )
     return cloned
 
@@ -723,19 +740,17 @@ _uninitialized_module_internal_state = _ModuleInternalState()
 
 
 _UNDEFINED_COPY_PICKLE_METHODS = (
-    '__getstate__',
-    '__setstate__',
-    '__getnewargs_ex__',
-    '__reduce__',
-    '__reduce_ex__',
-    '__copy__',
-    '__deepcopy__',
+  '__getstate__',
+  '__setstate__',
+  '__getnewargs_ex__',
+  '__reduce__',
+  '__reduce_ex__',
+  '__copy__',
+  '__deepcopy__',
 )
 
 
-_caches: 'weakref.WeakKeyDictionary[Scope, weakref.WeakValueDictionary[FlaxId, Module]]' = (
-    weakref.WeakKeyDictionary()
-)
+_caches: 'weakref.WeakKeyDictionary[Scope, weakref.WeakValueDictionary[FlaxId, Module]]' = weakref.WeakKeyDictionary()
 
 
 tuple_reduce = lambda xs, x: xs + (x,)
@@ -905,7 +920,7 @@ class Module(ModuleBase):
   if typing.TYPE_CHECKING:
     name: Optional[str] = module_field(kw_only=True, default=None)
     parent: Union['Module', _Sentinel, None] = module_field(
-        kw_only=True, default=None
+      kw_only=True, default=None
     )
 
     def __init__(self, *args, **kwargs):
@@ -964,29 +979,33 @@ class Module(ModuleBase):
         field_meta.repr = False
 
     extra_fields = [
-        (
-            'parent',
-            _ParentType,
-            kw_only_dataclasses.field(
-                repr=False, default=_unspecified_parent, kw_only=True
-            ),
+      (
+        'parent',
+        _ParentType,
+        kw_only_dataclasses.field(
+          repr=False, default=_unspecified_parent, kw_only=True
         ),
-        (
-            'name',
-            Optional[str],
-            kw_only_dataclasses.field(default=None, kw_only=True),
-        ),
+      ),
+      (
+        'name',
+        Optional[str],
+        kw_only_dataclasses.field(default=None, kw_only=True),
+      ),
     ]
 
     if kw_only:
       if tuple(sys.version_info)[:3] >= (3, 10, 0):
-        for name, annotation, default in extra_fields:  # pytype: disable=invalid-annotation
+        for (
+          name,
+          annotation,
+          default,
+        ) in extra_fields:  # pytype: disable=invalid-annotation
           setattr(cls, name, default)
           cls.__annotations__[name] = annotation
         dataclasses.dataclass(  # type: ignore[call-overload]
-            unsafe_hash='__hash__' not in cls.__dict__,
-            repr=False,
-            kw_only=True,
+          unsafe_hash='__hash__' not in cls.__dict__,
+          repr=False,
+          kw_only=True,
         )(cls)
       else:
         raise TypeError('`kw_only` is not available before Py 3.10.')
@@ -994,10 +1013,10 @@ class Module(ModuleBase):
       # Now apply dataclass transform (which operates in-place).
       # Do generate a hash function only if not provided by the class.
       kw_only_dataclasses.dataclass(
-          cls,
-          unsafe_hash='__hash__' not in cls.__dict__,
-          repr=False,
-          extra_fields=extra_fields,
+        cls,
+        unsafe_hash='__hash__' not in cls.__dict__,
+        repr=False,
+        extra_fields=extra_fields,
       )  # pytype: disable=wrong-keyword-args
 
     cls.__hash__ = _wrap_hash(cls.__hash__)  # type: ignore[method-assign]
@@ -1007,11 +1026,11 @@ class Module(ModuleBase):
     """Statically verifies that at most a single method is labelled compact."""
     methods = [m[0] for m in inspect.getmembers(cls, predicate=callable)]
     n_compact_fns = len(
-        [
-            method_name
-            for method_name in methods
-            if hasattr(getattr(cls, method_name), 'compact')
-        ]
+      [
+        method_name
+        for method_name in methods
+        if hasattr(getattr(cls, method_name), 'compact')
+      ]
     )
     if n_compact_fns > 1:
       raise errors.MultipleMethodsCompactError()
@@ -1024,11 +1043,11 @@ class Module(ModuleBase):
     """
     # wrap methods
     method_exclusions = [f.name for f in dataclasses.fields(cls)] + [
-        '__eq__',
-        '__repr__',
-        '__init__',
-        '__hash__',
-        '__post_init__',
+      '__eq__',
+      '__repr__',
+      '__init__',
+      '__hash__',
+      '__post_init__',
     ]
     for key in _get_local_method_names(cls, exclude=method_exclusions):
       method = getattr(cls, key)
@@ -1038,8 +1057,8 @@ class Module(ModuleBase):
 
     # wrap descriptors
     descriptor_exclusions = [f.name for f in dataclasses.fields(cls)] + [
-        'parent',
-        '__dict__',
+      'parent',
+      '__dict__',
     ]
     for key in _get_local_descriptor_names(cls, descriptor_exclusions):
       # don't use getattr here, since it will call the descriptor
@@ -1108,20 +1127,20 @@ class Module(ModuleBase):
           self.sow('intermediates', fun_name, y)
       if add_call_info:
         _args, _kwargs, _y = flax.linen.summary._represent_tree(
-            (args, kwargs, y)
+          (args, kwargs, y)
         )
         _context.call_info_stack[-1].calls.append(
-            _CallInfo(
-                call_index,
-                self.path,
-                self.clone(),
-                self.scope.rngs,
-                self.scope.mutable,
-                fun.__name__,
-                _args,
-                _kwargs,
-                _y,
-            )
+          _CallInfo(
+            call_index,
+            self.path,
+            self.clone(),
+            self.scope.rngs,
+            self.scope.mutable,
+            fun.__name__,
+            _args,
+            _kwargs,
+            _y,
+          )
         )
       return y
     finally:
@@ -1162,7 +1181,7 @@ class Module(ModuleBase):
         # We're past all initialization and setup logic:
         # Raises a TypeError just like frozen python dataclasses.
         raise errors.SetAttributeFrozenModuleError(
-            self.__class__.__name__, name, val
+          self.__class__.__name__, name, val
         )
 
     # We're inside the setup() method:
@@ -1188,8 +1207,8 @@ class Module(ModuleBase):
       msg = f'"{self.__class__.__name__}" object has no attribute "{name}".'
       if self.scope is None:
         msg += (
-            f' If "{name}" is defined in \'.setup()\', remember these fields '
-            "are only accessible from inside 'init' or 'apply'."
+          f' If "{name}" is defined in \'.setup()\', remember these fields '
+          "are only accessible from inside 'init' or 'apply'."
         )
       raise AttributeError(msg)
 
@@ -1224,7 +1243,9 @@ class Module(ModuleBase):
       # initialization is deferred until attachment by __setattr__
       # i.e. self.mymodule = MyModule(...)
       self.name: Optional[str]
-      if self.parent._state.in_setup and self.name is None:  # pytype: disable=attribute-error
+      if (
+        self.parent._state.in_setup and self.name is None
+      ):  # pytype: disable=attribute-error
         return
       if not self.parent._initialization_allowed:
         raise errors.AssignSubModuleError(self.__class__.__name__)
@@ -1236,8 +1257,8 @@ class Module(ModuleBase):
         self.parent._state.autoname_cursor[prefix] = cursor + 1
       # Allow scope aliasing under transforms for submodules defined in setup.
       reuse_scopes = (
-          self.parent._state.in_setup
-          and self.parent._state.setup_called == SetupState.TRANSFORMED
+        self.parent._state.in_setup
+        and self.parent._state.setup_called == SetupState.TRANSFORMED
       )
       # Perform name-collision check.
       if self.parent._name_taken(self.name, reuse_scopes=reuse_scopes):
@@ -1247,7 +1268,7 @@ class Module(ModuleBase):
       self.parent._state.children[self.name] = self
       assert self.parent.scope is not None
       object.__setattr__(
-          self, 'scope', self.parent.scope.push(self.name, reuse=reuse_scopes)
+        self, 'scope', self.parent.scope.push(self.name, reuse=reuse_scopes)
       )
 
     # Top-level invocation with a functional Scope.
@@ -1340,9 +1361,9 @@ class Module(ModuleBase):
       return subvalue
 
     val = _freeze_attr(
-        _map_over_modules_in_tree(
-            functools.partial(adopt_attr_modules, cache, queue), val
-        )
+      _map_over_modules_in_tree(
+        functools.partial(adopt_attr_modules, cache, queue), val
+      )
     )
     object.__setattr__(self, name, val)
     for x in queue:
@@ -1351,9 +1372,9 @@ class Module(ModuleBase):
   def _try_setup(self, shallow: bool = False) -> None:
     """Tries to setup module if scope is available and setup has not been called yet."""
     if (
-        self.scope
-        and not self._state.in_setup
-        and self._state.setup_called != SetupState.DONE
+      self.scope
+      and not self._state.in_setup
+      and self._state.setup_called != SetupState.DONE
     ):
       try:
         self._state.in_setup = True
@@ -1385,10 +1406,10 @@ class Module(ModuleBase):
     _ = jax.eval_shape(run_setup_only, 0)
 
   def _name_taken(
-      self,
-      name: str,
-      reuse_scopes: bool = False,
-      collection: Optional[str] = None,
+    self,
+    name: str,
+    reuse_scopes: bool = False,
+    collection: Optional[str] = None,
   ) -> bool:
     assert self.scope is not None
     if reuse_scopes:
@@ -1398,9 +1419,9 @@ class Module(ModuleBase):
   @property
   def _initialization_allowed(self):
     return (
-        not self._state.is_initialized  # allow eager attachment in post-init
-        or self._state.in_setup
-        or self._state.in_compact_method
+      not self._state.is_initialized  # allow eager attachment in post-init
+      or self._state.in_setup
+      or self._state.in_compact_method
     )
 
   @property
@@ -1411,12 +1432,12 @@ class Module(ModuleBase):
     return self.scope.path
 
   def clone(
-      self: M,
-      *,
-      parent: Optional[Union[Scope, 'Module']] = None,
-      _deep_clone: Union[bool, weakref.WeakValueDictionary] = False,
-      _reset_names: bool = False,
-      **updates,
+    self: M,
+    *,
+    parent: Optional[Union[Scope, 'Module']] = None,
+    _deep_clone: Union[bool, weakref.WeakValueDictionary] = False,
+    _reset_names: bool = False,
+    **updates,
   ) -> M:
     """Creates a clone of this Module, with optionally updated arguments.
 
@@ -1435,9 +1456,7 @@ class Module(ModuleBase):
       A clone of the this Module with the updated attributes and parent.
     """
     attrs = {
-        f.name: getattr(self, f.name)
-        for f in dataclasses.fields(self)
-        if f.init
+      f.name: getattr(self, f.name) for f in dataclasses.fields(self) if f.init
     }
 
     attrs.update(parent=parent, **updates)
@@ -1449,9 +1468,9 @@ class Module(ModuleBase):
       # We use a weak value dictionary to cache cloned submodules. When a shared
       # submodule is cloned, its only cloned once else its fetched from the cache.
       cache = (
-          weakref.WeakValueDictionary()
-          if isinstance(_deep_clone, bool)
-          else _deep_clone
+        weakref.WeakValueDictionary()
+        if isinstance(_deep_clone, bool)
+        else _deep_clone
       )
 
       def clone_fn(m: Module) -> Module:
@@ -1461,7 +1480,9 @@ class Module(ModuleBase):
             return cache[key]
           else:
             if _reset_names:
-              clone = m.clone(_deep_clone=cache, _reset_names=_reset_names, name=None)
+              clone = m.clone(
+                _deep_clone=cache, _reset_names=_reset_names, name=None
+              )
             else:
               clone = m.clone(_deep_clone=cache)
             cache[key] = clone
@@ -1482,54 +1503,54 @@ class Module(ModuleBase):
 
   @overload
   def variable(
-      self,
-      col: str,
-      name: str,
-      init_fn: Optional[Callable[..., T]] = None,
-      *init_args,
+    self,
+    col: str,
+    name: str,
+    init_fn: Optional[Callable[..., T]] = None,
+    *init_args,
   ) -> Variable[T]:
     ...
 
   @overload
   def variable(
-      self,
-      col: str,
-      name: str,
-      init_fn: Optional[Callable[..., T]] = None,
-      *init_args,
-      unbox: Literal[True],
+    self,
+    col: str,
+    name: str,
+    init_fn: Optional[Callable[..., T]] = None,
+    *init_args,
+    unbox: Literal[True],
   ) -> Variable[T]:
     ...
 
   @overload
   def variable(
-      self,
-      col: str,
-      name: str,
-      init_fn: Optional[Callable[..., T]] = None,
-      *init_args,
-      unbox: Literal[False],
+    self,
+    col: str,
+    name: str,
+    init_fn: Optional[Callable[..., T]] = None,
+    *init_args,
+    unbox: Literal[False],
   ) -> Variable[meta.AxisMetadata[T]]:
     ...
 
   @overload
   def variable(
-      self,
-      col: str,
-      name: str,
-      init_fn: Optional[Callable[..., T]] = None,
-      *init_args,
-      unbox: bool = True,
+    self,
+    col: str,
+    name: str,
+    init_fn: Optional[Callable[..., T]] = None,
+    *init_args,
+    unbox: bool = True,
   ) -> Union[Variable[T], Variable[meta.AxisMetadata[T]]]:
     ...
 
   def variable(
-      self,
-      col: str,
-      name: str,
-      init_fn: Optional[Callable[..., T]] = None,
-      *init_args,
-      unbox: bool = True,
+    self,
+    col: str,
+    name: str,
+    init_fn: Optional[Callable[..., T]] = None,
+    *init_args,
+    unbox: bool = True,
   ) -> Union[Variable[T], Variable[meta.AxisMetadata[T]]]:
     """Declares and returns a variable in this Module.
 
@@ -1564,8 +1585,8 @@ class Module(ModuleBase):
     """
     if not self._initialization_allowed:
       raise ValueError(
-          'Variables must be initialized in `setup()` or in a method '
-          'wrapped in `@compact`'
+        'Variables must be initialized in `setup()` or in a method '
+        'wrapped in `@compact`'
       )
     if self._name_taken(name, collection=col):
       raise errors.NameInUseError('variable', name, self.__class__.__name__)
@@ -1580,32 +1601,32 @@ class Module(ModuleBase):
 
   @overload
   def param(
-      self,
-      name: str,
-      init_fn: Callable[..., T],
-      *init_args,
-      unbox: Literal[True],
+    self,
+    name: str,
+    init_fn: Callable[..., T],
+    *init_args,
+    unbox: Literal[True],
   ) -> T:
     ...
 
   @overload
   def param(
-      self,
-      name: str,
-      init_fn: Callable[..., T],
-      *init_args,
-      unbox: Literal[False],
+    self,
+    name: str,
+    init_fn: Callable[..., T],
+    *init_args,
+    unbox: Literal[False],
   ) -> meta.AxisMetadata[T]:
     ...
 
   @overload
   def param(
-      self, name: str, init_fn: Callable[..., T], *init_args, unbox: bool
+    self, name: str, init_fn: Callable[..., T], *init_args, unbox: bool
   ) -> Union[T, meta.AxisMetadata[T]]:
     ...
 
   def param(
-      self, name: str, init_fn: Callable[..., T], *init_args, unbox: bool = True
+    self, name: str, init_fn: Callable[..., T], *init_args, unbox: bool = True
   ) -> Union[T, meta.AxisMetadata[T]]:
     """Declares and returns a parameter in this Module.
 
@@ -1637,8 +1658,8 @@ class Module(ModuleBase):
     """
     if not self._initialization_allowed:
       raise ValueError(
-          'Parameters must be initialized in `setup()` or in a method '
-          'wrapped in `@compact`'
+        'Parameters must be initialized in `setup()` or in a method '
+        'wrapped in `@compact`'
       )
     if self._name_taken(name, collection='params'):
       raise errors.NameInUseError('param', name, self.__class__.__name__)
@@ -1721,11 +1742,11 @@ class Module(ModuleBase):
 
   @traceback_util.api_boundary
   def bind(
-      self: M,
-      variables: VariableDict,
-      *args,
-      rngs: Optional[RNGSequences] = None,
-      mutable: CollectionFilter = False,
+    self: M,
+    variables: VariableDict,
+    *args,
+    rngs: Optional[RNGSequences] = None,
+    mutable: CollectionFilter = False,
   ) -> M:
     """Creates an interactive Module instance by binding variables and RNGs.
 
@@ -1819,16 +1840,14 @@ class Module(ModuleBase):
 
   @traceback_util.api_boundary
   def apply(
-      self,
-      variables: VariableDict,
-      *args,
-      rngs: Optional[RNGSequences] = None,
-      method: Union[Callable[..., Any], str, None] = None,
-      mutable: CollectionFilter = False,
-      capture_intermediates: Union[
-          bool, Callable[['Module', str], bool]
-      ] = False,
-      **kwargs,
+    self,
+    variables: VariableDict,
+    *args,
+    rngs: Optional[RNGSequences] = None,
+    method: Union[Callable[..., Any], str, None] = None,
+    mutable: CollectionFilter = False,
+    capture_intermediates: Union[bool, Callable[['Module', str], bool]] = False,
+    **kwargs,
   ) -> Union[Any, Tuple[Any, Union[FrozenVariableDict, Dict[str, Any]]]]:
     """Applies a module method to variables and returns output and modified variables.
 
@@ -1896,36 +1915,34 @@ class Module(ModuleBase):
       if not callable(method):
         class_name = type(self).__name__
         raise TypeError(
-            f"'{class_name}.{attribute_name}' must be a callable, got"
-            f' {type(method)}.'
+          f"'{class_name}.{attribute_name}' must be a callable, got"
+          f' {type(method)}.'
         )
       # if the `method` string is a submodule, we create a lambda function
       # that calls the submodule, forwarding all arguments.
       if isinstance(method, Module):
         method = lambda self, *args, **kwargs: getattr(self, attribute_name)(
-            *args, **kwargs
+          *args, **kwargs
         )
     elif method is None:
       method = self.__call__
     method = _get_unbound_fn(method)
     return apply(
-        method,
-        self,
-        mutable=mutable,
-        capture_intermediates=capture_intermediates,
+      method,
+      self,
+      mutable=mutable,
+      capture_intermediates=capture_intermediates,
     )(variables, *args, **kwargs, rngs=rngs)
 
   @traceback_util.api_boundary
   def init_with_output(
-      self,
-      rngs: Union[KeyArray, RNGSequences],
-      *args,
-      method: Union[Callable[..., Any], str, None] = None,
-      mutable: CollectionFilter = DenyList('intermediates'),
-      capture_intermediates: Union[
-          bool, Callable[['Module', str], bool]
-      ] = False,
-      **kwargs,
+    self,
+    rngs: Union[KeyArray, RNGSequences],
+    *args,
+    method: Union[Callable[..., Any], str, None] = None,
+    mutable: CollectionFilter = DenyList('intermediates'),
+    capture_intermediates: Union[bool, Callable[['Module', str], bool]] = False,
+    **kwargs,
   ) -> Tuple[Any, Union[FrozenVariableDict, Dict[str, Any]]]:
     """Initializes a module method with variables and returns output and modified variables.
 
@@ -1957,8 +1974,8 @@ class Module(ModuleBase):
     if not isinstance(rngs, dict):
       if not core.scope._is_valid_rng(rngs):
         raise errors.InvalidRngError(
-            'RNGs should be of shape (2,) or KeyArray in Module '
-            f'{self.__class__.__name__}, but rngs are: {rngs}'
+          'RNGs should be of shape (2,) or KeyArray in Module '
+          f'{self.__class__.__name__}, but rngs are: {rngs}'
         )
       rngs = {'params': rngs}
 
@@ -1968,30 +1985,28 @@ class Module(ModuleBase):
       if not callable(method):
         class_name = type(self).__name__
         raise TypeError(
-            f"'{class_name}.{attribute_name}' must be a callable, got"
-            f' {type(method)}.'
+          f"'{class_name}.{attribute_name}' must be a callable, got"
+          f' {type(method)}.'
         )
     elif method is None:
       method = self.__call__
     method = _get_unbound_fn(method)
     return init_with_output(
-        method,
-        self,
-        mutable=mutable,
-        capture_intermediates=capture_intermediates,
+      method,
+      self,
+      mutable=mutable,
+      capture_intermediates=capture_intermediates,
     )(rngs, *args, **kwargs)
 
   @traceback_util.api_boundary
   def init(
-      self,
-      rngs: Union[KeyArray, RNGSequences],
-      *args,
-      method: Union[Callable[..., Any], str, None] = None,
-      mutable: CollectionFilter = DenyList('intermediates'),
-      capture_intermediates: Union[
-          bool, Callable[['Module', str], bool]
-      ] = False,
-      **kwargs,
+    self,
+    rngs: Union[KeyArray, RNGSequences],
+    *args,
+    method: Union[Callable[..., Any], str, None] = None,
+    mutable: CollectionFilter = DenyList('intermediates'),
+    capture_intermediates: Union[bool, Callable[['Module', str], bool]] = False,
+    **kwargs,
   ) -> Union[FrozenVariableDict, Dict[str, Any]]:
     """Initializes a module method with variables and returns modified variables.
 
@@ -2081,23 +2096,23 @@ class Module(ModuleBase):
     Module._module_checks(self)
 
     _, v_out = self.init_with_output(
-        rngs,
-        *args,
-        method=method,
-        mutable=mutable,
-        capture_intermediates=capture_intermediates,
-        **kwargs,
+      rngs,
+      *args,
+      method=method,
+      mutable=mutable,
+      capture_intermediates=capture_intermediates,
+      **kwargs,
     )
     return v_out
 
   @traceback_util.api_boundary
   def lazy_init(
-      self,
-      rngs: Union[KeyArray, RNGSequences],
-      *args,
-      method: Optional[Callable[..., Any]] = None,
-      mutable: CollectionFilter = DenyList('intermediates'),
-      **kwargs,
+    self,
+    rngs: Union[KeyArray, RNGSequences],
+    *args,
+    method: Optional[Callable[..., Any]] = None,
+    mutable: CollectionFilter = DenyList('intermediates'),
+    **kwargs,
   ) -> FrozenVariableDict:
     """Initializes a module without computing on an actual input.
 
@@ -2183,22 +2198,22 @@ class Module(ModuleBase):
 
   @overload
   def sow(
-      self,
-      col: str,
-      name: str,
-      value: T,
-      reduce_fn: Callable[[K, T], K] = tuple_reduce,
-      init_fn: Callable[[], K] = tuple_init,  # type: ignore
+    self,
+    col: str,
+    name: str,
+    value: T,
+    reduce_fn: Callable[[K, T], K] = tuple_reduce,
+    init_fn: Callable[[], K] = tuple_init,  # type: ignore
   ) -> bool:
     ...
 
   def sow(
-      self,
-      col: str,
-      name: str,
-      value: T,
-      reduce_fn: Callable[[K, T], K] = tuple_reduce,
-      init_fn: Callable[[], K] = tuple_init,  # type: ignore
+    self,
+    col: str,
+    name: str,
+    value: T,
+    reduce_fn: Callable[[K, T], K] = tuple_reduce,
+    init_fn: Callable[[], K] = tuple_init,  # type: ignore
   ) -> bool:
     """Stores a value in a collection.
 
@@ -2277,7 +2292,7 @@ class Module(ModuleBase):
     return True
 
   def perturb(
-      self, name: str, value: T, collection: str = 'perturbations'
+    self, name: str, value: T, collection: str = 'perturbations'
   ) -> T:
     """Add an zero-value variable ('perturbation') to the intermediate value.
 
@@ -2337,22 +2352,26 @@ class Module(ModuleBase):
     # (e.g. during `init`) or if the collection was passed to `apply` (contained in
     # the root scope).
     if self.is_mutable_collection(collection) or _root_has_collection():
-      value += self.variable(collection, name, lambda: jnp.zeros_like(value)).value  # type: ignore
+      value += self.variable(
+        collection,
+        name,
+        lambda: jnp.zeros_like(value),  # type: ignore
+      ).value
     return value
 
   def tabulate(
-      self,
-      rngs: Union[KeyArray, RNGSequences],
-      *args,
-      depth: Optional[int] = None,
-      show_repeated: bool = False,
-      mutable: CollectionFilter = DenyList('intermediates'),
-      console_kwargs: Optional[Mapping[str, Any]] = None,
-      table_kwargs: Mapping[str, Any] = MappingProxyType({}),
-      column_kwargs: Mapping[str, Any] = MappingProxyType({}),
-      compute_flops: bool = False,
-      compute_vjp_flops: bool = False,
-      **kwargs,
+    self,
+    rngs: Union[KeyArray, RNGSequences],
+    *args,
+    depth: Optional[int] = None,
+    show_repeated: bool = False,
+    mutable: CollectionFilter = DenyList('intermediates'),
+    console_kwargs: Optional[Mapping[str, Any]] = None,
+    table_kwargs: Mapping[str, Any] = MappingProxyType({}),
+    column_kwargs: Mapping[str, Any] = MappingProxyType({}),
+    compute_flops: bool = False,
+    compute_vjp_flops: bool = False,
+    **kwargs,
   ) -> str:
     """Creates a summary of the Module represented as a table.
 
@@ -2459,16 +2478,16 @@ class Module(ModuleBase):
     from flax.linen import summary
 
     tabulate_fn = summary.tabulate(
-        self,
-        rngs,
-        depth=depth,
-        show_repeated=show_repeated,
-        mutable=mutable,
-        console_kwargs=console_kwargs,
-        table_kwargs=table_kwargs,
-        column_kwargs=column_kwargs,
-        compute_flops=compute_flops,
-        compute_vjp_flops=compute_vjp_flops,
+      self,
+      rngs,
+      depth=depth,
+      show_repeated=show_repeated,
+      mutable=mutable,
+      console_kwargs=console_kwargs,
+      table_kwargs=table_kwargs,
+      column_kwargs=column_kwargs,
+      compute_flops=compute_flops,
+      compute_vjp_flops=compute_vjp_flops,
     )
     return tabulate_fn(*args, **kwargs)
 
@@ -2504,12 +2523,12 @@ def merge_param(name: str, a: Optional[T], b: Optional[T]) -> T:
   """
   if a is None and b is None:
     raise ValueError(
-        f'Parameter "{name}" must be passed to the constructor or at call time.'
+      f'Parameter "{name}" must be passed to the constructor or at call time.'
     )
   if a is not None and b is not None:
     raise ValueError(
-        f'Parameter "{name}" was passed to the constructor and at call time.'
-        ' Should be passed just once.'
+      f'Parameter "{name}" was passed to the constructor and at call time.'
+      ' Should be passed just once.'
     )
   if a is None:
     assert b is not None
@@ -2519,10 +2538,10 @@ def merge_param(name: str, a: Optional[T], b: Optional[T]) -> T:
 
 @traceback_util.api_boundary
 def apply(
-    fn: Callable[..., Any],
-    module: Module,
-    mutable: CollectionFilter = False,
-    capture_intermediates: Union[bool, Callable[[Module, str], bool]] = False,
+  fn: Callable[..., Any],
+  module: Module,
+  mutable: CollectionFilter = False,
+  capture_intermediates: Union[bool, Callable[[Module, str], bool]] = False,
 ) -> Callable[..., Any]:
   """Creates an apply function to call ``fn`` with a bound module.
 
@@ -2582,10 +2601,10 @@ def apply(
 
 @traceback_util.api_boundary
 def init_with_output(
-    fn: Callable[..., Any],
-    module: Module,
-    mutable: CollectionFilter = DenyList('intermediates'),
-    capture_intermediates: Union[bool, Callable[[Module, str], bool]] = False,
+  fn: Callable[..., Any],
+  module: Module,
+  mutable: CollectionFilter = DenyList('intermediates'),
+  capture_intermediates: Union[bool, Callable[[Module, str], bool]] = False,
 ) -> Callable[..., Tuple[Any, Union[FrozenVariableDict, Dict[str, Any]]]]:
   """Creates an init function to call ``fn`` with a bound module that also returns the function outputs.
 
@@ -2647,10 +2666,10 @@ def init_with_output(
 
 @traceback_util.api_boundary
 def init(
-    fn: Callable[..., Any],
-    module: Module,
-    mutable: CollectionFilter = DenyList('intermediates'),
-    capture_intermediates: Union[bool, Callable[[Module, str], bool]] = False,
+  fn: Callable[..., Any],
+  module: Module,
+  mutable: CollectionFilter = DenyList('intermediates'),
+  capture_intermediates: Union[bool, Callable[[Module, str], bool]] = False,
 ) -> Callable[..., Union[FrozenVariableDict, Dict[str, Any]]]:
   """Creates an init function to call ``fn`` with a bound module.
 

--- a/flax/linen/pooling.py
+++ b/flax/linen/pooling.py
@@ -14,10 +14,9 @@
 
 """Pooling modules."""
 
-from jax import lax
 import jax.numpy as jnp
-
 import numpy as np
+from jax import lax
 
 
 def pool(inputs, init, reduce_fn, window_shape, strides, padding):
@@ -44,8 +43,8 @@ def pool(inputs, init, reduce_fn, window_shape, strides, padding):
   num_batch_dims = inputs.ndim - (len(window_shape) + 1)
   strides = strides or (1,) * len(window_shape)
   assert len(window_shape) == len(
-      strides
-  ), f"len({window_shape}) must equal len({strides})"
+    strides
+  ), f'len({window_shape}) must equal len({strides})'
   strides = (1,) * num_batch_dims + strides + (1,)
   dims = (1,) * num_batch_dims + window_shape + (1,)
 
@@ -58,16 +57,16 @@ def pool(inputs, init, reduce_fn, window_shape, strides, padding):
     dims = (1,) + dims
     is_single_input = True
 
-  assert inputs.ndim == len(dims), f"len({inputs.shape}) != len({dims})"
+  assert inputs.ndim == len(dims), f'len({inputs.shape}) != len({dims})'
   if not isinstance(padding, str):
     padding = tuple(map(tuple, padding))
     assert len(padding) == len(window_shape), (
-        f"padding {padding} must specify pads for same number of dims as "
-        f"window_shape {window_shape}"
+      f'padding {padding} must specify pads for same number of dims as '
+      f'window_shape {window_shape}'
     )
     assert all(
-        [len(x) == 2 for x in padding]
-    ), f"each entry in padding {padding} must be length 2"
+      [len(x) == 2 for x in padding]
+    ), f'each entry in padding {padding} must be length 2'
     padding = ((0, 0),) + padding + ((0, 0),)
   y = lax.reduce_window(inputs, init, reduce_fn, dims, strides, padding)
   if is_single_input:
@@ -76,7 +75,7 @@ def pool(inputs, init, reduce_fn, window_shape, strides, padding):
 
 
 def avg_pool(
-    inputs, window_shape, strides=None, padding="VALID", count_include_pad=True
+  inputs, window_shape, strides=None, padding='VALID', count_include_pad=True
 ):
   """Pools the input by taking the average over a window.
 
@@ -101,12 +100,12 @@ def avg_pool(
     if len(div_shape) - 2 == len(window_shape):
       div_shape = (1,) + div_shape[1:]
     y = y / pool(
-        jnp.ones(div_shape), 0.0, lax.add, window_shape, strides, padding
+      jnp.ones(div_shape), 0.0, lax.add, window_shape, strides, padding
     )
   return y
 
 
-def max_pool(inputs, window_shape, strides=None, padding="VALID"):
+def max_pool(inputs, window_shape, strides=None, padding='VALID'):
   """Pools the input by taking the maximum of a window slice.
 
   Args:
@@ -124,7 +123,7 @@ def max_pool(inputs, window_shape, strides=None, padding="VALID"):
   return y
 
 
-def min_pool(inputs, window_shape, strides=None, padding="VALID"):
+def min_pool(inputs, window_shape, strides=None, padding='VALID'):
   """Pools the input by taking the minimum of a window slice.
 
   Args:

--- a/flax/linen/stochastic.py
+++ b/flax/linen/stochastic.py
@@ -17,13 +17,10 @@
 from typing import Optional, Sequence
 
 import jax
-
-from flax.linen.module import compact
-from flax.linen.module import merge_param
-from flax.linen.module import Module
-from jax import lax
-from jax import random
 import jax.numpy as jnp
+from jax import lax, random
+
+from flax.linen.module import Module, compact, merge_param
 
 KeyArray = jax.Array
 
@@ -62,10 +59,10 @@ class Dropout(Module):
 
   @compact
   def __call__(
-      self,
-      inputs,
-      deterministic: Optional[bool] = None,
-      rng: Optional[KeyArray] = None,
+    self,
+    inputs,
+    deterministic: Optional[bool] = None,
+    rng: Optional[KeyArray] = None,
   ):
     """Applies a random dropout mask to the input.
 
@@ -81,7 +78,7 @@ class Dropout(Module):
       The masked inputs reweighted to preserve mean.
     """
     deterministic = merge_param(
-        'deterministic', self.deterministic, deterministic
+      'deterministic', self.deterministic, deterministic
     )
 
     if (self.rate == 0.0) or deterministic:

--- a/flax/linen/summary.py
+++ b/flax/linen/summary.py
@@ -14,21 +14,25 @@
 
 """Flax Module summary library."""
 
-from abc import ABC
-from abc import abstractmethod
 import dataclasses
 import io
+from abc import ABC, abstractmethod
 from types import MappingProxyType
-from typing import Any, Callable, Dict, Iterable, List, Mapping, Optional, Sequence, Set, Tuple, Type, Union
+from typing import (
+  Any,
+  Callable,
+  Dict,
+  Iterable,
+  List,
+  Mapping,
+  Optional,
+  Sequence,
+  Set,
+  Tuple,
+  Type,
+  Union,
+)
 
-from flax.core import meta
-from flax.core import unfreeze
-from flax.core.scope import CollectionFilter
-from flax.core.scope import DenyList
-from flax.core.scope import FrozenVariableDict
-from flax.core.scope import LazyRng
-from flax.core.scope import MutableVariableDict
-import flax.linen.module as module_lib
 import jax
 import jax.numpy as jnp
 import numpy as np
@@ -37,6 +41,15 @@ import rich.table
 import rich.text
 import yaml
 
+import flax.linen.module as module_lib
+from flax.core import meta, unfreeze
+from flax.core.scope import (
+  CollectionFilter,
+  DenyList,
+  FrozenVariableDict,
+  LazyRng,
+  MutableVariableDict,
+)
 
 PRNGKey = Any  # pylint: disable=invalid-name
 RNGSequences = Dict[str, PRNGKey]
@@ -76,10 +89,10 @@ class _PartitionedArrayRepresentation(_ValueRepresentation):
 
   @classmethod
   def from_partitioned(
-      cls, partitioned: meta.Partitioned
+    cls, partitioned: meta.Partitioned
   ) -> '_PartitionedArrayRepresentation':
     return cls(
-        _ArrayRepresentation.from_array(partitioned.value), partitioned.names
+      _ArrayRepresentation.from_array(partitioned.value), partitioned.names
     )
 
   def render(self):
@@ -132,15 +145,15 @@ class Row:
     self.counted_variables = self.counted_variables
 
   def size_and_bytes(
-      self, collections: Iterable[str]
+    self, collections: Iterable[str]
   ) -> Dict[str, Tuple[int, int]]:
     return {
-        col: (
-            _size_and_bytes(self.counted_variables[col])
-            if col in self.counted_variables
-            else (0, 0)
-        )
-        for col in collections
+      col: (
+        _size_and_bytes(self.counted_variables[col])
+        if col in self.counted_variables
+        else (0, 0)
+      )
+      for col in collections
     }
 
 
@@ -155,10 +168,10 @@ class Table(List[Row]):
   """
 
   def __init__(
-      self,
-      module: module_lib.Module,
-      collections: Sequence[str],
-      rows: Iterable[Row],
+    self,
+    module: module_lib.Module,
+    collections: Sequence[str],
+    rows: Iterable[Row],
   ):
     super().__init__(rows)
     self.module = module
@@ -166,17 +179,17 @@ class Table(List[Row]):
 
 
 def tabulate(
-    module: module_lib.Module,
-    rngs: Union[PRNGKey, RNGSequences],
-    depth: Optional[int] = None,
-    show_repeated: bool = False,
-    mutable: CollectionFilter = DenyList('intermediates'),
-    console_kwargs: Optional[Mapping[str, Any]] = None,
-    table_kwargs: Mapping[str, Any] = MappingProxyType({}),
-    column_kwargs: Mapping[str, Any] = MappingProxyType({}),
-    compute_flops: bool = False,
-    compute_vjp_flops: bool = False,
-    **kwargs,
+  module: module_lib.Module,
+  rngs: Union[PRNGKey, RNGSequences],
+  depth: Optional[int] = None,
+  show_repeated: bool = False,
+  mutable: CollectionFilter = DenyList('intermediates'),
+  console_kwargs: Optional[Mapping[str, Any]] = None,
+  table_kwargs: Mapping[str, Any] = MappingProxyType({}),
+  column_kwargs: Mapping[str, Any] = MappingProxyType({}),
+  compute_flops: bool = False,
+  compute_vjp_flops: bool = False,
+  **kwargs,
 ) -> Callable[..., str]:
   """Returns a function that creates a summary of the Module represented as a table.
 
@@ -292,20 +305,20 @@ def tabulate(
 
   def _tabulate_fn(*fn_args, **fn_kwargs):
     table_fn = _get_module_table(
-        module,
-        depth=depth,
-        show_repeated=show_repeated,
-        compute_flops=compute_flops,
-        compute_vjp_flops=compute_vjp_flops,
+      module,
+      depth=depth,
+      show_repeated=show_repeated,
+      compute_flops=compute_flops,
+      compute_vjp_flops=compute_vjp_flops,
     )
 
     table = table_fn(rngs, *fn_args, **fn_kwargs, **kwargs)
 
     non_param_cols = [
-        'path',
-        'module',
-        'inputs',
-        'outputs',
+      'path',
+      'module',
+      'inputs',
+      'outputs',
     ]
 
     if compute_flops:
@@ -314,7 +327,7 @@ def tabulate(
       non_param_cols.append('vjp_flops')
 
     return _render_table(
-        table, console_kwargs, table_kwargs, column_kwargs, non_param_cols
+      table, console_kwargs, table_kwargs, column_kwargs, non_param_cols
     )
 
   return _tabulate_fn
@@ -328,9 +341,9 @@ def _get_flops(fn, *args, **kwargs):
 
 
 def _get_call_flops(
-    c: module_lib._CallInfo,
-    compute_flops: bool,
-    compute_vjp_flops: bool,
+  c: module_lib._CallInfo,
+  compute_flops: bool,
+  compute_vjp_flops: bool,
 ) -> tuple[int, int]:
   """Return the FLOPs of executing the call `c` in the call stack.
 
@@ -351,7 +364,7 @@ def _get_call_flops(
     return -1, -1
 
   rngs = jax.tree_map(
-      lambda x: x.rng, c.rngs, is_leaf=lambda x: isinstance(x, LazyRng)
+    lambda x: x.rng, c.rngs, is_leaf=lambda x: isinstance(x, LazyRng)
   )
 
   args = jax.tree_map(_from_value_representation, c.args)
@@ -375,11 +388,11 @@ def _get_call_flops(
     """`c.module.init` closed over static keyword arguments."""
     args, kwargs = _get_inputs(dynamic_leaves)
     return c.module.init(
-        rngs,
-        *args,
-        method=c.method,
-        mutable=c.mutable,
-        **kwargs,
+      rngs,
+      *args,
+      method=c.method,
+      mutable=c.mutable,
+      **kwargs,
     )
 
   variables = jax.eval_shape(init, rngs, dynamic_leaves)
@@ -388,12 +401,12 @@ def _get_call_flops(
     """`c.module.apply` closed over static keyword arguments."""
     args, kwargs = _get_inputs(dynamic_leaves)
     return c.module.apply(
-        variables,
-        *args,
-        rngs=rngs,
-        method=c.method,
-        mutable=c.mutable,
-        **kwargs,
+      variables,
+      *args,
+      rngs=rngs,
+      method=c.method,
+      mutable=c.mutable,
+      **kwargs,
     )
 
   # Forward pass FLOPs
@@ -417,11 +430,11 @@ def _get_call_flops(
 
 
 def _get_module_table(
-    module: module_lib.Module,
-    depth: Optional[int],
-    show_repeated: bool,
-    compute_flops: bool,
-    compute_vjp_flops: bool,
+  module: module_lib.Module,
+  depth: Optional[int],
+  show_repeated: bool,
+  compute_flops: bool,
+  compute_vjp_flops: bool,
 ) -> Callable[..., Table]:
   """A function that takes a Module and returns function with the same signature
   as `init` but returns the Table representation of the Module."""
@@ -464,16 +477,16 @@ def _get_module_table(
 
       visited_paths.add(c.path)
       rows.append(
-          Row(
-              c.path,
-              type(c.module),
-              c.method,
-              inputs,
-              c.outputs,
-              module_vars,
-              counted_vars,
-              *_get_call_flops(c, compute_flops, compute_vjp_flops),
-          )
+        Row(
+          c.path,
+          type(c.module),
+          c.method,
+          inputs,
+          c.outputs,
+          module_vars,
+          counted_vars,
+          *_get_call_flops(c, compute_flops, compute_vjp_flops),
+        )
       )
 
     return Table(module, tuple(collections), rows)
@@ -482,9 +495,9 @@ def _get_module_table(
 
 
 def _get_module_variables(
-    path: Tuple[str, ...],
-    variables: FrozenVariableDict,
-    all_paths: Set[Tuple[str, ...]],
+  path: Tuple[str, ...],
+  variables: FrozenVariableDict,
+  all_paths: Set[Tuple[str, ...]],
 ) -> Tuple[MutableVariableDict, Any]:
   """A function that takes a path and variables structure and returns a
 
@@ -496,7 +509,7 @@ def _get_module_variables(
   module_variables = _get_path_variables(path, variables)
   submodule_variables: Any = {collection: {} for collection in module_variables}
   all_keys = set(
-      key for collection in module_variables.values() for key in collection
+    key for collection in module_variables.values() for key in collection
   )
 
   for key in all_keys:
@@ -505,14 +518,14 @@ def _get_module_variables(
       for collection in module_variables:
         if key in module_variables[collection]:
           submodule_variables[collection][key] = module_variables[
-              collection
+            collection
           ].pop(key)
 
   return module_variables, submodule_variables
 
 
 def _get_path_variables(
-    path: Tuple[str, ...], variables: FrozenVariableDict
+  path: Tuple[str, ...], variables: FrozenVariableDict
 ) -> MutableVariableDict:
   """A function that takes a path and a variables structure and returns the
   variable structure at that path.
@@ -550,11 +563,11 @@ def _process_inputs(args, kwargs) -> Any:
 
 
 def _render_table(
-    table: Table,
-    console_extras: Optional[Mapping[str, Any]],
-    table_kwargs: Mapping[str, Any],
-    column_kwargs: Mapping[str, Any],
-    non_params_cols: List[str],
+  table: Table,
+  console_extras: Optional[Mapping[str, Any]],
+  table_kwargs: Mapping[str, Any],
+  column_kwargs: Mapping[str, Any],
+  non_params_cols: List[str],
 ) -> str:
   """A function that renders a Table to a string representation using rich."""
   console_kwargs = {'force_terminal': True, 'force_jupyter': False}
@@ -562,11 +575,11 @@ def _render_table(
     console_kwargs.update(console_extras)
 
   rich_table = rich.table.Table(
-      show_header=True,
-      show_lines=True,
-      show_footer=True,
-      title=f'{table.module.__class__.__name__} Summary',
-      **table_kwargs,
+    show_header=True,
+    show_lines=True,
+    show_footer=True,
+    title=f'{table.module.__class__.__name__} Summary',
+    **table_kwargs,
   )
 
   for c in non_params_cols:
@@ -585,7 +598,7 @@ def _render_table(
         module_variables = _represent_tree(row.module_variables[collection])
         module_variables = _normalize_structure(module_variables)
         col_repr += _as_yaml_str(
-            _summary_tree_map(_maybe_render, module_variables)
+          _summary_tree_map(_maybe_render, module_variables)
         )
         if col_repr:
           col_repr += '\n\n'
@@ -596,28 +609,26 @@ def _render_table(
     no_show_methods = {'__call__', '<lambda>'}
     path_repr = '/'.join(row.path)
     method_repr = (
-        f' [dim]({row.method})[/dim]'
-        if row.method not in no_show_methods
-        else ''
+      f' [dim]({row.method})[/dim]' if row.method not in no_show_methods else ''
     )
     rich_table.add_row(
-        path_repr,
-        row.module_type.__name__ + method_repr,
-        *(
-            _as_yaml_str(
-                _summary_tree_map(
-                    _maybe_render, _normalize_structure(getattr(row, c))
-                )
-            )
-            for c in non_params_cols[2:]
-        ),
-        *collections_size_repr,
+      path_repr,
+      row.module_type.__name__ + method_repr,
+      *(
+        _as_yaml_str(
+          _summary_tree_map(
+            _maybe_render, _normalize_structure(getattr(row, c))
+          )
+        )
+        for c in non_params_cols[2:]
+      ),
+      *collections_size_repr,
     )
 
   # add footer with totals
   n_non_params_cols = len(non_params_cols)
   rich_table.columns[n_non_params_cols - 1].footer = rich.text.Text.from_markup(
-      'Total', justify='right'
+    'Total', justify='right'
   )
 
   # get collection totals
@@ -625,27 +636,27 @@ def _render_table(
   for row in table:
     for col, size_bytes in row.size_and_bytes(table.collections).items():
       collection_total[col] = (
-          collection_total[col][0] + size_bytes[0],
-          collection_total[col][1] + size_bytes[1],
+        collection_total[col][0] + size_bytes[0],
+        collection_total[col][1] + size_bytes[1],
       )
 
   # add totals to footer
   for i, col in enumerate(table.collections):
     rich_table.columns[n_non_params_cols + i].footer = _size_and_bytes_repr(
-        *collection_total[col]
+      *collection_total[col]
     )
 
   # add final totals to caption
   caption_totals = (0, 0)
   for size, num_bytes in collection_total.values():
     caption_totals = (
-        caption_totals[0] + size,
-        caption_totals[1] + num_bytes,
+      caption_totals[0] + size,
+      caption_totals[1] + num_bytes,
     )
 
   rich_table.caption_style = 'bold'
   rich_table.caption = (
-      f'\nTotal Parameters: {_size_and_bytes_repr(*caption_totals)}'
+    f'\nTotal Parameters: {_size_and_bytes_repr(*caption_totals)}'
   )
 
   return '\n' + _get_rich_repr(rich_table, console_kwargs) + '\n'
@@ -666,7 +677,7 @@ def _size_and_bytes(pytree: Any) -> Tuple[int, int]:
   leaves = jax.tree_util.tree_leaves(pytree)
   size = sum(x.size for x in leaves if hasattr(x, 'size'))
   num_bytes = sum(
-      x.size * x.dtype.itemsize for x in leaves if hasattr(x, 'size')
+    x.size * x.dtype.itemsize for x in leaves if hasattr(x, 'size')
   )
   return size, num_bytes
 
@@ -684,12 +695,12 @@ def _as_yaml_str(value) -> str:
 
   file = io.StringIO()
   yaml.safe_dump(
-      value,
-      file,
-      default_flow_style=False,
-      indent=2,
-      sort_keys=False,
-      explicit_end=False,
+    value,
+    file,
+    default_flow_style=False,
+    indent=2,
+    sort_keys=False,
+    explicit_end=False,
   )
   return file.getvalue().replace('\n...', '').replace("'", '').strip()
 
@@ -703,8 +714,8 @@ def _normalize_structure(obj):
     return {k: _normalize_structure(v) for k, v in obj.items()}
   elif dataclasses.is_dataclass(obj):
     return {
-        f.name: _normalize_structure(getattr(obj, f.name))
-        for f in dataclasses.fields(obj)
+      f.name: _normalize_structure(getattr(obj, f.name))
+      for f in dataclasses.fields(obj)
     }
   else:
     return obj
@@ -712,13 +723,13 @@ def _normalize_structure(obj):
 
 def _bytes_repr(num_bytes):
   count, units = (
-      (f'{num_bytes / 1e9 :,.1f}', 'GB')
-      if num_bytes > 1e9
-      else (f'{num_bytes / 1e6 :,.1f}', 'MB')
-      if num_bytes > 1e6
-      else (f'{num_bytes / 1e3 :,.1f}', 'KB')
-      if num_bytes > 1e3
-      else (f'{num_bytes:,}', 'B')
+    (f'{num_bytes / 1e9 :,.1f}', 'GB')
+    if num_bytes > 1e9
+    else (f'{num_bytes / 1e6 :,.1f}', 'MB')
+    if num_bytes > 1e6
+    else (f'{num_bytes / 1e3 :,.1f}', 'KB')
+    if num_bytes > 1e3
+    else (f'{num_bytes:,}', 'B')
   )
 
   return f'{count} {units}'
@@ -726,7 +737,7 @@ def _bytes_repr(num_bytes):
 
 def _get_value_representation(x: Any) -> _ValueRepresentation:
   if isinstance(x, (int, float, bool, type(None))) or (
-      isinstance(x, np.ndarray) and np.isscalar(x)
+    isinstance(x, np.ndarray) and np.isscalar(x)
   ):
     return _ObjectRepresentation(x)
   elif isinstance(x, meta.Partitioned):
@@ -743,7 +754,7 @@ def _from_value_representation(x: _ValueRepresentation) -> Any:
 
   elif isinstance(x, _PartitionedArrayRepresentation):
     return jax.ShapeDtypeStruct(
-        x.array_representation.shape, x.array_representation.dtype
+      x.array_representation.shape, x.array_representation.dtype
     )
 
   elif isinstance(x, _ObjectRepresentation):
@@ -756,9 +767,9 @@ def _represent_tree(x):
   """Returns a tree with the same structure as `x` but with each leaf replaced
   by a `_ValueRepresentation` object."""
   return jax.tree_util.tree_map(
-      _get_value_representation,
-      x,
-      is_leaf=lambda x: x is None or isinstance(x, meta.Partitioned),
+    _get_value_representation,
+    x,
+    is_leaf=lambda x: x is None or isinstance(x, meta.Partitioned),
   )
 
 

--- a/flax/metrics/tensorboard.py
+++ b/flax/metrics/tensorboard.py
@@ -18,12 +18,12 @@ import contextlib
 import functools
 import os
 
-# pylint: disable=g-import-not-at-top
-from flax import io
 import numpy as np
-
 import tensorflow as tf  # pytype: disable=import-error
 from tensorboard.plugins.hparams import api as hparams_api
+
+# pylint: disable=g-import-not-at-top
+from flax import io
 
 
 def _flatten_dict(input_dict, parent_key='', sep='.'):
@@ -43,14 +43,14 @@ def _flatten_dict(input_dict, parent_key='', sep='.'):
 
     # Valid types according to https://github.com/tensorflow/tensorboard/blob/1204566da5437af55109f7a4af18f9f8b7c4f864/tensorboard/plugins/hparams/summary_v2.py
     valid_types = (
-        bool,
-        int,
-        float,
-        str,
-        np.bool_,
-        np.integer,
-        np.floating,
-        np.character,
+      bool,
+      int,
+      float,
+      str,
+      np.bool_,
+      np.integer,
+      np.floating,
+      np.character,
     )
 
     if isinstance(v, dict):
@@ -175,12 +175,12 @@ class SummaryWriter:
     audio = tf.convert_to_tensor(audiodata, dtype=tf.float32)
     with self._as_default(self._event_writer):
       tf.summary.audio(
-          name=tag,
-          data=audio,
-          sample_rate=sample_rate,
-          step=step,
-          max_outputs=max_outputs,
-          encoding='wav',
+        name=tag,
+        data=audio,
+        sample_rate=sample_rate,
+        step=step,
+        max_outputs=max_outputs,
+        encoding='wav',
       )
 
   def histogram(self, tag, values, step, bins=None):

--- a/flax/struct.py
+++ b/flax/struct.py
@@ -17,11 +17,12 @@
 import dataclasses
 from typing import TypeVar
 
-from . import serialization
-
 import jax
-from typing_extensions import dataclass_transform  # pytype: disable=not-supported-yet
+from typing_extensions import (
+  dataclass_transform,  # pytype: disable=not-supported-yet
+)
 
+from . import serialization
 
 _T = TypeVar('_T')
 
@@ -121,8 +122,7 @@ def dataclass(clz: _T) -> _T:
   def iterate_clz_with_keys(x):
     meta = tuple(getattr(x, name) for name in meta_fields)
     data = tuple(
-        (jax.tree_util.GetAttrKey(name), getattr(x, name))
-        for name in data_fields
+      (jax.tree_util.GetAttrKey(name), getattr(x, name)) for name in data_fields
     )
     return data, meta
 
@@ -133,13 +133,13 @@ def dataclass(clz: _T) -> _T:
     return data_clz(**kwargs)
 
   jax.tree_util.register_pytree_with_keys(
-      data_clz, iterate_clz_with_keys, clz_from_iterable
+    data_clz, iterate_clz_with_keys, clz_from_iterable
   )
 
   def to_state_dict(x):
     state_dict = {
-        name: serialization.to_state_dict(getattr(x, name))
-        for name in data_fields
+      name: serialization.to_state_dict(getattr(x, name))
+      for name in data_fields
     }
     return state_dict
 
@@ -150,26 +150,26 @@ def dataclass(clz: _T) -> _T:
     for name in data_fields:
       if name not in state:
         raise ValueError(
-            f'Missing field {name} in state dict while restoring'
-            f' an instance of {clz.__name__},'
-            f' at path {serialization.current_path()}'
+          f'Missing field {name} in state dict while restoring'
+          f' an instance of {clz.__name__},'
+          f' at path {serialization.current_path()}'
         )
       value = getattr(x, name)
       value_state = state.pop(name)
       updates[name] = serialization.from_state_dict(
-          value, value_state, name=name
+        value, value_state, name=name
       )
     if state:
       names = ','.join(state.keys())
       raise ValueError(
-          f'Unknown field(s) "{names}" in state dict while'
-          f' restoring an instance of {clz.__name__}'
-          f' at path {serialization.current_path()}'
+        f'Unknown field(s) "{names}" in state dict while'
+        f' restoring an instance of {clz.__name__}'
+        f' at path {serialization.current_path()}'
       )
     return x.replace(**updates)
 
   serialization.register_serialization_state(
-      data_clz, to_state_dict, from_state_dict
+    data_clz, to_state_dict, from_state_dict
   )
 
   # add a _flax_dataclass flag to distinguish from regular dataclasses

--- a/flax/testing/benchmark.py
+++ b/flax/testing/benchmark.py
@@ -24,41 +24,41 @@ benchmark.
 """
 
 import functools
-import itertools
 import inspect
+import itertools
 import json
-from typing import Dict
 import os
 import tempfile
-from absl import flags
-from absl import logging
+from typing import Dict
+
+from absl import flags, logging
 from absl.testing import absltest
-
-from flax import io
-
-from tensorboard.backend.event_processing import directory_watcher
-from tensorboard.backend.event_processing import event_file_loader
-from tensorboard.backend.event_processing import io_wrapper
+from tensorboard.backend.event_processing import (
+  directory_watcher,
+  event_file_loader,
+  io_wrapper,
+)
 from tensorboard.summary import v1 as summary_lib
 from tensorboard.util import tensor_util
 
+from flax import io
 
 flags.DEFINE_string(
-    'benchmark_output_dir', default=None, help='Benchmark output directory.'
+  'benchmark_output_dir', default=None, help='Benchmark output directory.'
 )
 
 
 FLAGS = flags.FLAGS
 
 _SCALAR_PLUGIN_NAME = (
-    summary_lib.scalar_pb('', 0).value[0].metadata.plugin_data.plugin_name
+  summary_lib.scalar_pb('', 0).value[0].metadata.plugin_data.plugin_name
 )
 
 
 def _make_events_generator(path):
   """Makes a generator yielding TensorBoard events from files in `path`."""
   return directory_watcher.DirectoryWatcher(
-      path, event_file_loader.EventFileLoader, io_wrapper.IsSummaryEventsFile
+    path, event_file_loader.EventFileLoader, io_wrapper.IsSummaryEventsFile
   ).Load()
 
 
@@ -78,10 +78,10 @@ def _process_event(event):
 
     if value.HasField('tensor'):
       yield (
-          value.tag,
-          event.wall_time,
-          event.step,
-          tensor_util.make_ndarray(value.tensor).item(),
+        value.tag,
+        event.wall_time,
+        event.step,
+        tensor_util.make_ndarray(value.tensor).item(),
       )
 
 
@@ -166,7 +166,7 @@ class Benchmark(absltest.TestCase):
     else:
       model_dir = tempfile.mkdtemp()
     model_dir_path = os.path.join(
-        model_dir, self._reported_name or self._get_test_name()
+      model_dir, self._reported_name or self._get_test_name()
     )
     # Create directories if they don't exist.
     if not io.exists(model_dir_path):
@@ -260,17 +260,17 @@ class Benchmark(absltest.TestCase):
     name = self._reported_name
     if not name:
       raise ValueError(
-          'Unable to determine test name for reporting '
-          'benchmark results. Make sure you are using '
-          '`self.report_*` methods.'
+        'Unable to determine test name for reporting '
+        'benchmark results. Make sure you are using '
+        '`self.report_*` methods.'
       )
 
     succeeded = not self.has_outstanding_fails()
     results = {
-        'name': name,
-        'succeeded': succeeded,
-        'metrics': self._reported_metrics,
-        'extras': self._reported_extras,
+      'name': name,
+      'succeeded': succeeded,
+      'metrics': self._reported_metrics,
+      'extras': self._reported_extras,
     }
     if self._reported_wall_time is not None:
       results['wall_time'] = self._reported_wall_time

--- a/flax/traceback_util.py
+++ b/flax/traceback_util.py
@@ -15,6 +15,7 @@
 """Flax specific traceback_util functions."""
 
 from jax._src import traceback_util as jax_traceback_util
+
 from flax import config
 
 # pylint: disable=protected-access

--- a/flax/training/checkpoints.py
+++ b/flax/training/checkpoints.py
@@ -19,31 +19,38 @@ other numerical metric in filename.  Cleans up older / worse-performing
 checkpoint files.
 """
 
-from concurrent.futures import thread
 import functools
 import os
 import pathlib
 import re
 import time
-from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, Type, Union
 import warnings
+from concurrent.futures import thread
+from typing import (
+  Any,
+  Callable,
+  Dict,
+  Iterable,
+  List,
+  Optional,
+  Tuple,
+  Type,
+  Union,
+)
 
-from absl import logging
-from flax import config
-from flax import core
-from flax import errors
-from flax import io
-from flax import serialization
-from flax import traverse_util
-from flax.training import orbax_utils
 import jax
-from jax import monitoring
-from jax import process_index
-from jax import tree_util as jtu
-from jax.experimental.array_serialization.serialization import get_tensorstore_spec
-from jax.experimental.array_serialization.serialization import GlobalAsyncCheckpointManager
-from jax.experimental.multihost_utils import sync_global_devices
 import orbax.checkpoint as ocp
+from absl import logging
+from jax import monitoring, process_index
+from jax import tree_util as jtu
+from jax.experimental.array_serialization.serialization import (
+  GlobalAsyncCheckpointManager,
+  get_tensorstore_spec,
+)
+from jax.experimental.multihost_utils import sync_global_devices
+
+from flax import config, core, errors, io, serialization, traverse_util
+from flax.training import orbax_utils
 
 _READ_CHECKPOINT_EVENT: str = '/jax/checkpoint/read/durations_sec'
 _WRITE_CHECKPOINT_EVENT: str = '/jax/checkpoint/write/durations_sec'
@@ -54,7 +61,7 @@ _WRITE_CHECKPOINT_EVENT: str = '/jax/checkpoint/write/durations_sec'
 SIGNED_FLOAT_RE = re.compile(r'([-+]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][-+]?\d+)?)')
 # does not capture sign:
 UNSIGNED_FLOAT_RE = re.compile(
-    r'[-+]?((?:\d+(?:\.\d*)?|\.\d+)(?:[eE][-+]?\d+)?)'
+  r'[-+]?((?:\d+(?:\.\d*)?|\.\d+)(?:[eE][-+]?\d+)?)'
 )
 # Module name followed by number.
 MODULE_NUM_RE = re.compile(r'(.*)_\d+$')
@@ -93,7 +100,7 @@ def _is_multiprocess_array(value: Any) -> bool:
 
 
 def _checkpoint_path(
-    ckpt_dir: str, step: Union[int, float, str], prefix: str = 'checkpoint_'
+  ckpt_dir: str, step: Union[int, float, str], prefix: str = 'checkpoint_'
 ) -> str:
   return os.path.join(ckpt_dir, f'{prefix}{step}')
 
@@ -123,7 +130,7 @@ def _safe_remove(path: str):
 
 def _is_orbax_checkpoint(path: str) -> bool:
   return io.exists(os.path.join(path, ORBAX_CKPT_FILENAME)) or io.exists(
-      os.path.join(path, ORBAX_MANIFEST_OCDBT)
+    os.path.join(path, ORBAX_MANIFEST_OCDBT)
   )
 
 
@@ -143,8 +150,8 @@ class AsyncManager:
     """Block until the previous save finishes, to keep files' consistency."""
     if self.save_future and not self.save_future.done():
       logging.warning(
-          'The previous async save_checkpoint has not finished yet. Waiting '
-          'for it to complete before the next save.'
+        'The previous async save_checkpoint has not finished yet. Waiting '
+        'for it to complete before the next save.'
       )
       self.save_future.result()
 
@@ -161,7 +168,7 @@ class AsyncManager:
 
 
 def _split_mp_arrays(
-    target: Dict[str, Any]
+  target: Dict[str, Any]
 ) -> Tuple[Dict[str, Any], List[Tuple[MultiprocessArrayType, str]]]:
   """Split out the multiprocess arrays from the target pytree to save."""
   # When target is a single leaf instead of a pytree dict.
@@ -182,7 +189,7 @@ def _split_mp_arrays(
 
 
 def _make_mpa_dirs(
-    mpa_targets: List[Tuple[MultiprocessArrayType, str]], tmp_path: str
+  mpa_targets: List[Tuple[MultiprocessArrayType, str]], tmp_path: str
 ):
   # Temporary array path is not used in GCS.
   if tmp_path.startswith('gs://'):
@@ -199,22 +206,22 @@ def _make_mpa_dirs(
 
 
 def _save_mpas(
-    gda_manager,
-    mpa_targets: List[Tuple[MultiprocessArrayType, str]],
-    tmp_path: str,
-    final_path: str,
-    base_path: str,
-    keep: int,
-    overwrite: bool,
-    keep_every_n_steps: Optional[int],
-    ckpt_start_time: float,
-    async_manager: Optional[AsyncManager] = None,
+  gda_manager,
+  mpa_targets: List[Tuple[MultiprocessArrayType, str]],
+  tmp_path: str,
+  final_path: str,
+  base_path: str,
+  keep: int,
+  overwrite: bool,
+  keep_every_n_steps: Optional[int],
+  ckpt_start_time: float,
+  async_manager: Optional[AsyncManager] = None,
 ):
   """Save the multiprocess arrays given the paths."""
   mpa_list, mpa_subpaths = zip(*mpa_targets)
   mpa_tmp_path, mpa_final_path = (
-      tmp_path + MP_ARRAY_POSTFIX,
-      final_path + MP_ARRAY_POSTFIX,
+    tmp_path + MP_ARRAY_POSTFIX,
+    final_path + MP_ARRAY_POSTFIX,
   )
   write_commit_success = False
   # If the checkpoint directory is a GCS directory, then keep the final
@@ -228,31 +235,31 @@ def _save_mpas(
   mpa_paths = [os.path.join(mpa_tmp_path, x) for x in mpa_subpaths]
   ts_specs = [get_tensorstore_spec(x) for x in mpa_paths]
   gda_manager.serialize(
-      list(mpa_list),
-      ts_specs,
-      on_commit_callback=functools.partial(
-          _save_commit,
-          tmp_path,
-          final_path,
-          base_path,
-          keep,
-          overwrite,
-          keep_every_n_steps,
-          ckpt_start_time,
-          has_mpa=True,
-          write_commit_success=write_commit_success,
-          async_manager=async_manager,
-      ),
+    list(mpa_list),
+    ts_specs,
+    on_commit_callback=functools.partial(
+      _save_commit,
+      tmp_path,
+      final_path,
+      base_path,
+      keep,
+      overwrite,
+      keep_every_n_steps,
+      ckpt_start_time,
+      has_mpa=True,
+      write_commit_success=write_commit_success,
+      async_manager=async_manager,
+    ),
   )
 
 
 def _restore_mpas(
-    state_dict,
-    target: Optional[Any],
-    ckpt_path: str,
-    step: Optional[Union[int, float]],
-    gda_manager: Optional[GlobalAsyncCheckpointManager],
-    allow_partial: bool = False,
+  state_dict,
+  target: Optional[Any],
+  ckpt_path: str,
+  step: Optional[Union[int, float]],
+  gda_manager: Optional[GlobalAsyncCheckpointManager],
+  allow_partial: bool = False,
 ):
   """Restore the multiprocess arrays given the target structure and type."""
 
@@ -263,14 +270,14 @@ def _restore_mpas(
       raise errors.MPARestoreTargetRequiredError(ckpt_path, step)
 
   def _safe_deserialize(
-      target_mpas: List[Tuple[Tuple[Any, ...], MultiprocessArrayType, str]],
-      gda_manager: Any,
+    target_mpas: List[Tuple[Tuple[Any, ...], MultiprocessArrayType, str]],
+    gda_manager: Any,
   ) -> List[MultiprocessArrayType]:
     gda_manager.wait_until_finished()
 
     # Check if reading from GCS and the array dir is potentially corrupted.
     if ckpt_path.startswith('gs://') and not io.exists(
-        os.path.join(ckpt_path + MP_ARRAY_POSTFIX, COMMIT_SUCCESS_FILE)
+      os.path.join(ckpt_path + MP_ARRAY_POSTFIX, COMMIT_SUCCESS_FILE)
     ):
       raise errors.MPARestoreDataCorruptedError(step, ckpt_path)
 
@@ -287,13 +294,13 @@ def _restore_mpas(
   # When target is a single leaf instead of a pytree dict.
   if not isinstance(state_dict, (core.FrozenDict, dict)):
     if (
-        _is_multiprocess_array(target)
-        and isinstance(state_dict, str)
-        and state_dict.startswith(MP_ARRAY_PH)
+      _is_multiprocess_array(target)
+      and isinstance(state_dict, str)
+      and state_dict.startswith(MP_ARRAY_PH)
     ):
       _check_mpa_errors()
       return _safe_deserialize(
-          [((), target, ckpt_path + MP_ARRAY_POSTFIX)], gda_manager
+        [((), target, ckpt_path + MP_ARRAY_POSTFIX)], gda_manager
       )[0]
     return state_dict
 
@@ -302,7 +309,7 @@ def _restore_mpas(
   target_flattened = {}
   if target:
     target_flattened = traverse_util.flatten_dict(
-        serialization.to_state_dict(target), keep_empty_nodes=True
+      serialization.to_state_dict(target), keep_empty_nodes=True
     )
   # A list of (state_dict_key, target_array, array_file_path) for every array
   # to be restored
@@ -311,23 +318,23 @@ def _restore_mpas(
     if isinstance(value, str) and value.startswith(MP_ARRAY_PH):
       _check_mpa_errors()
       if (
-          not target
-          or (key not in target_flattened)
-          or (not _is_multiprocess_array(target_flattened[key]))
+        not target
+        or (key not in target_flattened)
+        or (not _is_multiprocess_array(target_flattened[key]))
       ):
         if allow_partial:
           logging.warning(
-              'Multiprocess array %s could not be restored because a valid'
-              ' array is not found in target at the corresponding location.'
-              ' Proceed to restore other arrays because'
-              ' allow_partial_restoration=True',
-              key,
+            'Multiprocess array %s could not be restored because a valid'
+            ' array is not found in target at the corresponding location.'
+            ' Proceed to restore other arrays because'
+            ' allow_partial_restoration=True',
+            key,
           )
         else:
           raise errors.MPARestoreTargetRequiredError(ckpt_path, step, key)
       else:
         mpa_path = os.path.join(
-            ckpt_path + MP_ARRAY_POSTFIX, value[len(MP_ARRAY_PH) :]
+          ckpt_path + MP_ARRAY_POSTFIX, value[len(MP_ARRAY_PH) :]
         )
         target_mpas.append((key, target_flattened[key], mpa_path))
 
@@ -377,22 +384,22 @@ def safe_normpath(path: str) -> str:
 
 
 def _remove_invalid_ckpts(
-    ckpt_path: str,
-    base_path: str,
-    keep: int,
-    overwrite: bool,
-    keep_every_n_steps: Optional[int],
-    has_mpa: bool,
+  ckpt_path: str,
+  base_path: str,
+  keep: int,
+  overwrite: bool,
+  keep_every_n_steps: Optional[int],
+  has_mpa: bool,
 ) -> None:
   """Clean up the checkpoint space according to `overwrite`, `keep`, and `keep_every_n_steps` parameters."""
   dir_path, prefix = os.path.split(base_path)
   checkpoint_files: List[Any] = [
-      pathlib.PurePath(c) for c in _allowempty_listdir(dir_path)
+    pathlib.PurePath(c) for c in _allowempty_listdir(dir_path)
   ]
   checkpoint_files = [
-      os.path.join(dir_path, c)
-      for c in checkpoint_files
-      if c.match(f'{prefix}*') and not c.match(f'*{MP_ARRAY_POSTFIX}')
+    os.path.join(dir_path, c)
+    for c in checkpoint_files
+    if c.match(f'{prefix}*') and not c.match(f'*{MP_ARRAY_POSTFIX}')
   ]
   checkpoint_files = natural_sort(checkpoint_files)
 
@@ -421,11 +428,11 @@ def _remove_invalid_ckpts(
         step_number = _checkpoint_path_step(path)
         if step_number and (step_number - last_kept) >= keep_every_n_steps:
           logging.debug(
-              'Not deleting %s, because last_kept=%f and keeping '
-              'every %d steps.',
-              path,
-              last_kept,
-              keep_every_n_steps,
+            'Not deleting %s, because last_kept=%f and keeping '
+            'every %d steps.',
+            path,
+            last_kept,
+            keep_every_n_steps,
           )
           last_kept = step_number
           continue
@@ -438,16 +445,16 @@ def _remove_invalid_ckpts(
 
 
 def _save_commit(
-    ckpt_tmp_path: str,
-    ckpt_path: str,
-    base_path: str,
-    keep: int,
-    overwrite: bool,
-    keep_every_n_steps: Optional[int],
-    ckpt_start_time: float,
-    has_mpa: bool,
-    write_commit_success: bool,
-    async_manager: Optional[AsyncManager] = None,
+  ckpt_tmp_path: str,
+  ckpt_path: str,
+  base_path: str,
+  keep: int,
+  overwrite: bool,
+  keep_every_n_steps: Optional[int],
+  ckpt_start_time: float,
+  has_mpa: bool,
+  write_commit_success: bool,
+  async_manager: Optional[AsyncManager] = None,
 ) -> None:
   """Commit changes after saving checkpoints to disk.
 
@@ -460,8 +467,8 @@ def _save_commit(
     4. Record program duration saved by this checkpoint.
   """
   mpa_ckpt_tmp_path, mpa_ckpt_path = (
-      ckpt_tmp_path + MP_ARRAY_POSTFIX,
-      ckpt_path + MP_ARRAY_POSTFIX,
+    ckpt_tmp_path + MP_ARRAY_POSTFIX,
+    ckpt_path + MP_ARRAY_POSTFIX,
   )
   # Rename the multiprocess array path once serialization and writing finished.
   if has_mpa:
@@ -487,29 +494,29 @@ def _save_commit(
 
   # Remove newer and older invalid checkpoints.
   _remove_invalid_ckpts(
-      ckpt_path, base_path, keep, overwrite, keep_every_n_steps, has_mpa
+    ckpt_path, base_path, keep, overwrite, keep_every_n_steps, has_mpa
   )
   # Record checkpoint-related metrics.
   ocp.utils.record_saved_duration(ckpt_start_time)
   if async_manager:
     jax.monitoring.record_event_duration_secs(
-        '/jax/checkpoint/write/async/total_duration_secs',
-        time.time() - ckpt_start_time,
+      '/jax/checkpoint/write/async/total_duration_secs',
+      time.time() - ckpt_start_time,
     )
 
 
 def _check_overwrite_error(
-    ckpt_tmp_path: str, ckpt_path: str, base_path: str, step: int
+  ckpt_tmp_path: str, ckpt_path: str, base_path: str, step: int
 ):
   """Throw error if a ckpt file of this step or higher already exists."""
   dir_path, prefix = os.path.split(base_path)
   checkpoint_files: List[Any] = [
-      pathlib.PurePath(c) for c in _allowempty_listdir(dir_path)
+    pathlib.PurePath(c) for c in _allowempty_listdir(dir_path)
   ]
   checkpoint_files = [
-      os.path.join(dir_path, c)
-      for c in checkpoint_files
-      if c.match(f'{prefix}*') and not c.match(f'*{MP_ARRAY_POSTFIX}')
+    os.path.join(dir_path, c)
+    for c in checkpoint_files
+    if c.match(f'{prefix}*') and not c.match(f'*{MP_ARRAY_POSTFIX}')
   ]
   if ckpt_path in checkpoint_files:
     raise errors.InvalidCheckpointError(ckpt_path, step)
@@ -525,15 +532,15 @@ def _check_overwrite_error(
 
 
 def _save_main_ckpt_file(
-    target: bytes,
-    has_mpa: bool,
-    paths: Tuple[str, str],
-    base_path: str,
-    step: int,
-    keep: int,
-    overwrite: bool,
-    keep_every_n_steps: Optional[int],
-    ckpt_start_time: float,
+  target: bytes,
+  has_mpa: bool,
+  paths: Tuple[str, str],
+  base_path: str,
+  step: int,
+  keep: int,
+  overwrite: bool,
+  keep_every_n_steps: Optional[int],
+  ckpt_start_time: float,
 ):
   """Save the main checkpoint file via file system."""
   ckpt_tmp_path, ckpt_path = paths
@@ -545,22 +552,22 @@ def _save_main_ckpt_file(
   # Postpone the commitment of checkpoint to after MPA writes are done.
   if not has_mpa:
     _save_commit(
-        ckpt_tmp_path,
-        ckpt_path,
-        base_path,
-        keep,
-        overwrite,
-        keep_every_n_steps,
-        ckpt_start_time,
-        has_mpa=False,
-        write_commit_success=False,
+      ckpt_tmp_path,
+      ckpt_path,
+      base_path,
+      keep,
+      overwrite,
+      keep_every_n_steps,
+      ckpt_start_time,
+      has_mpa=False,
+      write_commit_success=False,
     )
 
 
 def _get_checkpoint_paths(
-    ckpt_dir: Union[str, os.PathLike],
-    step: Union[int, float],
-    prefix: str = 'checkpoint_',
+  ckpt_dir: Union[str, os.PathLike],
+  step: Union[int, float],
+  prefix: str = 'checkpoint_',
 ) -> Tuple[str, str, str]:
   """Generate the checkpoint paths used in this save operation."""
   ckpt_dir = os.fspath(ckpt_dir)  # Pathlib -> str
@@ -574,15 +581,15 @@ def _get_checkpoint_paths(
 
 
 def save_checkpoint(
-    ckpt_dir: Union[str, os.PathLike],
-    target: PyTree,
-    step: Union[int, float],
-    prefix: str = 'checkpoint_',
-    keep: int = 1,
-    overwrite: bool = False,
-    keep_every_n_steps: Optional[int] = None,
-    async_manager: Optional[AsyncManager] = None,
-    orbax_checkpointer: Optional[ocp.Checkpointer] = None,
+  ckpt_dir: Union[str, os.PathLike],
+  target: PyTree,
+  step: Union[int, float],
+  prefix: str = 'checkpoint_',
+  keep: int = 1,
+  overwrite: bool = False,
+  keep_every_n_steps: Optional[int] = None,
+  async_manager: Optional[AsyncManager] = None,
+  orbax_checkpointer: Optional[ocp.Checkpointer] = None,
 ) -> str:
   """Save a checkpoint of the model. Suitable for single-host.
 
@@ -628,67 +635,68 @@ def save_checkpoint(
     async_manager.wait_previous_save()
 
   ckpt_path, ckpt_tmp_path, base_path = _get_checkpoint_paths(
-      ckpt_dir, step, prefix
+    ckpt_dir, step, prefix
   )
 
   if config.flax_use_orbax_checkpointing or orbax_checkpointer:
     logging.info(
-        'Using Orbax as backend to save Flax checkpoints. For potential'
-        ' troubleshooting see:'
-        ' https://flax.readthedocs.io/en/latest/guides/use_checkpointing.html#orbax-as-backend-troubleshooting'
+      'Using Orbax as backend to save Flax checkpoints. For potential'
+      ' troubleshooting see:'
+      ' https://flax.readthedocs.io/en/latest/guides/use_checkpointing.html#orbax-as-backend-troubleshooting'
     )
     if jax.process_count() > 1:
       logging.warning(
-          'Multiple JAX processes detected when calling single-process'
-          ' `save_checkpoint`. Your devices will HANG if this function is only'
-          ' called on process 0! Troubleshoot at:'
-          ' https://flax.readthedocs.io/en/latest/guides/use_checkpointing.html#if-your-devices-hang-when-writing-checkpoints'
+        'Multiple JAX processes detected when calling single-process'
+        ' `save_checkpoint`. Your devices will HANG if this function is only'
+        ' called on process 0! Troubleshoot at:'
+        ' https://flax.readthedocs.io/en/latest/guides/use_checkpointing.html#if-your-devices-hang-when-writing-checkpoints'
       )
 
     # Make sure any previous work is done before making file changes.
     if orbax_checkpointer and isinstance(
-        orbax_checkpointer, ocp.AsyncCheckpointer
+      orbax_checkpointer, ocp.AsyncCheckpointer
     ):
       orbax_checkpointer.wait_until_finished()
     # If no checkpointer provided, save synchronously with default setting.
     if not orbax_checkpointer:
       orbax_checkpointer = ocp.Checkpointer(
-          ocp.PyTreeCheckpointHandler(restore_with_serialized_types=False)
+        ocp.PyTreeCheckpointHandler(restore_with_serialized_types=False)
       )
     # Check singular target.
     if jtu.treedef_is_leaf(jtu.tree_structure(target)) and not isinstance(
-        orbax_checkpointer._handler, ocp.ArrayCheckpointHandler  # pylint: disable=protected-access
+      orbax_checkpointer._handler,
+      ocp.ArrayCheckpointHandler,  # pylint: disable=protected-access
     ):
       raise ValueError(
-          'Orbax backend only accept pytree as save target. To save singular'
-          ' objects like numbers or Numpy arrays, checkout'
-          ' https://flax.readthedocs.io/en/latest/guides/use_checkpointing.html#if-you-don-t-save-pytrees'
+        'Orbax backend only accept pytree as save target. To save singular'
+        ' objects like numbers or Numpy arrays, checkout'
+        ' https://flax.readthedocs.io/en/latest/guides/use_checkpointing.html#if-you-don-t-save-pytrees'
       )
 
     save_args = orbax_utils.save_args_from_target(target)
     orbax_checkpointer.save(
-        ckpt_path, target, save_args=save_args, force=overwrite
+      ckpt_path, target, save_args=save_args, force=overwrite
     )
     # Do a process check here in case people call this for multihost.
     if process_index() == 0:
       _remove_invalid_ckpts(
-          ckpt_path, base_path, keep, overwrite, keep_every_n_steps, True
+        ckpt_path, base_path, keep, overwrite, keep_every_n_steps, True
       )
     end_time = time.time()
     monitoring.record_event_duration_secs(
-        _WRITE_CHECKPOINT_EVENT, end_time - start_time
+      _WRITE_CHECKPOINT_EVENT, end_time - start_time
     )
     return ckpt_path
 
   warnings.warn(
-      (
-          'Flax Checkpointing will soon be deprecated in favor of Orbax'
-          ' (https://github.com/google/orbax). Please refer to the Checkpoint'
-          ' Upgrade Guide'
-          ' (https://flax.readthedocs.io/en/latest/guides/orbax_upgrade_guide.html)'
-          ' to self-migrate your code to ocp.'
-      ),
-      DeprecationWarning,
+    (
+      'Flax Checkpointing will soon be deprecated in favor of Orbax'
+      ' (https://github.com/google/orbax). Please refer to the Checkpoint'
+      ' Upgrade Guide'
+      ' (https://flax.readthedocs.io/en/latest/guides/orbax_upgrade_guide.html)'
+      ' to self-migrate your code to ocp.'
+    ),
+    DeprecationWarning,
   )
   if not overwrite:
     _check_overwrite_error(ckpt_tmp_path, ckpt_path, base_path, step)  # type: ignore
@@ -699,15 +707,15 @@ def save_checkpoint(
   def save_main_ckpt_task():
     jax.monitoring.record_event('/jax/flax/checkpoint/save_main_ckpt_task')
     return _save_main_ckpt_file(
-        target,
-        False,
-        (ckpt_tmp_path, ckpt_path),
-        base_path,
-        step,
-        keep,
-        overwrite,
-        keep_every_n_steps,
-        start_time,
+      target,
+      False,
+      (ckpt_tmp_path, ckpt_path),
+      base_path,
+      step,
+      keep,
+      overwrite,
+      keep_every_n_steps,
+      start_time,
     )
 
   if async_manager:
@@ -716,22 +724,22 @@ def save_checkpoint(
     save_main_ckpt_task()
   end_time = time.time()
   monitoring.record_event_duration_secs(
-      _WRITE_CHECKPOINT_EVENT, end_time - start_time
+    _WRITE_CHECKPOINT_EVENT, end_time - start_time
   )
   return ckpt_path
 
 
 def save_checkpoint_multiprocess(
-    ckpt_dir: Union[str, os.PathLike],
-    target: PyTree,
-    step: Union[int, float],
-    prefix: str = 'checkpoint_',
-    keep: int = 1,
-    overwrite: bool = False,
-    keep_every_n_steps: Optional[int] = None,
-    async_manager: Optional[AsyncManager] = None,
-    gda_manager: Optional[GlobalAsyncCheckpointManager] = None,
-    orbax_checkpointer: Optional[ocp.Checkpointer] = None,
+  ckpt_dir: Union[str, os.PathLike],
+  target: PyTree,
+  step: Union[int, float],
+  prefix: str = 'checkpoint_',
+  keep: int = 1,
+  overwrite: bool = False,
+  keep_every_n_steps: Optional[int] = None,
+  async_manager: Optional[AsyncManager] = None,
+  gda_manager: Optional[GlobalAsyncCheckpointManager] = None,
+  orbax_checkpointer: Optional[ocp.Checkpointer] = None,
 ) -> str:
   """Save a checkpoint of the model in multi-process environment.
 
@@ -783,59 +791,60 @@ def save_checkpoint_multiprocess(
     sync_global_devices('Flax:Checkpoint:WaitLastSaveDone')
 
   ckpt_path, ckpt_tmp_path, base_path = _get_checkpoint_paths(
-      ckpt_dir, step, prefix
+    ckpt_dir, step, prefix
   )
 
   if config.flax_use_orbax_checkpointing or orbax_checkpointer:
     logging.info(
-        'Using Orbax as backend to save Flax checkpoints. For potential'
-        ' troubleshooting see:'
-        ' https://flax.readthedocs.io/en/latest/guides/use_checkpointing.html#orbax-as-backend-troubleshooting'
+      'Using Orbax as backend to save Flax checkpoints. For potential'
+      ' troubleshooting see:'
+      ' https://flax.readthedocs.io/en/latest/guides/use_checkpointing.html#orbax-as-backend-troubleshooting'
     )
     # Make sure any previous work is done before making file changes.
     if orbax_checkpointer and isinstance(
-        orbax_checkpointer, ocp.AsyncCheckpointer
+      orbax_checkpointer, ocp.AsyncCheckpointer
     ):
       orbax_checkpointer.wait_until_finished()
 
     # If no checkpointer provided, save synchronously with default setting.
     if not orbax_checkpointer:
       orbax_checkpointer = ocp.Checkpointer(
-          ocp.PyTreeCheckpointHandler(restore_with_serialized_types=False)
+        ocp.PyTreeCheckpointHandler(restore_with_serialized_types=False)
       )
     # Check singular target.
     if jtu.treedef_is_leaf(jtu.tree_structure(target)) and not isinstance(
-        orbax_checkpointer._handler, ocp.ArrayCheckpointHandler  # pylint: disable=protected-access
+      orbax_checkpointer._handler,
+      ocp.ArrayCheckpointHandler,  # pylint: disable=protected-access
     ):
       raise ValueError(
-          'Orbax backend only accept pytree as save target. To save singular'
-          ' objects like numbers or Numpy arrays, checkout'
-          ' https://flax.readthedocs.io/en/latest/guides/use_checkpointing.html#if-you-don-t-save-pytrees'
+        'Orbax backend only accept pytree as save target. To save singular'
+        ' objects like numbers or Numpy arrays, checkout'
+        ' https://flax.readthedocs.io/en/latest/guides/use_checkpointing.html#if-you-don-t-save-pytrees'
       )
 
     if process_index() == 0:
       _remove_invalid_ckpts(
-          ckpt_path, base_path, keep, overwrite, keep_every_n_steps, True
+        ckpt_path, base_path, keep, overwrite, keep_every_n_steps, True
       )
     save_args = orbax_utils.save_args_from_target(target)
     orbax_checkpointer.save(
-        ckpt_path, target, save_args=save_args, force=overwrite
+      ckpt_path, target, save_args=save_args, force=overwrite
     )
     end_time = time.time()
     monitoring.record_event_duration_secs(
-        _WRITE_CHECKPOINT_EVENT, end_time - start_time
+      _WRITE_CHECKPOINT_EVENT, end_time - start_time
     )
     return ckpt_path
 
   warnings.warn(
-      (
-          'Flax Checkpointing will soon be deprecated in favor of Orbax'
-          ' (https://github.com/google/orbax). Please refer to the Checkpoint'
-          ' Upgrade Guide'
-          ' (https://flax.readthedocs.io/en/latest/guides/orbax_upgrade_guide.html)'
-          ' to self-migrate your code to ocp.'
-      ),
-      DeprecationWarning,
+    (
+      'Flax Checkpointing will soon be deprecated in favor of Orbax'
+      ' (https://github.com/google/orbax). Please refer to the Checkpoint'
+      ' Upgrade Guide'
+      ' (https://flax.readthedocs.io/en/latest/guides/orbax_upgrade_guide.html)'
+      ' to self-migrate your code to ocp.'
+    ),
+    DeprecationWarning,
   )
 
   target = serialization.to_state_dict(target)
@@ -851,15 +860,15 @@ def save_checkpoint_multiprocess(
   def save_main_ckpt_task():
     jax.monitoring.record_event('/jax/flax/checkpoint/save_main_ckpt_task')
     return _save_main_ckpt_file(
-        target,
-        has_mpa,
-        (ckpt_tmp_path, ckpt_path),
-        base_path,
-        step,
-        keep,
-        overwrite,
-        keep_every_n_steps,
-        start_time,
+      target,
+      has_mpa,
+      (ckpt_tmp_path, ckpt_path),
+      base_path,
+      step,
+      keep,
+      overwrite,
+      keep_every_n_steps,
+      start_time,
     )
 
   # Write the main checkpoint file only via process 0, to avoid race condition.
@@ -878,27 +887,27 @@ def save_checkpoint_multiprocess(
       _make_mpa_dirs(mpa_targets, ckpt_tmp_path)
     sync_global_devices('Flax:Checkpoint:AfterCreateMPADir')
     _save_mpas(
-        gda_manager,
-        mpa_targets,
-        ckpt_tmp_path,
-        ckpt_path,
-        base_path,
-        keep,
-        overwrite,
-        keep_every_n_steps,
-        start_time,
-        async_manager,
+      gda_manager,
+      mpa_targets,
+      ckpt_tmp_path,
+      ckpt_path,
+      base_path,
+      keep,
+      overwrite,
+      keep_every_n_steps,
+      start_time,
+      async_manager,
     )
 
   end_time = time.time()
   monitoring.record_event_duration_secs(
-      _WRITE_CHECKPOINT_EVENT, end_time - start_time
+    _WRITE_CHECKPOINT_EVENT, end_time - start_time
   )
   return ckpt_path
 
 
 def _all_checkpoints(
-    ckpt_dir: Union[str, os.PathLike], prefix: str = 'checkpoint_'
+  ckpt_dir: Union[str, os.PathLike], prefix: str = 'checkpoint_'
 ) -> List[str]:
   """Retrieve all checkpoint paths in directory.
 
@@ -911,15 +920,15 @@ def _all_checkpoints(
   """
   ckpt_dir = os.fspath(ckpt_dir)  # Pathlib -> str
   checkpoint_files: List[Any] = [
-      pathlib.PurePath(c) for c in _allowempty_listdir(ckpt_dir)
+    pathlib.PurePath(c) for c in _allowempty_listdir(ckpt_dir)
   ]
   checkpoint_files = [
-      os.path.join(ckpt_dir, c)
-      for c in checkpoint_files
-      if c.match(f'{prefix}*')
-      and not c.match(f'{prefix}tmp')
-      and not c.match(f'*{MP_ARRAY_POSTFIX}')
-      and not c.match(f'*{ocp.utils.TMP_DIR_SUFFIX}*')
+    os.path.join(ckpt_dir, c)
+    for c in checkpoint_files
+    if c.match(f'{prefix}*')
+    and not c.match(f'{prefix}tmp')
+    and not c.match(f'*{MP_ARRAY_POSTFIX}')
+    and not c.match(f'*{ocp.utils.TMP_DIR_SUFFIX}*')
   ]
   checkpoint_files = natural_sort(checkpoint_files)
   if checkpoint_files:
@@ -929,7 +938,7 @@ def _all_checkpoints(
 
 
 def latest_checkpoint(
-    ckpt_dir: Union[str, os.PathLike], prefix: str = 'checkpoint_'
+  ckpt_dir: Union[str, os.PathLike], prefix: str = 'checkpoint_'
 ) -> Optional[str]:
   """Retrieve the path of the latest checkpoint in a directory.
 
@@ -948,9 +957,9 @@ def latest_checkpoint(
 
 
 def available_steps(
-    ckpt_dir: Union[str, os.PathLike],
-    prefix: str = 'checkpoint_',
-    step_type: Type = int,
+  ckpt_dir: Union[str, os.PathLike],
+  prefix: str = 'checkpoint_',
+  step_type: Type = int,
 ) -> List[Union[int, float]]:
   """Return step numbers of available checkpoints in a directory.
 
@@ -975,15 +984,15 @@ def available_steps(
 
 
 def restore_checkpoint(
-    ckpt_dir: Union[str, os.PathLike],
-    target: Optional[Any],
-    step: Optional[Union[int, float]] = None,
-    prefix: str = 'checkpoint_',
-    parallel: bool = True,
-    gda_manager: Optional[GlobalAsyncCheckpointManager] = None,
-    allow_partial_mpa_restoration: bool = False,
-    orbax_checkpointer: Optional[ocp.Checkpointer] = None,
-    orbax_transforms: Optional[Dict] = None,
+  ckpt_dir: Union[str, os.PathLike],
+  target: Optional[Any],
+  step: Optional[Union[int, float]] = None,
+  prefix: str = 'checkpoint_',
+  parallel: bool = True,
+  gda_manager: Optional[GlobalAsyncCheckpointManager] = None,
+  allow_partial_mpa_restoration: bool = False,
+  orbax_checkpointer: Optional[ocp.Checkpointer] = None,
+  orbax_transforms: Optional[Dict] = None,
 ) -> PyTree:
   """Restore last/best checkpoint from checkpoints in path.
 
@@ -1028,7 +1037,7 @@ def restore_checkpoint(
   start_time = time.time()
   # Make sure any previous work is done before checking files.
   if orbax_checkpointer and isinstance(
-      orbax_checkpointer, ocp.AsyncCheckpointer
+    orbax_checkpointer, ocp.AsyncCheckpointer
   ):
     orbax_checkpointer.wait_until_finished()
 
@@ -1050,7 +1059,7 @@ def restore_checkpoint(
         ckpt_path = latest_checkpoint(ckpt_dir, prefix)  # type: ignore
         if not ckpt_path:
           logging.info(
-              'Found no checkpoint files in %s with prefix %s', ckpt_dir, prefix
+            'Found no checkpoint files in %s with prefix %s', ckpt_dir, prefix
           )
           return target
     else:
@@ -1063,29 +1072,29 @@ def restore_checkpoint(
   if is_orbax:
     if not orbax_checkpointer:
       orbax_checkpointer = ocp.Checkpointer(
-          ocp.PyTreeCheckpointHandler(restore_with_serialized_types=False)
+        ocp.PyTreeCheckpointHandler(restore_with_serialized_types=False)
       )
 
     restore_kwargs = {}
     if target is not None:
       restore_kwargs['restore_args'] = orbax_utils.restore_args_from_target(
-          target
+        target
       )
       if isinstance(orbax_checkpointer._handler, ocp.PyTreeCheckpointHandler):  # pylint: disable=protected-access
-        restore_kwargs['transforms'] = (
-            orbax_utils.maybe_construct_transformations(
-                target, orbax_transforms
-            )
+        restore_kwargs[
+          'transforms'
+        ] = orbax_utils.maybe_construct_transformations(
+          target, orbax_transforms
         )
     restored = orbax_checkpointer.restore(
-        ckpt_path, item=target, **restore_kwargs
+      ckpt_path, item=target, **restore_kwargs
     )
     restored = serialization.to_state_dict(restored)
     if target is not None:
       restored = serialization.from_state_dict(target, restored)
     end_time = time.time()
     monitoring.record_event_duration_secs(
-        _READ_CHECKPOINT_EVENT, end_time - start_time
+      _READ_CHECKPOINT_EVENT, end_time - start_time
     )
     return restored
 
@@ -1118,12 +1127,12 @@ def restore_checkpoint(
 
   state_dict = serialization.msgpack_restore(checkpoint_contents)
   state_dict = _restore_mpas(
-      state_dict,
-      target,
-      ckpt_path,
-      step,
-      gda_manager,
-      allow_partial_mpa_restoration,
+    state_dict,
+    target,
+    ckpt_path,
+    step,
+    gda_manager,
+    allow_partial_mpa_restoration,
   )
 
   if target is None:
@@ -1133,7 +1142,7 @@ def restore_checkpoint(
 
   end_time = time.time()
   monitoring.record_event_duration_secs(
-      _READ_CHECKPOINT_EVENT, end_time - start_time
+    _READ_CHECKPOINT_EVENT, end_time - start_time
   )
 
   return restored_checkpoint

--- a/flax/training/common_utils.py
+++ b/flax/training/common_utils.py
@@ -19,9 +19,9 @@ with helping write pmap-based data-parallel training loops.
 """
 
 import jax
-from jax import lax
 import jax.numpy as jnp
 import numpy as np
+from jax import lax
 
 
 def shard(xs):
@@ -35,7 +35,7 @@ def shard(xs):
   """
   local_device_count = jax.local_device_count()
   return jax.tree_util.tree_map(
-      lambda x: x.reshape((local_device_count, -1) + x.shape[1:]), xs
+    lambda x: x.reshape((local_device_count, -1) + x.shape[1:]), xs
   )
 
 
@@ -101,7 +101,7 @@ def onehot(labels, num_classes, on_value=1.0, off_value=0.0):
     num_classes.
   """
   x = labels[..., None] == jnp.arange(num_classes).reshape(
-      (1,) * labels.ndim + (-1,)
+    (1,) * labels.ndim + (-1,)
   )
   x = lax.select(x, jnp.full(x.shape, on_value), jnp.full(x.shape, off_value))
   return x.astype(jnp.float32)

--- a/flax/training/dynamic_scale.py
+++ b/flax/training/dynamic_scale.py
@@ -17,12 +17,11 @@
 import functools
 from typing import Any, Callable, NamedTuple, Optional, Sequence, Union
 
-from flax import struct
-
 import jax
-from jax import lax
 import jax.numpy as jnp
+from jax import lax
 
+from flax import struct
 
 Array = Any
 
@@ -86,15 +85,15 @@ class DynamicScale(struct.PyTreeNode):
   fin_steps: Array = 0
   scale: Array = 65536.0
   minimum_scale: Optional[float] = struct.field(
-      pytree_node=False, default=jnp.finfo(jnp.float32).tiny
+    pytree_node=False, default=jnp.finfo(jnp.float32).tiny
   )
 
   def value_and_grad(
-      self,
-      fun: Callable[..., Any],
-      argnums: Union[int, Sequence[int]] = 0,
-      has_aux: bool = False,
-      axis_name: Optional[str] = None,
+    self,
+    fun: Callable[..., Any],
+    argnums: Union[int, Sequence[int]] = 0,
+    has_aux: bool = False,
+    axis_name: Optional[str] = None,
   ) -> Callable[..., DynamicScaleResult]:
     """Wrapper around `jax.value_and_grad`.
 
@@ -135,7 +134,7 @@ class DynamicScale(struct.PyTreeNode):
       aux = (aux[0] / self.scale, aux[1]) if has_aux else aux / self.scale
 
       grad = jax.tree_util.tree_map(
-          lambda g: jnp.asarray(g, jnp.float32) / self.scale, grad
+        lambda g: jnp.asarray(g, jnp.float32) / self.scale, grad
       )
       if axis_name is not None:
         grad = lax.pmean(grad, axis_name)
@@ -146,11 +145,11 @@ class DynamicScale(struct.PyTreeNode):
 
       grow = self.fin_steps == self.growth_interval
       fin_scale = jnp.where(
-          grow & finite,
-          jnp.minimum(
-              self.scale * self.growth_factor, jnp.finfo(jnp.float32).max
-          ),
-          self.scale,
+        grow & finite,
+        jnp.minimum(
+          self.scale * self.growth_factor, jnp.finfo(jnp.float32).max
+        ),
+        self.scale,
       )
       inf_scale = self.scale * self.backoff_factor
       if self.minimum_scale is not None:

--- a/flax/training/early_stopping.py
+++ b/flax/training/early_stopping.py
@@ -15,6 +15,7 @@
 """Early stopping."""
 
 import math
+
 from flax import struct
 
 
@@ -56,7 +57,10 @@ class EarlyStopping(struct.PyTreeNode):
 
   def reset(self):
     return self.replace(
-        best_metric=float('inf'), patience_count=0, should_stop=False, has_improved=False
+      best_metric=float('inf'),
+      patience_count=0,
+      should_stop=False,
+      has_improved=False,
     )
 
   def update(self, metric):
@@ -69,12 +73,15 @@ class EarlyStopping(struct.PyTreeNode):
     """
 
     if (
-        math.isinf(self.best_metric)
-        or self.best_metric - metric > self.min_delta
+      math.isinf(self.best_metric) or self.best_metric - metric > self.min_delta
     ):
-      return self.replace(best_metric=metric, patience_count=0, has_improved=True)
+      return self.replace(
+        best_metric=metric, patience_count=0, has_improved=True
+      )
     else:
       should_stop = self.patience_count >= self.patience or self.should_stop
       return self.replace(
-          patience_count=self.patience_count + 1, should_stop=should_stop, has_improved=False
+        patience_count=self.patience_count + 1,
+        should_stop=should_stop,
+        has_improved=False,
       )

--- a/flax/training/lr_schedule.py
+++ b/flax/training/lr_schedule.py
@@ -23,9 +23,9 @@ Note that with `FLIP #1009`_ learning rate schedules in ``flax.training`` are
 .. _Optimizer Schedules: https://optax.readthedocs.io/en/latest/api.html#optimizer-schedules
 """
 
-from absl import logging
 import jax.numpy as jnp
 import numpy as np
+from absl import logging
 
 
 def _piecewise_constant(boundaries, values, t):
@@ -34,7 +34,7 @@ def _piecewise_constant(boundaries, values, t):
 
 
 def create_constant_learning_rate_schedule(
-    base_learning_rate, steps_per_epoch, warmup_length=0.0
+  base_learning_rate, steps_per_epoch, warmup_length=0.0
 ):
   """Create a constant learning rate schedule with optional warmup.
 
@@ -61,10 +61,10 @@ def create_constant_learning_rate_schedule(
     Function `f(step) -> lr` that computes the learning rate for a given step.
   """
   logging.warning(
-      'Learning rate schedules in ``flax.training`` are effectively deprecated '
-      'in favor of Optax schedules. Please refer to '
-      'https://optax.readthedocs.io/en/latest/api.html#optimizer-schedules'
-      ' for alternatives.'
+    'Learning rate schedules in ``flax.training`` are effectively deprecated '
+    'in favor of Optax schedules. Please refer to '
+    'https://optax.readthedocs.io/en/latest/api.html#optimizer-schedules'
+    ' for alternatives.'
   )
 
   def learning_rate_fn(step):
@@ -77,7 +77,7 @@ def create_constant_learning_rate_schedule(
 
 
 def create_stepped_learning_rate_schedule(
-    base_learning_rate, steps_per_epoch, lr_sched_steps, warmup_length=0.0
+  base_learning_rate, steps_per_epoch, lr_sched_steps, warmup_length=0.0
 ):
   """Create a stepped learning rate schedule with optional warmup.
 
@@ -119,10 +119,10 @@ def create_stepped_learning_rate_schedule(
     Function `f(step) -> lr` that computes the learning rate for a given step.
   """
   logging.warning(
-      'Learning rate schedules in ``flax.training`` are effectively deprecated '
-      'in favor of Optax schedules. Please refer to '
-      'https://optax.readthedocs.io/en/latest/api.html#optimizer-schedules'
-      ' for alternatives.'
+    'Learning rate schedules in ``flax.training`` are effectively deprecated '
+    'in favor of Optax schedules. Please refer to '
+    'https://optax.readthedocs.io/en/latest/api.html#optimizer-schedules'
+    ' for alternatives.'
   )
   boundaries = [step[0] for step in lr_sched_steps]
   decays = [step[1] for step in lr_sched_steps]
@@ -140,7 +140,7 @@ def create_stepped_learning_rate_schedule(
 
 
 def create_cosine_learning_rate_schedule(
-    base_learning_rate, steps_per_epoch, halfcos_epochs, warmup_length=0.0
+  base_learning_rate, steps_per_epoch, halfcos_epochs, warmup_length=0.0
 ):
   """Create a cosine learning rate schedule with optional warmup.
 
@@ -172,10 +172,10 @@ def create_cosine_learning_rate_schedule(
     Function `f(step) -> lr` that computes the learning rate for a given step.
   """
   logging.warning(
-      'Learning rate schedules in ``flax.training`` are effectively deprecated '
-      'in favor of Optax schedules. Please refer to '
-      'https://optax.readthedocs.io/en/latest/api.html#optimizer-schedules'
-      ' for alternatives.'
+    'Learning rate schedules in ``flax.training`` are effectively deprecated '
+    'in favor of Optax schedules. Please refer to '
+    'https://optax.readthedocs.io/en/latest/api.html#optimizer-schedules'
+    ' for alternatives.'
   )
   halfwavelength_steps = halfcos_epochs * steps_per_epoch
 

--- a/flax/training/prefetch_iterator.py
+++ b/flax/training/prefetch_iterator.py
@@ -43,9 +43,9 @@ class PrefetchIterator:
       buffer_size: how many items to prefetch (default: 1).
     """
     warnings.warn(
-        'PrefetchIterator is deprecated. Use the standard `tf.data`'
-        ' prefetch method instead',
-        DeprecationWarning,
+      'PrefetchIterator is deprecated. Use the standard `tf.data`'
+      ' prefetch method instead',
+      DeprecationWarning,
     )
 
     self._data_iter = data_iter

--- a/flax/training/train_state.py
+++ b/flax/training/train_state.py
@@ -14,10 +14,10 @@
 
 from typing import Any, Callable
 
-from flax import core
-from flax import struct
-from flax.linen.fp8_ops import OVERWRITE_WITH_GRADIENT
 import optax
+
+from flax import core, struct
+from flax.linen.fp8_ops import OVERWRITE_WITH_GRADIENT
 
 
 class TrainState(struct.PyTreeNode):
@@ -80,7 +80,7 @@ class TrainState(struct.PyTreeNode):
       params_with_opt = self.params
 
     updates, new_opt_state = self.tx.update(
-        grads_with_opt, self.opt_state, params_with_opt
+      grads_with_opt, self.opt_state, params_with_opt
     )
     new_params_with_opt = optax.apply_updates(params_with_opt, updates)
 
@@ -88,16 +88,16 @@ class TrainState(struct.PyTreeNode):
     # parameters.
     if OVERWRITE_WITH_GRADIENT in grads:
       new_params = {
-          'params': new_params_with_opt,
-          OVERWRITE_WITH_GRADIENT: grads[OVERWRITE_WITH_GRADIENT]
+        'params': new_params_with_opt,
+        OVERWRITE_WITH_GRADIENT: grads[OVERWRITE_WITH_GRADIENT],
       }
     else:
       new_params = new_params_with_opt
     return self.replace(
-        step=self.step + 1,
-        params=new_params,
-        opt_state=new_opt_state,
-        **kwargs,
+      step=self.step + 1,
+      params=new_params,
+      opt_state=new_opt_state,
+      **kwargs,
     )
 
   @classmethod
@@ -105,14 +105,14 @@ class TrainState(struct.PyTreeNode):
     """Creates a new instance with `step=0` and initialized `opt_state`."""
     # We exclude OWG params when present because they do not need opt states.
     params_with_opt = (
-        params['params'] if OVERWRITE_WITH_GRADIENT in params else params
+      params['params'] if OVERWRITE_WITH_GRADIENT in params else params
     )
     opt_state = tx.init(params_with_opt)
     return cls(
-        step=0,
-        apply_fn=apply_fn,
-        params=params,
-        tx=tx,
-        opt_state=opt_state,
-        **kwargs,
+      step=0,
+      apply_fn=apply_fn,
+      params=params,
+      tx=tx,
+      opt_state=opt_state,
+      **kwargs,
     )

--- a/flax/traverse_util.py
+++ b/flax/traverse_util.py
@@ -43,10 +43,11 @@ returns a copy of the data including the provided updates.
 import abc
 import copy
 import dataclasses
-from typing import Any, Callable, Tuple
 import warnings
+from typing import Any, Callable, Tuple
 
 import jax
+
 import flax
 from flax.core.scope import VariableDict
 
@@ -99,7 +100,7 @@ def flatten_dict(xs, keep_empty_nodes=False, is_leaf=None, sep=None):
     The flattened dictionary.
   """
   assert isinstance(
-      xs, (flax.core.FrozenDict, dict)
+    xs, (flax.core.FrozenDict, dict)
   ), f'expected (frozen)dict; got {type(xs)}'
 
   def _key(path):
@@ -109,7 +110,7 @@ def flatten_dict(xs, keep_empty_nodes=False, is_leaf=None, sep=None):
 
   def _flatten(xs, prefix):
     if not isinstance(xs, (flax.core.FrozenDict, dict)) or (
-        is_leaf and is_leaf(prefix, xs)
+      is_leaf and is_leaf(prefix, xs)
     ):
       return {_key(prefix): xs}
     result = {}
@@ -168,7 +169,7 @@ def unflatten_dict(xs, sep=None):
 
 
 def path_aware_map(
-    f: Callable[[Path, Any], Any], nested_dict: VariableDict
+  f: Callable[[Path, Any], Any], nested_dict: VariableDict
 ) -> VariableDict:
   """A map function that operates over nested dictionary structures while taking
   the path to each leaf into account.
@@ -193,7 +194,7 @@ def path_aware_map(
   """
   flat = flatten_dict(nested_dict, keep_empty_nodes=True)
   return unflatten_dict(
-      {k: f(k, v) if v is not empty_node else v for k, v in flat.items()}
+    {k: f(k, v) if v is not empty_node else v for k, v in flat.items()}
   )
 
 
@@ -203,11 +204,11 @@ class Traversal(abc.ABC):
   def __new__(cls, *args, **kwargs):
     # Must override __new__ instead of __init__ since this is an ABC
     warnings.warn(
-        '`flax.traverse_util.Traversal` will be deprecated. If you are using '
-        'it for `flax.optim`, use `optax` instead. Refer to the update guide '
-        'https://flax.readthedocs.io/en/latest/guides/optax_update_guide.html '
-        'for detailed instructions.',
-        DeprecationWarning,
+      '`flax.traverse_util.Traversal` will be deprecated. If you are using '
+      'it for `flax.optim`, use `optax` instead. Refer to the update guide '
+      'https://flax.readthedocs.io/en/latest/guides/optax_update_guide.html '
+      'for detailed instructions.',
+      DeprecationWarning,
     )
     return super().__new__(cls)
 
@@ -389,8 +390,7 @@ class TraverseItem(Traversal):
       indices = set(range(*sl.indices(len(inputs))))
 
       args = [
-          fn(inputs[i]) if i in indices else inputs[i]
-          for i in range(len(inputs))
+        fn(inputs[i]) if i in indices else inputs[i] for i in range(len(inputs))
       ]
       if _is_namedtuple(ty):
         return ty(*args)
@@ -441,8 +441,8 @@ def _get_params_dict(inputs):
     return flax.core.unfreeze(inputs)
   else:
     raise ValueError(
-        'Can only traverse a flax Model instance or a nested dict, not '
-        f'{type(inputs)}'
+      'Can only traverse a flax Model instance or a nested dict, not '
+      f'{type(inputs)}'
     )
 
 

--- a/flax/version.py
+++ b/flax/version.py
@@ -13,4 +13,4 @@
 # limitations under the License.
 
 """Current Flax version at head on Github."""
-__version__ = "0.8.0"
+__version__ = '0.8.0'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -172,17 +172,27 @@ line-length = 80
 preview = true
 
 [tool.ruff]
-# Enable Pyflakes (`F`) and a subset of the pycodestyle (`E`)  codes by default.
-select = ["F401"]
-ignore = []
-# Allow fix for all enabled rules (when `--fix`) is provided.
-# Full list of rules: https://docs.astral.sh/ruff/rules/
-fixable = ["F401"]
-unfixable = []
 # Exclude a variety of commonly ignored directories.
 exclude = [
   "__init__.py",
   "activation.py",
   "partitioning.py",
-  "variables.py"
+  "variables.py",
+  "examples/",
 ]
+
+line-length = 80
+indent-width = 2
+
+[tool.ruff.lint]
+# Enable Pyflakes (`F`) and a subset of the pycodestyle (`E`)  codes by default.
+select = ["F401", "I001"]
+ignore = []
+# Allow fix for all enabled rules (when `--fix`) is provided.
+# Full list of rules: https://docs.astral.sh/ruff/rules/
+fixable = ["ALL"]
+unfixable = []
+
+[tool.ruff.format]
+indent-style = "space"
+quote-style = "single"

--- a/tests/checkpoints_test.py
+++ b/tests/checkpoints_test.py
@@ -19,20 +19,15 @@ import os
 import pathlib
 from typing import Any
 
-from absl.testing import absltest
-from absl.testing import parameterized
-from flax import config
-from flax import core
-from flax import errors
-from flax import io
-from flax import linen as nn
-from flax import struct
-from flax.training import checkpoints
 import jax
-from jax import numpy as jnp
 import numpy as np
-
 import orbax.checkpoint as orbax
+from absl.testing import absltest, parameterized
+from jax import numpy as jnp
+
+from flax import config, core, errors, io, struct
+from flax import linen as nn
+from flax.training import checkpoints
 
 # Parse absl flags test_srcdir and test_tmpdir.
 jax.config.parse_flags_with_absl()
@@ -43,7 +38,7 @@ PyTree = Any
 
 def check_eq(xs, ys):
   return jax.tree_util.tree_all(
-      jax.tree_util.tree_map(np.testing.assert_allclose, xs, ys)
+    jax.tree_util.tree_map(np.testing.assert_allclose, xs, ys)
   )
 
 
@@ -85,7 +80,6 @@ class CustomDC:
 
 
 class CheckpointsTest(parameterized.TestCase):
-
   def setUp(self):
     super().setUp()
     config.update('flax_use_orbax_checkpointing', False)  # default value
@@ -93,11 +87,11 @@ class CheckpointsTest(parameterized.TestCase):
   def test_naturalsort(self):
     np.random.seed(0)
     tests = [
-        ['file_1', 'file_2', 'file_10', 'file_11', 'file_21'],
-        ['file_0.001', 'file_0.01', 'file_0.1', 'file_1'],
-        ['file_-3.0', 'file_-2', 'file_-1', 'file_0.0'],
-        ['file_1e1', 'file_1.0e2', 'file_1e3', 'file_1.0e4'],
-        ['file_1', 'file_2', 'file_9', 'file_1.0e1', 'file_11'],
+      ['file_1', 'file_2', 'file_10', 'file_11', 'file_21'],
+      ['file_0.001', 'file_0.01', 'file_0.1', 'file_1'],
+      ['file_-3.0', 'file_-2', 'file_-1', 'file_0.0'],
+      ['file_1e1', 'file_1.0e2', 'file_1e3', 'file_1.0e4'],
+      ['file_1', 'file_2', 'file_9', 'file_1.0e1', 'file_11'],
     ]
     for test in tests:
       self.assertEqual(test, checkpoints.natural_sort(shuffle(test)))
@@ -113,69 +107,69 @@ class CheckpointsTest(parameterized.TestCase):
     config.update('flax_use_orbax_checkpointing', use_orbax)
     tmp_dir = pathlib.Path(self.create_tempdir().full_path)
     test_object0 = {
-        'a': np.array([0, 0, 0], np.int32),
-        'b': np.array([0, 0, 0], np.int32),
+      'a': np.array([0, 0, 0], np.int32),
+      'b': np.array([0, 0, 0], np.int32),
     }
     test_object1 = {
-        'a': np.array([1, 2, 3], np.int32),
-        'b': np.array([1, 1, 1], np.int32),
+      'a': np.array([1, 2, 3], np.int32),
+      'b': np.array([1, 1, 1], np.int32),
     }
     test_object2 = {
-        'a': np.array([4, 5, 6], np.int32),
-        'b': np.array([2, 2, 2], np.int32),
+      'a': np.array([4, 5, 6], np.int32),
+      'b': np.array([2, 2, 2], np.int32),
     }
     new_object = checkpoints.restore_checkpoint(
-        tmp_dir, test_object0, prefix='test_'
+      tmp_dir, test_object0, prefix='test_'
     )
     check_eq(new_object, test_object0)
     checkpoints.save_checkpoint(
-        tmp_dir, test_object1, 0, prefix='test_', keep=1
+      tmp_dir, test_object1, 0, prefix='test_', keep=1
     )
     self.assertIn('test_0', os.listdir(tmp_dir))
     new_object = checkpoints.restore_checkpoint(
-        tmp_dir, test_object0, prefix='test_'
+      tmp_dir, test_object0, prefix='test_'
     )
     check_eq(new_object, test_object1)
     checkpoints.save_checkpoint(
-        tmp_dir, test_object1, 1, prefix='test_', keep=1
+      tmp_dir, test_object1, 1, prefix='test_', keep=1
     )
     checkpoints.save_checkpoint(
-        tmp_dir, test_object2, 2, prefix='test_', keep=1
+      tmp_dir, test_object2, 2, prefix='test_', keep=1
     )
     new_object = checkpoints.restore_checkpoint(
-        tmp_dir, test_object0, prefix='test_'
+      tmp_dir, test_object0, prefix='test_'
     )
     check_eq(new_object, test_object2)
     checkpoints.save_checkpoint(
-        tmp_dir, test_object2, 3, prefix='test_', keep=2
+      tmp_dir, test_object2, 3, prefix='test_', keep=2
     )
     checkpoints.save_checkpoint(
-        tmp_dir, test_object1, 4, prefix='test_', keep=2
+      tmp_dir, test_object1, 4, prefix='test_', keep=2
     )
     new_object = checkpoints.restore_checkpoint(
-        tmp_dir, test_object0, prefix='test_'
+      tmp_dir, test_object0, prefix='test_'
     )
     check_eq(new_object, test_object1)
     new_object = checkpoints.restore_checkpoint(
-        tmp_dir, test_object0, step=3, prefix='test_'
+      tmp_dir, test_object0, step=3, prefix='test_'
     )
     check_eq(new_object, test_object2)
 
     # Restore with a specific checkpoint path, not the directory path.
     new_object = checkpoints.restore_checkpoint(
-        os.path.join(tmp_dir, 'test_3'), test_object0
+      os.path.join(tmp_dir, 'test_3'), test_object0
     )
     check_eq(new_object, test_object2)
     # If a specific path is specified, but it does not exist, the same behavior
     # as when a directory is empty should apply: the target is returned
     # unchanged.
     new_object = checkpoints.restore_checkpoint(
-        os.path.join(tmp_dir, 'test_not_there'), test_object0
+      os.path.join(tmp_dir, 'test_not_there'), test_object0
     )
     check_eq(new_object, test_object0)
     with self.assertRaises(ValueError):
       checkpoints.restore_checkpoint(
-          tmp_dir, test_object0, step=5, prefix='test_'
+        tmp_dir, test_object0, step=5, prefix='test_'
       )
 
   @parameterized.parameters({'use_orbax': True}, {'use_orbax': False})
@@ -199,8 +193,8 @@ class CheckpointsTest(parameterized.TestCase):
     check_eq(new_object, test_object)
 
   @parameterized.parameters(
-      {'use_orbax': True, 'keep_every_n_steps': None},
-      {'use_orbax': False, 'keep_every_n_steps': 7},
+    {'use_orbax': True, 'keep_every_n_steps': None},
+    {'use_orbax': False, 'keep_every_n_steps': 7},
   )
   def test_keep(self, use_orbax, keep_every_n_steps):
     config.update('flax_use_orbax_checkpointing', use_orbax)
@@ -213,20 +207,20 @@ class CheckpointsTest(parameterized.TestCase):
 
     for step in range(steps_start, steps_end, increment):
       checkpoints.save_checkpoint(
-          tmp_dir,
-          test_object,
-          step=step,
-          keep=keep,
-          keep_every_n_steps=keep_every_n_steps,
+        tmp_dir,
+        test_object,
+        step=step,
+        keep=keep,
+        keep_every_n_steps=keep_every_n_steps,
       )
 
     last_checkpoint = -float('inf')
     for step in range(steps_start, steps_end, increment):
       if ((steps_end - step) / increment <= keep) or (
-          keep_every_n_steps and (step - last_checkpoint) >= keep_every_n_steps
+        keep_every_n_steps and (step - last_checkpoint) >= keep_every_n_steps
       ):
         restored = checkpoints.restore_checkpoint(
-            tmp_dir, target=None, step=step
+          tmp_dir, target=None, step=step
         )
         check_eq(restored, test_object)
         last_checkpoint = step
@@ -239,30 +233,30 @@ class CheckpointsTest(parameterized.TestCase):
     config.update('flax_use_orbax_checkpointing', use_orbax)
     tmp_dir = self.create_tempdir().full_path
     test_object0 = {
-        'a': np.array([0, 0, 0], np.int32),
-        'b': np.array([0, 0, 0], np.int32),
+      'a': np.array([0, 0, 0], np.int32),
+      'b': np.array([0, 0, 0], np.int32),
     }
     test_object1 = {
-        'a': np.array([1, 2, 3], np.int32),
-        'b': np.array([1, 1, 1], np.int32),
+      'a': np.array([1, 2, 3], np.int32),
+      'b': np.array([1, 1, 1], np.int32),
     }
     test_object2 = {
-        'a': np.array([4, 5, 6], np.int32),
-        'b': np.array([2, 2, 2], np.int32),
+      'a': np.array([4, 5, 6], np.int32),
+      'b': np.array([2, 2, 2], np.int32),
     }
     checkpoints.save_checkpoint(
-        tmp_dir, test_object1, 0.0, prefix='test_', keep=1
+      tmp_dir, test_object1, 0.0, prefix='test_', keep=1
     )
     self.assertIn('test_0.0', os.listdir(tmp_dir))
     new_object = checkpoints.restore_checkpoint(
-        tmp_dir, test_object0, prefix='test_'
+      tmp_dir, test_object0, prefix='test_'
     )
     check_eq(new_object, test_object1)
     checkpoints.save_checkpoint(
-        tmp_dir, test_object1, 2.0, prefix='test_', keep=1
+      tmp_dir, test_object1, 2.0, prefix='test_', keep=1
     )
     checkpoints.save_checkpoint(
-        tmp_dir, test_object2, 3.0, prefix='test_', keep=2
+      tmp_dir, test_object2, 3.0, prefix='test_', keep=2
     )
     self.assertIn('test_3.0', os.listdir(tmp_dir))
     self.assertIn('test_2.0', os.listdir(tmp_dir))
@@ -273,8 +267,8 @@ class CheckpointsTest(parameterized.TestCase):
     config.update('flax_use_orbax_checkpointing', use_orbax)
     tmp_dir = self.create_tempdir().full_path
     test_object0 = {
-        'a': np.array([0, 0, 0], np.int32),
-        'b': np.array([0, 0, 0], np.int32),
+      'a': np.array([0, 0, 0], np.int32),
+      'b': np.array([0, 0, 0], np.int32),
     }
     # Target pytree is a dictionary, so it's equal to a restored state_dict.
     checkpoints.save_checkpoint(tmp_dir, test_object0, 0)
@@ -282,8 +276,8 @@ class CheckpointsTest(parameterized.TestCase):
     check_eq(new_object, test_object0)
     # Target pytree it's a tuple, check the expected state_dict is recovered.
     test_object1 = (
-        np.array([0, 0, 0], np.int32),
-        np.array([1, 1, 1], np.int32),
+      np.array([0, 0, 0], np.int32),
+      np.array([1, 1, 1], np.int32),
     )
     checkpoints.save_checkpoint(tmp_dir, test_object1, 1)
     new_object = checkpoints.restore_checkpoint(tmp_dir, target=None)
@@ -330,43 +324,43 @@ class CheckpointsTest(parameterized.TestCase):
   def test_async_save_checkpoints(self):
     tmp_dir = pathlib.Path(self.create_tempdir().full_path)
     test_object0 = {
-        'a': np.array([0, 0, 0], np.int32),
-        'b': np.array([0, 0, 0], np.int32),
+      'a': np.array([0, 0, 0], np.int32),
+      'b': np.array([0, 0, 0], np.int32),
     }
     test_object1 = {
-        'a': np.random.normal(size=(1000, 1000)),
-        'b': np.random.normal(size=(1000, 1000)),
+      'a': np.random.normal(size=(1000, 1000)),
+      'b': np.random.normal(size=(1000, 1000)),
     }
     test_object2 = {
-        'a': np.random.normal(size=(1000, 1000)),
-        'b': np.random.normal(size=(1000, 1000)),
+      'a': np.random.normal(size=(1000, 1000)),
+      'b': np.random.normal(size=(1000, 1000)),
     }
     test_object3 = {
-        'a': np.random.normal(size=(1000, 1000)),
-        'b': np.random.normal(size=(1000, 1000)),
+      'a': np.random.normal(size=(1000, 1000)),
+      'b': np.random.normal(size=(1000, 1000)),
     }
     am = checkpoints.AsyncManager()
     checkpoints.save_checkpoint(
-        tmp_dir, test_object1, 0, prefix='test_', keep=1, async_manager=am
+      tmp_dir, test_object1, 0, prefix='test_', keep=1, async_manager=am
     )
     # Hard-wait the write to be done, then check its content.
     am.save_future.result()
     self.assertIn('test_0', os.listdir(tmp_dir))
     new_object = checkpoints.restore_checkpoint(
-        tmp_dir, test_object1, prefix='test_'
+      tmp_dir, test_object1, prefix='test_'
     )
     check_eq(new_object, test_object1)
     # Check two consecutive saves happen in the right order.
     checkpoints.save_checkpoint(
-        tmp_dir, test_object2, 1, prefix='test_', keep=1, async_manager=am
+      tmp_dir, test_object2, 1, prefix='test_', keep=1, async_manager=am
     )
     checkpoints.save_checkpoint(
-        tmp_dir, test_object3, 2, prefix='test_', keep=1, async_manager=am
+      tmp_dir, test_object3, 2, prefix='test_', keep=1, async_manager=am
     )
     am.save_future.result()
     self.assertIn('test_2', os.listdir(tmp_dir))
     new_object = checkpoints.restore_checkpoint(
-        tmp_dir, test_object1, prefix='test_'
+      tmp_dir, test_object1, prefix='test_'
     )
     check_eq(new_object, test_object3)
 
@@ -381,15 +375,15 @@ class CheckpointsTest(parameterized.TestCase):
       f.write('test_0')
     io.makedirs(os.path.join(tmp_dir, 'test_0_gda'))
     self.assertEqual(
-        checkpoints.latest_checkpoint(tmp_dir, 'test_'),
-        os.path.join(tmp_dir, 'test_0'),
+      checkpoints.latest_checkpoint(tmp_dir, 'test_'),
+      os.path.join(tmp_dir, 'test_0'),
     )
 
     with io.GFile(os.path.join(tmp_dir, 'test_10'), 'w') as f:
       f.write('test_10')
     self.assertEqual(
-        checkpoints.latest_checkpoint(tmp_dir, 'test_'),
-        os.path.join(tmp_dir, 'test_10'),
+      checkpoints.latest_checkpoint(tmp_dir, 'test_'),
+      os.path.join(tmp_dir, 'test_10'),
     )
     self.assertEqual(checkpoints.latest_checkpoint(tmp_dir, 'ckpt_'), None)
 
@@ -399,8 +393,8 @@ class CheckpointsTest(parameterized.TestCase):
     self.assertIsNone(checkpoints.latest_checkpoint(tmp_dir, 'orbaxtest_'))
 
   @parameterized.parameters(
-      {'step_type': int, 'steps': [1, 5, 112]},
-      {'step_type': float, 'steps': [1.0, 4.5, 5.6]},
+    {'step_type': int, 'steps': [1, 5, 112]},
+    {'step_type': float, 'steps': [1.0, 4.5, 5.6]},
   )
   def test_available_steps(self, step_type, steps):
     tmp_dir = pathlib.Path(self.create_tempdir().full_path)
@@ -414,8 +408,8 @@ class CheckpointsTest(parameterized.TestCase):
       io.makedirs(os.path.join(tmp_dir, 'test_' + str(step) + '_gda'))
 
     self.assertEqual(
-        checkpoints.available_steps(tmp_dir, 'test_', step_type=step_type),
-        steps,
+      checkpoints.available_steps(tmp_dir, 'test_', step_type=step_type),
+      steps,
     )
 
   @parameterized.parameters({'use_orbax': True}, {'use_orbax': False})
@@ -423,12 +417,12 @@ class CheckpointsTest(parameterized.TestCase):
     config.update('flax_use_orbax_checkpointing', use_orbax)
     tmp_dir = self.create_tempdir().full_path
     to_save = [
-        CustomDC(foo=12, bar=core.freeze({'x': jnp.array((1, 4))})),
-        np.array((2, 3)),
+      CustomDC(foo=12, bar=core.freeze({'x': jnp.array((1, 4))})),
+      np.array((2, 3)),
     ]
     target = [
-        CustomDC(foo=0, bar=core.freeze({'x': jnp.array((0, 0))})),
-        np.array((0, 0)),
+      CustomDC(foo=0, bar=core.freeze({'x': jnp.array((0, 0))})),
+      np.array((0, 0)),
     ]
     checkpoints.save_checkpoint(tmp_dir, to_save, 0)
     restored = checkpoints.restore_checkpoint(tmp_dir, target=target)
@@ -448,11 +442,11 @@ class CheckpointsTest(parameterized.TestCase):
 
     # Both gets restored with same API.
     restored = checkpoints.restore_checkpoint(
-        os.path.join(tmp_dir, 'test_0'), target=target
+      os.path.join(tmp_dir, 'test_0'), target=target
     )
     check_eq(restored, to_save)
     restored = checkpoints.restore_checkpoint(
-        os.path.join(tmp_dir, 'test_1'), target=target
+      os.path.join(tmp_dir, 'test_1'), target=target
     )
     check_eq(restored, to_save)
 
@@ -468,28 +462,30 @@ class CheckpointsTest(parameterized.TestCase):
     check_eq(new_object, to_save)
 
   def test_convert_pre_linen(self):
-    params = checkpoints.convert_pre_linen({
+    params = checkpoints.convert_pre_linen(
+      {
         'mod_0': {
-            'submod1_0': {},
-            'submod2_1': {},
-            'submod1_2': {},
+          'submod1_0': {},
+          'submod2_1': {},
+          'submod1_2': {},
         },
         'mod2_2': {'submod2_2_0': {}},
         'mod2_11': {'submod2_11_0': {}},
         'mod2_1': {'submod2_1_0': {}},
-    })
+      }
+    )
     self.assertDictEqual(
-        core.unfreeze(params),
-        {
-            'mod_0': {
-                'submod1_0': {},
-                'submod1_1': {},
-                'submod2_0': {},
-            },
-            'mod2_0': {'submod2_1_0': {}},
-            'mod2_1': {'submod2_2_0': {}},
-            'mod2_2': {'submod2_11_0': {}},
+      core.unfreeze(params),
+      {
+        'mod_0': {
+          'submod1_0': {},
+          'submod1_1': {},
+          'submod2_0': {},
         },
+        'mod2_0': {'submod2_1_0': {}},
+        'mod2_1': {'submod2_2_0': {}},
+        'mod2_2': {'submod2_11_0': {}},
+      },
     )
 
 

--- a/tests/core/core_frozen_dict_test.py
+++ b/tests/core/core_frozen_dict_test.py
@@ -12,13 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from absl.testing import absltest, parameterized
-from flax.core import FrozenDict, copy, freeze, pop, unfreeze, pretty_repr
 import jax
+from absl.testing import absltest, parameterized
+
+from flax.core import FrozenDict, copy, freeze, pop, pretty_repr, unfreeze
 
 
 class FrozenDictTest(parameterized.TestCase):
-
   def test_frozen_dict_copies(self):
     xs = {'a': 1, 'b': {'c': 2}}
     frozen = freeze(xs)
@@ -40,7 +40,7 @@ class FrozenDictTest(parameterized.TestCase):
 
   def test_frozen_dict_partially_maps(self):
     x = jax.tree_util.tree_map(
-        lambda a, b: (a, b), freeze({'a': 2}), freeze({'a': {'b': 1}})
+      lambda a, b: (a, b), freeze({'a': 2}), freeze({'a': {'b': 1}})
     )
     self.assertEqual(unfreeze(x), {'a': (2, {'b': 1})})
 
@@ -81,73 +81,73 @@ class FrozenDictTest(parameterized.TestCase):
     self.assertEqual(result, {'a': 1, 'cls': 2})
 
   @parameterized.parameters(
-      {
-          'x': {'a': 1, 'b': {'c': 2}},
-          'key': 'b',
-          'actual_new_x': {'a': 1},
-          'actual_value': {'c': 2},
-      },
-      {
-          'x': FrozenDict({'a': 1, 'b': {'c': 2}}),
-          'key': 'b',
-          'actual_new_x': FrozenDict({'a': 1}),
-          'actual_value': FrozenDict({'c': 2}),
-      },
+    {
+      'x': {'a': 1, 'b': {'c': 2}},
+      'key': 'b',
+      'actual_new_x': {'a': 1},
+      'actual_value': {'c': 2},
+    },
+    {
+      'x': FrozenDict({'a': 1, 'b': {'c': 2}}),
+      'key': 'b',
+      'actual_new_x': FrozenDict({'a': 1}),
+      'actual_value': FrozenDict({'c': 2}),
+    },
   )
   def test_utility_pop(self, x, key, actual_new_x, actual_value):
     new_x, value = pop(x, key)
     self.assertTrue(
-        new_x == actual_new_x and isinstance(new_x, type(actual_new_x))
+      new_x == actual_new_x and isinstance(new_x, type(actual_new_x))
     )
     self.assertTrue(
-        value == actual_value and isinstance(value, type(actual_value))
+      value == actual_value and isinstance(value, type(actual_value))
     )
 
   @parameterized.parameters(
-      {
-          'x': {'a': 1, 'b': {'c': 2}},
-          'add_or_replace': {'b': {'c': -1, 'd': 3}},
-          'actual_new_x': {'a': 1, 'b': {'c': -1, 'd': 3}},
-      },
-      {
-          'x': FrozenDict({'a': 1, 'b': {'c': 2}}),
-          'add_or_replace': FrozenDict({'b': {'c': -1, 'd': 3}}),
-          'actual_new_x': FrozenDict({'a': 1, 'b': {'c': -1, 'd': 3}}),
-      },
+    {
+      'x': {'a': 1, 'b': {'c': 2}},
+      'add_or_replace': {'b': {'c': -1, 'd': 3}},
+      'actual_new_x': {'a': 1, 'b': {'c': -1, 'd': 3}},
+    },
+    {
+      'x': FrozenDict({'a': 1, 'b': {'c': 2}}),
+      'add_or_replace': FrozenDict({'b': {'c': -1, 'd': 3}}),
+      'actual_new_x': FrozenDict({'a': 1, 'b': {'c': -1, 'd': 3}}),
+    },
   )
   def test_utility_copy(self, x, add_or_replace, actual_new_x):
     new_x = copy(x, add_or_replace=add_or_replace)
     self.assertTrue(
-        new_x == actual_new_x and isinstance(new_x, type(actual_new_x))
+      new_x == actual_new_x and isinstance(new_x, type(actual_new_x))
     )
 
   @parameterized.parameters(
-      {
-          'x': {'a': 1, 'b': {'c': 2}},
-      },
-      {
-          'x': FrozenDict({'a': 1, 'b': {'c': 2}}),
-      },
+    {
+      'x': {'a': 1, 'b': {'c': 2}},
+    },
+    {
+      'x': FrozenDict({'a': 1, 'b': {'c': 2}}),
+    },
   )
   def test_utility_copy_singlearg(self, x):
     new_x = copy(x)
     self.assertTrue(new_x == x and isinstance(new_x, type(x)))
 
   @parameterized.parameters(
-      {
-          'x': {'a': 1, 'b': {'c': 2}},
-          'pretty_str': '{\n    a: 1,\n    b: {\n        c: 2,\n    },\n}',
-      },
-      {
-          'x': FrozenDict({'a': 1, 'b': {'c': 2}}),
-          'pretty_str': (
-              'FrozenDict({\n    a: 1,\n    b: {\n        c: 2,\n    },\n})'
-          ),
-      },
-      {
-          'x': 345,
-          'pretty_str': '345',
-      },
+    {
+      'x': {'a': 1, 'b': {'c': 2}},
+      'pretty_str': '{\n    a: 1,\n    b: {\n        c: 2,\n    },\n}',
+    },
+    {
+      'x': FrozenDict({'a': 1, 'b': {'c': 2}}),
+      'pretty_str': (
+        'FrozenDict({\n    a: 1,\n    b: {\n        c: 2,\n    },\n})'
+      ),
+    },
+    {
+      'x': 345,
+      'pretty_str': '345',
+    },
   )
   def test_utility_pretty_repr(self, x, pretty_str):
     self.assertEqual(pretty_repr(x), pretty_str)
@@ -157,20 +157,20 @@ class FrozenDictTest(parameterized.TestCase):
     flat_leaves, tdef = jax.tree_util.tree_flatten(frozen)
     self.assertEqual(flat_leaves, [2, 1])
     self.assertEqual(
-        jax.tree_util.tree_unflatten(tdef, flat_leaves),
-        frozen,
+      jax.tree_util.tree_unflatten(tdef, flat_leaves),
+      frozen,
     )
     flat_path_leaves, tdef = jax.tree_util.tree_flatten_with_path(frozen)
     self.assertEqual(
-        flat_path_leaves,
-        [
-            ((jax.tree_util.DictKey('b'), jax.tree_util.DictKey('a')), 2),
-            ((jax.tree_util.DictKey('c'),), 1),
-        ],
+      flat_path_leaves,
+      [
+        ((jax.tree_util.DictKey('b'), jax.tree_util.DictKey('a')), 2),
+        ((jax.tree_util.DictKey('c'),), 1),
+      ],
     )
     self.assertEqual(
-        jax.tree_util.tree_unflatten(tdef, [l for _, l in flat_path_leaves]),
-        frozen,
+      jax.tree_util.tree_unflatten(tdef, [l for _, l in flat_path_leaves]),
+      frozen,
     )
 
 

--- a/tests/core/design/core_auto_encoder_test.py
+++ b/tests/core/design/core_auto_encoder_test.py
@@ -12,18 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from absl.testing import absltest
-
-
-from flax.core import Scope, Array, init, nn, unfreeze
-
-import jax
-from jax import numpy as jnp, random
-
-
-
 from dataclasses import dataclass
 from typing import Callable
+
+import jax
+from absl.testing import absltest
+from jax import numpy as jnp
+from jax import random
+
+from flax.core import Array, Scope, init, nn, unfreeze
 
 
 def mlp(scope: Scope, x: Array, hidden: int, out: int):
@@ -98,77 +95,76 @@ class AutoEncoder3:
 
 
 class AutoEncoderTest(absltest.TestCase):
-
   def test_auto_encoder_hp_struct(self):
     ae = AutoEncoder(latents=2, features=4, hidden=3)
     x = jnp.ones((1, 4))
     x_r, variables = init(ae)(random.key(0), x)
     self.assertEqual(x.shape, x_r.shape)
     variable_shapes = unfreeze(
-        jax.tree_util.tree_map(jnp.shape, variables['params'])
+      jax.tree_util.tree_map(jnp.shape, variables['params'])
     )
     self.assertEqual(
-        variable_shapes,
-        {
-            'encoder': {
-                'hidden': {'kernel': (4, 3), 'bias': (3,)},
-                'out': {'kernel': (3, 2), 'bias': (2,)},
-            },
-            'decoder': {
-                'hidden': {'kernel': (2, 3), 'bias': (3,)},
-                'out': {'kernel': (3, 4), 'bias': (4,)},
-            },
+      variable_shapes,
+      {
+        'encoder': {
+          'hidden': {'kernel': (4, 3), 'bias': (3,)},
+          'out': {'kernel': (3, 2), 'bias': (2,)},
         },
+        'decoder': {
+          'hidden': {'kernel': (2, 3), 'bias': (3,)},
+          'out': {'kernel': (3, 4), 'bias': (4,)},
+        },
+      },
     )
 
   def test_auto_encoder_with_scope(self):
     ae = lambda scope, x: AutoEncoder2(scope, latents=2, features=4, hidden=3)(
-        x
+      x
     )
     x = jnp.ones((1, 4))
 
     x_r, variables = init(ae)(random.key(0), x)
     self.assertEqual(x.shape, x_r.shape)
     variable_shapes = unfreeze(
-        jax.tree_util.tree_map(jnp.shape, variables['params'])
+      jax.tree_util.tree_map(jnp.shape, variables['params'])
     )
     self.assertEqual(
-        variable_shapes,
-        {
-            'encode': {
-                'hidden': {'kernel': (4, 3), 'bias': (3,)},
-                'out': {'kernel': (3, 2), 'bias': (2,)},
-            },
-            'decode': {
-                'hidden': {'kernel': (2, 3), 'bias': (3,)},
-                'out': {'kernel': (3, 4), 'bias': (4,)},
-            },
+      variable_shapes,
+      {
+        'encode': {
+          'hidden': {'kernel': (4, 3), 'bias': (3,)},
+          'out': {'kernel': (3, 2), 'bias': (2,)},
         },
+        'decode': {
+          'hidden': {'kernel': (2, 3), 'bias': (3,)},
+          'out': {'kernel': (3, 4), 'bias': (4,)},
+        },
+      },
     )
 
   def test_auto_encoder_bind_method(self):
     ae = lambda scope, x: AutoEncoder3.create(
-        scope, latents=2, features=4, hidden=3
+      scope, latents=2, features=4, hidden=3
     )(x)
     x = jnp.ones((1, 4))
 
     x_r, variables = init(ae)(random.key(0), x)
     self.assertEqual(x.shape, x_r.shape)
     variable_shapes = unfreeze(
-        jax.tree_util.tree_map(jnp.shape, variables['params'])
+      jax.tree_util.tree_map(jnp.shape, variables['params'])
     )
     self.assertEqual(
-        variable_shapes,
-        {
-            'encode': {
-                'hidden': {'kernel': (4, 3), 'bias': (3,)},
-                'out': {'kernel': (3, 2), 'bias': (2,)},
-            },
-            'decode': {
-                'hidden': {'kernel': (2, 3), 'bias': (3,)},
-                'out': {'kernel': (3, 4), 'bias': (4,)},
-            },
+      variable_shapes,
+      {
+        'encode': {
+          'hidden': {'kernel': (4, 3), 'bias': (3,)},
+          'out': {'kernel': (3, 2), 'bias': (2,)},
         },
+        'decode': {
+          'hidden': {'kernel': (2, 3), 'bias': (3,)},
+          'out': {'kernel': (3, 4), 'bias': (4,)},
+        },
+      },
     )
 
 

--- a/tests/core/design/core_custom_vjp_test.py
+++ b/tests/core/design/core_custom_vjp_test.py
@@ -12,24 +12,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Sequence, Callable
 from functools import partial
-
-from absl.testing import absltest
-
-import numpy as np
-
-from flax.core import Scope, Array, init, apply, unfreeze, lift, nn
+from typing import Callable, Sequence
 
 import jax
-from jax import random, numpy as jnp
+import numpy as np
+from absl.testing import absltest
+from jax import numpy as jnp
+from jax import random
+
+from flax.core import Array, Scope, apply, init, lift, nn, unfreeze
 
 
 def mlp_custom_grad(
-    scope: Scope,
-    x: Array,
-    sizes: Sequence[int] = (8, 1),
-    act_fn: Callable[[Array], Array] = nn.relu,
+  scope: Scope,
+  x: Array,
+  sizes: Sequence[int] = (8, 1),
+  act_fn: Callable[[Array], Array] = nn.relu,
 ):
   f = nn.dense
 
@@ -45,7 +44,7 @@ def mlp_custom_grad(
     return (params_t, *input_t)
 
   dense_custom_grad = lift.custom_vjp(
-      f, forward_fn=fwd, backward_fn=bwd, nondiff_argnums=(2,)
+    f, forward_fn=fwd, backward_fn=bwd, nondiff_argnums=(2,)
   )
 
   # hidden layers
@@ -58,20 +57,19 @@ def mlp_custom_grad(
 
 
 class CustomVJPTest(absltest.TestCase):
-
   def test_custom_vjp(self):
     x = random.normal(random.key(0), (1, 4))
     y, variables = init(mlp_custom_grad)(random.key(1), x)
     param_shapes = unfreeze(
-        jax.tree_util.tree_map(jnp.shape, variables['params'])
+      jax.tree_util.tree_map(jnp.shape, variables['params'])
     )
     loss_fn = lambda p, x: jnp.mean(apply(mlp_custom_grad)(p, x) ** 2)
     grad = jax.grad(loss_fn)(variables, x)
     grad_shapes = unfreeze(jax.tree_util.tree_map(jnp.shape, grad['params']))
     self.assertEqual(y.shape, (1, 1))
     expected_param_shapes = {
-        'hidden_0': {'kernel': (4, 8), 'bias': (8,)},
-        'out': {'kernel': (8, 1), 'bias': (1,)},
+      'hidden_0': {'kernel': (4, 8), 'bias': (8,)},
+      'out': {'kernel': (8, 1), 'bias': (1,)},
     }
     self.assertEqual(param_shapes, expected_param_shapes)
     self.assertEqual(grad_shapes, expected_param_shapes)

--- a/tests/core/design/core_flow_test.py
+++ b/tests/core/design/core_flow_test.py
@@ -13,16 +13,15 @@
 # limitations under the License.
 
 from dataclasses import dataclass
-from typing import Any, Sequence, Any
+from typing import Any, Sequence
 
-from absl.testing import absltest
-
-from flax.core import Scope, Array, init, apply, unfreeze, nn
 import jax
-from jax import numpy as jnp, random
-
+from absl.testing import absltest
+from jax import numpy as jnp
+from jax import random
 from jax.scipy.linalg import expm
 
+from flax.core import Array, Scope, apply, init, nn, unfreeze
 
 Initializer = Any
 Flow = Any
@@ -63,22 +62,21 @@ class StackFlow:
 
 
 class FlowTest(absltest.TestCase):
-
   def test_flow(self):
     x = jnp.ones((1, 3))
     flow = StackFlow((DenseFlow(),) * 3)
     y, variables = init(flow.forward)(random.key(0), x)
     param_shapes = unfreeze(
-        jax.tree_util.tree_map(jnp.shape, variables['params'])
+      jax.tree_util.tree_map(jnp.shape, variables['params'])
     )
     self.assertEqual(y.shape, (1, 3))
     self.assertEqual(
-        param_shapes,
-        {
-            '0': {'kernel': (3, 3), 'bias': (3,)},
-            '1': {'kernel': (3, 3), 'bias': (3,)},
-            '2': {'kernel': (3, 3), 'bias': (3,)},
-        },
+      param_shapes,
+      {
+        '0': {'kernel': (3, 3), 'bias': (3,)},
+        '1': {'kernel': (3, 3), 'bias': (3,)},
+        '2': {'kernel': (3, 3), 'bias': (3,)},
+      },
     )
     x_restored = apply(flow.backward)(variables, y)
     self.assertTrue(jnp.allclose(x, x_restored))

--- a/tests/core/design/core_resnet_test.py
+++ b/tests/core/design/core_resnet_test.py
@@ -14,19 +14,18 @@
 
 from functools import partial
 
-from absl.testing import absltest
-
-from flax.core import Scope, Array, init, unfreeze, nn
-
 import jax
-from jax import random, numpy as jnp
+from absl.testing import absltest
+from jax import numpy as jnp
+from jax import random
 
+from flax.core import Array, Scope, init, nn, unfreeze
 
 default_norm = partial(nn.batch_norm)
 
 
 def residual_block(
-    scope: Scope, x: Array, conv, norm, act, features: int, strides=(1, 1)
+  scope: Scope, x: Array, conv, norm, act, features: int, strides=(1, 1)
 ):
   residual = x
   x = scope.child(conv, 'conv_1')(x, features, (1, 1))
@@ -40,7 +39,7 @@ def residual_block(
 
   if x.shape != residual.shape:
     residual = scope.child(conv, 'proj_conv')(
-        residual, 4 * features, (1, 1), strides=strides
+      residual, 4 * features, (1, 1), strides=strides
     )
     residual = scope.child(norm, 'proj_bn')(residual)
 
@@ -48,14 +47,14 @@ def residual_block(
 
 
 def resnet(
-    scope: Scope,
-    x,
-    block_sizes=(3, 4, 6, 3),
-    features=16,
-    num_classes=1000,
-    dtype=jnp.float32,
-    norm=default_norm,
-    act=nn.relu,
+  scope: Scope,
+  x,
+  block_sizes=(3, 4, 6, 3),
+  features=16,
+  num_classes=1000,
+  dtype=jnp.float32,
+  norm=default_norm,
+  act=nn.relu,
 ):
   conv = partial(nn.conv, bias=False, dtype=dtype)
   norm = partial(norm, dtype=dtype)
@@ -73,7 +72,7 @@ def resnet(
       block_features = features * 2**i
       block_scope = scope.push(f'block_{i}_{j}')
       x = residual_block(
-          block_scope, x, conv, norm, act, block_features, strides
+        block_scope, x, conv, norm, act, block_features, strides
       )
       # we can access parameters of the sub module by operating on the scope
       # Example:
@@ -84,61 +83,60 @@ def resnet(
 
 
 class ResNetTest(absltest.TestCase):
-
   def test_resnet(self):
     block_sizes = (2, 2)
     x = random.normal(random.key(0), (1, 64, 64, 3))
     y, variables = init(resnet)(
-        random.key(1), x, block_sizes=block_sizes, features=16
+      random.key(1), x, block_sizes=block_sizes, features=16
     )
     param_shapes = unfreeze(
-        jax.tree_util.tree_map(jnp.shape, variables['params'])
+      jax.tree_util.tree_map(jnp.shape, variables['params'])
     )
     self.assertEqual(y.shape, (1, 1000))
 
     self.assertEqual(
-        param_shapes,
-        {
-            'init_conv': {'kernel': (7, 7, 3, 16)},
-            'init_bn': {'bias': (16,), 'scale': (16,)},
-            'out': {'kernel': (128, 1000), 'bias': (1000,)},
-            'block_0_0': {
-                'conv_1': {'kernel': (1, 1, 16, 16)},
-                'conv_2': {'kernel': (3, 3, 16, 64)},
-                'conv_3': {'kernel': (1, 1, 64, 64)},
-                'bn_1': {'bias': (16,), 'scale': (16,)},
-                'bn_2': {'bias': (64,), 'scale': (64,)},
-                'bn_3': {'bias': (64,), 'scale': (64,)},
-                'proj_conv': {'kernel': (1, 1, 16, 64)},
-                'proj_bn': {'bias': (64,), 'scale': (64,)},
-            },
-            'block_0_1': {
-                'conv_1': {'kernel': (1, 1, 64, 16)},
-                'conv_2': {'kernel': (3, 3, 16, 64)},
-                'conv_3': {'kernel': (1, 1, 64, 64)},
-                'bn_1': {'bias': (16,), 'scale': (16,)},
-                'bn_2': {'bias': (64,), 'scale': (64,)},
-                'bn_3': {'bias': (64,), 'scale': (64,)},
-            },
-            'block_1_0': {
-                'conv_1': {'kernel': (1, 1, 64, 32)},
-                'conv_2': {'kernel': (3, 3, 32, 128)},
-                'conv_3': {'kernel': (1, 1, 128, 128)},
-                'bn_1': {'bias': (32,), 'scale': (32,)},
-                'bn_2': {'bias': (128,), 'scale': (128,)},
-                'bn_3': {'bias': (128,), 'scale': (128,)},
-                'proj_conv': {'kernel': (1, 1, 64, 128)},
-                'proj_bn': {'bias': (128,), 'scale': (128,)},
-            },
-            'block_1_1': {
-                'conv_1': {'kernel': (1, 1, 128, 32)},
-                'conv_2': {'kernel': (3, 3, 32, 128)},
-                'conv_3': {'kernel': (1, 1, 128, 128)},
-                'bn_1': {'bias': (32,), 'scale': (32,)},
-                'bn_2': {'bias': (128,), 'scale': (128,)},
-                'bn_3': {'bias': (128,), 'scale': (128,)},
-            },
+      param_shapes,
+      {
+        'init_conv': {'kernel': (7, 7, 3, 16)},
+        'init_bn': {'bias': (16,), 'scale': (16,)},
+        'out': {'kernel': (128, 1000), 'bias': (1000,)},
+        'block_0_0': {
+          'conv_1': {'kernel': (1, 1, 16, 16)},
+          'conv_2': {'kernel': (3, 3, 16, 64)},
+          'conv_3': {'kernel': (1, 1, 64, 64)},
+          'bn_1': {'bias': (16,), 'scale': (16,)},
+          'bn_2': {'bias': (64,), 'scale': (64,)},
+          'bn_3': {'bias': (64,), 'scale': (64,)},
+          'proj_conv': {'kernel': (1, 1, 16, 64)},
+          'proj_bn': {'bias': (64,), 'scale': (64,)},
         },
+        'block_0_1': {
+          'conv_1': {'kernel': (1, 1, 64, 16)},
+          'conv_2': {'kernel': (3, 3, 16, 64)},
+          'conv_3': {'kernel': (1, 1, 64, 64)},
+          'bn_1': {'bias': (16,), 'scale': (16,)},
+          'bn_2': {'bias': (64,), 'scale': (64,)},
+          'bn_3': {'bias': (64,), 'scale': (64,)},
+        },
+        'block_1_0': {
+          'conv_1': {'kernel': (1, 1, 64, 32)},
+          'conv_2': {'kernel': (3, 3, 32, 128)},
+          'conv_3': {'kernel': (1, 1, 128, 128)},
+          'bn_1': {'bias': (32,), 'scale': (32,)},
+          'bn_2': {'bias': (128,), 'scale': (128,)},
+          'bn_3': {'bias': (128,), 'scale': (128,)},
+          'proj_conv': {'kernel': (1, 1, 64, 128)},
+          'proj_bn': {'bias': (128,), 'scale': (128,)},
+        },
+        'block_1_1': {
+          'conv_1': {'kernel': (1, 1, 128, 32)},
+          'conv_2': {'kernel': (3, 3, 32, 128)},
+          'conv_3': {'kernel': (1, 1, 128, 128)},
+          'bn_1': {'bias': (32,), 'scale': (32,)},
+          'bn_2': {'bias': (128,), 'scale': (128,)},
+          'bn_3': {'bias': (128,), 'scale': (128,)},
+        },
+      },
     )
 
 

--- a/tests/core/design/core_scan_test.py
+++ b/tests/core/design/core_scan_test.py
@@ -12,12 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from flax.core import Scope, Array, init, unfreeze, lift, nn
-
-from absl.testing import absltest
-
 import jax
-from jax import random, numpy as jnp
+from absl.testing import absltest
+from jax import numpy as jnp
+from jax import random
+
+from flax.core import Array, Scope, init, lift, nn, unfreeze
 
 
 def mlp_scan(scope: Scope, xs: Array, share_params: bool = False):
@@ -31,17 +31,17 @@ def mlp_scan(scope: Scope, xs: Array, share_params: bool = False):
 
   if share_params:
     _, ys = lift.scan(
-        body_fn,
-        variable_carry='counter',
-        variable_broadcast='params',
-        split_rngs={'params': False},
+      body_fn,
+      variable_carry='counter',
+      variable_broadcast='params',
+      split_rngs={'params': False},
     )(scope, (), xs)
   else:
     _, ys = lift.scan(
-        body_fn,
-        variable_carry='counter',
-        variable_axes={'params': 0},
-        split_rngs={'params': True},
+      body_fn,
+      variable_carry='counter',
+      variable_axes={'params': 0},
+      split_rngs={'params': True},
     )(scope, (), xs)
 
   # output layer
@@ -49,21 +49,20 @@ def mlp_scan(scope: Scope, xs: Array, share_params: bool = False):
 
 
 class ScanTest(absltest.TestCase):
-
   def test_scan_unshared_params(self):
     x = random.normal(random.key(0), (1, 4))
     x = jnp.concatenate([x, x], 0)
     y, variables = init(mlp_scan)(random.key(1), x, share_params=False)
 
     param_shapes = unfreeze(
-        jax.tree_util.tree_map(jnp.shape, variables['params'])
+      jax.tree_util.tree_map(jnp.shape, variables['params'])
     )
     self.assertEqual(variables['counter']['i'], 2)
     self.assertEqual(
-        param_shapes,
-        {
-            'dense_0': {'kernel': (2, 4, 1), 'bias': (2, 1)},
-        },
+      param_shapes,
+      {
+        'dense_0': {'kernel': (2, 4, 1), 'bias': (2, 1)},
+      },
     )
 
     self.assertNotEqual(y[0], y[1])
@@ -76,14 +75,14 @@ class ScanTest(absltest.TestCase):
     y, variables = init(mlp_scan)(random.key(1), x, share_params=True)
 
     param_shapes = unfreeze(
-        jax.tree_util.tree_map(jnp.shape, variables['params'])
+      jax.tree_util.tree_map(jnp.shape, variables['params'])
     )
     self.assertEqual(variables['counter']['i'], 2)
     self.assertEqual(
-        param_shapes,
-        {
-            'dense_0': {'kernel': (4, 1), 'bias': (1,)},
-        },
+      param_shapes,
+      {
+        'dense_0': {'kernel': (4, 1), 'bias': (1,)},
+      },
     )
 
     self.assertEqual(y[0], y[1])

--- a/tests/core/design/core_tied_autoencoder_test.py
+++ b/tests/core/design/core_tied_autoencoder_test.py
@@ -14,13 +14,12 @@
 
 from dataclasses import dataclass
 
-from absl.testing import absltest
-
-from jax import numpy as jnp, random
 import jax
+from absl.testing import absltest
+from jax import numpy as jnp
+from jax import random
 
-
-from flax.core import init, unfreeze, lift, nn
+from flax.core import init, lift, nn, unfreeze
 
 
 def transpose(fn):
@@ -28,7 +27,7 @@ def transpose(fn):
     return jax.tree_util.tree_map(lambda x: x.T, variables)
 
   return lift.map_variables(
-      fn, 'params', map_in_fn=trans, map_out_fn=trans, mutable=True
+    fn, 'params', map_in_fn=trans, map_out_fn=trans, mutable=True
   )
 
 
@@ -49,20 +48,19 @@ class TiedAutoEncoder:
 
 
 class TiedAutoEncoderTest(absltest.TestCase):
-
   def test_tied_auto_encoder(self):
     ae = TiedAutoEncoder(latents=2, features=4)
     x = jnp.ones((1, ae.features))
     x_r, variables = init(ae)(random.key(0), x)
 
     param_shapes = unfreeze(
-        jax.tree_util.tree_map(jnp.shape, variables['params'])
+      jax.tree_util.tree_map(jnp.shape, variables['params'])
     )
     self.assertEqual(
-        param_shapes,
-        {
-            'kernel': (4, 2),
-        },
+      param_shapes,
+      {
+        'kernel': (4, 2),
+      },
     )
     self.assertEqual(x.shape, x_r.shape)
 
@@ -72,13 +70,13 @@ class TiedAutoEncoderTest(absltest.TestCase):
     x_r, variables = init(ae.decode)(random.key(0), z)
 
     param_shapes = unfreeze(
-        jax.tree_util.tree_map(jnp.shape, variables['params'])
+      jax.tree_util.tree_map(jnp.shape, variables['params'])
     )
     self.assertEqual(
-        param_shapes,
-        {
-            'kernel': (4, 2),
-        },
+      param_shapes,
+      {
+        'kernel': (4, 2),
+      },
     )
     self.assertEqual(x_r.shape, (1, 4))
 

--- a/tests/cursor_test.py
+++ b/tests/cursor_test.py
@@ -15,17 +15,18 @@
 """Tests for flax.struct."""
 
 
-from absl.testing import absltest
 import dataclasses
-import flax
+from typing import Any, NamedTuple
+
 import jax
 import jax.numpy as jnp
 import optax
-from typing import Any, NamedTuple
+from absl.testing import absltest
 
+import flax
 import flax.linen as nn
 from flax.core import freeze
-from flax.cursor import cursor, _traverse_tree, AccessType
+from flax.cursor import AccessType, _traverse_tree, cursor
 from flax.errors import CursorFindError, TraverseTreeError
 from flax.training import train_state
 
@@ -47,15 +48,14 @@ class GenericDataClass:
 
 
 class CursorTest(absltest.TestCase):
-
   def test_repr(self):
     g = GenericTuple(1, 'a', (2, 'b'))
     c = cursor(
-        {'a': {1: {(2, 3): 'z', 4: g, '6': (7, 8)}, 'b': [1, 2, 3]}, 'z': -1}
+      {'a': {1: {(2, 3): 'z', 4: g, '6': (7, 8)}, 'b': [1, 2, 3]}, 'z': -1}
     )
     self.assertEqual(
-        repr(c),
-        """Cursor(
+      repr(c),
+      """Cursor(
   _obj={'a': {1: {(2, 3): 'z', 4: GenericTuple(x=1, y='a', z=(2, 'b')), '6': (7, 8)}, 'b': [1, 2, 3]}, 'z': -1},
   _changes={}
 )""",
@@ -72,8 +72,8 @@ class CursorTest(absltest.TestCase):
     c['a'][1][4].z[0] = flax.core.freeze({'a': 1, 'b': {'c': 2, 'd': 3}})
 
     self.assertEqual(
-        repr(c),
-        """Cursor(
+      repr(c),
+      """Cursor(
   _obj={'a': {1: {(2, 3): 'z', 4: GenericTuple(x=1, y='a', z=(2, 'b')), '6': (7, 8)}, 'b': [1, 2, 3]}, 'z': -1},
   _changes={
     'z': Cursor(
@@ -126,10 +126,10 @@ class CursorTest(absltest.TestCase):
     def same_value(v1, v2):
       if isinstance(v1, tuple):
         return all(
-            [
-                jnp.all(jax.tree_map(lambda x, y: x == y, e1, e2))
-                for e1, e2 in zip(v1, v2)
-            ]
+          [
+            jnp.all(jax.tree_map(lambda x, y: x == y, e1, e2))
+            for e1, e2 in zip(v1, v2)
+          ]
         )
       return jnp.all(jax.tree_map(lambda x, y: x == y, v1, v2))
 
@@ -148,18 +148,18 @@ class CursorTest(absltest.TestCase):
       self.assertEqual(c.build(), tuple_wrap([(1, 5), (3, 7)]))
     # test __iter__ error
     with self.assertRaisesRegex(
-        NotImplementedError,
-        '__iter__ method only implemented for tuples and lists, not type <class'
-        " 'dict'>",
+      NotImplementedError,
+      '__iter__ method only implemented for tuples and lists, not type <class'
+      " 'dict'>",
     ):
       c = cursor({'a': 1, 'b': 2})
       for key in c:
         c[key] *= -1
     # test __iter__ error
     with self.assertRaisesRegex(
-        NotImplementedError,
-        '__reversed__ method only implemented for tuples and lists, not type'
-        " <class 'dict'>",
+      NotImplementedError,
+      '__reversed__ method only implemented for tuples and lists, not type'
+      " <class 'dict'>",
     ):
       c = cursor({'a': 1, 'b': 2})
       for key in reversed(c):
@@ -167,13 +167,13 @@ class CursorTest(absltest.TestCase):
 
     for obj_value in (2, jnp.array([[1, -2], [3, 4]])):
       for c in (
-          cursor(obj_value),
-          cursor([obj_value])[0],
-          cursor((obj_value,))[0],
-          cursor({0: obj_value})[0],
-          cursor(flax.core.freeze({0: obj_value}))[0],
-          cursor(GenericTuple(x=obj_value)).x,
-          cursor(GenericDataClass(x=obj_value)).x,
+        cursor(obj_value),
+        cursor([obj_value])[0],
+        cursor((obj_value,))[0],
+        cursor({0: obj_value})[0],
+        cursor(flax.core.freeze({0: obj_value}))[0],
+        cursor(GenericTuple(x=obj_value)).x,
+        cursor(GenericDataClass(x=obj_value)).x,
       ):
         # test __neg__
         self.assertTrue(same_value(-c, -obj_value))
@@ -186,7 +186,7 @@ class CursorTest(absltest.TestCase):
         # test __round__
         self.assertTrue(same_value(round(c + 0.123), round(obj_value + 0.123)))
         self.assertTrue(
-            same_value(round(c + 0.123, 2), round(obj_value + 0.123, 2))
+          same_value(round(c + 0.123, 2), round(obj_value + 0.123, 2))
         )
 
         for other_value in (3, jnp.array([[5, 6], [7, 8]])):
@@ -208,11 +208,11 @@ class CursorTest(absltest.TestCase):
           self.assertTrue(same_value(other_value / c, other_value / obj_value))
           # test __floordiv__
           self.assertTrue(
-              same_value(c // other_value, obj_value // other_value)
+            same_value(c // other_value, obj_value // other_value)
           )
           # test __rfloordiv__
           self.assertTrue(
-              same_value(other_value // c, other_value // obj_value)
+            same_value(other_value // c, other_value // obj_value)
           )
           # test __mod__
           self.assertTrue(same_value(c % other_value, obj_value % other_value))
@@ -220,35 +220,35 @@ class CursorTest(absltest.TestCase):
           self.assertTrue(same_value(other_value % c, other_value % obj_value))
           # test __divmod__
           self.assertTrue(
-              same_value(divmod(c, other_value), divmod(obj_value, other_value))
+            same_value(divmod(c, other_value), divmod(obj_value, other_value))
           )
           # test __rdivmod__
           self.assertTrue(
-              same_value(divmod(other_value, c), divmod(other_value, obj_value))
+            same_value(divmod(other_value, c), divmod(other_value, obj_value))
           )
           # test __pow__
           self.assertTrue(
-              same_value(pow(c, other_value), pow(obj_value, other_value))
+            same_value(pow(c, other_value), pow(obj_value, other_value))
           )
           # test __rpow__
           self.assertTrue(
-              same_value(pow(other_value, c), pow(other_value, obj_value))
+            same_value(pow(other_value, c), pow(other_value, obj_value))
           )
           # test __lshift__
           self.assertTrue(
-              same_value(c << other_value, obj_value << other_value)
+            same_value(c << other_value, obj_value << other_value)
           )
           # test __rlshift__
           self.assertTrue(
-              same_value(other_value << c, other_value << obj_value)
+            same_value(other_value << c, other_value << obj_value)
           )
           # test __rshift__
           self.assertTrue(
-              same_value(c >> other_value, obj_value >> other_value)
+            same_value(c >> other_value, obj_value >> other_value)
           )
           # test __rrshift__
           self.assertTrue(
-              same_value(other_value >> c, other_value >> obj_value)
+            same_value(other_value >> c, other_value >> obj_value)
           )
           # test __and__
           self.assertTrue(same_value(c & other_value, obj_value & other_value))
@@ -264,15 +264,15 @@ class CursorTest(absltest.TestCase):
           self.assertTrue(same_value(other_value | c, other_value | obj_value))
 
           if isinstance(obj_value, jax.Array) and isinstance(
-              other_value, jax.Array
+            other_value, jax.Array
           ):
             # test __matmul__
             self.assertTrue(
-                same_value(c @ other_value, obj_value @ other_value)
+              same_value(c @ other_value, obj_value @ other_value)
             )
             # test __rmatmul__
             self.assertTrue(
-                same_value(other_value @ c, other_value @ obj_value)
+              same_value(other_value @ c, other_value @ obj_value)
             )
 
           # test __lt__
@@ -280,51 +280,51 @@ class CursorTest(absltest.TestCase):
           self.assertTrue(same_value(other_value < c, other_value < obj_value))
           # test __le__
           self.assertTrue(
-              same_value(c <= other_value, obj_value <= other_value)
+            same_value(c <= other_value, obj_value <= other_value)
           )
           self.assertTrue(
-              same_value(other_value <= c, other_value <= obj_value)
+            same_value(other_value <= c, other_value <= obj_value)
           )
           # test __eq__
           self.assertTrue(
-              same_value(c == other_value, obj_value == other_value)
+            same_value(c == other_value, obj_value == other_value)
           )
           self.assertTrue(
-              same_value(other_value == c, other_value == obj_value)
+            same_value(other_value == c, other_value == obj_value)
           )
           # test __ne__
           self.assertTrue(
-              same_value(c != other_value, obj_value != other_value)
+            same_value(c != other_value, obj_value != other_value)
           )
           self.assertTrue(
-              same_value(other_value != c, other_value != obj_value)
+            same_value(other_value != c, other_value != obj_value)
           )
           # test __gt__
           self.assertTrue(same_value(c > other_value, obj_value > other_value))
           self.assertTrue(same_value(other_value > c, other_value > obj_value))
           # test __ge__
           self.assertTrue(
-              same_value(c >= other_value, obj_value >= other_value)
+            same_value(c >= other_value, obj_value >= other_value)
           )
           self.assertTrue(
-              same_value(other_value >= c, other_value >= obj_value)
+            same_value(other_value >= c, other_value >= obj_value)
           )
 
   def test_path(self):
     c = cursor(
-        GenericTuple(
-            x=[
-                0,
-                {'a': 1, 'b': (2, 3), ('c', 'd'): [4, 5]},
-                (100, 200),
-                [3, 4, 5],
-            ],
-            y=train_state.TrainState.create(
-                apply_fn=lambda x: x,
-                params=freeze({'a': 1, 'b': (2, 3), 'c': [4, 5]}),
-                tx=optax.adam(1e-3),
-            ),
-        )
+      GenericTuple(
+        x=[
+          0,
+          {'a': 1, 'b': (2, 3), ('c', 'd'): [4, 5]},
+          (100, 200),
+          [3, 4, 5],
+        ],
+        y=train_state.TrainState.create(
+          apply_fn=lambda x: x,
+          params=freeze({'a': 1, 'b': (2, 3), 'c': [4, 5]}),
+          tx=optax.adam(1e-3),
+        ),
+      )
     )
     self.assertEqual(c.x[1][('c', 'd')][0]._path, ".x[1][('c', 'd')][0]")
     self.assertEqual(c.x[2][1]._path, '.x[2][1]')
@@ -337,15 +337,15 @@ class CursorTest(absltest.TestCase):
 
   def test_traverse_tree(self):
     c = cursor(
-        GenericTuple(
-            x=[
-                0,
-                {'a': 1, 'b': (2, 3), ('c', 'd'): [4, 5]},
-                (100, 200),
-                [3, 4, 5],
-            ],
-            y=3,
-        )
+      GenericTuple(
+        x=[
+          0,
+          {'a': 1, 'b': (2, 3), ('c', 'd'): [4, 5]},
+          (100, 200),
+          [3, 4, 5],
+        ],
+        y=3,
+      )
     )
 
     def update_fn(path, value):
@@ -357,46 +357,46 @@ class CursorTest(absltest.TestCase):
       return value == 3
 
     with self.assertRaisesRegex(
-        TraverseTreeError,
-        'Both update_fn and cond_fn are None. Exactly one of them must be'
-        ' None.',
+      TraverseTreeError,
+      'Both update_fn and cond_fn are None. Exactly one of them must be'
+      ' None.',
     ):
       next(_traverse_tree((), c._obj))
     with self.assertRaisesRegex(
-        TraverseTreeError,
-        'Both update_fn and cond_fn are not None. Exactly one of them must be'
-        ' not None.',
+      TraverseTreeError,
+      'Both update_fn and cond_fn are not None. Exactly one of them must be'
+      ' not None.',
     ):
       next(_traverse_tree((), c._obj, update_fn=update_fn, cond_fn=cond_fn))
 
     (p, v), (p2, v2) = _traverse_tree((), c._obj, update_fn=update_fn)
     self.assertEqual(
-        p,
-        (
-            ('x', AccessType.ATTR),
-            (1, AccessType.ITEM),
-            (('c', 'd'), AccessType.ITEM),
-            (0, AccessType.ITEM),
-        ),
+      p,
+      (
+        ('x', AccessType.ATTR),
+        (1, AccessType.ITEM),
+        (('c', 'd'), AccessType.ITEM),
+        (0, AccessType.ITEM),
+      ),
     )
     self.assertEqual(v, -4)
     self.assertEqual(
-        p2, (('x', AccessType.ATTR), (3, AccessType.ITEM), (1, AccessType.ITEM))
+      p2, (('x', AccessType.ATTR), (3, AccessType.ITEM), (1, AccessType.ITEM))
     )
     self.assertEqual(v2, -4)
 
     p, p2, p3 = _traverse_tree((), c._obj, cond_fn=cond_fn)
     self.assertEqual(
-        p,
-        (
-            ('x', AccessType.ATTR),
-            (1, AccessType.ITEM),
-            ('b', AccessType.ITEM),
-            (1, AccessType.ITEM),
-        ),
+      p,
+      (
+        ('x', AccessType.ATTR),
+        (1, AccessType.ITEM),
+        ('b', AccessType.ITEM),
+        (1, AccessType.ITEM),
+      ),
     )
     self.assertEqual(
-        p2, (('x', AccessType.ATTR), (3, AccessType.ITEM), (0, AccessType.ITEM))
+      p2, (('x', AccessType.ATTR), (3, AccessType.ITEM), (0, AccessType.ITEM))
     )
     self.assertEqual(p3, (('y', AccessType.ATTR),))
 
@@ -406,8 +406,8 @@ class CursorTest(absltest.TestCase):
     for d, freeze_wrap in ((dict_obj, lambda x: x), (freeze(dict_obj), freeze)):
       # set API
       self.assertEqual(
-          cursor(d)['b'][0].set(10),
-          freeze_wrap({'a': 1, 'b': (10, 3), 'c': [4, 5]}),
+        cursor(d)['b'][0].set(10),
+        freeze_wrap({'a': 1, 'b': (10, 3), 'c': [4, 5]}),
       )
       # build API
       c = cursor(d)
@@ -415,10 +415,10 @@ class CursorTest(absltest.TestCase):
       c['a'] = (100, 200)
       d2 = c.build()
       self.assertEqual(
-          d2, freeze_wrap({'a': (100, 200), 'b': (20, 3), 'c': [4, 5]})
+        d2, freeze_wrap({'a': (100, 200), 'b': (20, 3), 'c': [4, 5]})
       )
     self.assertEqual(
-        dict_obj, {'a': 1, 'b': (2, 3), 'c': [4, 5]}
+      dict_obj, {'a': 1, 'b': (2, 3), 'c': [4, 5]}
     )  # make sure original object is unchanged
 
     # test list and tuple
@@ -426,10 +426,8 @@ class CursorTest(absltest.TestCase):
     for l, tuple_wrap in ((list_obj, lambda x: x), (tuple(list_obj), tuple)):
       # set API
       self.assertEqual(
-          cursor(l)[1]['b'][0].set(10),
-          tuple_wrap(
-              [0, {'a': 1, 'b': (10, 3), 'c': [4, 5]}, (1, 2), [3, 4, 5]]
-          ),
+        cursor(l)[1]['b'][0].set(10),
+        tuple_wrap([0, {'a': 1, 'b': (10, 3), 'c': [4, 5]}, (1, 2), [3, 4, 5]]),
       )
       # build API
       c = cursor(l)
@@ -437,25 +435,25 @@ class CursorTest(absltest.TestCase):
       c[2] = (100, 200)
       l2 = c.build()
       self.assertEqual(
-          l2,
-          tuple_wrap(
-              [0, {'a': 1, 'b': (20, 3), 'c': [4, 5]}, (100, 200), [3, 4, 5]]
-          ),
+        l2,
+        tuple_wrap(
+          [0, {'a': 1, 'b': (20, 3), 'c': [4, 5]}, (100, 200), [3, 4, 5]]
+        ),
       )
     self.assertEqual(
-        list_obj, [0, {'a': 1, 'b': (2, 3), 'c': [4, 5]}, (1, 2), [3, 4, 5]]
+      list_obj, [0, {'a': 1, 'b': (2, 3), 'c': [4, 5]}, (1, 2), [3, 4, 5]]
     )  # make sure original object is unchanged
 
     # test TrainState
     state = train_state.TrainState.create(
-        apply_fn=lambda x: x,
-        params=dict_obj,
-        tx=optax.adam(1e-3),
+      apply_fn=lambda x: x,
+      params=dict_obj,
+      tx=optax.adam(1e-3),
     )
     # set API
     self.assertEqual(
-        cursor(state).params['b'][0].set(10).params,
-        {'a': 1, 'b': (10, 3), 'c': [4, 5]},
+      cursor(state).params['b'][0].set(10).params,
+      {'a': 1, 'b': (10, 3), 'c': [4, 5]},
     )
     # build API
     new_fn = lambda x: x + 1
@@ -466,11 +464,11 @@ class CursorTest(absltest.TestCase):
     state2 = c.build()
     self.assertEqual(state2.apply_fn, new_fn)
     self.assertEqual(
-        state2.params, {'a': (100, 200), 'b': (20, 3), 'c': [4, 5]}
+      state2.params, {'a': (100, 200), 'b': (20, 3), 'c': [4, 5]}
     )
 
     self.assertEqual(
-        dict_obj, {'a': 1, 'b': (2, 3), 'c': [4, 5]}
+      dict_obj, {'a': 1, 'b': (2, 3), 'c': [4, 5]}
     )  # make sure original object is unchanged
 
     # test NamedTuple
@@ -487,7 +485,7 @@ class CursorTest(absltest.TestCase):
     self.assertEqual(t2, GenericTuple(GenericTuple(2, 3), 4))
 
     self.assertEqual(
-        t, GenericTuple(GenericTuple(0))
+      t, GenericTuple(GenericTuple(0))
     )  # make sure original object is unchanged
 
   def test_apply_update(self):
@@ -503,10 +501,10 @@ class CursorTest(absltest.TestCase):
       c = cursor(l)
       l2 = c.apply_update(update_fn).build()
       self.assertEqual(
-          l2, tuple_wrap([tuple_wrap([-1, 2]), tuple_wrap([-3, 4])])
+        l2, tuple_wrap([tuple_wrap([-1, 2]), tuple_wrap([-3, 4])])
       )
       self.assertEqual(
-          l, tuple_wrap([tuple_wrap([1, 2]), tuple_wrap([3, 4])])
+        l, tuple_wrap([tuple_wrap([1, 2]), tuple_wrap([3, 4])])
       )  # make sure the original object is unchanged
 
     # test regular dict and FrozenDict
@@ -520,7 +518,6 @@ class CursorTest(absltest.TestCase):
       return value
 
     class Model(nn.Module):
-
       @nn.compact
       def __call__(self, x):
         x = nn.Dense(3)(x)
@@ -533,35 +530,33 @@ class CursorTest(absltest.TestCase):
 
     for freeze_wrap in (lambda x: x, freeze):
       params = freeze_wrap(
-          Model().init(jax.random.key(0), jnp.empty((1, 2)))['params']
+        Model().init(jax.random.key(0), jnp.empty((1, 2)))['params']
       )
 
       c = cursor(params)
       params2 = c.apply_update(update_fn).build()
       for layer in ('Dense_0', 'Dense_1', 'Dense_2'):
         self.assertTrue(
-            (params2[layer]['kernel'] == 2 * params[layer]['kernel'] + 1).all()
+          (params2[layer]['kernel'] == 2 * params[layer]['kernel'] + 1).all()
         )
         if layer == 'Dense_1':
           self.assertTrue(
-              (params2[layer]['bias'] == jnp.array([-1, -1, -1])).all()
+            (params2[layer]['bias'] == jnp.array([-1, -1, -1])).all()
           )
         else:
           self.assertTrue(
-              (params2[layer]['bias'] == params[layer]['bias']).all()
+            (params2[layer]['bias'] == params[layer]['bias']).all()
           )
       self.assertTrue(
-          jax.tree_util.tree_all(
-              jax.tree_util.tree_map(
-                  lambda x, y: (x == y).all(),
-                  params,
-                  freeze_wrap(
-                      Model().init(jax.random.key(0), jnp.empty((1, 2)))[
-                          'params'
-                      ]
-                  ),
-              )
+        jax.tree_util.tree_all(
+          jax.tree_util.tree_map(
+            lambda x, y: (x == y).all(),
+            params,
+            freeze_wrap(
+              Model().init(jax.random.key(0), jnp.empty((1, 2)))['params']
+            ),
           )
+        )
       )  # make sure original params are unchanged
 
     # test TrainState
@@ -572,15 +567,15 @@ class CursorTest(absltest.TestCase):
       return value
 
     state = train_state.TrainState.create(
-        apply_fn=lambda x: x,
-        params={'a': 1, 'b': 2},
-        tx=optax.adam(1e-3),
+      apply_fn=lambda x: x,
+      params={'a': 1, 'b': 2},
+      tx=optax.adam(1e-3),
     )
     c = cursor(state)
     state2 = c.apply_update(update_fn).build()
     self.assertEqual(state2.params, {})
     self.assertEqual(
-        state.params, {'a': 1, 'b': 2}
+      state.params, {'a': 1, 'b': 2}
     )  # make sure original params are unchanged
 
     # test NamedTuple
@@ -595,7 +590,7 @@ class CursorTest(absltest.TestCase):
     t2 = c.apply_update(update_fn).build()
     self.assertEqual(t2, GenericTuple(GenericTuple(5, 1), GenericTuple(7, 3)))
     self.assertEqual(
-        t, GenericTuple(GenericTuple(0, 1), GenericTuple(2, 3))
+      t, GenericTuple(GenericTuple(0, 1), GenericTuple(2, 3))
     )  # make sure original object is unchanged
 
   def test_apply_update_root_node_unmodified(self):
@@ -631,7 +626,7 @@ class CursorTest(absltest.TestCase):
     l[1] = -1
     l2 = c.build()
     self.assertEqual(
-        l2, [100, -1]
+      l2, [100, -1]
     )  # change in l affects l2 (this is expected behavior)
     self.assertEqual(l, [1, -1])
 
@@ -642,23 +637,23 @@ class CursorTest(absltest.TestCase):
     d['b'] = -1
     d2 = c.build()
     self.assertEqual(
-        d2, {'a': 100, 'b': -1}
+      d2, {'a': 100, 'b': -1}
     )  # change in d affects d2 (this is expected behavior)
     self.assertEqual(d, {'a': 1, 'b': -1})
 
     # test TrainState
     params = {'a': 1, 'b': 2}
     state = train_state.TrainState.create(
-        apply_fn=lambda x: x,
-        params=params,
-        tx=optax.adam(1e-3),
+      apply_fn=lambda x: x,
+      params=params,
+      tx=optax.adam(1e-3),
     )
     c = cursor(state)
     c.params['a'] = 100
     params['b'] = -1
     state2 = c.build()
     self.assertEqual(
-        state2.params, {'a': 100, 'b': -1}
+      state2.params, {'a': 100, 'b': -1}
     )  # change in state affects state2 (this is expected behavior)
     self.assertEqual(state.params, {'a': 1, 'b': -1})
 
@@ -670,61 +665,59 @@ class CursorTest(absltest.TestCase):
     c.y.x = 6
     c.y[1] = 7
     self.assertEqual(
-        c.build(), GenericTuple(GenericTuple(4, 5), GenericTuple(6, 7))
+      c.build(), GenericTuple(GenericTuple(4, 5), GenericTuple(6, 7))
     )
 
     c[0][1] = -5
     self.assertEqual(
-        c.build(), GenericTuple(GenericTuple(4, -5), GenericTuple(6, 7))
+      c.build(), GenericTuple(GenericTuple(4, -5), GenericTuple(6, 7))
     )
     c.x[1] = -6
     self.assertEqual(
-        c.build(), GenericTuple(GenericTuple(4, -6), GenericTuple(6, 7))
+      c.build(), GenericTuple(GenericTuple(4, -6), GenericTuple(6, 7))
     )
     c.x.y = -7
     self.assertEqual(
-        c.build(), GenericTuple(GenericTuple(4, -7), GenericTuple(6, 7))
+      c.build(), GenericTuple(GenericTuple(4, -7), GenericTuple(6, 7))
     )
     c[0].y = -8
     self.assertEqual(
-        c.build(), GenericTuple(GenericTuple(4, -8), GenericTuple(6, 7))
+      c.build(), GenericTuple(GenericTuple(4, -8), GenericTuple(6, 7))
     )
 
   def test_find(self):
     c = cursor(
-        GenericTuple(
-            x=[
-                0,
-                {'a': 1, 'b': (2, 3), ('c', 'd'): [4, 5]},
-                (100, 200),
-                [3, 4, 5],
-            ],
-            y=train_state.TrainState.create(
-                apply_fn=lambda x: x,
-                params=freeze({'a': 1, 'b': (2, 3), 'c': [4, 5]}),
-                tx=optax.adam(1e-3),
-            ),
-        )
+      GenericTuple(
+        x=[
+          0,
+          {'a': 1, 'b': (2, 3), ('c', 'd'): [4, 5]},
+          (100, 200),
+          [3, 4, 5],
+        ],
+        y=train_state.TrainState.create(
+          apply_fn=lambda x: x,
+          params=freeze({'a': 1, 'b': (2, 3), 'c': [4, 5]}),
+          tx=optax.adam(1e-3),
+        ),
+      )
     )
 
     with self.assertRaisesRegex(
-        CursorFindError,
-        'More than one object found given the conditions of the cond_fn\\. '
-        'The first two objects found have the following paths: '
-        "\\.x\\[1]\\['b'] and \\.y\\.params\\['b'] ",
+      CursorFindError,
+      'More than one object found given the conditions of the cond_fn\\. '
+      'The first two objects found have the following paths: '
+      "\\.x\\[1]\\['b'] and \\.y\\.params\\['b'] ",
     ):
       c.find(lambda path, value: 'b' in path and isinstance(value, tuple))
     with self.assertRaisesRegex(
-        CursorFindError,
-        'No object found given the conditions of the cond_fn\\.',
+      CursorFindError,
+      'No object found given the conditions of the cond_fn\\.',
     ):
       c.find(lambda path, value: 'b' in path and isinstance(value, str))
 
     self.assertEqual(
-        c.find(lambda path, value: path.endswith('params/b'))[1]
-        .set(30)
-        .y.params,
-        freeze({'a': 1, 'b': (2, 30), 'c': [4, 5]}),
+      c.find(lambda path, value: path.endswith('params/b'))[1].set(30).y.params,
+      freeze({'a': 1, 'b': (2, 30), 'c': [4, 5]}),
     )
 
   def test_find_all(self):
@@ -735,23 +728,23 @@ class CursorTest(absltest.TestCase):
 
     for tuple_wrap in (lambda x: x, tuple):
       l = tuple_wrap(
-          [tuple_wrap([1, 2]), tuple_wrap([3, 4]), tuple_wrap([5, 6])]
+        [tuple_wrap([1, 2]), tuple_wrap([3, 4]), tuple_wrap([5, 6])]
       )
       c = cursor(l)
       c2, c3 = c.find_all(cond_fn)
       c2[0] *= -1
       c3[1] *= -2
       self.assertEqual(
-          c.build(),
-          tuple_wrap(
-              [tuple_wrap([1, 2]), tuple_wrap([-3, 4]), tuple_wrap([5, -12])]
-          ),
+        c.build(),
+        tuple_wrap(
+          [tuple_wrap([1, 2]), tuple_wrap([-3, 4]), tuple_wrap([5, -12])]
+        ),
       )
       self.assertEqual(
-          l,
-          tuple_wrap(
-              [tuple_wrap([1, 2]), tuple_wrap([3, 4]), tuple_wrap([5, 6])]
-          ),
+        l,
+        tuple_wrap(
+          [tuple_wrap([1, 2]), tuple_wrap([3, 4]), tuple_wrap([5, 6])]
+        ),
       )  # make sure the original object is unchanged
 
     # test regular dict and FrozenDict
@@ -760,7 +753,6 @@ class CursorTest(absltest.TestCase):
       return 'Dense_1' in path or 'Dense_2' in path
 
     class Model(nn.Module):
-
       @nn.compact
       def __call__(self, x):
         x = nn.Dense(3)(x)
@@ -773,28 +765,24 @@ class CursorTest(absltest.TestCase):
 
     for freeze_wrap in (lambda x: x, freeze):
       params = freeze_wrap(
-          Model().init(jax.random.PRNGKey(0), jnp.empty((1, 2)))['params']
+        Model().init(jax.random.PRNGKey(0), jnp.empty((1, 2)))['params']
       )
       c = cursor(params)
       for i, c2 in enumerate(c.find_all(cond_fn)):
         self.assertEqual(
-            c2['kernel'].set(123)[f'Dense_{i+1}'],
-            freeze_wrap(
-                {'kernel': 123, 'bias': params[f'Dense_{i+1}']['bias']}
-            ),
+          c2['kernel'].set(123)[f'Dense_{i+1}'],
+          freeze_wrap({'kernel': 123, 'bias': params[f'Dense_{i+1}']['bias']}),
         )
       self.assertTrue(
-          jax.tree_util.tree_all(
-              jax.tree_util.tree_map(
-                  lambda x, y: (x == y).all(),
-                  params,
-                  freeze_wrap(
-                      Model().init(jax.random.PRNGKey(0), jnp.empty((1, 2)))[
-                          'params'
-                      ]
-                  ),
-              )
+        jax.tree_util.tree_all(
+          jax.tree_util.tree_map(
+            lambda x, y: (x == y).all(),
+            params,
+            freeze_wrap(
+              Model().init(jax.random.PRNGKey(0), jnp.empty((1, 2)))['params']
+            ),
           )
+        )
       )  # make sure original params are unchanged
 
     # test TrainState
@@ -803,9 +791,9 @@ class CursorTest(absltest.TestCase):
       return 'params' in path
 
     state = train_state.TrainState.create(
-        apply_fn=lambda x: x,
-        params={'a': 1, 'b': 2},
-        tx=optax.adam(1e-3),
+      apply_fn=lambda x: x,
+      params={'a': 1, 'b': 2},
+      tx=optax.adam(1e-3),
     )
     c = cursor(state)
     c2 = list(c.find_all(cond_fn))
@@ -813,7 +801,7 @@ class CursorTest(absltest.TestCase):
     c2 = c2[0]
     self.assertEqual(c2['b'].set(-1).params, {'a': 1, 'b': -1})
     self.assertEqual(
-        state.params, {'a': 1, 'b': 2}
+      state.params, {'a': 1, 'b': 2}
     )  # make sure original params are unchanged
 
     # test NamedTuple
@@ -822,23 +810,23 @@ class CursorTest(absltest.TestCase):
       return isinstance(value, GenericTuple) and isinstance(value.x, int)
 
     t = GenericTuple(
-        GenericTuple(0, 'a'), GenericTuple(1, 'b'), GenericTuple('c', 2)
+      GenericTuple(0, 'a'), GenericTuple(1, 'b'), GenericTuple('c', 2)
     )
     c = cursor(t)
     c2, c3 = c.find_all(cond_fn)
     c2.x += 5
     c3.x += 6
     self.assertEqual(
-        c.build(),
-        GenericTuple(
-            GenericTuple(5, 'a'), GenericTuple(7, 'b'), GenericTuple('c', 2)
-        ),
+      c.build(),
+      GenericTuple(
+        GenericTuple(5, 'a'), GenericTuple(7, 'b'), GenericTuple('c', 2)
+      ),
     )
     self.assertEqual(
-        t,
-        GenericTuple(
-            GenericTuple(0, 'a'), GenericTuple(1, 'b'), GenericTuple('c', 2)
-        ),
+      t,
+      GenericTuple(
+        GenericTuple(0, 'a'), GenericTuple(1, 'b'), GenericTuple('c', 2)
+      ),
     )  # make sure original object is unchanged
 
 

--- a/tests/early_stopping_test.py
+++ b/tests/early_stopping_test.py
@@ -15,16 +15,16 @@
 """Tests for flax.training.early_stopping."""
 
 
-from absl.testing import absltest
-from flax.training import early_stopping
 import jax
+from absl.testing import absltest
+
+from flax.training import early_stopping
 
 # Parse absl flags test_srcdir and test_tmpdir.
 jax.config.parse_flags_with_absl()
 
 
 class EarlyStoppingTests(absltest.TestCase):
-
   def test_update(self):
     es = early_stopping.EarlyStopping(min_delta=0, patience=0)
 
@@ -85,16 +85,16 @@ class EarlyStoppingTests(absltest.TestCase):
     self.assertEqual(step, 1)
 
     metrics = [
-        0.01,
-        0.005,
-        0.0033,
-        0.0025,
-        0.002,
-        0.0017,
-        0.0014,
-        0.0012,
-        0.0011,
-        0.001,
+      0.01,
+      0.005,
+      0.0033,
+      0.0025,
+      0.002,
+      0.0017,
+      0.0014,
+      0.0012,
+      0.0011,
+      0.001,
     ]
     improvement_steps = 0
     for step in range(10):

--- a/tests/io_test.py
+++ b/tests/io_test.py
@@ -17,30 +17,28 @@
 import os
 import tempfile
 
-from absl.testing import absltest
-from absl.testing import parameterized
-from flax import io
-from flax import errors
-import tensorflow as tf
 import jax
+import tensorflow as tf
+from absl.testing import absltest, parameterized
+
+from flax import errors, io
 
 # Parse absl flags test_srcdir and test_tmpdir.
 jax.config.parse_flags_with_absl()
 
 
 class IOTest(parameterized.TestCase):
-
   @parameterized.parameters(
-      {'backend_mode': io.BackendMode.DEFAULT},
-      {'backend_mode': io.BackendMode.TF},
+    {'backend_mode': io.BackendMode.DEFAULT},
+    {'backend_mode': io.BackendMode.TF},
   )
   def test_override(self, backend_mode):
     with io.override_mode(backend_mode):
       self.assertEqual(io.io_mode, backend_mode)
 
   @parameterized.parameters(
-      {'write_mode': io.BackendMode.DEFAULT, 'read_mode': io.BackendMode.TF},
-      {'write_mode': io.BackendMode.TF, 'read_mode': io.BackendMode.DEFAULT},
+    {'write_mode': io.BackendMode.DEFAULT, 'read_mode': io.BackendMode.TF},
+    {'write_mode': io.BackendMode.TF, 'read_mode': io.BackendMode.DEFAULT},
   )
   def test_GFile(self, write_mode, read_mode):
     test_string = b'testing write and read'
@@ -72,8 +70,8 @@ class IOTest(parameterized.TestCase):
       self.assertEqual(default_dir_set, tf_dir_set)
 
   @parameterized.parameters(
-      {'create_temp_fn': tempfile.TemporaryDirectory},
-      {'create_temp_fn': tempfile.NamedTemporaryFile},
+    {'create_temp_fn': tempfile.TemporaryDirectory},
+    {'create_temp_fn': tempfile.NamedTemporaryFile},
   )
   def test_isdir(self, create_temp_fn):
     with create_temp_fn() as temp:
@@ -107,14 +105,14 @@ class IOTest(parameterized.TestCase):
         self.assertEqual(file.read(), test_string)
 
   @parameterized.parameters(
-      {
-          'backend_mode': io.BackendMode.DEFAULT,
-          'error_type': errors.AlreadyExistsError,
-      },
-      {
-          'backend_mode': io.BackendMode.TF,
-          'error_type': tf.errors.AlreadyExistsError,
-      },
+    {
+      'backend_mode': io.BackendMode.DEFAULT,
+      'error_type': errors.AlreadyExistsError,
+    },
+    {
+      'backend_mode': io.BackendMode.TF,
+      'error_type': tf.errors.AlreadyExistsError,
+    },
   )
   def test_copy_raises_error(self, backend_mode, error_type):
     with tempfile.NamedTemporaryFile() as temp_file:
@@ -141,14 +139,14 @@ class IOTest(parameterized.TestCase):
         self.assertTrue(os.path.exists(rename2_path))
 
   @parameterized.parameters(
-      {
-          'backend_mode': io.BackendMode.DEFAULT,
-          'error_type': errors.AlreadyExistsError,
-      },
-      {
-          'backend_mode': io.BackendMode.TF,
-          'error_type': tf.errors.AlreadyExistsError,
-      },
+    {
+      'backend_mode': io.BackendMode.DEFAULT,
+      'error_type': errors.AlreadyExistsError,
+    },
+    {
+      'backend_mode': io.BackendMode.TF,
+      'error_type': tf.errors.AlreadyExistsError,
+    },
   )
   def test_rename_raises_error(self, backend_mode, error_type):
     with tempfile.NamedTemporaryFile() as temp_file:
@@ -167,8 +165,8 @@ class IOTest(parameterized.TestCase):
       self.assertEqual(default_exists, tf_exists)
 
   @parameterized.parameters(
-      {'backend_mode': io.BackendMode.DEFAULT},
-      {'backend_mode': io.BackendMode.TF},
+    {'backend_mode': io.BackendMode.DEFAULT},
+    {'backend_mode': io.BackendMode.TF},
   )
   def test_makedirs(self, backend_mode):
     with tempfile.TemporaryDirectory() as temp_dir_path:
@@ -177,7 +175,7 @@ class IOTest(parameterized.TestCase):
       with io.override_mode(backend_mode):
         io.makedirs(test_dir_path)
       self.assertTrue(
-          os.path.exists(test_dir_path) and (os.path.isdir(test_dir_path))
+        os.path.exists(test_dir_path) and (os.path.isdir(test_dir_path))
       )
 
   def test_glob(self):
@@ -197,8 +195,8 @@ class IOTest(parameterized.TestCase):
     self.assertEqual(default_glob_set, tf_glob_set)
 
   @parameterized.parameters(
-      {'backend_mode': io.BackendMode.DEFAULT},
-      {'backend_mode': io.BackendMode.TF},
+    {'backend_mode': io.BackendMode.DEFAULT},
+    {'backend_mode': io.BackendMode.TF},
   )
   def test_remove(self, backend_mode):
     with tempfile.TemporaryDirectory() as temp_dir_path:
@@ -213,8 +211,8 @@ class IOTest(parameterized.TestCase):
       self.assertTrue(not os.path.exists(test_path))
 
   @parameterized.parameters(
-      {'backend_mode': io.BackendMode.DEFAULT},
-      {'backend_mode': io.BackendMode.TF},
+    {'backend_mode': io.BackendMode.DEFAULT},
+    {'backend_mode': io.BackendMode.TF},
   )
   def test_rmtree(self, backend_mode):
     with tempfile.TemporaryDirectory() as temp_dir_path:
@@ -234,8 +232,8 @@ class IOTest(parameterized.TestCase):
       self.assertTrue(not os.path.exists(dir0_path))
 
   @parameterized.parameters(
-      {'backend_mode': io.BackendMode.DEFAULT},
-      {'backend_mode': io.BackendMode.TF},
+    {'backend_mode': io.BackendMode.DEFAULT},
+    {'backend_mode': io.BackendMode.TF},
   )
   def test_getsize(self, backend_mode):
     with tempfile.TemporaryDirectory() as temp_dir_path:

--- a/tests/jax_utils_test.py
+++ b/tests/jax_utils_test.py
@@ -15,12 +15,14 @@
 """Tests for flax.jax_utils."""
 
 from functools import partial
-from absl.testing import parameterized
+
 import chex
-from flax import jax_utils
 import jax
 import numpy as np
 import tensorflow as tf
+from absl.testing import parameterized
+
+from flax import jax_utils
 
 NDEV = 4
 

--- a/tests/linen/initializers_test.py
+++ b/tests/linen/initializers_test.py
@@ -14,49 +14,45 @@
 
 """Tests for flax.linen.initializers."""
 
-from absl.testing import absltest
-from absl.testing import parameterized
+import jax
+import jax.numpy as jnp
+import numpy as np
+from absl.testing import absltest, parameterized
+from jax import random
 
 from flax import linen as nn
 from flax.linen import initializers
-
-import jax
-from jax import random
-import jax.numpy as jnp
-
-import numpy as np
 
 # Parse absl flags test_srcdir and test_tmpdir.
 jax.config.parse_flags_with_absl()
 
 
 class InitializersTest(parameterized.TestCase):
-
   @parameterized.parameters(
-      {
-          'builder_fn': initializers.zeros_init,
-          'params_shape': (2, 3),
-          'expected_params': jnp.zeros((2, 3)),
-      },
-      {
-          'builder_fn': initializers.ones_init,
-          'params_shape': (3, 2),
-          'expected_params': jnp.ones((3, 2)),
-      },
+    {
+      'builder_fn': initializers.zeros_init,
+      'params_shape': (2, 3),
+      'expected_params': jnp.zeros((2, 3)),
+    },
+    {
+      'builder_fn': initializers.ones_init,
+      'params_shape': (3, 2),
+      'expected_params': jnp.ones((3, 2)),
+    },
   )
   def test_call_builder(self, builder_fn, params_shape, expected_params):
     params = builder_fn()(random.key(42), params_shape, jnp.float32)
     np.testing.assert_allclose(params, expected_params)
 
   @parameterized.parameters(
-      {
-          'builder_fn': initializers.zeros_init,
-          'expected_params': jnp.zeros((2, 5)),
-      },
-      {
-          'builder_fn': initializers.ones_init,
-          'expected_params': jnp.ones((2, 5)),
-      },
+    {
+      'builder_fn': initializers.zeros_init,
+      'expected_params': jnp.zeros((2, 5)),
+    },
+    {
+      'builder_fn': initializers.ones_init,
+      'expected_params': jnp.ones((2, 5)),
+    },
   )
   def test_kernel_builder(self, builder_fn, expected_params):
     layer = nn.Dense(5, kernel_init=builder_fn())

--- a/tests/linen/kw_only_dataclasses_test.py
+++ b/tests/linen/kw_only_dataclasses_test.py
@@ -16,13 +16,13 @@
 
 import dataclasses
 import inspect
+
 from absl.testing import absltest
 
 from flax.linen import kw_only_dataclasses
 
 
 class KwOnlyDataclassesTest(absltest.TestCase):
-
   def test_kwonly_args_moved_to_end(self):
     @kw_only_dataclasses.dataclass
     class TestClass:
@@ -102,7 +102,7 @@ class KwOnlyDataclassesTest(absltest.TestCase):
 
     value = C(4, 'foo')  # pylint: disable=too-many-function-args
     self.assertDictEqual(
-        dataclasses.asdict(value), dict(name='foo', size=4, x=2, y=3)
+      dataclasses.asdict(value), dict(name='foo', size=4, x=2, y=3)
     )
 
   def test_kwonly_marker(self):

--- a/tests/linen/linen_activation_test.py
+++ b/tests/linen/linen_activation_test.py
@@ -14,22 +14,18 @@
 
 """Tests for flax.linen.activation."""
 
-from absl.testing import absltest
-from absl.testing import parameterized
+import jax
+import jax.numpy as jnp
+from absl.testing import absltest, parameterized
+from jax import random
 
 from flax import linen as nn
-
-import jax
-from jax import random
-import jax.numpy as jnp
-
 
 # Parse absl flags test_srcdir and test_tmpdir.
 jax.config.parse_flags_with_absl()
 
 
 class ActivationTest(parameterized.TestCase):
-
   def test_prelu(self):
     rng = random.key(0)
     x = jnp.ones((4, 6, 5))

--- a/tests/linen/linen_attention_test.py
+++ b/tests/linen/linen_attention_test.py
@@ -14,37 +14,31 @@
 
 """Tests for flax.linen.attention."""
 
-from absl.testing import absltest
-from absl.testing import parameterized
-
-from flax import errors
-from flax import linen as nn
-from flax import jax_utils
-from flax.core import pop
-
 import jax
-from jax import lax
-from jax import random
-from jax.nn import initializers
 import jax.numpy as jnp
-
 import numpy as np
+from absl.testing import absltest, parameterized
+from jax import lax, random
+from jax.nn import initializers
+
+from flax import errors, jax_utils
+from flax import linen as nn
+from flax.core import pop
 
 # Parse absl flags test_srcdir and test_tmpdir.
 jax.config.parse_flags_with_absl()
 
 
 class AttentionTest(parameterized.TestCase):
-
   def test_multihead_self_attention(self):
     rng = random.key(0)
     x = jnp.ones((4, 6, 5))
     sa_module = nn.SelfAttention(
-        num_heads=8,
-        qkv_features=16,
-        kernel_init=initializers.ones,
-        bias_init=initializers.zeros,
-        deterministic=False,
+      num_heads=8,
+      qkv_features=16,
+      kernel_init=initializers.ones,
+      bias_init=initializers.zeros,
+      deterministic=False,
     )
     y, _ = sa_module.init_with_output(rng, x)
     self.assertEqual(y.shape, x.shape)
@@ -54,11 +48,11 @@ class AttentionTest(parameterized.TestCase):
     rng = random.key(0)
     x = jnp.ones((4, 6, 5), jnp.complex64)
     sa_module = nn.SelfAttention(
-        num_heads=8,
-        qkv_features=16,
-        kernel_init=initializers.ones,
-        bias_init=initializers.zeros,
-        deterministic=False,
+      num_heads=8,
+      qkv_features=16,
+      kernel_init=initializers.ones,
+      bias_init=initializers.zeros,
+      deterministic=False,
     )
     y, _ = sa_module.init_with_output(rng, x)
     self.assertEqual(y.shape, x.shape)
@@ -68,11 +62,11 @@ class AttentionTest(parameterized.TestCase):
     rng = random.key(0)
     q = jnp.ones((4, 2, 3, 5))
     sa_module = nn.MultiHeadDotProductAttention(
-        num_heads=8,
-        qkv_features=16,
-        kernel_init=initializers.ones,
-        bias_init=initializers.zeros,
-        deterministic=False,
+      num_heads=8,
+      qkv_features=16,
+      kernel_init=initializers.ones,
+      bias_init=initializers.zeros,
+      deterministic=False,
     )
     y, _ = sa_module.init_with_output(rng, q)
     self.assertEqual(y.shape, q.shape)
@@ -81,12 +75,12 @@ class AttentionTest(parameterized.TestCase):
     rng = random.key(0)
     x = jnp.ones((4, 2, 3, 5))
     sa_module = nn.MultiHeadDotProductAttention(
-        num_heads=8,
-        qkv_features=16,
-        kernel_init=initializers.ones,
-        bias_init=initializers.zeros,
-        dropout_rate=0.1,
-        deterministic=False,
+      num_heads=8,
+      qkv_features=16,
+      kernel_init=initializers.ones,
+      bias_init=initializers.zeros,
+      dropout_rate=0.1,
+      deterministic=False,
     )
     rng1, rng2 = random.split(rng)
     rngs = {'params': rng1, 'dropout': rng2}
@@ -96,10 +90,15 @@ class AttentionTest(parameterized.TestCase):
   def test_multihead_self_attention_explicit_dropout(self):
     class Foo(nn.Module):
       attention_kwargs: dict
+
       @nn.compact
       def __call__(self, x, dropout_rng=None):
-        a = nn.MultiHeadDotProductAttention(**self.attention_kwargs)(x, x, dropout_rng=dropout_rng)
-        b = nn.MultiHeadDotProductAttention(**self.attention_kwargs)(x, x, dropout_rng=dropout_rng)
+        a = nn.MultiHeadDotProductAttention(**self.attention_kwargs)(
+          x, x, dropout_rng=dropout_rng
+        )
+        b = nn.MultiHeadDotProductAttention(**self.attention_kwargs)(
+          x, x, dropout_rng=dropout_rng
+        )
         return a, b
 
     module = Foo(
@@ -110,8 +109,8 @@ class AttentionTest(parameterized.TestCase):
         bias_init=initializers.zeros,
         dropout_rate=0.5,
         deterministic=False,
-        )
       )
+    )
     rng1, rng2, rng3 = random.split(random.key(0), 3)
     x = jnp.ones((4, 2, 3, 5))
     rngs = {'params': rng1, 'dropout': rng2}
@@ -128,12 +127,12 @@ class AttentionTest(parameterized.TestCase):
     rng = random.key(0)
     x = jnp.ones((4, 2, 3, 5))
     sa_module0 = nn.MultiHeadDotProductAttention(
-        num_heads=8,
-        qkv_features=16,
-        kernel_init=initializers.ones,
-        bias_init=initializers.zeros,
-        dropout_rate=0.0,
-        deterministic=True,
+      num_heads=8,
+      qkv_features=16,
+      kernel_init=initializers.ones,
+      bias_init=initializers.zeros,
+      dropout_rate=0.0,
+      deterministic=True,
     )
     rng1, rng2, rng3, rng4 = random.split(rng, 4)
     rngs1 = {'params': rng1, 'dropout': rng2}
@@ -145,21 +144,21 @@ class AttentionTest(parameterized.TestCase):
     y4 = sa_module0.apply(vs, x, rngs=rngs2)
     np.testing.assert_allclose(y3, y4)
     sa_module1 = nn.MultiHeadDotProductAttention(
-        num_heads=8,
-        qkv_features=16,
-        kernel_init=initializers.ones,
-        bias_init=initializers.zeros,
-        dropout_rate=0.0,
+      num_heads=8,
+      qkv_features=16,
+      kernel_init=initializers.ones,
+      bias_init=initializers.zeros,
+      dropout_rate=0.0,
     )
     y5 = sa_module1.apply(vs, x, deterministic=True, rngs=rngs1)
     y6 = sa_module1.apply(vs, x, deterministic=True, rngs=rngs2)
     np.testing.assert_allclose(y5, y6)
     sa_module2 = nn.MultiHeadDotProductAttention(
-        num_heads=8,
-        qkv_features=16,
-        kernel_init=initializers.ones,
-        bias_init=initializers.zeros,
-        dropout_rate=0.5,
+      num_heads=8,
+      qkv_features=16,
+      kernel_init=initializers.ones,
+      bias_init=initializers.zeros,
+      dropout_rate=0.5,
     )
     y7 = sa_module2.apply(vs, x, deterministic=True, rngs=rngs1)
     y8 = sa_module2.apply(vs, x, deterministic=True, rngs=rngs2)
@@ -173,8 +172,8 @@ class AttentionTest(parameterized.TestCase):
     mask_1d_simple = (ts[:, None] >= ts[None, :])[None, None, :, :]
     mask_1d_simple = jnp.broadcast_to(mask_1d_simple, (3, 1, 16, 16))
     np.testing.assert_allclose(
-        mask_1d,
-        mask_1d_simple,
+      mask_1d,
+      mask_1d_simple,
     )
 
   @parameterized.parameters([((5,), (1,)), ((6, 5), (2,))])
@@ -185,14 +184,14 @@ class AttentionTest(parameterized.TestCase):
     rng = random.key(0)
     key1, key2 = random.split(rng)
     inputs = random.normal(
-        key1, (bs,) + spatial_shape + (num_heads * num_features,)
+      key1, (bs,) + spatial_shape + (num_heads * num_features,)
     )
     module = nn.SelfAttention(
-        num_heads=num_heads,
-        qkv_features=num_heads * num_features,
-        precision=lax.Precision.HIGHEST,
-        deterministic=False,
-        decode=False,
+      num_heads=num_heads,
+      qkv_features=num_heads * num_features,
+      precision=lax.Precision.HIGHEST,
+      deterministic=False,
+      decode=False,
     )
     decode_module = module.clone(decode=True)
 
@@ -200,19 +199,19 @@ class AttentionTest(parameterized.TestCase):
     state, params = pop(initial_vars, 'params')
     causal_mask = nn.attention.make_causal_mask(jnp.ones((bs,) + spatial_shape))
     y_ref = jax.jit(lambda x, y: module.apply(initial_vars, x, y))(
-        inputs, causal_mask
+      inputs, causal_mask
     )
 
     # feed the inputs sequentially to simulate decoding
     def body_fn(state, x):
       y, state = decode_module.apply(
-          {'params': params, **state}, x, mutable=['cache']
+        {'params': params, **state}, x, mutable=['cache']
       )
       return state, y
 
     # scan_in_dim supports scanning multiple dims
     _, y = jax_utils.scan_in_dim(
-        body_fn, state, inputs, axis=attn_dims, keepdims=True
+      body_fn, state, inputs, axis=attn_dims, keepdims=True
     )
 
     np.testing.assert_allclose(y_ref, y, atol=1e-5)
@@ -229,9 +228,9 @@ class AttentionTest(parameterized.TestCase):
     inputs = random.normal(rng2, input_shape)
 
     module = nn.MultiHeadDotProductAttention(
-        num_heads=num_heads,
-        kernel_init=jax.nn.initializers.ones,
-        deterministic=False,
+      num_heads=num_heads,
+      kernel_init=jax.nn.initializers.ones,
+      deterministic=False,
     )
 
     initial_vars = module.init(rng1, inputs)
@@ -252,33 +251,39 @@ class AttentionTest(parameterized.TestCase):
     for i in range(length):
       deps = get_receptive_field_1d(i)
       assert (deps[:i] == 1).all(), (
-          'Receptive Field Error: Some of the '
-          'previous postions are not reachable '
-          'in autoregressive self-attention.'
+        'Receptive Field Error: Some of the '
+        'previous postions are not reachable '
+        'in autoregressive self-attention.'
       )
       if i != length - 1:
         k = i + 1
         assert (deps[k:] == 0).all(), (
-            'Receptive Field Error: Some of the '
-            'future postions are reachable in '
-            'autoregressive self-attention.'
+          'Receptive Field Error: Some of the '
+          'future postions are reachable in '
+          'autoregressive self-attention.'
         )
 
   def test_multihead_self_attention_equality(self):
     rng = random.key(0)
     q = jnp.ones((4, 2, 3, 5))
-    module_kwargs = {'num_heads': 8,
-                     'qkv_features': 16,
-                     'kernel_init': initializers.ones,
-                     'bias_init': initializers.zeros,
-                     'deterministic': False}
+    module_kwargs = {
+      'num_heads': 8,
+      'qkv_features': 16,
+      'kernel_init': initializers.ones,
+      'bias_init': initializers.zeros,
+      'deterministic': False,
+    }
     sa_module0 = nn.MultiHeadDotProductAttention(**module_kwargs)
     sa_module1 = nn.SelfAttention(**module_kwargs)
     y0, v0 = sa_module0.init_with_output(rng, q)
-    with self.assertWarnsRegex(DeprecationWarning, 'SelfAttention will be deprecated soon.'):
+    with self.assertWarnsRegex(
+      DeprecationWarning, 'SelfAttention will be deprecated soon.'
+    ):
       y1, v1 = sa_module1.init_with_output(rng, q)
     self.assertTrue((y0 == y1).all())
-    self.assertTrue(jax.tree_util.tree_all(jax.tree_map(lambda x, y: (x == y).all(), v0, v1)))
+    self.assertTrue(
+      jax.tree_util.tree_all(jax.tree_map(lambda x, y: (x == y).all(), v0, v1))
+    )
 
   def test_multihead_kv_args(self):
     key1, key2 = random.split(random.key(0), 2)
@@ -291,22 +296,41 @@ class AttentionTest(parameterized.TestCase):
       bias_init=initializers.zeros,
       deterministic=False,
     )
-    y0, v0 = module.init_with_output(key2, query, inputs_k=key_value, inputs_v=key_value)
+    y0, v0 = module.init_with_output(
+      key2, query, inputs_k=key_value, inputs_v=key_value
+    )
     y1, v1 = module.init_with_output(key2, query, inputs_k=key_value)
-    with self.assertWarnsRegex(DeprecationWarning, 'The inputs_kv arg will be deprecated soon.'):
+    with self.assertWarnsRegex(
+      DeprecationWarning, 'The inputs_kv arg will be deprecated soon.'
+    ):
       y2, v2 = module.init_with_output(key2, query, inputs_kv=key_value)
     self.assertTrue((y0 == y1).all() and (y1 == y2).all())
     self.assertTrue(
       jax.tree_util.tree_all(
-        jax.tree_map(lambda x, y, z: (x == y).all() and (y == z).all(),
-                     v0, v1, v2)))
+        jax.tree_map(
+          lambda x, y, z: (x == y).all() and (y == z).all(), v0, v1, v2
+        )
+      )
+    )
 
-    with self.assertRaisesRegex(ValueError, '`inputs_k` cannot be None if `inputs_v` is not None.'):
+    with self.assertRaisesRegex(
+      ValueError, '`inputs_k` cannot be None if `inputs_v` is not None.'
+    ):
       y3, v3 = module.init_with_output(key2, query, inputs_v=key_value)
-    with self.assertRaisesRegex(ValueError, 'If either `inputs_k` or `inputs_v` is not None, `inputs_kv` must be None.'):
-      y3, v3 = module.init_with_output(key2, query, inputs_kv=key_value, inputs_v=key_value)
-    with self.assertRaisesRegex(ValueError, 'If either `inputs_k` or `inputs_v` is not None, `inputs_kv` must be None.'):
-      y3, v3 = module.init_with_output(key2, query, key_value, key_value, inputs_kv=key_value)
+    with self.assertRaisesRegex(
+      ValueError,
+      'If either `inputs_k` or `inputs_v` is not None, `inputs_kv` must be None.',
+    ):
+      y3, v3 = module.init_with_output(
+        key2, query, inputs_kv=key_value, inputs_v=key_value
+      )
+    with self.assertRaisesRegex(
+      ValueError,
+      'If either `inputs_k` or `inputs_v` is not None, `inputs_kv` must be None.',
+    ):
+      y3, v3 = module.init_with_output(
+        key2, query, key_value, key_value, inputs_kv=key_value
+      )
 
   def test_multihead_mask_warning(self):
     rng = random.key(0)
@@ -319,17 +343,19 @@ class AttentionTest(parameterized.TestCase):
     query = key = random.normal(rng2, input_shape)
 
     module = nn.MultiHeadDotProductAttention(
-        num_heads=num_heads,
-        kernel_init=jax.nn.initializers.ones,
-        deterministic=False,
+      num_heads=num_heads,
+      kernel_init=jax.nn.initializers.ones,
+      deterministic=False,
     )
 
     initial_vars = module.init(rng1, query, key)
     causal_mask = nn.attention.make_causal_mask(jnp.ones(input_shape[:-1]))
 
     module.apply(initial_vars, query, key, mask=causal_mask)
-    with self.assertWarnsRegex(DeprecationWarning,
-                               "the function signature of MultiHeadDotProductAttention's `__call__` method has changed"):
+    with self.assertWarnsRegex(
+      DeprecationWarning,
+      "the function signature of MultiHeadDotProductAttention's `__call__` method has changed",
+    ):
       with self.assertRaises(errors.ScopeParamShapeError):
         module.apply(initial_vars, query, key, causal_mask)
 

--- a/tests/linen/linen_combinators_test.py
+++ b/tests/linen/linen_combinators_test.py
@@ -16,13 +16,13 @@
 
 from typing import Any, Optional, Sequence
 
-from absl.testing import absltest
-
-from flax import linen as nn
 import jax
+import numpy as np
+from absl.testing import absltest
 from jax import numpy as jnp
 from jax import random
-import numpy as np
+
+from flax import linen as nn
 
 # Parse absl flags test_srcdir and test_tmpdir.
 jax.config.parse_flags_with_absl()
@@ -38,12 +38,12 @@ class MLP(nn.Module):
     x = inputs
     for layer_size in self.layer_sizes[:-1]:
       x = nn.Dense(
-          features=layer_size, kernel_init=nn.initializers.ones_init()
+        features=layer_size, kernel_init=nn.initializers.ones_init()
       )(x)
       if self.activation is not None:
         x = self.activation(x)
     x = nn.Dense(
-        features=self.layer_sizes[-1], kernel_init=nn.initializers.ones_init()
+      features=self.layer_sizes[-1], kernel_init=nn.initializers.ones_init()
     )(x)
     if self.activation_final is None:
       return x
@@ -57,7 +57,7 @@ class AttentionTuple(nn.Module):
   @nn.compact
   def __call__(self, query, key_value):
     output = nn.MultiHeadDotProductAttention(
-        num_heads=self.num_heads, qkv_features=self.qkv_features
+      num_heads=self.num_heads, qkv_features=self.qkv_features
     )(query, key_value)
     return output, key_value
 
@@ -69,13 +69,12 @@ class AttentionDict(nn.Module):
   @nn.compact
   def __call__(self, query, key_value):
     output = nn.MultiHeadDotProductAttention(
-        num_heads=self.num_heads, qkv_features=self.qkv_features
+      num_heads=self.num_heads, qkv_features=self.qkv_features
     )(query, key_value)
     return dict(query=output, key_value=key_value)
 
 
 class SequentialTest(absltest.TestCase):
-
   def test_construction(self):
     sequential = nn.Sequential([nn.Dense(4), nn.Dense(2)])
     key1, key2 = random.split(random.key(0), 2)
@@ -90,11 +89,13 @@ class SequentialTest(absltest.TestCase):
       sequential.init(random.key(42), jnp.ones((3, 5)))
 
   def test_same_output_as_mlp(self):
-    sequential = nn.Sequential([
+    sequential = nn.Sequential(
+      [
         nn.Dense(4, kernel_init=nn.initializers.ones_init()),
         nn.Dense(8, kernel_init=nn.initializers.ones_init()),
         nn.Dense(2, kernel_init=nn.initializers.ones_init()),
-    ])
+      ]
+    )
     mlp = MLP(layer_sizes=[4, 8, 2])
 
     key1, key2 = random.split(random.key(0), 2)
@@ -107,19 +108,21 @@ class SequentialTest(absltest.TestCase):
     np.testing.assert_array_equal(output_1, output_2)
 
   def test_same_output_as_mlp_with_activation(self):
-    sequential = nn.Sequential([
+    sequential = nn.Sequential(
+      [
         nn.Dense(4, kernel_init=nn.initializers.ones_init()),
         nn.relu,
         nn.Dense(8, kernel_init=nn.initializers.ones_init()),
         nn.relu,
         nn.Dense(2, kernel_init=nn.initializers.ones_init()),
         nn.log_softmax,
-    ])
+      ]
+    )
 
     mlp = MLP(
-        layer_sizes=[4, 8, 2],
-        activation=nn.relu,
-        activation_final=nn.log_softmax,
+      layer_sizes=[4, 8, 2],
+      activation=nn.relu,
+      activation_final=nn.log_softmax,
     )
 
     key1, key2 = random.split(random.key(0), 2)
@@ -132,10 +135,12 @@ class SequentialTest(absltest.TestCase):
     np.testing.assert_array_equal(output_1, output_2)
 
   def test_tuple_output(self):
-    sequential = nn.Sequential([
+    sequential = nn.Sequential(
+      [
         AttentionTuple(),
         AttentionTuple(),
-    ])
+      ]
+    )
 
     key1, key2 = random.split(random.key(0), 2)
     query = random.uniform(key1, (3, 5))
@@ -148,10 +153,12 @@ class SequentialTest(absltest.TestCase):
     np.testing.assert_equal(out_key_value.shape, (9, 5))
 
   def test_dict_output(self):
-    sequential = nn.Sequential([
+    sequential = nn.Sequential(
+      [
         AttentionDict(),
         AttentionDict(),
-    ])
+      ]
+    )
 
     key1, key2 = random.split(random.key(0), 2)
     query = random.uniform(key1, (3, 5))

--- a/tests/linen/linen_dtypes_test.py
+++ b/tests/linen/linen_dtypes_test.py
@@ -15,18 +15,16 @@
 """Tests for flax.linen.dtypes."""
 
 
+import jax
 from absl.testing import absltest
+from jax import numpy as jnp
 
 from flax.linen import dtypes
-
-import jax
-from jax import numpy as jnp
 
 default_float_dtype = jnp.result_type(1.0)
 
 
 class DtypesTest(absltest.TestCase):
-
   def test_no_inexact_dtype(self):
     i32 = jnp.int32(1.0)
     self.assertEqual(dtypes.canonicalize_dtype(i32, inexact=False), jnp.int32)

--- a/tests/linen/linen_linear_test.py
+++ b/tests/linen/linen_linear_test.py
@@ -16,31 +16,27 @@
 
 import functools
 
-from absl.testing import absltest
-from absl.testing import parameterized
-
-from flax import linen as nn
-
 import jax
+import jax.numpy as jnp
+import numpy as np
+from absl.testing import absltest, parameterized
 from jax import random
 from jax.nn import initializers
-import jax.numpy as jnp
 
-import numpy as np
+from flax import linen as nn
 
 # Parse absl flags test_srcdir and test_tmpdir.
 jax.config.parse_flags_with_absl()
 
 
 class LinearTest(parameterized.TestCase):
-
   def test_dense(self):
     rng = dict(params=random.key(0))
     x = jnp.ones((1, 3))
     dense_module = nn.Dense(
-        features=4,
-        kernel_init=initializers.ones,
-        bias_init=initializers.ones,
+      features=4,
+      kernel_init=initializers.ones,
+      bias_init=initializers.ones,
     )
     y, _ = dense_module.init_with_output(rng, x)
     self.assertEqual(y.shape, (1, 4))
@@ -51,9 +47,9 @@ class LinearTest(parameterized.TestCase):
     rng = dict(params=random.key(0))
     x = jnp.ones((1, 2, 3))
     dense_module = nn.Dense(
-        features=4,
-        kernel_init=initializers.ones,
-        bias_init=initializers.ones,
+      features=4,
+      kernel_init=initializers.ones,
+      bias_init=initializers.ones,
     )
     y, _ = dense_module.init_with_output(rng, x)
     np.testing.assert_allclose(y, np.full((1, 2, 4), 4.0))
@@ -62,9 +58,9 @@ class LinearTest(parameterized.TestCase):
     rng = dict(params=random.key(0))
     x = jnp.ones((1, 3))
     dense_module = nn.Dense(
-        features=4,
-        use_bias=False,
-        kernel_init=initializers.ones,
+      features=4,
+      use_bias=False,
+      kernel_init=initializers.ones,
     )
     y, _ = dense_module.init_with_output(rng, x)
     np.testing.assert_allclose(y, np.full((1, 4), 3.0))
@@ -72,15 +68,15 @@ class LinearTest(parameterized.TestCase):
   def test_dense_is_dense_general(self):
     x = jax.random.normal(random.key(0), (5, 3))
     dense_module = nn.Dense(
-        features=4,
-        use_bias=True,
-        bias_init=initializers.normal(),
+      features=4,
+      use_bias=True,
+      bias_init=initializers.normal(),
     )
     y1, _ = dense_module.init_with_output(dict(params=random.key(1)), x)
     dg_module = nn.DenseGeneral(
-        features=4,
-        use_bias=True,
-        bias_init=initializers.normal(),
+      features=4,
+      use_bias=True,
+      bias_init=initializers.normal(),
     )
     y2, _ = dg_module.init_with_output(dict(params=random.key(1)), x)
 
@@ -91,10 +87,10 @@ class LinearTest(parameterized.TestCase):
     x = jnp.ones((1, 3, 2, 5))
     with self.assertRaises(ValueError):
       dg_module = nn.DenseGeneral(
-          features=4,
-          batch_dims=(0, 2),
-          kernel_init=initializers.ones,
-          bias_init=initializers.ones,
+        features=4,
+        batch_dims=(0, 2),
+        kernel_init=initializers.ones,
+        bias_init=initializers.ones,
       )
       dg_module.init_with_output(rng, x)
 
@@ -102,9 +98,9 @@ class LinearTest(parameterized.TestCase):
     rng = dict(params=random.key(0))
     x = jnp.ones((1, 3))
     dg_module = nn.DenseGeneral(
-        features=(2, 2),
-        kernel_init=initializers.ones,
-        bias_init=initializers.ones,
+      features=(2, 2),
+      kernel_init=initializers.ones,
+      bias_init=initializers.ones,
     )
     y, _ = dg_module.init_with_output(rng, x)
     np.testing.assert_allclose(y, np.full((1, 2, 2), 4.0))
@@ -113,10 +109,10 @@ class LinearTest(parameterized.TestCase):
     rng = dict(params=random.key(0))
     x = jnp.ones((1, 2, 2))
     dg_module = nn.DenseGeneral(
-        features=3,
-        axis=(-2, 2),
-        kernel_init=initializers.ones,
-        bias_init=initializers.ones,
+      features=3,
+      axis=(-2, 2),
+      kernel_init=initializers.ones,
+      bias_init=initializers.ones,
     )
     y, _ = dg_module.init_with_output(rng, x)
     np.testing.assert_allclose(y, np.full((1, 3), 5.0))
@@ -135,31 +131,33 @@ class LinearTest(parameterized.TestCase):
     counter_init = functools.partial(_counter_init, state=state)
 
     dg_module = nn.DenseGeneral(
-        features=7,
-        axis=(3, -2),
-        batch_dims=0,
-        bias_init=initializers.ones,
-        kernel_init=counter_init,
+      features=7,
+      axis=(3, -2),
+      batch_dims=0,
+      bias_init=initializers.ones,
+      kernel_init=counter_init,
     )
     y, _ = dg_module.init_with_output(rng, x)
     target = np.full((2, 1, 7), 16.0)
     np.testing.assert_allclose(y, target)
 
-  @parameterized.parameters([
+  @parameterized.parameters(
+    [
       ((-2, 3), (), 'bijk,jklm->bilm'),
       ((3, -2), (), 'bijk,jklm->bilm'),
       ((-2, 3), (0,), 'bijk,bjklm->bilm'),
-  ])
+    ]
+  )
   def test_dense_general_vs_numpy(self, axis, batch_dims, einsum_expr):
     rng = dict(params=random.key(0))
     x = jnp.ones((16, 8, 9, 10))
 
     dg_module = nn.DenseGeneral(
-        features=(11, 12),
-        axis=axis,
-        batch_dims=batch_dims,
-        bias_init=initializers.ones,
-        kernel_init=initializers.normal(),
+      features=(11, 12),
+      axis=axis,
+      batch_dims=batch_dims,
+      bias_init=initializers.ones,
+      kernel_init=initializers.normal(),
     )
     y, initial_params = dg_module.init_with_output(rng, x)
     target = np.einsum(einsum_expr, x, initial_params['params']['kernel']) + 1.0
@@ -188,12 +186,12 @@ class LinearTest(parameterized.TestCase):
     rng = dict(params=random.key(0))
     x = jnp.ones((1, 8, 3))
     conv_module = nn.Conv(
-        features=4,
-        use_bias=use_bias,
-        kernel_size=(3,),
-        padding='VALID',
-        kernel_init=initializers.ones,
-        bias_init=initializers.ones,
+      features=4,
+      use_bias=use_bias,
+      kernel_size=(3,),
+      padding='VALID',
+      kernel_init=initializers.ones,
+      bias_init=initializers.ones,
     )
     y, initial_params = conv_module.init_with_output(rng, x)
     self.assertEqual(initial_params['params']['kernel'].shape, (3, 3, 4))
@@ -205,12 +203,12 @@ class LinearTest(parameterized.TestCase):
     rng = dict(params=random.key(0))
     x = jnp.ones((2, 5, 8, 3))
     conv_module = nn.Conv(
-        features=4,
-        use_bias=use_bias,
-        kernel_size=(3,),
-        padding='VALID',
-        kernel_init=initializers.ones,
-        bias_init=initializers.ones,
+      features=4,
+      use_bias=use_bias,
+      kernel_size=(3,),
+      padding='VALID',
+      kernel_init=initializers.ones,
+      bias_init=initializers.ones,
     )
     y, initial_params = conv_module.init_with_output(rng, x)
     self.assertEqual(initial_params['params']['kernel'].shape, (3, 3, 4))
@@ -221,11 +219,11 @@ class LinearTest(parameterized.TestCase):
     rng = dict(params=random.key(0))
     x = jnp.ones((1, 8, 2))
     conv_module = nn.ConvLocal(
-        features=4,
-        kernel_size=(3,),
-        padding='VALID',
-        kernel_init=initializers.ones,
-        bias_init=initializers.ones,
+      features=4,
+      kernel_size=(3,),
+      padding='VALID',
+      kernel_init=initializers.ones,
+      bias_init=initializers.ones,
     )
     y, initial_params = conv_module.init_with_output(rng, x)
     self.assertEqual(initial_params['params']['kernel'].shape, (6, 3 * 2, 4))
@@ -235,11 +233,11 @@ class LinearTest(parameterized.TestCase):
     rng = dict(params=random.key(0))
     x = jnp.ones((8, 3))
     conv_module = nn.Conv(
-        features=4,
-        kernel_size=(3,),
-        padding='VALID',
-        kernel_init=initializers.ones,
-        bias_init=initializers.ones,
+      features=4,
+      kernel_size=(3,),
+      padding='VALID',
+      kernel_init=initializers.ones,
+      bias_init=initializers.ones,
     )
     y, initial_params = conv_module.init_with_output(rng, x)
     self.assertEqual(initial_params['params']['kernel'].shape, (3, 3, 4))
@@ -250,21 +248,23 @@ class LinearTest(parameterized.TestCase):
     x = jnp.ones((8, 3))
     m = jnp.tril(jnp.ones((3, 3, 4)))
     conv_module = nn.Conv(
-        features=4,
-        kernel_size=(3,),
-        padding='VALID',
-        mask=m,
-        kernel_init=initializers.ones,
-        bias_init=initializers.ones,
+      features=4,
+      kernel_size=(3,),
+      padding='VALID',
+      mask=m,
+      kernel_init=initializers.ones,
+      bias_init=initializers.ones,
     )
-    expected = jnp.array([
+    expected = jnp.array(
+      [
         [10.0, 7.0, 4.0, 1.0],
         [10.0, 7.0, 4.0, 1.0],
         [10.0, 7.0, 4.0, 1.0],
         [10.0, 7.0, 4.0, 1.0],
         [10.0, 7.0, 4.0, 1.0],
         [10.0, 7.0, 4.0, 1.0],
-    ])
+      ]
+    )
     y, initial_params = conv_module.init_with_output(rng, x)
     self.assertEqual(initial_params['params']['kernel'].shape, (3, 3, 4))
     np.testing.assert_allclose(y, expected)
@@ -273,11 +273,11 @@ class LinearTest(parameterized.TestCase):
     rng = dict(params=random.key(0))
     x = jnp.ones((8, 2))
     conv_module = nn.ConvLocal(
-        features=4,
-        kernel_size=(3,),
-        padding='VALID',
-        kernel_init=initializers.ones,
-        bias_init=initializers.ones,
+      features=4,
+      kernel_size=(3,),
+      padding='VALID',
+      kernel_init=initializers.ones,
+      bias_init=initializers.ones,
     )
     y, initial_params = conv_module.init_with_output(rng, x)
     self.assertEqual(initial_params['params']['kernel'].shape, (6, 3 * 2, 4))
@@ -287,33 +287,33 @@ class LinearTest(parameterized.TestCase):
     rng = dict(params=random.key(0))
     x = jnp.ones((1, 8, 4))
     conv_module = nn.Conv(
-        features=4,
-        kernel_size=(3,),
-        feature_group_count=2,
-        padding='VALID',
-        kernel_init=initializers.ones,
-        bias_init=initializers.ones,
+      features=4,
+      kernel_size=(3,),
+      feature_group_count=2,
+      padding='VALID',
+      kernel_init=initializers.ones,
+      bias_init=initializers.ones,
     )
     y, initial_params = conv_module.init_with_output(rng, x)
     self.assertEqual(initial_params['params']['kernel'].shape, (3, 2, 4))
     np.testing.assert_allclose(y, np.full((1, 6, 4), 7.0))
 
   @parameterized.product(
-      n_batch=(1, 3),
-      n_features=(1, 2),
-      kernel_size=(1, 2, 3, 9),
-      n_input_features=(1, 3),
-      input_size=(1, 8, 16),
-      module=(nn.Conv, nn.ConvLocal),
+    n_batch=(1, 3),
+    n_features=(1, 2),
+    kernel_size=(1, 2, 3, 9),
+    n_input_features=(1, 3),
+    input_size=(1, 8, 16),
+    module=(nn.Conv, nn.ConvLocal),
   )
   def test_circular_conv_1d_constant(
-      self,
-      n_batch,
-      n_features,
-      kernel_size,
-      n_input_features,
-      input_size,
-      module,
+    self,
+    n_batch,
+    n_features,
+    kernel_size,
+    n_input_features,
+    input_size,
+    module,
   ):
     """
     Test 1D convolution with circular padding: filter with all elements equal
@@ -325,24 +325,24 @@ class LinearTest(parameterized.TestCase):
     rng = dict(params=random.key(0))
     x = jnp.ones((n_batch, input_size, n_input_features))
     conv_module = module(
-        features=n_features,
-        kernel_size=(kernel_size,),
-        padding='CIRCULAR',
-        kernel_init=initializers.ones,
-        bias_init=initializers.zeros,
+      features=n_features,
+      kernel_size=(kernel_size,),
+      padding='CIRCULAR',
+      kernel_init=initializers.ones,
+      bias_init=initializers.zeros,
     )
     y, initial_params = conv_module.init_with_output(rng, x)
 
     kernel_shape = self._get_kernel_shape(
-        x.shape, (kernel_size,), module, n_features
+      x.shape, (kernel_size,), module, n_features
     )
 
     self.assertEqual(
-        initial_params['params']['kernel'].shape,
-        kernel_shape,
+      initial_params['params']['kernel'].shape,
+      kernel_shape,
     )
     correct_ans = np.full(
-        (n_batch, input_size, n_features), kernel_size * n_input_features
+      (n_batch, input_size, n_features), kernel_size * n_input_features
     )
     np.testing.assert_allclose(y, correct_ans)
 
@@ -351,31 +351,31 @@ class LinearTest(parameterized.TestCase):
       kernel_shape = kernel_size + (input_shape[-1], n_features)
     elif module == nn.ConvLocal:
       kernel_shape = input_shape[1:-1] + (
-          input_shape[-1] * np.prod(kernel_size),
-          n_features,
+        input_shape[-1] * np.prod(kernel_size),
+        n_features,
       )
     else:
       raise ValueError(module)
     return kernel_shape
 
   @parameterized.product(
-      n_batch=(1, 3),
-      n_features=(1, 2, 10),
-      kernel_lin_size=(1, 2, 3, 9),
-      n_input_features=(1, 5),
-      input_x_size=(14,),
-      input_y_size=(5, 10),
-      module=(nn.Conv, nn.ConvLocal),
+    n_batch=(1, 3),
+    n_features=(1, 2, 10),
+    kernel_lin_size=(1, 2, 3, 9),
+    n_input_features=(1, 5),
+    input_x_size=(14,),
+    input_y_size=(5, 10),
+    module=(nn.Conv, nn.ConvLocal),
   )
   def test_circular_conv_2d_constant(
-      self,
-      n_batch,
-      n_features,
-      kernel_lin_size,
-      n_input_features,
-      input_x_size,
-      input_y_size,
-      module,
+    self,
+    n_batch,
+    n_features,
+    kernel_lin_size,
+    n_input_features,
+    input_x_size,
+    input_y_size,
+    module,
   ):
     """
     Test 2D convolution with circular padding: square filter with all elements
@@ -388,25 +388,25 @@ class LinearTest(parameterized.TestCase):
     x = jnp.ones((n_batch, input_x_size, input_y_size, n_input_features))
     kernel_size = (kernel_lin_size, kernel_lin_size)
     conv_module = module(
-        features=n_features,
-        kernel_size=kernel_size,
-        padding='CIRCULAR',
-        kernel_init=initializers.ones,
-        bias_init=initializers.zeros,
+      features=n_features,
+      kernel_size=kernel_size,
+      padding='CIRCULAR',
+      kernel_init=initializers.ones,
+      bias_init=initializers.zeros,
     )
     y, initial_params = conv_module.init_with_output(rng, x)
 
     kernel_shape = self._get_kernel_shape(
-        x.shape, kernel_size, module, n_features
+      x.shape, kernel_size, module, n_features
     )
 
     self.assertEqual(
-        initial_params['params']['kernel'].shape,
-        kernel_shape,
+      initial_params['params']['kernel'].shape,
+      kernel_shape,
     )
     correct_ans = np.full(
-        (n_batch, input_x_size, input_y_size, n_features),
-        kernel_lin_size * kernel_lin_size * n_input_features,
+      (n_batch, input_x_size, input_y_size, n_features),
+      kernel_lin_size * kernel_lin_size * n_input_features,
     )
     np.testing.assert_allclose(y, correct_ans)
 
@@ -419,12 +419,12 @@ class LinearTest(parameterized.TestCase):
     kernel = np.expand_dims(kernel, (1, 2))
 
     conv_module = nn.Conv(
-        features=1,
-        kernel_size=(3,),
-        strides=(3,),
-        padding='CIRCULAR',
-        kernel_init=lambda *_: kernel,
-        bias_init=initializers.zeros,
+      features=1,
+      kernel_size=(3,),
+      strides=(3,),
+      padding='CIRCULAR',
+      kernel_init=lambda *_: kernel,
+      bias_init=initializers.zeros,
     )
     y, initial_params = conv_module.init_with_output(rng, x)
 
@@ -444,12 +444,12 @@ class LinearTest(parameterized.TestCase):
     kernel = np.array(((-1, 2, 3), (4, 5, 6)))
     kernel = np.expand_dims(kernel, (2,))
     conv_module = nn.ConvLocal(
-        features=1,
-        kernel_size=(3,),
-        strides=(3,),
-        padding='CIRCULAR',
-        kernel_init=lambda *_: kernel,
-        bias_init=initializers.zeros,
+      features=1,
+      kernel_size=(3,),
+      strides=(3,),
+      padding='CIRCULAR',
+      kernel_init=lambda *_: kernel,
+      bias_init=initializers.zeros,
     )
     y, initial_params = conv_module.init_with_output(rng, x)
 
@@ -468,24 +468,26 @@ class LinearTest(parameterized.TestCase):
     kernel = np.expand_dims(kernel, (1, 2))
 
     conv_module = nn.Conv(
-        features=1,
-        kernel_size=(3,),
-        padding='CIRCULAR',
-        kernel_init=lambda *_: kernel,
-        bias_init=initializers.zeros,
-        kernel_dilation=(3,),
+      features=1,
+      kernel_size=(3,),
+      padding='CIRCULAR',
+      kernel_init=lambda *_: kernel,
+      bias_init=initializers.zeros,
+      kernel_dilation=(3,),
     )
     y, initial_params = conv_module.init_with_output(rng, x)
 
     self.assertEqual(initial_params['params']['kernel'].shape, (3, 1, 1))
     # Compare with manually computed convolution
-    correct_ans = np.array((
+    correct_ans = np.array(
+      (
         3 + 2 * 1 + 4,
         4 + 2 * 2 + 5,
         5 + 2 * 3 + 1,
         1 + 2 * 4 + 2,
         2 + 2 * 5 + 3,
-    ))
+      )
+    )
     correct_ans = np.expand_dims(correct_ans, (0, 2))
     np.testing.assert_allclose(y, correct_ans)
 
@@ -497,29 +499,31 @@ class LinearTest(parameterized.TestCase):
     x = np.arange(1, 6)
     x = np.expand_dims(x, (0, 2))
     kernel = np.array(
-        ((1, 2, 1), (3, 4, 5), (-1, 1, 2), (2, 3, 4), (-1, -2, -3))
+      ((1, 2, 1), (3, 4, 5), (-1, 1, 2), (2, 3, 4), (-1, -2, -3))
     )
     kernel = np.expand_dims(kernel, (2,))
 
     conv_module = nn.ConvLocal(
-        features=1,
-        kernel_size=(3,),
-        padding='CIRCULAR',
-        kernel_init=lambda *_: kernel,
-        bias_init=initializers.zeros,
-        kernel_dilation=(3,),
+      features=1,
+      kernel_size=(3,),
+      padding='CIRCULAR',
+      kernel_init=lambda *_: kernel,
+      bias_init=initializers.zeros,
+      kernel_dilation=(3,),
     )
     y, initial_params = conv_module.init_with_output(rng, x)
 
     self.assertEqual(initial_params['params']['kernel'].shape, (5, 3, 1))
     # Compare with manually computed convolution
-    correct_ans = np.array((
+    correct_ans = np.array(
+      (
         1 * 3 + 2 * 1 + 1 * 4,
         3 * 4 + 4 * 2 + 5 * 5,
         -1 * 5 + 1 * 3 + 2 * 1,
         2 * 1 + 3 * 4 + 4 * 2,
         -1 * 2 + -2 * 5 + -3 * 3,
-    ))
+      )
+    )
     correct_ans = np.expand_dims(correct_ans, (0, 2))
     np.testing.assert_allclose(y, correct_ans)
 
@@ -532,21 +536,23 @@ class LinearTest(parameterized.TestCase):
     kernel = np.expand_dims(kernel, (2, 3))
 
     conv_module = nn.Conv(
-        features=1,
-        kernel_size=(3, 3),
-        padding='CIRCULAR',
-        kernel_init=lambda *_: kernel,
-        bias_init=initializers.zeros,
+      features=1,
+      kernel_size=(3, 3),
+      padding='CIRCULAR',
+      kernel_init=lambda *_: kernel,
+      bias_init=initializers.zeros,
     )
     y, initial_params = conv_module.init_with_output(rng, x)
 
     self.assertEqual(initial_params['params']['kernel'].shape, (3, 3, 1, 1))
     # Compare with manually computed convolution
-    correct_ans = np.array((
+    correct_ans = np.array(
+      (
         (2 * 1 + 7 + 2 + 4 + 3, 2 * 2 + 8 + 3 + 5 + 1, 2 * 3 + 9 + 1 + 6 + 2),
         (2 * 4 + 1 + 5 + 7 + 6, 2 * 5 + 2 + 6 + 8 + 4, 2 * 6 + 3 + 4 + 9 + 5),
         (2 * 7 + 4 + 8 + 1 + 9, 2 * 8 + 5 + 9 + 2 + 7, 2 * 9 + 6 + 7 + 3 + 8),
-    ))
+      )
+    )
     correct_ans = np.expand_dims(correct_ans, (0, 3))
     np.testing.assert_allclose(y, correct_ans)
 
@@ -557,42 +563,46 @@ class LinearTest(parameterized.TestCase):
     rng = dict(params=random.key(0))
     x = np.array(((1, 2, 3), (4, 5, 6), (7, 8, 9)))
     x = np.expand_dims(x, (0, 3))
-    kernel = np.array((
+    kernel = np.array(
+      (
         (
-            ((0, 1, 0), (1, 2, 1), (0, 1, 0)),
-            ((0, 1, 0), (1, 3, 1), (0, 1, 0)),
-            ((0, 1, 0), (1, 4, 1), (0, 1, 0)),
+          ((0, 1, 0), (1, 2, 1), (0, 1, 0)),
+          ((0, 1, 0), (1, 3, 1), (0, 1, 0)),
+          ((0, 1, 0), (1, 4, 1), (0, 1, 0)),
         ),
         (
-            ((0, 1, 0), (1, 5, 1), (0, 1, 0)),
-            ((0, 1, 0), (1, 6, 1), (0, 1, 0)),
-            ((0, 1, 0), (1, 7, 1), (0, 1, 0)),
+          ((0, 1, 0), (1, 5, 1), (0, 1, 0)),
+          ((0, 1, 0), (1, 6, 1), (0, 1, 0)),
+          ((0, 1, 0), (1, 7, 1), (0, 1, 0)),
         ),
         (
-            ((0, 1, 0), (1, 8, 1), (0, 1, 0)),
-            ((0, 1, 0), (1, 9, 1), (0, 1, 0)),
-            ((0, 1, 0), (1, 10, 1), (0, 1, 0)),
+          ((0, 1, 0), (1, 8, 1), (0, 1, 0)),
+          ((0, 1, 0), (1, 9, 1), (0, 1, 0)),
+          ((0, 1, 0), (1, 10, 1), (0, 1, 0)),
         ),
-    ))
+      )
+    )
     kernel = np.expand_dims(kernel, (3,))
     kernel = np.reshape(kernel, (3, 3, 9, 1))
 
     conv_module = nn.ConvLocal(
-        features=1,
-        kernel_size=(3, 3),
-        padding='CIRCULAR',
-        kernel_init=lambda *_: kernel,
-        bias_init=initializers.zeros,
+      features=1,
+      kernel_size=(3, 3),
+      padding='CIRCULAR',
+      kernel_init=lambda *_: kernel,
+      bias_init=initializers.zeros,
     )
     y, initial_params = conv_module.init_with_output(rng, x)
 
     self.assertEqual(initial_params['params']['kernel'].shape, (3, 3, 9, 1))
     # Compare with manually computed convolution
-    correct_ans = np.array((
+    correct_ans = np.array(
+      (
         (2 * 1 + 7 + 2 + 4 + 3, 3 * 2 + 8 + 3 + 5 + 1, 4 * 3 + 9 + 1 + 6 + 2),
         (5 * 4 + 1 + 5 + 7 + 6, 6 * 5 + 2 + 6 + 8 + 4, 7 * 6 + 3 + 4 + 9 + 5),
         (8 * 7 + 4 + 8 + 1 + 9, 9 * 8 + 5 + 9 + 2 + 7, 10 * 9 + 6 + 7 + 3 + 8),
-    ))
+      )
+    )
     correct_ans = np.expand_dims(correct_ans, (0, 3))
     np.testing.assert_allclose(y, correct_ans)
 
@@ -600,86 +610,98 @@ class LinearTest(parameterized.TestCase):
     rng = dict(params=random.key(0))
     x = jnp.ones((1, 8, 4))
     conv_module = nn.Conv(
-        features=4,
-        kernel_size=(3,),
-        padding='CAUSAL',
-        kernel_init=initializers.ones,
-        bias_init=initializers.ones,
+      features=4,
+      kernel_size=(3,),
+      padding='CAUSAL',
+      kernel_init=initializers.ones,
+      bias_init=initializers.ones,
     )
     y, _ = conv_module.init_with_output(rng, x)
-    correct_ans = np.array([[
-        [5.0, 5.0, 5.0, 5.0],
-        [9.0, 9.0, 9.0, 9.0],
-        [13.0, 13.0, 13.0, 13.0],
-        [13.0, 13.0, 13.0, 13.0],
-        [13.0, 13.0, 13.0, 13.0],
-        [13.0, 13.0, 13.0, 13.0],
-        [13.0, 13.0, 13.0, 13.0],
-        [13.0, 13.0, 13.0, 13.0],
-    ]])
+    correct_ans = np.array(
+      [
+        [
+          [5.0, 5.0, 5.0, 5.0],
+          [9.0, 9.0, 9.0, 9.0],
+          [13.0, 13.0, 13.0, 13.0],
+          [13.0, 13.0, 13.0, 13.0],
+          [13.0, 13.0, 13.0, 13.0],
+          [13.0, 13.0, 13.0, 13.0],
+          [13.0, 13.0, 13.0, 13.0],
+          [13.0, 13.0, 13.0, 13.0],
+        ]
+      ]
+    )
     np.testing.assert_allclose(y, correct_ans)
     np.testing.assert_array_equal(correct_ans.shape, y.shape)
 
   @parameterized.product(
-      use_bias=(True, False),
+    use_bias=(True, False),
   )
   def test_conv_transpose(self, use_bias):
     rng = dict(params=random.key(0))
     x = jnp.ones((1, 8, 3))
     conv_transpose_module = nn.ConvTranspose(
-        features=4,
-        use_bias=use_bias,
-        kernel_size=(3,),
-        padding='VALID',
-        kernel_init=initializers.ones,
-        bias_init=initializers.ones,
+      features=4,
+      use_bias=use_bias,
+      kernel_size=(3,),
+      padding='VALID',
+      kernel_init=initializers.ones,
+      bias_init=initializers.ones,
     )
     y, initial_params = conv_transpose_module.init_with_output(rng, x)
     self.assertEqual(initial_params['params']['kernel'].shape, (3, 3, 4))
-    correct_ans = np.array([[
-        [4.0, 4.0, 4.0, 4.0],
-        [7.0, 7.0, 7.0, 7.0],
-        [10.0, 10.0, 10.0, 10.0],
-        [10.0, 10.0, 10.0, 10.0],
-        [10.0, 10.0, 10.0, 10.0],
-        [10.0, 10.0, 10.0, 10.0],
-        [10.0, 10.0, 10.0, 10.0],
-        [10.0, 10.0, 10.0, 10.0],
-        [7.0, 7.0, 7.0, 7.0],
-        [4.0, 4.0, 4.0, 4.0],
-    ]])
+    correct_ans = np.array(
+      [
+        [
+          [4.0, 4.0, 4.0, 4.0],
+          [7.0, 7.0, 7.0, 7.0],
+          [10.0, 10.0, 10.0, 10.0],
+          [10.0, 10.0, 10.0, 10.0],
+          [10.0, 10.0, 10.0, 10.0],
+          [10.0, 10.0, 10.0, 10.0],
+          [10.0, 10.0, 10.0, 10.0],
+          [10.0, 10.0, 10.0, 10.0],
+          [7.0, 7.0, 7.0, 7.0],
+          [4.0, 4.0, 4.0, 4.0],
+        ]
+      ]
+    )
     if not use_bias:
       correct_ans -= 1.0
     np.testing.assert_allclose(y, correct_ans)
 
   @parameterized.product(
-      use_bias=(True, False),
+    use_bias=(True, False),
   )
   def test_multibatch_input_conv_transpose(self, use_bias):
     rng = dict(params=random.key(0))
     x = jnp.ones((2, 5, 8, 3))
     conv_transpose_module = nn.ConvTranspose(
-        features=4,
-        use_bias=use_bias,
-        kernel_size=(3,),
-        padding='VALID',
-        kernel_init=initializers.ones,
-        bias_init=initializers.ones,
+      features=4,
+      use_bias=use_bias,
+      kernel_size=(3,),
+      padding='VALID',
+      kernel_init=initializers.ones,
+      bias_init=initializers.ones,
     )
     y, initial_params = conv_transpose_module.init_with_output(rng, x)
     self.assertEqual(initial_params['params']['kernel'].shape, (3, 3, 4))
-    correct_ans = np.array([[
-        [4.0, 4.0, 4.0, 4.0],
-        [7.0, 7.0, 7.0, 7.0],
-        [10.0, 10.0, 10.0, 10.0],
-        [10.0, 10.0, 10.0, 10.0],
-        [10.0, 10.0, 10.0, 10.0],
-        [10.0, 10.0, 10.0, 10.0],
-        [10.0, 10.0, 10.0, 10.0],
-        [10.0, 10.0, 10.0, 10.0],
-        [7.0, 7.0, 7.0, 7.0],
-        [4.0, 4.0, 4.0, 4.0],
-    ]])
+    correct_ans = np.array(
+      [
+        [
+          [4.0, 4.0, 4.0, 4.0],
+          [7.0, 7.0, 7.0, 7.0],
+          [10.0, 10.0, 10.0, 10.0],
+          [10.0, 10.0, 10.0, 10.0],
+          [10.0, 10.0, 10.0, 10.0],
+          [10.0, 10.0, 10.0, 10.0],
+          [10.0, 10.0, 10.0, 10.0],
+          [10.0, 10.0, 10.0, 10.0],
+          [7.0, 7.0, 7.0, 7.0],
+          [4.0, 4.0, 4.0, 4.0],
+        ]
+      ]
+    )
     correct_ans = np.repeat(correct_ans[None], repeats=2, axis=0)
     correct_ans = np.repeat(correct_ans, repeats=5, axis=1)
     if not use_bias:
@@ -690,15 +712,16 @@ class LinearTest(parameterized.TestCase):
     rng = dict(params=random.key(0))
     x = jnp.ones((8, 3))
     conv_transpose_module = nn.ConvTranspose(
-        features=4,
-        kernel_size=(3,),
-        padding='VALID',
-        kernel_init=initializers.ones,
-        bias_init=initializers.ones,
+      features=4,
+      kernel_size=(3,),
+      padding='VALID',
+      kernel_init=initializers.ones,
+      bias_init=initializers.ones,
     )
     y, initial_params = conv_transpose_module.init_with_output(rng, x)
     self.assertEqual(initial_params['params']['kernel'].shape, (3, 3, 4))
-    correct_ans = np.array([
+    correct_ans = np.array(
+      [
         [4.0, 4.0, 4.0, 4.0],
         [7.0, 7.0, 7.0, 7.0],
         [10.0, 10.0, 10.0, 10.0],
@@ -709,7 +732,8 @@ class LinearTest(parameterized.TestCase):
         [10.0, 10.0, 10.0, 10.0],
         [7.0, 7.0, 7.0, 7.0],
         [4.0, 4.0, 4.0, 4.0],
-    ])
+      ]
+    )
     np.testing.assert_allclose(y, correct_ans)
 
   def test_single_input_masked_conv_transpose(self):
@@ -717,16 +741,17 @@ class LinearTest(parameterized.TestCase):
     x = jnp.ones((8, 3))
     m = jnp.tril(jnp.ones((3, 3, 4)))
     conv_transpose_module = nn.ConvTranspose(
-        features=4,
-        kernel_size=(3,),
-        padding='VALID',
-        mask=m,
-        kernel_init=initializers.ones,
-        bias_init=initializers.ones,
+      features=4,
+      kernel_size=(3,),
+      padding='VALID',
+      mask=m,
+      kernel_init=initializers.ones,
+      bias_init=initializers.ones,
     )
     y, initial_params = conv_transpose_module.init_with_output(rng, x)
     self.assertEqual(initial_params['params']['kernel'].shape, (3, 3, 4))
-    correct_ans = np.array([
+    correct_ans = np.array(
+      [
         [4.0, 3.0, 2.0, 1.0],
         [7.0, 5.0, 3.0, 1.0],
         [10.0, 7.0, 4.0, 1.0],
@@ -737,18 +762,19 @@ class LinearTest(parameterized.TestCase):
         [10.0, 7.0, 4.0, 1.0],
         [7.0, 5.0, 3.0, 1.0],
         [4.0, 3.0, 2.0, 1.0],
-    ])
+      ]
+    )
     np.testing.assert_allclose(y, correct_ans)
 
   @parameterized.product(
-      n_batch=(1, 3),
-      n_features=(1, 2),
-      kernel_size=(1, 2, 3, 9),
-      n_input_features=(1, 3),
-      input_size=(1, 8, 16),
+    n_batch=(1, 3),
+    n_features=(1, 2),
+    kernel_size=(1, 2, 3, 9),
+    n_input_features=(1, 3),
+    input_size=(1, 8, 16),
   )
   def test_circular_conv_transpose_1d_constant(
-      self, n_batch, n_features, kernel_size, n_input_features, input_size
+    self, n_batch, n_features, kernel_size, n_input_features, input_size
   ):
     """
     Test 1D transposed convolution with circular padding: filter with all
@@ -760,39 +786,39 @@ class LinearTest(parameterized.TestCase):
     rng = dict(params=random.key(0))
     x = jnp.ones((n_batch, input_size, n_input_features))
     conv_module = nn.ConvTranspose(
-        features=n_features,
-        kernel_size=(kernel_size,),
-        padding='CIRCULAR',
-        kernel_init=initializers.ones,
-        bias_init=initializers.zeros,
+      features=n_features,
+      kernel_size=(kernel_size,),
+      padding='CIRCULAR',
+      kernel_init=initializers.ones,
+      bias_init=initializers.zeros,
     )
     y, initial_params = conv_module.init_with_output(rng, x)
 
     self.assertEqual(
-        initial_params['params']['kernel'].shape,
-        (kernel_size, n_input_features, n_features),
+      initial_params['params']['kernel'].shape,
+      (kernel_size, n_input_features, n_features),
     )
     correct_ans = np.full(
-        (n_batch, input_size, n_features), kernel_size * n_input_features
+      (n_batch, input_size, n_features), kernel_size * n_input_features
     )
     np.testing.assert_allclose(y, correct_ans)
 
   @parameterized.product(
-      n_batch=(1, 3),
-      n_features=(1, 2, 10),
-      kernel_lin_size=(1, 2, 3, 9),
-      n_input_features=(1, 5),
-      input_x_size=(14,),
-      input_y_size=(5, 10),
+    n_batch=(1, 3),
+    n_features=(1, 2, 10),
+    kernel_lin_size=(1, 2, 3, 9),
+    n_input_features=(1, 5),
+    input_x_size=(14,),
+    input_y_size=(5, 10),
   )
   def test_circular_conv_transpose_2d_constant(
-      self,
-      n_batch,
-      n_features,
-      kernel_lin_size,
-      n_input_features,
-      input_x_size,
-      input_y_size,
+    self,
+    n_batch,
+    n_features,
+    kernel_lin_size,
+    n_input_features,
+    input_x_size,
+    input_y_size,
   ):
     """
     Test 2D transposed convolution with circular padding: square filter with all
@@ -804,21 +830,21 @@ class LinearTest(parameterized.TestCase):
     rng = dict(params=random.key(0))
     x = jnp.ones((n_batch, input_x_size, input_y_size, n_input_features))
     conv_module = nn.ConvTranspose(
-        features=n_features,
-        kernel_size=(kernel_lin_size, kernel_lin_size),
-        padding='CIRCULAR',
-        kernel_init=initializers.ones,
-        bias_init=initializers.zeros,
+      features=n_features,
+      kernel_size=(kernel_lin_size, kernel_lin_size),
+      padding='CIRCULAR',
+      kernel_init=initializers.ones,
+      bias_init=initializers.zeros,
     )
     y, initial_params = conv_module.init_with_output(rng, x)
 
     self.assertEqual(
-        initial_params['params']['kernel'].shape,
-        (kernel_lin_size, kernel_lin_size, n_input_features, n_features),
+      initial_params['params']['kernel'].shape,
+      (kernel_lin_size, kernel_lin_size, n_input_features, n_features),
     )
     correct_ans = np.full(
-        (n_batch, input_x_size, input_y_size, n_features),
-        kernel_lin_size * kernel_lin_size * n_input_features,
+      (n_batch, input_x_size, input_y_size, n_features),
+      kernel_lin_size * kernel_lin_size * n_input_features,
     )
     np.testing.assert_allclose(y, correct_ans)
 
@@ -846,18 +872,19 @@ class LinearTest(parameterized.TestCase):
     kernel = np.expand_dims(kernel, (1, 2))
 
     conv_module = nn.ConvTranspose(
-        features=1,
-        kernel_size=(3,),
-        strides=(3,),
-        padding='CIRCULAR',
-        kernel_init=lambda *_: kernel,
-        bias_init=initializers.zeros,
+      features=1,
+      kernel_size=(3,),
+      strides=(3,),
+      padding='CIRCULAR',
+      kernel_init=lambda *_: kernel,
+      bias_init=initializers.zeros,
     )
     y, initial_params = conv_module.init_with_output(rng, x)
 
     self.assertEqual(initial_params['params']['kernel'].shape, (3, 1, 1))
     # Compare with manually computed convolution
-    correct_ans = np.array((  # pyformat: disable
+    correct_ans = np.array(
+      (  # pyformat: disable
         1 * 1,
         1 * 2,
         1 * 1,
@@ -873,38 +900,43 @@ class LinearTest(parameterized.TestCase):
         5 * 1,
         5 * 2,
         5 * 1,
-    ))
+      )
+    )
     correct_ans = np.expand_dims(correct_ans, (0, 2))
     np.testing.assert_allclose(y, correct_ans)
 
   def test_circular_conv_transpose_2d_custom(self):
     """Test 2d transposed convolution with circular padding on a 3x3 example."""
     rng = dict(params=random.key(0))
-    x = np.array((
+    x = np.array(
+      (
         (1, 2, 3),
         (4, 5, 6),
         (7, 8, 9),
-    ))
+      )
+    )
     x = np.expand_dims(x, (0, 3))
     kernel = np.array(((0, 1, 0), (1, 2, 1), (0, 1, 0)))
     kernel = np.expand_dims(kernel, (2, 3))
 
     conv_module = nn.ConvTranspose(
-        features=1,
-        kernel_size=(3, 3),
-        padding='CIRCULAR',
-        kernel_init=lambda *_: kernel,
-        bias_init=initializers.zeros,
+      features=1,
+      kernel_size=(3, 3),
+      padding='CIRCULAR',
+      kernel_init=lambda *_: kernel,
+      bias_init=initializers.zeros,
     )
     y, initial_params = conv_module.init_with_output(rng, x)
 
     self.assertEqual(initial_params['params']['kernel'].shape, (3, 3, 1, 1))
     # Compare with manually computed convolution
-    correct_ans = np.array((
+    correct_ans = np.array(
+      (
         (18, 21, 24),
         (27, 30, 33),
         (36, 39, 42),
-    ))
+      )
+    )
     correct_ans = np.expand_dims(correct_ans, (0, 3))
     np.testing.assert_allclose(y, correct_ans)
 
@@ -913,27 +945,31 @@ class LinearTest(parameterized.TestCase):
     rng = dict(params=random.key(0))
     x = np.array(((1, 2), (3, 4)))
     x = np.expand_dims(x, (0, 3))
-    kernel = np.array((
+    kernel = np.array(
+      (
         (1, 2),
         (3, 4),
-    ))
+      )
+    )
     kernel = np.expand_dims(kernel, (2, 3))
 
     conv_module = nn.ConvTranspose(
-        features=1,
-        kernel_size=(2, 2),
-        padding='CIRCULAR',
-        kernel_init=lambda *_: kernel,
-        bias_init=initializers.ones,
+      features=1,
+      kernel_size=(2, 2),
+      padding='CIRCULAR',
+      kernel_init=lambda *_: kernel,
+      bias_init=initializers.ones,
     )
     y, initial_params = conv_module.init_with_output(rng, x)
 
     self.assertEqual(initial_params['params']['kernel'].shape, (2, 2, 1, 1))
     # Compare with manually computed convolution
-    correct_ans = np.array((
+    correct_ans = np.array(
+      (
         (21, 23),
         (29, 31),
-    ))
+      )
+    )
     correct_ans = np.expand_dims(correct_ans, (0, 3))
     np.testing.assert_allclose(y, correct_ans)
 
@@ -942,12 +978,12 @@ class LinearTest(parameterized.TestCase):
     rng = dict(params=random.key(0))
     x = jnp.ones((1, 15, 15, 3))
     conv_module = nn.ConvTranspose(
-        features=4,
-        use_bias=use_bias,
-        strides=(2, 2),
-        kernel_size=(6, 6),
-        padding='CIRCULAR',
-        transpose_kernel=True,
+      features=4,
+      use_bias=use_bias,
+      strides=(2, 2),
+      kernel_size=(6, 6),
+      padding='CIRCULAR',
+      transpose_kernel=True,
     )
     y, initial_params = conv_module.init_with_output(rng, x)
     self.assertEqual(initial_params['params']['kernel'].shape, (6, 6, 4, 3))
@@ -964,17 +1000,17 @@ class LinearTest(parameterized.TestCase):
     rng = dict(params=random.key(0))
     x = jnp.arange(4)[None]
     dummy_embedding = jnp.broadcast_to(jnp.arange(4)[..., None], (4, 3)).astype(
-        jnp.float32
+      jnp.float32
     )
     embed_module = nn.Embed(
-        num_embeddings=4,
-        features=3,
-        embedding_init=lambda rng, shape, dtype: dummy_embedding,
+      num_embeddings=4,
+      features=3,
+      embedding_init=lambda rng, shape, dtype: dummy_embedding,
     )
     y, initial_params = embed_module.init_with_output(rng, x)
     np.testing.assert_allclose(y, dummy_embedding[None])
     z = embed_module.apply(
-        initial_params, jnp.ones((3,)), method=embed_module.attend
+      initial_params, jnp.ones((3,)), method=embed_module.attend
     )
     np.testing.assert_allclose(z, 3.0 * jnp.arange(4))
 
@@ -982,17 +1018,17 @@ class LinearTest(parameterized.TestCase):
     rng = dict(params=random.key(0))
     x = jnp.arange(4)[None]
     dummy_embedding = np.broadcast_to(np.arange(4)[..., None], (4, 3)).astype(
-        np.float32
+      np.float32
     )
     embed_module = nn.Embed(
-        num_embeddings=4,
-        features=3,
-        embedding_init=lambda rng, shape, dtype: dummy_embedding,
+      num_embeddings=4,
+      features=3,
+      embedding_init=lambda rng, shape, dtype: dummy_embedding,
     )
     y, initial_params = embed_module.init_with_output(rng, x)
     np.testing.assert_allclose(y, dummy_embedding[None])
     z = embed_module.apply(
-        initial_params, jnp.ones((3,)), method=embed_module.attend
+      initial_params, jnp.ones((3,)), method=embed_module.attend
     )
     np.testing.assert_allclose(z, 3.0 * jnp.arange(4))
 
@@ -1002,7 +1038,6 @@ class LinearTest(parameterized.TestCase):
 
   def test_non_final_axis(self):
     class Foo(nn.Module):
-
       @nn.compact
       def __call__(self, x):
         return nn.DenseGeneral(features=6, axis=1, name='dense')(x)
@@ -1010,14 +1045,13 @@ class LinearTest(parameterized.TestCase):
     x = jnp.ones((2, 4, 8))
     y, variables = Foo().init_with_output(random.key(0), x)
     self.assertEqual(
-        jax.tree_util.tree_map(jnp.shape, variables['params']),
-        {'dense': {'kernel': (4, 6), 'bias': (6,)}},
+      jax.tree_util.tree_map(jnp.shape, variables['params']),
+      {'dense': {'kernel': (4, 6), 'bias': (6,)}},
     )
     self.assertEqual(y.shape, (2, 8, 6))
 
   def test_non_final_axes(self):
     class Foo(nn.Module):
-
       @nn.compact
       def __call__(self, x):
         return nn.DenseGeneral(features=6, axis=(0, 1), name='dense')(x)
@@ -1025,8 +1059,8 @@ class LinearTest(parameterized.TestCase):
     x = jnp.ones((2, 4, 8))
     y, variables = Foo().init_with_output(random.key(0), x)
     self.assertEqual(
-        jax.tree_util.tree_map(jnp.shape, variables['params']),
-        {'dense': {'kernel': (2, 4, 6), 'bias': (6,)}},
+      jax.tree_util.tree_map(jnp.shape, variables['params']),
+      {'dense': {'kernel': (2, 4, 6), 'bias': (6,)}},
     )
     self.assertEqual(y.shape, (8, 6))
 

--- a/tests/linen/linen_meta_test.py
+++ b/tests/linen/linen_meta_test.py
@@ -14,25 +14,23 @@
 
 """Tests for linen_meta."""
 
-from absl.testing import absltest
-from flax import linen as nn
 import jax
+from absl.testing import absltest
 from jax import numpy as jnp
 from jax import random
 from jax.experimental import mesh_utils
-from jax.sharding import Mesh
-from jax.sharding import PartitionSpec
+from jax.sharding import Mesh, PartitionSpec
+
+from flax import linen as nn
 
 
 class LinenMetaTest(absltest.TestCase):
-
   def test_boxed_param(self):
     class Bar(nn.Module):
-
       @nn.compact
       def __call__(mdl_self, x):  # pylint: disable=no-self-argument
         kernel_init = nn.with_partitioning(
-            nn.initializers.ones_init(), ('in', 'out')
+          nn.initializers.ones_init(), ('in', 'out')
         )
         kernel = mdl_self.param('kernel', kernel_init, (x.shape[-1], 2))
         kernel_box = mdl_self.get_variable('params', 'kernel')
@@ -41,37 +39,35 @@ class LinenMetaTest(absltest.TestCase):
         return x @ kernel
 
     class Foo(nn.Module):
-
       @nn.compact
       def __call__(self, xs):
         return nn.vmap(
-            Bar,
-            in_axes=0,
-            variable_axes={'params': 0},
-            split_rngs={'params': True},
-            metadata_params={nn.PARTITION_NAME: 'batch'},
+          Bar,
+          in_axes=0,
+          variable_axes={'params': 0},
+          split_rngs={'params': True},
+          metadata_params={nn.PARTITION_NAME: 'batch'},
         )(name='bar')(xs)
 
     m = Foo()
     variables = m.init(random.key(0), jnp.zeros((8, 3)))
     self.assertEqual(
-        variables['params']['bar']['kernel'].names, ('batch', 'in', 'out')
+      variables['params']['bar']['kernel'].names, ('batch', 'in', 'out')
     )
 
   def test_boxed_variable(self):
     class Bar(nn.Module):
-
       @nn.compact
       def __call__(mdl_self, x):  # pylint: disable=no-self-argument
         kernel_init = nn.with_partitioning(
-            nn.initializers.ones_init(), ('in', 'out')
+          nn.initializers.ones_init(), ('in', 'out')
         )
         kernel = mdl_self.variable(
-            'params',
-            'kernel',
-            kernel_init,
-            mdl_self.make_rng('params'),
-            (x.shape[-1], 2),
+          'params',
+          'kernel',
+          kernel_init,
+          mdl_self.make_rng('params'),
+          (x.shape[-1], 2),
         )
         kernel.value += 1.0
         self.assertEqual(kernel.value.sum(), kernel.value.size * 2)
@@ -81,21 +77,20 @@ class LinenMetaTest(absltest.TestCase):
         return x @ kernel.value
 
     class Foo(nn.Module):
-
       @nn.compact
       def __call__(self, xs):
         return nn.vmap(
-            Bar,
-            in_axes=0,
-            variable_axes={'params': 0},
-            split_rngs={'params': True},
-            metadata_params={nn.PARTITION_NAME: 'batch'},
+          Bar,
+          in_axes=0,
+          variable_axes={'params': 0},
+          split_rngs={'params': True},
+          metadata_params={nn.PARTITION_NAME: 'batch'},
         )(name='bar')(xs)
 
     m = Foo()
     variables = m.init(random.key(0), jnp.zeros((8, 3)))
     self.assertEqual(
-        variables['params']['bar']['kernel'].names, ('batch', 'in', 'out')
+      variables['params']['bar']['kernel'].names, ('batch', 'in', 'out')
     )
 
   # def test_boxed_variable(self):
@@ -129,16 +124,15 @@ class LinenMetaTest(absltest.TestCase):
       def __call__(self, x):
         ki = nn.linear.default_kernel_init
         h = nn.Dense(
-            self.hidden_size,
-            kernel_init=nn.with_partitioning(ki, ('data', 'model')),
+          self.hidden_size,
+          kernel_init=nn.with_partitioning(ki, ('data', 'model')),
         )(x)
         h = nn.relu(h)
         return nn.Dense(
-            x.shape[-1], kernel_init=nn.with_partitioning(ki, ('model', 'data'))
+          x.shape[-1], kernel_init=nn.with_partitioning(ki, ('model', 'data'))
         )(h)
 
     class Model(nn.Module):
-
       @nn.compact
       def __call__(self, x):
         def body(_, c):
@@ -146,11 +140,11 @@ class LinenMetaTest(absltest.TestCase):
           return c, ()
 
         c, _ = nn.scan(
-            body,
-            variable_axes={'params': 0},
-            split_rngs={'params': 0},
-            length=8,
-            metadata_params={nn.PARTITION_NAME: None},
+          body,
+          variable_axes={'params': 0},
+          split_rngs={'params': 0},
+          length=8,
+          metadata_params={nn.PARTITION_NAME: None},
         )(self, x)
         return c
 
@@ -160,35 +154,35 @@ class LinenMetaTest(absltest.TestCase):
     x = jnp.ones((8, 128))
     spec = nn.get_partition_spec(jax.eval_shape(model.init, random.key(0), x))
     self.assertEqual(
-        spec,
-        {
-            'params': {
-                'MLP_0': {
-                    'Dense_0': {
-                        'bias': PartitionSpec(),
-                        'kernel': PartitionSpec(None, 'data', 'model'),
-                    },
-                    'Dense_1': {
-                        'bias': PartitionSpec(),
-                        'kernel': PartitionSpec(None, 'model', 'data'),
-                    },
-                },
+      spec,
+      {
+        'params': {
+          'MLP_0': {
+            'Dense_0': {
+              'bias': PartitionSpec(),
+              'kernel': PartitionSpec(None, 'data', 'model'),
             },
+            'Dense_1': {
+              'bias': PartitionSpec(),
+              'kernel': PartitionSpec(None, 'model', 'data'),
+            },
+          },
         },
+      },
     )
     x_spec = PartitionSpec('data', 'model')
     f = lambda x: jax.sharding.NamedSharding(mesh, x)
     key_spec = PartitionSpec()
     init_fn = jax.jit(
-        model.init,
-        in_shardings=jax.tree_map(f, (key_spec, x_spec)),
-        out_shardings=jax.tree_map(f, spec),
+      model.init,
+      in_shardings=jax.tree_map(f, (key_spec, x_spec)),
+      out_shardings=jax.tree_map(f, spec),
     )
     variables = init_fn(random.key(0), x)
     apply_fn = jax.jit(
-        model.apply,
-        in_shardings=jax.tree_map(f, (spec, x_spec)),
-        out_shardings=jax.tree_map(f, x_spec),
+      model.apply,
+      in_shardings=jax.tree_map(f, (spec, x_spec)),
+      out_shardings=jax.tree_map(f, x_spec),
     )
     y = apply_fn(variables, x)
     self.assertEqual(y.shape, (8, 128))

--- a/tests/linen/linen_recurrent_test.py
+++ b/tests/linen/linen_recurrent_test.py
@@ -15,10 +15,11 @@
 """Recurrent tests."""
 
 
-from absl.testing import absltest
 import jax
 import jax.numpy as jnp
 import numpy as np
+from absl.testing import absltest
+
 from flax import linen as nn
 from flax.linen.recurrent import flip_sequences
 
@@ -27,7 +28,6 @@ jax.config.parse_flags_with_absl()
 
 
 class RNNTest(absltest.TestCase):
-
   def test_rnn_basic_forward(self):
     batch_size = 10
     seq_len = 40
@@ -47,7 +47,7 @@ class RNNTest(absltest.TestCase):
       if 'bias' in layer_params:
         self.assertEqual(layer_params['bias'].shape, (channels_out,))
       self.assertIn(
-          layer_params['kernel'].shape[0], [channels_in, channels_out]
+        layer_params['kernel'].shape[0], [channels_in, channels_out]
       )
       self.assertEqual(layer_params['kernel'].shape[1], channels_out)
 
@@ -70,7 +70,7 @@ class RNNTest(absltest.TestCase):
       if 'bias' in layer_params:
         self.assertEqual(layer_params['bias'].shape, (channels_out,))
       self.assertIn(
-          layer_params['kernel'].shape[0], [channels_in, channels_out]
+        layer_params['kernel'].shape[0], [channels_in, channels_out]
       )
       self.assertEqual(layer_params['kernel'].shape[1], channels_out)
 
@@ -93,7 +93,7 @@ class RNNTest(absltest.TestCase):
       if 'bias' in layer_params:
         self.assertEqual(layer_params['bias'].shape, (channels_out,))
       self.assertIn(
-          layer_params['kernel'].shape[0], [channels_in, channels_out]
+        layer_params['kernel'].shape[0], [channels_in, channels_out]
       )
       self.assertEqual(layer_params['kernel'].shape[1], channels_out)
 
@@ -122,7 +122,7 @@ class RNNTest(absltest.TestCase):
       if 'bias' in layer_params:
         self.assertEqual(layer_params['bias'].shape, (channels_out,))
       self.assertIn(
-          layer_params['kernel'].shape[0], [channels_in, channels_out]
+        layer_params['kernel'].shape[0], [channels_in, channels_out]
       )
       self.assertEqual(layer_params['kernel'].shape[1], channels_out)
 
@@ -135,7 +135,7 @@ class RNNTest(absltest.TestCase):
     channels_out = 15
 
     rnn = nn.RNN(
-        nn.ConvLSTMCell(channels_out, kernel_size),
+      nn.ConvLSTMCell(channels_out, kernel_size),
     )
 
     xs = jnp.ones((batch_size, seq_len, *image_size, channels_in))
@@ -156,8 +156,8 @@ class RNNTest(absltest.TestCase):
       if 'bias' in layer_params:
         self.assertEqual(layer_params['bias'].shape, (channels_out * 4,))
       self.assertIn(
-          layer_params['kernel'].shape[2],
-          [channels_in, channels_out, channels_out * 4],
+        layer_params['kernel'].shape[2],
+        [channels_in, channels_out, channels_out * 4],
       )
       self.assertEqual(layer_params['kernel'].shape[3], channels_out * 4)
 
@@ -178,7 +178,7 @@ class RNNTest(absltest.TestCase):
 
     for i in range(seq_len):
       cell_carry, y = rnn.cell.apply(
-          {'params': cell_params}, cell_carry, xs[:, i, :]
+        {'params': cell_params}, cell_carry, xs[:, i, :]
       )
       np.testing.assert_allclose(y, ys[:, i, :], rtol=1e-5)
 
@@ -192,7 +192,7 @@ class RNNTest(absltest.TestCase):
 
     key = jax.random.key(0)
     seq_lengths = jax.random.randint(
-        key, (batch_size,), minval=1, maxval=seq_len + 1
+      key, (batch_size,), minval=1, maxval=seq_len + 1
     )
 
     rnn = nn.RNN(nn.LSTMCell(channels_out), return_carry=True)
@@ -200,7 +200,7 @@ class RNNTest(absltest.TestCase):
     xs = jnp.ones((batch_size, seq_len, channels_in))
     ys: jnp.ndarray
     (carry, ys), variables = rnn.init_with_output(
-        jax.random.key(0), xs, seq_lengths=seq_lengths
+      jax.random.key(0), xs, seq_lengths=seq_lengths
     )
 
     cell_carry = rnn.cell.initialize_carry(jax.random.key(0), xs[:, 0].shape)
@@ -209,7 +209,7 @@ class RNNTest(absltest.TestCase):
 
     for i in range(seq_len):
       cell_carry, y = rnn.cell.apply(
-          {'params': cell_params}, cell_carry, xs[:, i, :]
+        {'params': cell_params}, cell_carry, xs[:, i, :]
       )
       np.testing.assert_allclose(y, ys[:, i, :], rtol=1e-5)
       carries.append(cell_carry)
@@ -218,7 +218,7 @@ class RNNTest(absltest.TestCase):
       t = int(length) - 1
       for carries_t_, carry_ in zip(carries[t], carry):
         np.testing.assert_allclose(
-            carries_t_[batch_idx], carry_[batch_idx], rtol=1e-5
+          carries_t_[batch_idx], carry_[batch_idx], rtol=1e-5
         )
 
   def test_numerical_equivalence_single_batch(self):
@@ -240,7 +240,7 @@ class RNNTest(absltest.TestCase):
 
       for i in range(seq_len):
         cell_carry, y = rnn.cell.apply(
-            {'params': cell_params}, cell_carry, xs[batch_idx, i, :][None]
+          {'params': cell_params}, cell_carry, xs[batch_idx, i, :][None]
         )
         np.testing.assert_allclose(y[0], ys[batch_idx, i, :], rtol=1e-6)
 
@@ -255,11 +255,11 @@ class RNNTest(absltest.TestCase):
 
     cell: nn.LSTMCell = nn.LSTMCell(channels_out)
     rnn: nn.LSTMCell = nn.scan(
-        nn.LSTMCell,
-        in_axes=1,
-        out_axes=1,
-        variable_broadcast='params',
-        split_rngs={'params': False},
+      nn.LSTMCell,
+      in_axes=1,
+      out_axes=1,
+      variable_broadcast='params',
+      split_rngs={'params': False},
     )(channels_out)
 
     xs = jnp.ones((batch_size, seq_len, channels_in))
@@ -274,9 +274,9 @@ class RNNTest(absltest.TestCase):
 
       for i in range(seq_len):
         cell_carry, y = cell.apply(
-            {'params': cell_params},
-            cell_carry,
-            xs[batch_idx : batch_idx + 1, i, :],
+          {'params': cell_params},
+          cell_carry,
+          xs[batch_idx : batch_idx + 1, i, :],
         )
         np.testing.assert_allclose(y[0], ys[batch_idx, i, :], rtol=1e-5)
 
@@ -290,7 +290,7 @@ class RNNTest(absltest.TestCase):
     channels_out = 6
 
     xs = jax.random.uniform(
-        jax.random.key(0), (batch_size, seq_len, channels_in)
+      jax.random.key(0), (batch_size, seq_len, channels_in)
     )
     cell: nn.LSTMCell = nn.LSTMCell(channels_out)
     carry = cell.initialize_carry(jax.random.key(0), xs[:, 0].shape)
@@ -308,7 +308,7 @@ class RNNTest(absltest.TestCase):
 
     for i in range(seq_len):
       cell_carry, y = cell.apply(
-          {'params': cell_params}, cell_carry, xs[:, i, :]
+        {'params': cell_params}, cell_carry, xs[:, i, :]
       )
       np.testing.assert_allclose(y, ys[:, i, :], rtol=1e-4)
 
@@ -333,16 +333,16 @@ class RNNTest(absltest.TestCase):
 
       for i in range(seq_len):
         cell_carry, y = rnn.cell.apply(
-            {'params': cell_params},
-            cell_carry,
-            xs[batch_idx, seq_len - i - 1, :][None],
+          {'params': cell_params},
+          cell_carry,
+          xs[batch_idx, seq_len - i - 1, :][None],
         )
         np.testing.assert_allclose(y[0], ys[batch_idx, i, :], rtol=1e-5)
 
       np.testing.assert_allclose(
-          cell_carry,
-          jax.tree_map(lambda x: x[batch_idx : batch_idx + 1], carry),
-          rtol=1e-5,
+        cell_carry,
+        jax.tree_map(lambda x: x[batch_idx : batch_idx + 1], carry),
+        rtol=1e-5,
       )
 
   def test_reverse_but_keep_order(self):
@@ -352,10 +352,10 @@ class RNNTest(absltest.TestCase):
     channels_out = 6
 
     rnn = nn.RNN(
-        nn.LSTMCell(channels_out),
-        return_carry=True,
-        reverse=True,
-        keep_order=True,
+      nn.LSTMCell(channels_out),
+      return_carry=True,
+      reverse=True,
+      keep_order=True,
     )
 
     xs = jnp.ones((batch_size, seq_len, channels_in))
@@ -369,18 +369,18 @@ class RNNTest(absltest.TestCase):
 
       for i in range(seq_len):
         cell_carry, y = rnn.cell.apply(
-            {'params': cell_params},
-            cell_carry,
-            xs[batch_idx, seq_len - i - 1, :][None],
+          {'params': cell_params},
+          cell_carry,
+          xs[batch_idx, seq_len - i - 1, :][None],
         )
         np.testing.assert_allclose(
-            y[0], ys[batch_idx, seq_len - i - 1, :], rtol=1e-5
+          y[0], ys[batch_idx, seq_len - i - 1, :], rtol=1e-5
         )
 
       np.testing.assert_allclose(
-          cell_carry,
-          jax.tree_map(lambda x: x[batch_idx : batch_idx + 1], carry),
-          rtol=1e-5,
+        cell_carry,
+        jax.tree_map(lambda x: x[batch_idx : batch_idx + 1], carry),
+        rtol=1e-5,
       )
 
   def test_flip_sequence(self):
@@ -431,7 +431,6 @@ class RNNTest(absltest.TestCase):
 
 
 class BidirectionalTest(absltest.TestCase):
-
   def test_bidirectional(self):
     batch_size = 3
     seq_len = 4
@@ -439,7 +438,7 @@ class BidirectionalTest(absltest.TestCase):
     channels_out = 6
 
     bdirectional = nn.Bidirectional(
-        nn.RNN(nn.LSTMCell(channels_out)), nn.RNN(nn.LSTMCell(channels_out))
+      nn.RNN(nn.LSTMCell(channels_out)), nn.RNN(nn.LSTMCell(channels_out))
     )
 
     xs = jnp.ones((batch_size, seq_len, channels_in))
@@ -470,9 +469,9 @@ class BidirectionalTest(absltest.TestCase):
     channels_out = 6
 
     bdirectional = nn.Bidirectional(
-        nn.RNN(nn.LSTMCell(channels_out)),
-        nn.RNN(nn.LSTMCell(channels_out)),
-        merge_fn=lambda x, y: x + y,
+      nn.RNN(nn.LSTMCell(channels_out)),
+      nn.RNN(nn.LSTMCell(channels_out)),
+      merge_fn=lambda x, y: x + y,
     )
 
     xs = jnp.ones((batch_size, seq_len, channels_in))
@@ -488,26 +487,26 @@ class BidirectionalTest(absltest.TestCase):
     channels_out = 6
 
     bdirectional = nn.Bidirectional(
-        nn.RNN(nn.LSTMCell(channels_out)),
-        nn.RNN(nn.LSTMCell(channels_out)),
-        return_carry=True,
+      nn.RNN(nn.LSTMCell(channels_out)),
+      nn.RNN(nn.LSTMCell(channels_out)),
+      return_carry=True,
     )
 
     xs = jnp.ones((batch_size, seq_len, channels_in))
     ys: jnp.ndarray
     (carry, ys), variables = bdirectional.init_with_output(
-        jax.random.key(0), xs
+      jax.random.key(0), xs
     )
     carry_forward, carry_backward = carry
 
     self.assertEqual(ys.shape, (batch_size, seq_len, channels_out * 2))
     self.assertEqual(
-        jax.tree_map(jnp.shape, carry_forward),
-        ((batch_size, channels_out), (batch_size, channels_out)),
+      jax.tree_map(jnp.shape, carry_forward),
+      ((batch_size, channels_out), (batch_size, channels_out)),
     )
     self.assertEqual(
-        jax.tree_map(jnp.shape, carry_backward),
-        ((batch_size, channels_out), (batch_size, channels_out)),
+      jax.tree_map(jnp.shape, carry_backward),
+      ((batch_size, channels_out), (batch_size, channels_out)),
     )
 
 

--- a/tests/linen/linen_transforms_test.py
+++ b/tests/linen/linen_transforms_test.py
@@ -14,19 +14,20 @@
 
 """Transforms tests."""
 
-from functools import partial
-from typing import Any, Callable, Sequence
 import operator
 import unittest
+from functools import partial
+from typing import Any, Callable, Sequence
 
-from absl.testing import absltest
 import jax
-from jax import random
 import jax.numpy as jnp
 import numpy as np
+from absl.testing import absltest
+from jax import random
+
 from flax import errors
 from flax import linen as nn
-from flax.core import freeze, copy
+from flax.core import copy, freeze
 
 # Parse absl flags test_srcdir and test_tmpdir.
 jax.config.parse_flags_with_absl()
@@ -40,7 +41,7 @@ def tree_equals(x, y):
 
 def tree_allclose(x, y):
   return jax.tree_util.tree_all(
-      jax.tree_util.tree_map(lambda x, y: np.all(np.isclose(x, y)), x, y)
+    jax.tree_util.tree_map(lambda x, y: np.all(np.isclose(x, y)), x, y)
   )
 
 
@@ -81,7 +82,6 @@ def decorated_MLP(transform: Callable = id_fn):
 
 
 class TransformTest(absltest.TestCase):
-
   def test_jit(self):
     key1, key2 = random.split(random.key(3), 2)
     x = random.uniform(key1, (4, 4))
@@ -134,7 +134,6 @@ class TransformTest(absltest.TestCase):
     raise unittest.SkipTest('test breaks with grad')
 
     class ConditionalReLU(nn.Module):
-
       @nn.compact
       def __call__(self, input, apply_relu: bool = False):
         return nn.relu(input) if apply_relu else input
@@ -186,7 +185,6 @@ class TransformTest(absltest.TestCase):
     test = self
 
     class FooTrainStatic(nn.Module):
-
       @partial(nn.remat, static_argnums=(2,))
       @nn.compact
       def __call__(self, inputs, train: bool):
@@ -203,7 +201,6 @@ class TransformTest(absltest.TestCase):
     self.assertEqual(y.shape, (1, 3))
 
     class FooTrainDynamic(nn.Module):
-
       @partial(nn.remat, static_argnums=())
       @nn.compact
       def __call__(self, inputs, train: bool):
@@ -225,10 +222,10 @@ class TransformTest(absltest.TestCase):
 
     def vmap(cls):
       return nn.vmap(
-          cls,
-          in_axes=(0,),
-          variable_axes={'params': None},
-          split_rngs={'params': False},
+        cls,
+        in_axes=(0,),
+        variable_axes={'params': None},
+        split_rngs={'params': False},
       )
 
     normal_model = TransformedMLP(features=[3, 4, 5])
@@ -236,10 +233,10 @@ class TransformTest(absltest.TestCase):
     init_variables = normal_model.init(key2, x)
     # simulate vmap in python for comparison:
     y1 = jnp.vstack(
-        [
-            normal_model.apply(init_variables, x2[i])[None, ...]
-            for i in np.arange(x2.shape[0])
-        ]
+      [
+        normal_model.apply(init_variables, x2[i])[None, ...]
+        for i in np.arange(x2.shape[0])
+      ]
     )
     y2 = vmap_model.apply(init_variables, x2)
     np.testing.assert_allclose(y1, y2, atol=1e-7)
@@ -251,10 +248,10 @@ class TransformTest(absltest.TestCase):
 
     def vmap(fn):
       return nn.vmap(
-          fn,
-          in_axes=(0,),
-          variable_axes={'params': None},
-          split_rngs={'params': False},
+        fn,
+        in_axes=(0,),
+        variable_axes={'params': None},
+        split_rngs={'params': False},
       )
 
     normal_model = decorated_MLP()(features=[3, 4, 5])
@@ -262,10 +259,10 @@ class TransformTest(absltest.TestCase):
     init_variables = normal_model.init(key2, x)
     # simulate vmap in python for comparison:
     y1 = jnp.vstack(
-        [
-            normal_model.apply(init_variables, x2[i])[None, ...]
-            for i in np.arange(x2.shape[0])
-        ]
+      [
+        normal_model.apply(init_variables, x2[i])[None, ...]
+        for i in np.arange(x2.shape[0])
+      ]
     )
     y2 = vmap_model.apply(init_variables, x2)
     np.testing.assert_allclose(y1, y2, atol=1e-7)
@@ -277,11 +274,11 @@ class TransformTest(absltest.TestCase):
 
     def vmap(cls):
       return nn.vmap(
-          cls,
-          in_axes=(0,),
-          variable_axes={'params': None, 'batch_stats': None},
-          split_rngs={'params': False},
-          axis_name='batch',
+        cls,
+        in_axes=(0,),
+        variable_axes={'params': None, 'batch_stats': None},
+        split_rngs={'params': False},
+        axis_name='batch',
       )
 
     class MlpBn(nn.Module):
@@ -297,7 +294,7 @@ class TransformTest(absltest.TestCase):
     vmap_model = vmap(MlpBn)(axis_name='batch')
     init_variables = normal_model.init(key2, x)
     y1 = normal_model.apply(
-        init_variables, x2.reshape((-1, 4)), mutable=['batch_stats']
+      init_variables, x2.reshape((-1, 4)), mutable=['batch_stats']
     )[0]
     y1 = y1.reshape((5, 4, 3))
     y2 = vmap_model.apply(init_variables, x2, mutable=['batch_stats'])[0]
@@ -310,9 +307,9 @@ class TransformTest(absltest.TestCase):
       @nn.compact
       def __call__(self, c, xs):
         LSTM = nn.scan(
-            nn.LSTMCell,
-            variable_broadcast='params',
-            split_rngs={'params': False},
+          nn.LSTMCell,
+          variable_broadcast='params',
+          split_rngs={'params': False},
         )
         return LSTM(self.features, name='lstm_cell')(c, xs)
 
@@ -326,7 +323,7 @@ class TransformTest(absltest.TestCase):
     c = init_carry
     ys = []
     lstmcell_variables = freeze(
-        {'params': init_variables['params']['lstm_cell']}
+      {'params': init_variables['params']['lstm_cell']}
     )
     for i in range(xs.shape[0]):
       c, y = nn.LSTMCell(2).apply(lstmcell_variables, c, xs[i])
@@ -343,10 +340,10 @@ class TransformTest(absltest.TestCase):
       features: int
 
       @partial(
-          nn.scan,
-          variable_broadcast='params',
-          in_axes=(nn.broadcast, 0),
-          split_rngs={'params': False},
+        nn.scan,
+        variable_broadcast='params',
+        in_axes=(nn.broadcast, 0),
+        split_rngs={'params': False},
       )
       @nn.compact
       def __call__(self, c, b, xs):
@@ -364,7 +361,7 @@ class TransformTest(absltest.TestCase):
     c = init_carry
     ys = []
     lstmcell_variables = freeze(
-        {'params': init_variables['params']['lstm_cell']}
+      {'params': init_variables['params']['lstm_cell']}
     )
     for i in range(xs.shape[0]):
       c, y = nn.LSTMCell(2).apply(lstmcell_variables, c, xs[i])
@@ -378,7 +375,6 @@ class TransformTest(absltest.TestCase):
 
   def test_multiscope_lifting_simple(self):
     class Counter(nn.Module):
-
       @nn.compact
       def __call__(self):
         v = self.variable('counter', 'foo', lambda: jnp.array([0]))
@@ -386,7 +382,6 @@ class TransformTest(absltest.TestCase):
         return v.value
 
     class Outer(nn.Module):
-
       @nn.compact
       def __call__(self, x):
         cntr = nn.jit(Counter)(name='cntr')()
@@ -400,7 +395,6 @@ class TransformTest(absltest.TestCase):
         return self.outer_module(x)
 
     class Test(nn.Module):
-
       @nn.compact
       def __call__(self, x):
         outer_dense = nn.jit(Outer)(name='outer')
@@ -415,15 +409,14 @@ class TransformTest(absltest.TestCase):
     init_vars = Test(parent=None).init(rngs, x)
     _, new_vars = Test(parent=None).apply(init_vars, x, mutable=['counter'])
     self.assertEqual(
-        init_vars['counter']['outer']['cntr']['foo'], jnp.array([2], jnp.int32)
+      init_vars['counter']['outer']['cntr']['foo'], jnp.array([2], jnp.int32)
     )
     self.assertEqual(
-        new_vars['counter']['outer']['cntr']['foo'], jnp.array([4], jnp.int32)
+      new_vars['counter']['outer']['cntr']['foo'], jnp.array([4], jnp.int32)
     )
 
   def test_multiscope_lifting_simple_decorator(self):
     class Counter(nn.Module):
-
       @nn.jit
       @nn.compact
       def __call__(self):
@@ -432,7 +425,6 @@ class TransformTest(absltest.TestCase):
         return v.value
 
     class Outer(nn.Module):
-
       @nn.jit
       @nn.compact
       def __call__(self, x):
@@ -448,7 +440,6 @@ class TransformTest(absltest.TestCase):
         return self.outer_module(x)
 
     class Test(nn.Module):
-
       @nn.compact
       def __call__(self, x):
         outer_dense = Outer(name='outer')
@@ -463,15 +454,14 @@ class TransformTest(absltest.TestCase):
     init_vars = Test(parent=None).init(rngs, x)
     _, new_vars = Test(parent=None).apply(init_vars, x, mutable=['counter'])
     self.assertEqual(
-        init_vars['counter']['outer']['cntr']['foo'], jnp.array([2], jnp.int32)
+      init_vars['counter']['outer']['cntr']['foo'], jnp.array([2], jnp.int32)
     )
     self.assertEqual(
-        new_vars['counter']['outer']['cntr']['foo'], jnp.array([4], jnp.int32)
+      new_vars['counter']['outer']['cntr']['foo'], jnp.array([4], jnp.int32)
     )
 
   def test_multiscope_lifting_argtree(self):
     class Counter(nn.Module):
-
       @nn.compact
       def __call__(self):
         v = self.variable('counter', 'foo', lambda: jnp.array([0]))
@@ -479,7 +469,6 @@ class TransformTest(absltest.TestCase):
         return v.value
 
     class Outer(nn.Module):
-
       @nn.compact
       def __call__(self, x):
         cntr = nn.jit(Counter)(name='cntr')()
@@ -493,7 +482,6 @@ class TransformTest(absltest.TestCase):
         return self.outer_module[0](x) + self.outer_module[1](x)
 
     class Test(nn.Module):
-
       @nn.compact
       def __call__(self, x):
         outer_dense1 = nn.jit(Outer)(name='outer1')
@@ -509,21 +497,20 @@ class TransformTest(absltest.TestCase):
     init_vars = Test(parent=None).init(rngs, x)
     _, new_vars = Test(parent=None).apply(init_vars, x, mutable=['counter'])
     self.assertEqual(
-        init_vars['counter']['outer1']['cntr']['foo'], jnp.array([2], jnp.int32)
+      init_vars['counter']['outer1']['cntr']['foo'], jnp.array([2], jnp.int32)
     )
     self.assertEqual(
-        new_vars['counter']['outer1']['cntr']['foo'], jnp.array([4], jnp.int32)
+      new_vars['counter']['outer1']['cntr']['foo'], jnp.array([4], jnp.int32)
     )
     self.assertEqual(
-        init_vars['counter']['outer2']['cntr']['foo'], jnp.array([2], jnp.int32)
+      init_vars['counter']['outer2']['cntr']['foo'], jnp.array([2], jnp.int32)
     )
     self.assertEqual(
-        new_vars['counter']['outer2']['cntr']['foo'], jnp.array([4], jnp.int32)
+      new_vars['counter']['outer2']['cntr']['foo'], jnp.array([4], jnp.int32)
     )
 
   def test_multiscope_lifting_argtree_decorator(self):
     class Counter(nn.Module):
-
       @nn.jit
       @nn.compact
       def __call__(self):
@@ -532,7 +519,6 @@ class TransformTest(absltest.TestCase):
         return v.value
 
     class Outer(nn.Module):
-
       @nn.jit
       @nn.compact
       def __call__(self, x):
@@ -548,7 +534,6 @@ class TransformTest(absltest.TestCase):
         return self.outer_module[0](x) + self.outer_module[1](x)
 
     class Test(nn.Module):
-
       @nn.compact
       def __call__(self, x):
         outer_dense1 = Outer(name='outer1')
@@ -564,22 +549,21 @@ class TransformTest(absltest.TestCase):
     init_vars = Test(parent=None).init(rngs, x)
     _, new_vars = Test(parent=None).apply(init_vars, x, mutable=['counter'])
     self.assertEqual(
-        init_vars['counter']['outer1']['cntr']['foo'], jnp.array([2], jnp.int32)
+      init_vars['counter']['outer1']['cntr']['foo'], jnp.array([2], jnp.int32)
     )
     self.assertEqual(
-        new_vars['counter']['outer1']['cntr']['foo'], jnp.array([4], jnp.int32)
+      new_vars['counter']['outer1']['cntr']['foo'], jnp.array([4], jnp.int32)
     )
     self.assertEqual(
-        init_vars['counter']['outer2']['cntr']['foo'], jnp.array([2], jnp.int32)
+      init_vars['counter']['outer2']['cntr']['foo'], jnp.array([2], jnp.int32)
     )
     self.assertEqual(
-        new_vars['counter']['outer2']['cntr']['foo'], jnp.array([4], jnp.int32)
+      new_vars['counter']['outer2']['cntr']['foo'], jnp.array([4], jnp.int32)
     )
 
   def test_multiscope_lifting_simple_decorator_w_jit(self):
     # TODO: actually test jaxpr on a simpler module.
     class Counter(nn.Module):
-
       @nn.jit
       @nn.compact
       def __call__(self):
@@ -588,7 +572,6 @@ class TransformTest(absltest.TestCase):
         return v.value
 
     class Outer(nn.Module):
-
       @nn.jit
       @nn.compact
       def __call__(self, x):
@@ -604,7 +587,6 @@ class TransformTest(absltest.TestCase):
         return self.outer_module(x)
 
     class Test(nn.Module):
-
       @nn.jit
       @nn.compact
       def __call__(self, x):
@@ -620,15 +602,14 @@ class TransformTest(absltest.TestCase):
     init_vars = Test(parent=None).init(rngs, x)
     _, new_vars = Test(parent=None).apply(init_vars, x, mutable=['counter'])
     self.assertEqual(
-        init_vars['counter']['outer']['cntr']['foo'], jnp.array([2], jnp.int32)
+      init_vars['counter']['outer']['cntr']['foo'], jnp.array([2], jnp.int32)
     )
     self.assertEqual(
-        new_vars['counter']['outer']['cntr']['foo'], jnp.array([4], jnp.int32)
+      new_vars['counter']['outer']['cntr']['foo'], jnp.array([4], jnp.int32)
     )
 
   def test_vmapped_outer_module(self):
     class Outer(nn.Module):
-
       @nn.jit
       @nn.compact
       def __call__(self, x):
@@ -638,10 +619,10 @@ class TransformTest(absltest.TestCase):
       outer_module: nn.Module
 
       @partial(
-          nn.vmap,
-          in_axes=(0,),
-          variable_axes={'params': 0},
-          split_rngs={'params': True},
+        nn.vmap,
+        in_axes=(0,),
+        variable_axes={'params': 0},
+        split_rngs={'params': True},
       )
       @nn.jit
       @nn.compact
@@ -649,7 +630,6 @@ class TransformTest(absltest.TestCase):
         return self.outer_module(x)
 
     class Test(nn.Module):
-
       @nn.compact
       def __call__(self, x):
         outer_dense = Outer(name='outer')
@@ -663,16 +643,15 @@ class TransformTest(absltest.TestCase):
     init_vars = Test(parent=None).init(rngs, x)
     y = Test(parent=None).apply(init_vars, x)
     self.assertEqual(
-        init_vars['params']['outer']['Dense_0']['kernel'].shape, (3, 2, 5)
+      init_vars['params']['outer']['Dense_0']['kernel'].shape, (3, 2, 5)
     )
     self.assertEqual(
-        init_vars['params']['outer']['Dense_0']['bias'].shape, (3, 5)
+      init_vars['params']['outer']['Dense_0']['bias'].shape, (3, 5)
     )
     self.assertEqual(y.shape, (3, 1, 5))
 
   def test_module_transform_with_setup(self):
     class Foo(nn.Module):
-
       def setup(self):
         self.test = self.param('test', nn.initializers.ones_init(), ())
 
@@ -680,18 +659,17 @@ class TransformTest(absltest.TestCase):
         return x * self.test
 
     FooVmap = nn.vmap(
-        Foo,
-        in_axes=0,
-        out_axes=0,
-        variable_axes={'params': 0},
-        split_rngs={'params': True},
+      Foo,
+      in_axes=0,
+      out_axes=0,
+      variable_axes={'params': 0},
+      split_rngs={'params': True},
     )
     variables = FooVmap().init(random.key(0), jnp.ones((4,)))
     self.assertEqual(variables['params']['test'].shape, (4,))
 
   def test_nested_module_args_vmap(self):
     class A(nn.Module):
-
       @nn.compact
       def __call__(self, x):
         return nn.Dense(3)(x)
@@ -707,14 +685,13 @@ class TransformTest(absltest.TestCase):
       B: nn.Module
 
       @partial(
-          nn.vmap, variable_axes={'params': 0}, split_rngs={'params': True}
+        nn.vmap, variable_axes={'params': 0}, split_rngs={'params': True}
       )
       @nn.compact
       def __call__(self, x):
         return self.B(x)
 
     class D(nn.Module):
-
       @nn.compact
       def __call__(self, x):
         a = A()
@@ -728,15 +705,14 @@ class TransformTest(absltest.TestCase):
 
     variable_shapes = jax.tree_util.tree_map(jnp.shape, p)
     self.assertEqual(
-        variable_shapes['params']['A_0']['Dense_0']['kernel'], (10, 10, 3)
+      variable_shapes['params']['A_0']['Dense_0']['kernel'], (10, 10, 3)
     )
     self.assertEqual(
-        variable_shapes['params']['A_0']['Dense_0']['bias'], (10, 3)
+      variable_shapes['params']['A_0']['Dense_0']['bias'], (10, 3)
     )
 
   def test_nested_module_args_vmap_2(self):
     class A(nn.Module):
-
       @nn.compact
       def __call__(self, x):
         return nn.Dense(3)(x)
@@ -753,14 +729,13 @@ class TransformTest(absltest.TestCase):
       B: nn.Module
 
       @partial(
-          nn.vmap, variable_axes={'params': 0}, split_rngs={'params': True}
+        nn.vmap, variable_axes={'params': 0}, split_rngs={'params': True}
       )
       @nn.compact
       def __call__(self, x):
         return self.B(x) + self.A(x)
 
     class D(nn.Module):
-
       @nn.compact
       def __call__(self, x):
         a1 = A()
@@ -775,16 +750,16 @@ class TransformTest(absltest.TestCase):
 
     variable_shapes = jax.tree_util.tree_map(jnp.shape, p)
     self.assertEqual(
-        variable_shapes['params']['A_0']['Dense_0']['kernel'], (10, 10, 3)
+      variable_shapes['params']['A_0']['Dense_0']['kernel'], (10, 10, 3)
     )
     self.assertEqual(
-        variable_shapes['params']['A_0']['Dense_0']['bias'], (10, 3)
+      variable_shapes['params']['A_0']['Dense_0']['bias'], (10, 3)
     )
     self.assertEqual(
-        variable_shapes['params']['A_1']['Dense_0']['kernel'], (10, 10, 3)
+      variable_shapes['params']['A_1']['Dense_0']['kernel'], (10, 10, 3)
     )
     self.assertEqual(
-        variable_shapes['params']['A_1']['Dense_0']['bias'], (10, 3)
+      variable_shapes['params']['A_1']['Dense_0']['bias'], (10, 3)
     )
 
   def test_nested_setup_calls_count(self):
@@ -806,7 +781,6 @@ class TransformTest(absltest.TestCase):
         return x
 
     class Counter(nn.Module):
-
       def setup(self):
         nonlocal setup_cntr
         setup_cntr += 1
@@ -833,7 +807,6 @@ class TransformTest(absltest.TestCase):
     cntr = 0
 
     class A(nn.Module):
-
       def setup(self):
         nonlocal cntr
         cntr += 1
@@ -848,7 +821,6 @@ class TransformTest(absltest.TestCase):
         return self.d(x)
 
     class B(nn.Module):
-
       def setup(self):
         self.a = A()
 
@@ -869,7 +841,6 @@ class TransformTest(absltest.TestCase):
 
   def test_toplevel_submodule_adoption_transform(self):
     class A(nn.Module):
-
       @nn.compact
       def __call__(self, x):
         return nn.Dense(3)(x)
@@ -886,7 +857,7 @@ class TransformTest(absltest.TestCase):
       B: nn.Module
 
       @partial(
-          nn.vmap, variable_axes={'params': 0}, split_rngs={'params': True}
+        nn.vmap, variable_axes={'params': 0}, split_rngs={'params': True}
       )
       @nn.compact
       def __call__(self, x):
@@ -901,7 +872,6 @@ class TransformTest(absltest.TestCase):
         return self.B(x) + self.A(x)
 
     class D(nn.Module):
-
       @nn.compact
       def __call__(self, x):
         a1 = A()
@@ -919,14 +889,14 @@ class TransformTest(absltest.TestCase):
     a2 = A()
     b = B(a1)
     p2 = freeze(
-        {
-            'params': {
-                'A': p1['params']['A_0'],
-                'B': {
-                    'A': p1['params']['A_1'],
-                },
-            }
+      {
+        'params': {
+          'A': p1['params']['A_0'],
+          'B': {
+            'A': p1['params']['A_1'],
+          },
         }
+      }
     )
 
     # Test method wrapper transform.
@@ -934,7 +904,7 @@ class TransformTest(absltest.TestCase):
     np.testing.assert_allclose(y1, y2, atol=1e-7)
     # Test class transform.
     Ctrafo = nn.vmap(
-        Csimple, variable_axes={'params': 0}, split_rngs={'params': True}
+      Csimple, variable_axes={'params': 0}, split_rngs={'params': True}
     )
 
     y3 = Ctrafo(a2, b).apply(p2, x)
@@ -942,7 +912,6 @@ class TransformTest(absltest.TestCase):
 
   def test_toplevel_submodule_adoption_pytree_transform(self):
     class A(nn.Module):
-
       @nn.compact
       def __call__(self, c, x):
         counter = self.variable('counter', 'i', jnp.zeros, ())
@@ -960,11 +929,11 @@ class TransformTest(absltest.TestCase):
     a = A()
     As = {'foo': A(), 'bar': A()}
     b = nn.scan(
-        B,
-        in_axes=0,
-        variable_carry='counter',
-        variable_broadcast='params',
-        split_rngs={'params': False},
+      B,
+      in_axes=0,
+      variable_carry='counter',
+      variable_broadcast='params',
+      split_rngs={'params': False},
     )(As)
 
     key = random.key(0)
@@ -973,23 +942,23 @@ class TransformTest(absltest.TestCase):
     p = B(As).init(key, x, x)
     y, cntrs = b.apply(p, x, x, mutable='counter')
     ref_cntrs = {
-        'counter': {
-            'A_bar': {
-                'i': jnp.array(11.0),
-            },
-            'A_foo': {
-                'i': jnp.array(11.0),
-            },
+      'counter': {
+        'A_bar': {
+          'i': jnp.array(11.0),
         },
+        'A_foo': {
+          'i': jnp.array(11.0),
+        },
+      },
     }
     self.assertTrue(
-        jax.tree_util.tree_all(
-            jax.tree_util.tree_map(
-                lambda x, y: np.testing.assert_allclose(x, y, atol=1e-7),
-                cntrs,
-                ref_cntrs,
-            )
+      jax.tree_util.tree_all(
+        jax.tree_util.tree_map(
+          lambda x, y: np.testing.assert_allclose(x, y, atol=1e-7),
+          cntrs,
+          ref_cntrs,
         )
+      )
     )
 
   def test_partially_applied_module_constructor_transform(self):
@@ -997,14 +966,14 @@ class TransformTest(absltest.TestCase):
     x = jnp.ones((3, 4, 4))
     dense = partial(nn.Dense, use_bias=False)
     vmap_dense = nn.vmap(
-        dense, variable_axes={'params': 0}, split_rngs={'params': True}
+      dense, variable_axes={'params': 0}, split_rngs={'params': True}
     )(4)
     init_vars = vmap_dense.init(k, x)
     init_vars_shapes = jax.tree_util.tree_map(jnp.shape, init_vars)
     ref_var_shapes = {
-        'params': {
-            'kernel': (3, 4, 4),
-        },
+      'params': {
+        'kernel': (3, 4, 4),
+      },
     }
     self.assertTrue(tree_equals(init_vars_shapes, ref_var_shapes))
 
@@ -1013,28 +982,26 @@ class TransformTest(absltest.TestCase):
     x = jnp.ones((3, 4, 4))
 
     class Foo(nn.Module):
-
       @nn.compact
       def inner(self, x):
         return nn.Dense(2, use_bias=False)(x)
 
       def __call__(self, x):
         return nn.vmap(
-            partial(Foo.inner),
-            variable_axes={'params': 0},
-            split_rngs={'params': True},
+          partial(Foo.inner),
+          variable_axes={'params': 0},
+          split_rngs={'params': True},
         )(self, x)
 
     init_vars = Foo().init(k, x)
     init_vars_shapes = jax.tree_util.tree_map(jnp.shape, init_vars)
     ref_var_shapes = {
-        'params': {'Dense_0': {'kernel': (3, 4, 2)}},
+      'params': {'Dense_0': {'kernel': (3, 4, 2)}},
     }
     self.assertTrue(tree_equals(init_vars_shapes, ref_var_shapes))
 
   def test_variable_in_args_transform(self):
     class Test(nn.Module):
-
       @nn.jit
       @nn.compact
       def __call__(self, x):
@@ -1051,24 +1018,27 @@ class TransformTest(absltest.TestCase):
     x = jnp.ones((1,))
     variables = Test().init(k, x)
     np.testing.assert_allclose(
-        variables['test']['baz'],
-        jnp.array([
-            1.0,
-        ]),
-        atol=1e-7,
+      variables['test']['baz'],
+      jnp.array(
+        [
+          1.0,
+        ]
+      ),
+      atol=1e-7,
     )
     y, variables = Test().apply(variables, x, mutable=['test'])
     np.testing.assert_allclose(
-        variables['test']['baz'],
-        jnp.array([
-            2.0,
-        ]),
-        atol=1e-7,
+      variables['test']['baz'],
+      jnp.array(
+        [
+          2.0,
+        ]
+      ),
+      atol=1e-7,
     )
 
   def test_module_instance_in_args_transform(self):
     class Inner(nn.Module):
-
       @nn.jit
       @nn.compact
       def __call__(self, x):
@@ -1077,7 +1047,6 @@ class TransformTest(absltest.TestCase):
         return baz.value
 
     class Test(nn.Module):
-
       @nn.jit
       @nn.compact
       def __call__(self, x):
@@ -1093,24 +1062,27 @@ class TransformTest(absltest.TestCase):
     x = jnp.ones((1,))
     variables = Test().init(k, x)
     np.testing.assert_allclose(
-        variables['test']['inner']['baz'],
-        jnp.array([
-            1.0,
-        ]),
-        atol=1e-7,
+      variables['test']['inner']['baz'],
+      jnp.array(
+        [
+          1.0,
+        ]
+      ),
+      atol=1e-7,
     )
     y, variables = Test().apply(variables, x, mutable=['test'])
     np.testing.assert_allclose(
-        variables['test']['inner']['baz'],
-        jnp.array([
-            2.0,
-        ]),
-        atol=1e-7,
+      variables['test']['inner']['baz'],
+      jnp.array(
+        [
+          2.0,
+        ]
+      ),
+      atol=1e-7,
     )
 
   def test_module_instance_in_args_transform_nested(self):
     class Inner(nn.Module):
-
       @nn.jit
       @nn.compact
       def __call__(self, x):
@@ -1119,7 +1091,6 @@ class TransformTest(absltest.TestCase):
         return baz.value
 
     class Outer(nn.Module):
-
       @nn.jit
       @nn.compact
       def __call__(self, inner, x):
@@ -1131,7 +1102,6 @@ class TransformTest(absltest.TestCase):
         return inner(x)
 
     class Test(nn.Module):
-
       @nn.jit
       @nn.compact
       def __call__(self, x):
@@ -1143,19 +1113,23 @@ class TransformTest(absltest.TestCase):
     x = jnp.ones((1,))
     variables = Test().init(k, x)
     np.testing.assert_allclose(
-        variables['test']['inner']['baz'],
-        jnp.array([
-            1.0,
-        ]),
-        atol=1e-7,
+      variables['test']['inner']['baz'],
+      jnp.array(
+        [
+          1.0,
+        ]
+      ),
+      atol=1e-7,
     )
     y, variables = Test().apply(variables, x, mutable=['test'])
     np.testing.assert_allclose(
-        variables['test']['inner']['baz'],
-        jnp.array([
-            2.0,
-        ]),
-        atol=1e-7,
+      variables['test']['inner']['baz'],
+      jnp.array(
+        [
+          2.0,
+        ]
+      ),
+      atol=1e-7,
     )
 
   def test_nested_variable_passing(self):
@@ -1177,7 +1151,6 @@ class TransformTest(absltest.TestCase):
         return NestedVarUser(self.somevar)(x)
 
     class VarPasser(nn.Module):
-
       @nn.jit
       @nn.compact
       def __call__(self, x):
@@ -1189,30 +1162,32 @@ class TransformTest(absltest.TestCase):
     x = jnp.ones((1,))
     variables = VarPasser().init(k, x)
     np.testing.assert_allclose(
-        variables['test']['baz'],
-        jnp.array([
-            1.0,
-        ]),
-        atol=1e-7,
+      variables['test']['baz'],
+      jnp.array(
+        [
+          1.0,
+        ]
+      ),
+      atol=1e-7,
     )
     y, variables = VarPasser().apply(variables, x, mutable=['test'])
     np.testing.assert_allclose(
-        variables['test']['baz'],
-        jnp.array([
-            2.0,
-        ]),
-        atol=1e-7,
+      variables['test']['baz'],
+      jnp.array(
+        [
+          2.0,
+        ]
+      ),
+      atol=1e-7,
     )
 
   def test_returned_module_warning(self):
     class Foo(nn.Module):
-
       @nn.compact
       def __call__(self, x):
         return x
 
     class Bar(nn.Module):
-
       @nn.compact
       def __call__(self, x):
         f = self._helper()
@@ -1228,7 +1203,6 @@ class TransformTest(absltest.TestCase):
 
   def test_returned_variable_warning(self):
     class Bar(nn.Module):
-
       @nn.compact
       def __call__(self, x):
         f = self._helper()
@@ -1244,7 +1218,6 @@ class TransformTest(absltest.TestCase):
 
   def test_nowrap(self):
     class Bar(nn.Module):
-
       @nn.compact
       def __call__(self, x):
         return self._helper(x)
@@ -1270,7 +1243,7 @@ class TransformTest(absltest.TestCase):
       def _call(self, x, decode):
         def f(self):
           return nn.Dense(
-              self.features if decode else self.latents, use_bias=False
+            self.features if decode else self.latents, use_bias=False
           )(x)
 
         if decode:
@@ -1296,7 +1269,6 @@ class TransformTest(absltest.TestCase):
 
   def test_map_variables_bit_weights(self):
     class BitWeights(nn.Module):
-
       @nn.compact
       def __call__(self, x):
         def sign(x):
@@ -1313,7 +1285,6 @@ class TransformTest(absltest.TestCase):
 
   def test_remat_scan(self):
     class BigModel(nn.Module):
-
       @nn.compact
       def __call__(self, x):
         DenseStack = nn.remat_scan(nn.Dense, lengths=(100,))
@@ -1330,7 +1301,6 @@ class TransformTest(absltest.TestCase):
 
   def test_vjp(self):
     class Bar(nn.Module):
-
       @nn.compact
       def __call__(self, x, y):
         p = self.param('test', nn.initializers.constant(0.5), ())
@@ -1338,7 +1308,6 @@ class TransformTest(absltest.TestCase):
         return p * x * y
 
     class Foo(nn.Module):
-
       @nn.compact
       def __call__(self, x, y):
         z, bwd = nn.vjp(Bar.__call__, Bar(), x, y)
@@ -1349,17 +1318,16 @@ class TransformTest(absltest.TestCase):
     params = Foo().init(random.key(0), x, y)
     params_grad, x_grad, y_grad = Foo().apply(params, x, y)
     self.assertEqual(
-        params_grad,
-        {
-            'params': nn.FrozenDict({'test': 32.0}),
-        },
+      params_grad,
+      {
+        'params': nn.FrozenDict({'test': 32.0}),
+      },
     )
     np.testing.assert_allclose(x_grad, [2.0, 2.5, 3.0])
     np.testing.assert_allclose(y_grad, [0.5, 1.0, 1.5])
 
   def test_jvp(self):
     class Bar(nn.Module):
-
       @nn.compact
       def __call__(self, x):
         p = self.param('test', nn.initializers.zeros, ())
@@ -1367,15 +1335,14 @@ class TransformTest(absltest.TestCase):
         return p * x
 
     class Foo(nn.Module):
-
       @nn.compact
       def __call__(self, x):
         bar = Bar()
         vars_t = jax.tree_util.tree_map(
-            jnp.ones_like, bar.variables.get('params', {})
+          jnp.ones_like, bar.variables.get('params', {})
         )
         _, out_t = nn.jvp(
-            Bar.__call__, bar, (x,), (jnp.zeros_like(x),), {'params': vars_t}
+          Bar.__call__, bar, (x,), (jnp.zeros_like(x),), {'params': vars_t}
         )
         return out_t
 
@@ -1404,7 +1371,6 @@ class TransformTest(absltest.TestCase):
         return z
 
     class C(nn.Module):
-
       @nn.jit
       @nn.compact
       def __call__(self, x):
@@ -1419,22 +1385,21 @@ class TransformTest(absltest.TestCase):
     x = jnp.ones((1,), jnp.float32)
     vs = a.init(k, x)
     y, vs_new = a.apply(
-        vs,
-        x,
-        mutable=[
-            'muts',
-        ],
+      vs,
+      x,
+      mutable=[
+        'muts',
+      ],
     )
     np.testing.assert_array_equal(
-        vs_new['muts']['b']['c']['v'], jnp.array([1.0], jnp.float32)
+      vs_new['muts']['b']['c']['v'], jnp.array([1.0], jnp.float32)
     )
     np.testing.assert_array_equal(
-        vs_new['muts']['b']['outer_c']['v'], jnp.array([1.0], jnp.float32)
+      vs_new['muts']['b']['outer_c']['v'], jnp.array([1.0], jnp.float32)
     )
 
   def test_custom_vjp(self):
     class Foo(nn.Module):
-
       @nn.compact
       def __call__(self, x):
         def f(mdl, x):
@@ -1462,7 +1427,6 @@ class TransformTest(absltest.TestCase):
     # SetupState as a triple-enum to handle multiple setup() calls
     # across transform boundaries and scope reuse.
     class Foo(nn.Module):
-
       def setup(self):
         self.inner = nn.Dense(2)
 
@@ -1477,7 +1441,6 @@ class TransformTest(absltest.TestCase):
     vs_foo = Foo().init(k, x)
 
     class Bar(nn.Module):
-
       def setup(self):
         self.inner = nn.Dense(2)
 
@@ -1491,15 +1454,14 @@ class TransformTest(absltest.TestCase):
 
     vs_bar = Bar().init(k, x)
     self.assertTrue(
-        tree_equals(
-            jax.tree_util.tree_map(jnp.shape, vs_foo),
-            jax.tree_util.tree_map(jnp.shape, vs_bar),
-        )
+      tree_equals(
+        jax.tree_util.tree_map(jnp.shape, vs_foo),
+        jax.tree_util.tree_map(jnp.shape, vs_bar),
+      )
     )
 
   def test_transform_methods_on_submodules_still_reserve_names(self):
     class Foo(nn.Module):
-
       @nn.jit
       def helper(self, x, m):
         conflicting_a = nn.Dense(2, name='a')
@@ -1518,13 +1480,11 @@ class TransformTest(absltest.TestCase):
 
   def test_transform_setup_still_reserve_names(self):
     class Identity(nn.Module):
-
       @nn.compact
       def __call__(self, x):
         return x
 
     class Test(nn.Module):
-
       def setup(self):
         self.sub = Identity()
         self.sub = Identity()
@@ -1541,7 +1501,6 @@ class TransformTest(absltest.TestCase):
 
   def test_transform_with_setup_and_methods_on_submodule_pytrees(self):
     class Foo(nn.Module):
-
       def setup(self):
         self.inners = [nn.Dense(2), nn.Dense(2)]
 
@@ -1552,7 +1511,6 @@ class TransformTest(absltest.TestCase):
         return self.helper(x, self.inners)
 
     class JitFoo(nn.Module):
-
       def setup(self):
         self.inners = [nn.Dense(2), nn.Dense(2)]
 
@@ -1574,13 +1532,11 @@ class TransformTest(absltest.TestCase):
 
   def test_transform_setup_still_reserve_names_pytrees(self):
     class Identity(nn.Module):
-
       @nn.compact
       def __call__(self, x):
         return x
 
     class Test(nn.Module):
-
       def setup(self):
         self.subs = [Identity(), Identity()]
         self.subs = [Identity(), Identity()]
@@ -1598,7 +1554,6 @@ class TransformTest(absltest.TestCase):
 
   def test_scan_of_setup_parameter(self):
     class Body(nn.Module):
-
       def setup(self):
         self.dense = nn.Dense(1)
         self.p = self.param('p', lambda k: jnp.ones((1,)))
@@ -1607,7 +1562,7 @@ class TransformTest(absltest.TestCase):
         return self.dense(x) + self.p, None
 
     scanbody = nn.scan(
-        Body, variable_axes={'params': 0}, split_rngs={'params': True}, length=2
+      Body, variable_axes={'params': 0}, split_rngs={'params': True}, length=2
     )
     k = random.key(0)
     x = jnp.ones((1,))
@@ -1616,7 +1571,6 @@ class TransformTest(absltest.TestCase):
 
   def test_multi_method_class_transform(self):
     class Foo(nn.Module):
-
       def setup(self):
         self.dense0 = nn.Dense(2)
         self.dense1 = nn.Dense(2)
@@ -1628,26 +1582,25 @@ class TransformTest(absltest.TestCase):
         return self.dense1(x) + y, None
 
     class Bar(nn.Module):
-
       @nn.compact
       def __call__(self, x):
         ScanFoo = nn.scan(
-            Foo,
-            methods={
-                'method_0': dict(
-                    variable_axes={'params': 0},
-                    split_rngs={'params': True},
-                    in_axes=nn.broadcast,
-                    out_axes=0,
-                    length=3,
-                ),
-                'method_1': dict(
-                    variable_axes={'params': 0},
-                    split_rngs={'params': True},
-                    in_axes=0,
-                    length=3,
-                ),
-            },
+          Foo,
+          methods={
+            'method_0': dict(
+              variable_axes={'params': 0},
+              split_rngs={'params': True},
+              in_axes=nn.broadcast,
+              out_axes=0,
+              length=3,
+            ),
+            'method_1': dict(
+              variable_axes={'params': 0},
+              split_rngs={'params': True},
+              in_axes=0,
+              length=3,
+            ),
+          },
         )
         sf = ScanFoo()
         y, ys = sf.method_0(x)
@@ -1670,7 +1623,6 @@ class TransformTest(absltest.TestCase):
         return x
 
     class Bar(nn.Module):
-
       @nn.compact
       def __call__(self, x):
         dense = nn.Dense(2)
@@ -1691,7 +1643,6 @@ class TransformTest(absltest.TestCase):
         return x
 
     class Bar(nn.Module):
-
       @nn.compact
       def __call__(self, x):
         dense = nn.Dense(2)
@@ -1704,7 +1655,6 @@ class TransformTest(absltest.TestCase):
 
   def test_jit_with_setup_helpers(self):
     class Foo(nn.Module):
-
       def setup(self):
         self.a = nn.Dense(2)
         self.setup_helper()
@@ -1716,7 +1666,6 @@ class TransformTest(absltest.TestCase):
         return self.b(self.a(x))
 
     class JitFoo(nn.Module):
-
       def setup(self):
         self.a = nn.Dense(2)
         self.setup_helper()
@@ -1738,7 +1687,6 @@ class TransformTest(absltest.TestCase):
 
   def test_while_loop(self):
     class Foo(nn.Module):
-
       @nn.compact
       def __call__(self, x):
         key_zero = random.key(0)
@@ -1757,49 +1705,48 @@ class TransformTest(absltest.TestCase):
           p_rng = mdl.make_rng('params')
           l_rng = mdl.make_rng('loop')
           mdl.put_variable(
-              'state',
-              'rng_params',
-              mdl.get_variable('state', 'rng_params').at[i].set(p_rng),
+            'state',
+            'rng_params',
+            mdl.get_variable('state', 'rng_params').at[i].set(p_rng),
           )
           mdl.put_variable(
-              'state',
-              'rng_loop',
-              mdl.get_variable('state', 'rng_loop').at[i].set(l_rng),
+            'state',
+            'rng_loop',
+            mdl.get_variable('state', 'rng_loop').at[i].set(l_rng),
           )
           inc = mdl.get_variable('params', 'inc')
           mdl.put_variable('state', 'acc', i + inc)
           return c
 
         return nn.while_loop(
-            cond_fn,
-            body_fn,
-            self,
-            (),
-            carry_variables='state',
-            split_rngs={'params': False, 'loop': True},
+          cond_fn,
+          body_fn,
+          self,
+          (),
+          carry_variables='state',
+          split_rngs={'params': False, 'loop': True},
         )
 
     x = 2
     mdl = Foo()
     _, vars = mdl.apply(
-        {},
-        x,
-        mutable=True,
-        rngs={'params': random.key(1), 'loop': random.key(2)},
+      {},
+      x,
+      mutable=True,
+      rngs={'params': random.key(1), 'loop': random.key(2)},
     )
     self.assertEqual(vars['state']['acc'], x)
     np.testing.assert_array_equal(
-        vars['state']['rng_params'][0], vars['state']['rng_params'][1]
+      vars['state']['rng_params'][0], vars['state']['rng_params'][1]
     )
     np.testing.assert_array_compare(
-        operator.__ne__,
-        vars['state']['rng_loop'][0],
-        vars['state']['rng_loop'][1],
+      operator.__ne__,
+      vars['state']['rng_loop'][0],
+      vars['state']['rng_loop'][1],
     )
 
   def test_cond(self):
     class Foo(nn.Module):
-
       @nn.compact
       def __call__(self, x, pred):
         self.variable('state', 'true_count', lambda: 0)
@@ -1817,7 +1764,6 @@ class TransformTest(absltest.TestCase):
 
   def test_switch(self):
     class Foo(nn.Module):
-
       @nn.compact
       def __call__(self, x, pred):
         self.variable('state', 'a_count', lambda: 0)
@@ -1853,12 +1799,11 @@ class TransformTest(absltest.TestCase):
 
   def test_switch_multihead(self):
     class Foo(nn.Module):
-
       def setup(self) -> None:
         self.heads = [
-            nn.Sequential([nn.Dense(10), nn.Dense(7), nn.Dense(5)]),
-            nn.Sequential([nn.Dense(11), nn.Dense(5)]),
-            nn.Dense(5),
+          nn.Sequential([nn.Dense(10), nn.Dense(7), nn.Dense(5)]),
+          nn.Sequential([nn.Dense(11), nn.Dense(5)]),
+          nn.Dense(5),
         ]
 
       @nn.compact
@@ -1890,24 +1835,24 @@ class TransformTest(absltest.TestCase):
     self.assertEqual(vars['state'], {'0_count': 1, '1_count': 1, '2_count': 1})
 
     self.assertEqual(
-        vars['params']['heads_0']['layers_0']['kernel'].shape, (3, 10)
+      vars['params']['heads_0']['layers_0']['kernel'].shape, (3, 10)
     )
     self.assertEqual(vars['params']['heads_0']['layers_0']['bias'].shape, (10,))
     self.assertEqual(
-        vars['params']['heads_0']['layers_1']['kernel'].shape, (10, 7)
+      vars['params']['heads_0']['layers_1']['kernel'].shape, (10, 7)
     )
     self.assertEqual(vars['params']['heads_0']['layers_1']['bias'].shape, (7,))
     self.assertEqual(
-        vars['params']['heads_0']['layers_2']['kernel'].shape, (7, 5)
+      vars['params']['heads_0']['layers_2']['kernel'].shape, (7, 5)
     )
     self.assertEqual(vars['params']['heads_0']['layers_2']['bias'].shape, (5,))
 
     self.assertEqual(
-        vars['params']['heads_1']['layers_0']['kernel'].shape, (3, 11)
+      vars['params']['heads_1']['layers_0']['kernel'].shape, (3, 11)
     )
     self.assertEqual(vars['params']['heads_1']['layers_0']['bias'].shape, (11,))
     self.assertEqual(
-        vars['params']['heads_1']['layers_1']['kernel'].shape, (11, 5)
+      vars['params']['heads_1']['layers_1']['kernel'].shape, (11, 5)
     )
     self.assertEqual(vars['params']['heads_1']['layers_1']['bias'].shape, (5,))
 
@@ -1916,7 +1861,6 @@ class TransformTest(absltest.TestCase):
 
   def test_lift_instance_error(self):
     class Foo(nn.Module):
-
       @nn.compact
       def __call__(self, x):
         return nn.checkpoint(nn.Dense(2))(x)
@@ -1934,10 +1878,10 @@ class TransformTest(absltest.TestCase):
           return nn.Dense(features=x.shape[-1])(x), ()
 
         x, _ = nn.scan(
-            body_fn,
-            length=self.num_layers,
-            variable_axes={'params': 0},
-            split_rngs={'params': True},
+          body_fn,
+          length=self.num_layers,
+          variable_axes={'params': 0},
+          split_rngs={'params': True},
         )(self, x)
         return x
 
@@ -1949,7 +1893,6 @@ class TransformTest(absltest.TestCase):
 
   def test_bound_methods_in_direct_transforms(self):
     class CondModel(nn.Module):
-
       def setup(self):
         self.dense = nn.Dense(3)
 
@@ -1967,31 +1910,29 @@ class TransformTest(absltest.TestCase):
     cond_model = CondModel()
 
     output, init_params = jax.jit(cond_model.init_with_output)(
-        jax.random.key(0), x=jnp.ones(3)
+      jax.random.key(0), x=jnp.ones(3)
     )
 
   def test_add_metadata_axis(self):
     vars_copy = None
 
     class Foo(nn.Module):
-
       @nn.compact
       def __call__(self, x):
         nonlocal vars_copy
         kernel_init = nn.with_partitioning(
-            nn.initializers.lecun_normal(), ('foo', 'bar')
+          nn.initializers.lecun_normal(), ('foo', 'bar')
         )
         vars_copy = self.variables
         return nn.Dense(
-            4, kernel_init=kernel_init, use_bias=False, name='dense'
+          4, kernel_init=kernel_init, use_bias=False, name='dense'
         )(x)
 
     class Test(nn.Module):
-
       @partial(
-          nn.add_metadata_axis,
-          variable_axes={'params': 0},
-          metadata_params={nn.PARTITION_NAME: 'baz'},
+        nn.add_metadata_axis,
+        variable_axes={'params': 0},
+        metadata_params={nn.PARTITION_NAME: 'baz'},
       )
       @nn.compact
       def __call__(self, x):
@@ -2002,41 +1943,38 @@ class TransformTest(absltest.TestCase):
     vs = Test().init(k, x)
     y = Test().apply(vs, x)
     outer_expect = jax.tree_map(
-        jnp.shape,
-        freeze(
-            {
-                'params': {
-                    'foo': {
-                        'dense': {
-                            'kernel': nn.Partitioned(
-                                jnp.ones((4, 4)), names=('baz', 'foo', 'bar')
-                            )
-                        }
-                    }
-                }
+      jnp.shape,
+      freeze(
+        {
+          'params': {
+            'foo': {
+              'dense': {
+                'kernel': nn.Partitioned(
+                  jnp.ones((4, 4)), names=('baz', 'foo', 'bar')
+                )
+              }
             }
-        ),
+          }
+        }
+      ),
     )
     inner_expect = jax.tree_map(
-        jnp.shape,
-        freeze(
-            {
-                'params': {
-                    'dense': {
-                        'kernel': nn.Partitioned(
-                            jnp.ones((4, 4)), names=('foo', 'bar')
-                        )
-                    }
-                }
+      jnp.shape,
+      freeze(
+        {
+          'params': {
+            'dense': {
+              'kernel': nn.Partitioned(jnp.ones((4, 4)), names=('foo', 'bar'))
             }
-        ),
+          }
+        }
+      ),
     )
     self.assertEqual(jax.tree_map(jnp.shape, vs), outer_expect)
     self.assertEqual(jax.tree_map(jnp.shape, vars_copy), inner_expect)
 
   def test_outer_setup_called_with_sharing_across_transforms(self):
     class A(nn.Module):
-
       def setup(self):
         self.foo = self.param('foo', nn.initializers.zeros, (2, 2), jnp.float32)
 
@@ -2051,7 +1989,6 @@ class TransformTest(absltest.TestCase):
         return self.a(x)
 
     class C(nn.Module):
-
       def setup(self):
         self.a = A()
         self.b = nn.jit(B)(self.a)
@@ -2066,7 +2003,7 @@ class TransformTest(absltest.TestCase):
     vs = C().init(k, x)
     y = C().apply(vs, x)
     outer_expect = jax.tree_map(
-        jnp.shape, freeze({'params': {'a': {'foo': jnp.zeros((2, 2))}}})
+      jnp.shape, freeze({'params': {'a': {'foo': jnp.zeros((2, 2))}}})
     )
     self.assertEqual(jax.tree_map(jnp.shape, vs), outer_expect)
 

--- a/tests/linen/partitioning_test.py
+++ b/tests/linen/partitioning_test.py
@@ -14,17 +14,15 @@
 
 """Tests for flax.linen.partitioning."""
 
-from absl.testing import absltest
-from absl.testing import parameterized
+import jax
+import jax.numpy as jnp
+from absl.testing import absltest, parameterized
+from jax import random, sharding
+from jax.experimental import mesh_utils
+
 from flax import linen as nn
 from flax.core import freeze, unfreeze
 from flax.linen import partitioning
-from jax.experimental import mesh_utils
-from jax import sharding
-import jax
-from jax import random
-import jax.numpy as jnp
-
 
 mock = absltest.mock
 
@@ -37,7 +35,6 @@ AXIS_RULES_2 = (('foo', 'model'), ('bar', None), ('baz', 'data'))
 
 
 class PartitioningTest(parameterized.TestCase):
-
   def test_axis_rules(self):
     self.assertEqual(partitioning._axis_rules.rules, ())
     partitioning.set_axis_rules(AXIS_RULES_1)
@@ -56,18 +53,18 @@ class PartitioningTest(parameterized.TestCase):
     axes_0 = ('foo', 'bar')
     # direct rule assignment
     self.assertEqual(
-        partitioning.logical_to_mesh_axes(axes_0, rules=AXIS_RULES_1),
-        ('data', 'model'),
+      partitioning.logical_to_mesh_axes(axes_0, rules=AXIS_RULES_1),
+      ('data', 'model'),
     )
     # axis rules context
     with partitioning.axis_rules(AXIS_RULES_1):
       self.assertEqual(
-          partitioning.logical_to_mesh_axes(axes_0), ('data', 'model')
+        partitioning.logical_to_mesh_axes(axes_0), ('data', 'model')
       )
       # nested context
       with partitioning.axis_rules(AXIS_RULES_2):
         self.assertEqual(
-            partitioning.logical_to_mesh_axes(axes_0), ('model', None)
+          partitioning.logical_to_mesh_axes(axes_0), ('model', None)
         )
     # duplicated logical names
     with partitioning.axis_rules(AXIS_RULES_1):
@@ -78,61 +75,59 @@ class PartitioningTest(parameterized.TestCase):
     p_rules = (('foo', 'model'), ('bar', 'model'), ('baz', 'data'))
     with partitioning.axis_rules(p_rules):
       self.assertEqual(
-          partitioning.logical_to_mesh_axes(('foo', 'bar', 'baz')),
-          ('model', None, 'data'),
+        partitioning.logical_to_mesh_axes(('foo', 'bar', 'baz')),
+        ('model', None, 'data'),
       )
       self.assertEqual(
-          partitioning.logical_to_mesh_axes(('bar', 'foo', 'baz')),
-          (None, 'model', 'data'),
+        partitioning.logical_to_mesh_axes(('bar', 'foo', 'baz')),
+        (None, 'model', 'data'),
       )
       self.assertEqual(
-          partitioning.logical_to_mesh_axes(('baz', 'bar', 'foo')),
-          ('data', None, 'model'),
+        partitioning.logical_to_mesh_axes(('baz', 'bar', 'foo')),
+        ('data', None, 'model'),
       )
       self.assertEqual(
-          partitioning.logical_to_mesh_axes(
-              ('baz', 'bar', 'foo', 'unassigned')
-          ),
-          ('data', None, 'model', None),
+        partitioning.logical_to_mesh_axes(('baz', 'bar', 'foo', 'unassigned')),
+        ('data', None, 'model', None),
       )
 
   @parameterized.parameters(
-      dict(
-          rules=(('a', ('model', 'data')), ('b', 'data')),
-          axes=('a', 'b'),
-          expected=(('model', 'data'), None),
+    dict(
+      rules=(('a', ('model', 'data')), ('b', 'data')),
+      axes=('a', 'b'),
+      expected=(('model', 'data'), None),
+    ),
+    dict(
+      rules=(('a', ('model', 'replica')), ('b', 'data')),
+      axes=('a', 'b'),
+      expected=(('model', 'replica'), 'data'),
+    ),
+    dict(
+      rules=(('a', ('model', 'replica')), ('b', ('data', 'model'))),
+      axes=('a', 'b'),
+      expected=(('model', 'replica'), None),
+    ),
+    dict(
+      rules=(('a', ('model', 'replica')), ('b', 'model')),
+      axes=('a', 'b', 'c'),
+      expected=(('model', 'replica'), None, None),
+    ),
+    dict(rules=(), axes=('a', 'b', 'c'), expected=(None, None, None)),
+    dict(
+      rules=(('a', None), ('a', 'model')),
+      axes=('a', 'b'),
+      expected=(None, None),
+    ),
+    dict(
+      rules=(
+        ('baz', 'data'),
+        ('bar', None),
+        ('foo', 'model'),
+        ('foo', 'data'),
       ),
-      dict(
-          rules=(('a', ('model', 'replica')), ('b', 'data')),
-          axes=('a', 'b'),
-          expected=(('model', 'replica'), 'data'),
-      ),
-      dict(
-          rules=(('a', ('model', 'replica')), ('b', ('data', 'model'))),
-          axes=('a', 'b'),
-          expected=(('model', 'replica'), None),
-      ),
-      dict(
-          rules=(('a', ('model', 'replica')), ('b', 'model')),
-          axes=('a', 'b', 'c'),
-          expected=(('model', 'replica'), None, None),
-      ),
-      dict(rules=(), axes=('a', 'b', 'c'), expected=(None, None, None)),
-      dict(
-          rules=(('a', None), ('a', 'model')),
-          axes=('a', 'b'),
-          expected=(None, None),
-      ),
-      dict(
-          rules=(
-              ('baz', 'data'),
-              ('bar', None),
-              ('foo', 'model'),
-              ('foo', 'data'),
-          ),
-          axes=('baz', 'bar', 'foo'),
-          expected=('data', None, 'model'),
-      ),
+      axes=('baz', 'bar', 'foo'),
+      expected=('data', None, 'model'),
+    ),
   )
   def test_logical_to_mesh_axes_cases(self, rules, axes, expected):
     with partitioning.axis_rules(rules):
@@ -151,7 +146,7 @@ class PartitioningTest(parameterized.TestCase):
       wsc_fn.assert_not_called()
       _ = partitioning.with_sharding_constraint(arr, axes)
       wsc_fn.assert_called_with(
-          arr, jax.sharding.PartitionSpec('data', 'model'), mesh=None
+        arr, jax.sharding.PartitionSpec('data', 'model'), mesh=None
       )
 
   @mock.patch('flax.linen.spmd._with_sharding_constraint')
@@ -160,44 +155,43 @@ class PartitioningTest(parameterized.TestCase):
     with partitioning.axis_rules(AXIS_RULES_1):
       _ = partitioning.with_sharding_constraint(arr, ('foo', 'not_recognized'))
       wsc_fn.assert_called_with(
-          arr, jax.sharding.PartitionSpec('data', None), mesh=None
+        arr, jax.sharding.PartitionSpec('data', None), mesh=None
       )
       wsc_fn.reset_mock()
       _ = partitioning.with_sharding_constraint(
-          arr,
-          ('foo', 'not_recognized'),
-          fallback=partitioning.RulesFallback.AXIS_IS_UNSHARDED,
+        arr,
+        ('foo', 'not_recognized'),
+        fallback=partitioning.RulesFallback.AXIS_IS_UNSHARDED,
       )
       wsc_fn.assert_called_with(
-          arr, jax.sharding.PartitionSpec('data', None), mesh=None
+        arr, jax.sharding.PartitionSpec('data', None), mesh=None
       )
       wsc_fn.reset_mock()
       with self.assertRaises(ValueError):
         _ = partitioning.with_sharding_constraint(
-            arr,
-            ('foo', 'not_recognized'),
-            fallback=partitioning.RulesFallback.RAISE_ERROR,
+          arr,
+          ('foo', 'not_recognized'),
+          fallback=partitioning.RulesFallback.RAISE_ERROR,
         )
       wsc_fn.assert_not_called()
       _ = partitioning.with_sharding_constraint(
-          arr,
-          ('foo', 'not_recognized'),
-          fallback=partitioning.RulesFallback.NO_CONSTRAINT,
+        arr,
+        ('foo', 'not_recognized'),
+        fallback=partitioning.RulesFallback.NO_CONSTRAINT,
       )
       wsc_fn.assert_not_called()
 
   @parameterized.parameters(dict(axes_spec=None), dict(axes_spec=()))
   def test_param_with_axes_no_axes(self, axes_spec):
     class ParamTest(nn.Module):
-
       @nn.compact
       def __call__(self, x):
         foo = partitioning.param_with_axes(
-            'foo',
-            lambda k, s, d: jnp.zeros(s, d),
-            (2, 2),
-            x.dtype,
-            axes=axes_spec,
+          'foo',
+          lambda k, s, d: jnp.zeros(s, d),
+          (2, 2),
+          x.dtype,
+          axes=axes_spec,
         )
         return x + foo
 
@@ -207,15 +201,14 @@ class PartitioningTest(parameterized.TestCase):
 
   def test_param_with_axes(self):
     class ParamTest(nn.Module):
-
       @nn.compact
       def __call__(self, x):
         foo = partitioning.param_with_axes(
-            'foo',
-            lambda k, s, d: jnp.zeros(s, d),
-            (2, 2),
-            x.dtype,
-            axes=('foo', 'bar'),
+          'foo',
+          lambda k, s, d: jnp.zeros(s, d),
+          (2, 2),
+          x.dtype,
+          axes=('foo', 'bar'),
         )
         return x + foo
 
@@ -227,12 +220,12 @@ class PartitioningTest(parameterized.TestCase):
     self.assertIn('params', variables)
     self.assertIn('params_axes', variables)
     self.assertEqual(
-        variables['params_axes']['foo_axes'],
-        partitioning.AxisMetadata(names=('foo', 'bar')),
+      variables['params_axes']['foo_axes'],
+      partitioning.AxisMetadata(names=('foo', 'bar')),
     )
     logical_axis_names = partitioning.get_axis_names(variables['params_axes'])
     self.assertEqual(
-        logical_axis_names, {'foo': jax.sharding.PartitionSpec('foo', 'bar')}
+      logical_axis_names, {'foo': jax.sharding.PartitionSpec('foo', 'bar')}
     )
 
   def test_param_pytree_with_axes(self):
@@ -243,11 +236,10 @@ class PartitioningTest(parameterized.TestCase):
     axes = {'a': ('foo', 'bar'), 'b': (('foo', 'bar'), ('bar', 'foo'))}
 
     class ParamTest(nn.Module):
-
       @nn.compact
       def __call__(self, x):
         foo = partitioning.param_with_axes(
-            'foo', init_fn, (2, 2), x.dtype, axes=axes
+          'foo', init_fn, (2, 2), x.dtype, axes=axes
         )
         return x + foo['a']
 
@@ -259,31 +251,30 @@ class PartitioningTest(parameterized.TestCase):
     self.assertIn('params', variables)
     self.assertIn('params_axes', variables)
     self.assertEqual(
-        variables['params_axes']['foo_axes'],
-        partitioning.AxisMetadata(names=axes),
+      variables['params_axes']['foo_axes'],
+      partitioning.AxisMetadata(names=axes),
     )
     logical_axis_names = partitioning.get_axis_names(variables['params_axes'])
     expected = freeze(
-        {
-            'foo': {
-                'a': jax.sharding.PartitionSpec('foo', 'bar'),
-                'b': (
-                    jax.sharding.PartitionSpec('foo', 'bar'),
-                    jax.sharding.PartitionSpec('bar', 'foo'),
-                ),
-            }
+      {
+        'foo': {
+          'a': jax.sharding.PartitionSpec('foo', 'bar'),
+          'b': (
+            jax.sharding.PartitionSpec('foo', 'bar'),
+            jax.sharding.PartitionSpec('bar', 'foo'),
+          ),
         }
+      }
     )
     self.assertEqual(logical_axis_names, expected)
 
   @parameterized.parameters(dict(axes_spec=None), dict(axes_spec=()))
   def test_variable_with_axes_no_axes(self, axes_spec):
     class VarTest(nn.Module):
-
       @nn.compact
       def __call__(self, x):
         foo = partitioning.variable_with_axes(
-            'test', 'foo', jnp.zeros, (2, 2), x.dtype, axes=axes_spec
+          'test', 'foo', jnp.zeros, (2, 2), x.dtype, axes=axes_spec
         )
         return x + foo.value
 
@@ -293,11 +284,10 @@ class PartitioningTest(parameterized.TestCase):
 
   def test_variable_with_empty_tuple_has_empty_axes(self):
     class VarTest(nn.Module):
-
       @nn.compact
       def __call__(self, x):
         foo = partitioning.variable_with_axes(
-            'test', 'foo', jnp.zeros, (2, 2), x.dtype, axes=()
+          'test', 'foo', jnp.zeros, (2, 2), x.dtype, axes=()
         )
         return x + foo.value
 
@@ -309,11 +299,10 @@ class PartitioningTest(parameterized.TestCase):
 
   def test_variable_with_axes(self):
     class VarTest(nn.Module):
-
       @nn.compact
       def __call__(self, x):
         foo = partitioning.variable_with_axes(
-            'test', 'foo', jnp.zeros, (2, 2), x.dtype, axes=('foo', 'bar')
+          'test', 'foo', jnp.zeros, (2, 2), x.dtype, axes=('foo', 'bar')
         )
         return x + foo.value
 
@@ -325,35 +314,34 @@ class PartitioningTest(parameterized.TestCase):
     self.assertIn('test', variables)
     self.assertIn('test_axes', variables)
     self.assertEqual(
-        variables['test_axes']['foo_axes'],
-        partitioning.AxisMetadata(names=('foo', 'bar')),
+      variables['test_axes']['foo_axes'],
+      partitioning.AxisMetadata(names=('foo', 'bar')),
     )
     logical_axis_names = partitioning.get_axis_names(variables['test_axes'])
     self.assertEqual(
-        logical_axis_names, {'foo': jax.sharding.PartitionSpec('foo', 'bar')}
+      logical_axis_names, {'foo': jax.sharding.PartitionSpec('foo', 'bar')}
     )
 
   @mock.patch('flax.linen.partitioning._with_sharding_constraint')
   def test_variable_with_axes_fallback(self, wsc_fn):
     class VarTest(nn.Module):
-
       @nn.compact
       def __call__(self, x):
         foo = partitioning.variable_with_axes(
-            'test',
-            'foo',
-            jnp.zeros,
-            (2, 2),
-            x.dtype,
-            axes=('foo', 'bar'),
-            fallback=partitioning.RulesFallback.NO_CONSTRAINT,
+          'test',
+          'foo',
+          jnp.zeros,
+          (2, 2),
+          x.dtype,
+          axes=('foo', 'bar'),
+          fallback=partitioning.RulesFallback.NO_CONSTRAINT,
         )
         return x + foo.value
 
     p_rules = (
-        # No rule for 'foo':
-        ('bar', 'data'),
-        ('baz', None),
+      # No rule for 'foo':
+      ('bar', 'data'),
+      ('baz', None),
     )
     k = random.key(0)
     x = jnp.ones((2, 2))
@@ -364,12 +352,12 @@ class PartitioningTest(parameterized.TestCase):
     self.assertIn('test', variables)
     self.assertIn('test_axes', variables)
     self.assertEqual(
-        variables['test_axes']['foo_axes'],
-        partitioning.AxisMetadata(names=('foo', 'bar')),
+      variables['test_axes']['foo_axes'],
+      partitioning.AxisMetadata(names=('foo', 'bar')),
     )
     logical_axis_names = partitioning.get_axis_names(variables['test_axes'])
     self.assertEqual(
-        logical_axis_names, {'foo': jax.sharding.PartitionSpec('foo', 'bar')}
+      logical_axis_names, {'foo': jax.sharding.PartitionSpec('foo', 'bar')}
     )
 
   def test_scan_with_axes(self):
@@ -385,20 +373,20 @@ class PartitioningTest(parameterized.TestCase):
       @nn.compact
       def __call__(self, x):
         W1 = partitioning.param_with_axes(  # pylint: disable=invalid-name
-            'W1',
-            nn.initializers.xavier_normal(),
-            (x.shape[-1], self.depth),
-            axes=('emb', 'mlp'),
+          'W1',
+          nn.initializers.xavier_normal(),
+          (x.shape[-1], self.depth),
+          axes=('emb', 'mlp'),
         )
         W2 = partitioning.param_with_axes(  # pylint: disable=invalid-name
-            'W2',
-            nn.initializers.xavier_normal(),
-            (self.depth, x.shape[-1]),
-            axes=('mlp', 'emb'),
+          'W2',
+          nn.initializers.xavier_normal(),
+          (self.depth, x.shape[-1]),
+          axes=('mlp', 'emb'),
         )
         y = jnp.dot(jnp.sin(jnp.dot(x, W1)), W2)
         _ = partitioning.variable_with_axes(
-            'stats', 'y_st', lambda: y, axes=('batch', 'emb')
+          'stats', 'y_st', lambda: y, axes=('batch', 'emb')
         )
         # scan expects a (carry, out) return signature.
         return y, None
@@ -410,13 +398,13 @@ class PartitioningTest(parameterized.TestCase):
       @nn.compact
       def __call__(self, x):
         scanned_sindot = partitioning.scan_with_axes(
-            SinDot,
-            in_axes=(),
-            variable_axes={'params': 0, 'stats': 1},
-            split_rngs={'params': True},
-            axis_name='layer',
-            axes_collections=('params', 'stats'),
-            length=self.num_layers,
+          SinDot,
+          in_axes=(),
+          variable_axes={'params': 0, 'stats': 1},
+          split_rngs={'params': True},
+          axis_name='layer',
+          axes_collections=('params', 'stats'),
+          length=self.num_layers,
         )(self.depth, name='scanned_layer')
         y, _ = scanned_sindot(x)
         # test calling again to test metadata compatibility across calls
@@ -434,52 +422,50 @@ class PartitioningTest(parameterized.TestCase):
     self.assertIn('stats', variables)
     self.assertIn('stats_axes', variables)
     self.assertEqual(
-        variables['params_axes']['scanned_layer']['W1_axes'],
-        partitioning.AxisMetadata(names=('layer', 'emb', 'mlp')),
+      variables['params_axes']['scanned_layer']['W1_axes'],
+      partitioning.AxisMetadata(names=('layer', 'emb', 'mlp')),
     )
     logical_axis_names = partitioning.get_axis_names(variables['params_axes'])
     self.assertEqual(
-        logical_axis_names,
-        {
-            'scanned_layer': {
-                'W1': jax.sharding.PartitionSpec('layer', 'emb', 'mlp'),
-                'W2': jax.sharding.PartitionSpec('layer', 'mlp', 'emb'),
-            }
-        },
+      logical_axis_names,
+      {
+        'scanned_layer': {
+          'W1': jax.sharding.PartitionSpec('layer', 'emb', 'mlp'),
+          'W2': jax.sharding.PartitionSpec('layer', 'mlp', 'emb'),
+        }
+      },
     )
     logical_axis_names = partitioning.get_axis_names(variables['stats_axes'])
     self.assertEqual(
-        logical_axis_names,
-        {
-            'scanned_layer': {
-                'y_st': jax.sharding.PartitionSpec('batch', 'layer', 'emb')
-            }
-        },
+      logical_axis_names,
+      {
+        'scanned_layer': {
+          'y_st': jax.sharding.PartitionSpec('batch', 'layer', 'emb')
+        }
+      },
     )
 
   def test_vmap_with_axes(self):
     class Foo(nn.Module):
-
       @nn.compact
       def __call__(self, x):
         return (
-            partitioning.param_with_axes(
-                'w', jax.nn.initializers.uniform(), [4, 3], axes=('out', 'in')
-            )
-            @ x
+          partitioning.param_with_axes(
+            'w', jax.nn.initializers.uniform(), [4, 3], axes=('out', 'in')
+          )
+          @ x
         )
 
     class Vmapped(nn.Module):
-
       @nn.compact
       def __call__(self, x):
         FooVmapped = partitioning.vmap_with_axes(  # pylint: disable=invalid-name
-            Foo,
-            variable_axes={
-                'params': 1,
-            },
-            split_rngs={'params': True},
-            partitioning_axis_names={'params': 'vmap_axis'},
+          Foo,
+          variable_axes={
+            'params': 1,
+          },
+          split_rngs={'params': True},
+          partitioning_axis_names={'params': 'vmap_axis'},
         )
         return FooVmapped(name='foo_vmapped')(x)
 
@@ -490,39 +476,39 @@ class PartitioningTest(parameterized.TestCase):
       variables = Foo().init(jax.random.key(0), jnp.array([1, 2, 3]))
     variables = unfreeze(variables)
     variables['params'] = jax.tree_util.tree_map(
-        lambda x: x.shape, variables['params']
+      lambda x: x.shape, variables['params']
     )
     self.assertDictEqual(
-        variables,
-        {
-            'params': {'w': (4, 3)},
-            'params_axes': {
-                'w_axes': partitioning.AxisMetadata(names=('out', 'in'))
-            },
+      variables,
+      {
+        'params': {'w': (4, 3)},
+        'params_axes': {
+          'w_axes': partitioning.AxisMetadata(names=('out', 'in'))
         },
+      },
     )
 
     # check that FooVmapped adds 'vmap_axis' to axis 1
     with partitioning.axis_rules(p_rules):
       variables = Vmapped().init(
-          jax.random.key(0), jnp.array([[1, 2, 3], [4, 5, 6]])
+        jax.random.key(0), jnp.array([[1, 2, 3], [4, 5, 6]])
       )
     variables = unfreeze(variables)
     variables['params'] = jax.tree_util.tree_map(
-        lambda x: x.shape, variables['params']
+      lambda x: x.shape, variables['params']
     )
     self.assertDictEqual(
-        variables,
-        {
-            'params': {'foo_vmapped': {'w': (4, 2, 3)}},
-            'params_axes': {
-                'foo_vmapped': {
-                    'w_axes': partitioning.AxisMetadata(
-                        names=('out', 'vmap_axis', 'in')
-                    )
-                }
-            },
+      variables,
+      {
+        'params': {'foo_vmapped': {'w': (4, 2, 3)}},
+        'params_axes': {
+          'foo_vmapped': {
+            'w_axes': partitioning.AxisMetadata(
+              names=('out', 'vmap_axis', 'in')
+            )
+          }
         },
+      },
     )
 
   def test_logical_with_mesh_and_rules(self):
@@ -532,11 +518,10 @@ class PartitioningTest(parameterized.TestCase):
     rules = (('a', 'in'), ('b', 'out'))
 
     class Foo(nn.Module):
-
       @nn.compact
       def __call__(self, x):
         kernel_init = nn.with_logical_partitioning(
-            nn.initializers.ones_init(), ('a', 'b'), mesh=mesh, rules=rules
+          nn.initializers.ones_init(), ('a', 'b'), mesh=mesh, rules=rules
         )
         kernel = self.param('kernel', kernel_init, (x.shape[-1], 2))
         kernel_box = self.get_variable('params', 'kernel')

--- a/tests/linen/summary_test.py
+++ b/tests/linen/summary_test.py
@@ -14,16 +14,16 @@
 
 from typing import List
 
+import jax
+import jax.numpy as jnp
+import numpy as np
 from absl.testing import absltest
+from jax import random
+
 from flax import linen as nn
 from flax import struct
 from flax.core.scope import Array
 from flax.linen import summary
-import jax
-from jax import random
-import jax.numpy as jnp
-import numpy as np
-
 
 # Parse absl flags test_srcdir and test_tmpdir.
 jax.config.parse_flags_with_absl()
@@ -33,7 +33,7 @@ CONSOLE_TEST_KWARGS = dict(force_terminal=False, no_color=True, width=10_000)
 
 def _get_shapes(pytree):
   return jax.tree_util.tree_map(
-      lambda x: x.shape if hasattr(x, "shape") else x, pytree
+    lambda x: x.shape if hasattr(x, 'shape') else x, pytree
   )
 
 
@@ -57,7 +57,7 @@ class ConvBlock(nn.Module):
     x = self.conv(x)
 
     if self.test_sow:
-      self.sow("intermediates", "INTERM", x)
+      self.sow('intermediates', 'INTERM', x)
 
     x = self.bn(x, use_running_average=not training)
     x = self.dropout(x, deterministic=not training)
@@ -68,7 +68,7 @@ class ConvBlock(nn.Module):
     x = self.conv(x)
 
     if self.test_sow:
-      self.sow("intermediates", "INTERM", x)
+      self.sow('intermediates', 'INTERM', x)
 
     x = self.bn(x, use_running_average=not training)
     x = self.dropout(x, deterministic=not training)
@@ -90,7 +90,7 @@ class CNN(nn.Module):
     x = x.mean(axis=(1, 2))
 
     if self.test_sow:
-      self.sow("intermediates", "INTERM", x)
+      self.sow('intermediates', 'INTERM', x)
 
     x = self.dense(x)
 
@@ -102,7 +102,7 @@ class CNN(nn.Module):
     x = x.mean(axis=(1, 2))
 
     if self.test_sow:
-      self.sow("intermediates", "INTERM", x)
+      self.sow('intermediates', 'INTERM', x)
 
     x = self.dense(x)
 
@@ -110,7 +110,6 @@ class CNN(nn.Module):
 
 
 class SummaryTest(absltest.TestCase):
-
   def test_module_summary(self):
     """
     This test creates a Table using `module_summary` and checks that it
@@ -124,16 +123,16 @@ class SummaryTest(absltest.TestCase):
     module = CNN(test_sow=False)
 
     table = summary._get_module_table(
-        module,
-        depth=None,
-        show_repeated=True,
-        compute_flops=True,
-        compute_vjp_flops=True,
+      module,
+      depth=None,
+      show_repeated=True,
+      compute_flops=True,
+      compute_vjp_flops=True,
     )(
-        {"dropout": random.key(0), "params": random.key(1)},
-        x,
-        training=True,
-        mutable=True,
+      {'dropout': random.key(0), 'params': random.key(1)},
+      x,
+      training=True,
+      mutable=True,
     )
     # get values for inputs and outputs from their _ValueRepresentation
     for row in table:
@@ -146,61 +145,61 @@ class SummaryTest(absltest.TestCase):
     # check paths
     self.assertEqual(table[0].path, ())
 
-    self.assertEqual(table[1].path, ("block1",))
-    self.assertEqual(table[2].path, ("block1", "conv"))
-    self.assertEqual(table[3].path, ("block1", "bn"))
-    self.assertEqual(table[4].path, ("block1", "dropout"))
+    self.assertEqual(table[1].path, ('block1',))
+    self.assertEqual(table[2].path, ('block1', 'conv'))
+    self.assertEqual(table[3].path, ('block1', 'bn'))
+    self.assertEqual(table[4].path, ('block1', 'dropout'))
 
-    self.assertEqual(table[5].path, ("block2",))
-    self.assertEqual(table[6].path, ("block2", "conv"))
-    self.assertEqual(table[7].path, ("block2", "bn"))
-    self.assertEqual(table[8].path, ("block2", "dropout"))
+    self.assertEqual(table[5].path, ('block2',))
+    self.assertEqual(table[6].path, ('block2', 'conv'))
+    self.assertEqual(table[7].path, ('block2', 'bn'))
+    self.assertEqual(table[8].path, ('block2', 'dropout'))
 
-    self.assertEqual(table[9].path, ("dense",))
+    self.assertEqual(table[9].path, ('dense',))
 
     # check outputs shapes
     self.assertEqual(
-        (table[0].inputs[0].shape, table[0].inputs[1]),
-        (x.shape, dict(training=True)),
+      (table[0].inputs[0].shape, table[0].inputs[1]),
+      (x.shape, dict(training=True)),
     )
     self.assertEqual(
-        _get_shapes(table[0].outputs),
-        ((batch_size, 10), dict(a=(batch_size, 10), b=(batch_size, 10))),
+      _get_shapes(table[0].outputs),
+      ((batch_size, 10), dict(a=(batch_size, 10), b=(batch_size, 10))),
     )
 
     self.assertEqual(
-        _get_shapes(table[1].inputs),
-        ((batch_size, 28, 28, 1), {"training": True}),
+      _get_shapes(table[1].inputs),
+      ((batch_size, 28, 28, 1), {'training': True}),
     )
     self.assertEqual(table[1].outputs.shape, (batch_size, 28, 28, 32))
     self.assertEqual(table[2].inputs.shape, (batch_size, 28, 28, 1))
     self.assertEqual(table[2].outputs.shape, (batch_size, 28, 28, 32))
     self.assertEqual(
-        _get_shapes(table[3].inputs),
-        ((batch_size, 28, 28, 32), {"use_running_average": False}),
+      _get_shapes(table[3].inputs),
+      ((batch_size, 28, 28, 32), {'use_running_average': False}),
     )
     self.assertEqual(table[3].outputs.shape, (batch_size, 28, 28, 32))
     self.assertEqual(
-        _get_shapes(table[4].inputs),
-        ((batch_size, 28, 28, 32), {"deterministic": False}),
+      _get_shapes(table[4].inputs),
+      ((batch_size, 28, 28, 32), {'deterministic': False}),
     )
     self.assertEqual(table[4].outputs.shape, (batch_size, 28, 28, 32))
 
     self.assertEqual(
-        _get_shapes(table[5].inputs),
-        ((batch_size, 28, 28, 32), {"training": True}),
+      _get_shapes(table[5].inputs),
+      ((batch_size, 28, 28, 32), {'training': True}),
     )
     self.assertEqual(table[5].outputs.shape, (batch_size, 28, 28, 64))
     self.assertEqual(table[6].inputs.shape, (batch_size, 28, 28, 32))
     self.assertEqual(table[6].outputs.shape, (batch_size, 28, 28, 64))
     self.assertEqual(
-        _get_shapes(table[7].inputs),
-        ((batch_size, 28, 28, 64), {"use_running_average": False}),
+      _get_shapes(table[7].inputs),
+      ((batch_size, 28, 28, 64), {'use_running_average': False}),
     )
     self.assertEqual(table[7].outputs.shape, (batch_size, 28, 28, 64))
     self.assertEqual(
-        _get_shapes(table[8].inputs),
-        ((batch_size, 28, 28, 64), {"deterministic": False}),
+      _get_shapes(table[8].inputs),
+      ((batch_size, 28, 28, 64), {'deterministic': False}),
     )
     self.assertEqual(table[8].outputs.shape, (batch_size, 28, 28, 64))
 
@@ -210,8 +209,8 @@ class SummaryTest(absltest.TestCase):
     # check no summary is performed
     for row in table:
       self.assertEqual(
-          row.module_variables,
-          row.counted_variables,
+        row.module_variables,
+        row.counted_variables,
       )
 
     # Each module FLOPs >= sum of its submodule FLOPs.
@@ -238,16 +237,16 @@ class SummaryTest(absltest.TestCase):
     module = CNN(test_sow=False)
 
     table = summary._get_module_table(
-        module,
-        depth=1,
-        show_repeated=True,
-        compute_flops=True,
-        compute_vjp_flops=True,
+      module,
+      depth=1,
+      show_repeated=True,
+      compute_flops=True,
+      compute_vjp_flops=True,
     )(
-        {"dropout": random.key(0), "params": random.key(1)},
-        x,
-        training=True,
-        mutable=True,
+      {'dropout': random.key(0), 'params': random.key(1)},
+      x,
+      training=True,
+      mutable=True,
     )
     # get values for inputs and outputs from their _ValueRepresentation
 
@@ -261,29 +260,29 @@ class SummaryTest(absltest.TestCase):
     # check paths
     self.assertEqual(table[0].path, ())
 
-    self.assertEqual(table[1].path, ("block1",))
-    self.assertEqual(table[2].path, ("block2",))
-    self.assertEqual(table[3].path, ("dense",))
+    self.assertEqual(table[1].path, ('block1',))
+    self.assertEqual(table[2].path, ('block2',))
+    self.assertEqual(table[3].path, ('dense',))
 
     # check outputs shapes
     self.assertEqual(
-        (table[0].inputs[0].shape, table[0].inputs[1]),
-        (x.shape, dict(training=True)),
+      (table[0].inputs[0].shape, table[0].inputs[1]),
+      (x.shape, dict(training=True)),
     )
     self.assertEqual(
-        _get_shapes(table[0].outputs),
-        ((batch_size, 10), dict(a=(batch_size, 10), b=(batch_size, 10))),
+      _get_shapes(table[0].outputs),
+      ((batch_size, 10), dict(a=(batch_size, 10), b=(batch_size, 10))),
     )
 
     self.assertEqual(
-        _get_shapes(table[1].inputs),
-        ((batch_size, 28, 28, 1), {"training": True}),
+      _get_shapes(table[1].inputs),
+      ((batch_size, 28, 28, 1), {'training': True}),
     )
     self.assertEqual(table[1].outputs.shape, (batch_size, 28, 28, 32))
 
     self.assertEqual(
-        _get_shapes(table[2].inputs),
-        ((batch_size, 28, 28, 32), {"training": True}),
+      _get_shapes(table[2].inputs),
+      ((batch_size, 28, 28, 32), {'training': True}),
     )
     self.assertEqual(table[2].outputs.shape, (batch_size, 28, 28, 64))
 
@@ -314,44 +313,44 @@ class SummaryTest(absltest.TestCase):
     module = CNN(test_sow=False)
 
     module_repr = module.tabulate(
-        {"dropout": random.key(0), "params": random.key(1)},
-        x,
-        training=True,
-        console_kwargs=CONSOLE_TEST_KWARGS,
-        compute_flops=True,
-        compute_vjp_flops=True,
+      {'dropout': random.key(0), 'params': random.key(1)},
+      x,
+      training=True,
+      console_kwargs=CONSOLE_TEST_KWARGS,
+      compute_flops=True,
+      compute_vjp_flops=True,
     )
 
     # NOTE: it's tricky to validate the content of lines
     # because it seems to be shell-dependent, so we will
     # just check lines that won't change between environments
-    lines = module_repr.split("\n")
+    lines = module_repr.split('\n')
 
     # check title
     module_name = module.__class__.__name__
-    self.assertIn(f"{module_name} Summary", lines[1])
+    self.assertIn(f'{module_name} Summary', lines[1])
 
     # check headers are correct
-    self.assertIn("path", lines[3])
-    self.assertIn("module", lines[3])
-    self.assertIn("inputs", lines[3])
-    self.assertIn("outputs", lines[3])
-    self.assertIn("params", lines[3])
-    self.assertIn("flops", lines[3])
-    self.assertIn("vjp_flops", lines[3])
-    self.assertIn("batch_stats", lines[3])
+    self.assertIn('path', lines[3])
+    self.assertIn('module', lines[3])
+    self.assertIn('inputs', lines[3])
+    self.assertIn('outputs', lines[3])
+    self.assertIn('params', lines[3])
+    self.assertIn('flops', lines[3])
+    self.assertIn('vjp_flops', lines[3])
+    self.assertIn('batch_stats', lines[3])
 
     # collection counts
-    self.assertIn("Total", lines[-6])
-    self.assertIn("192", lines[-6])
-    self.assertIn("768 B", lines[-6])
-    self.assertIn("19,658", lines[-6])
-    self.assertIn("78.6 KB", lines[-6])
+    self.assertIn('Total', lines[-6])
+    self.assertIn('192', lines[-6])
+    self.assertIn('768 B', lines[-6])
+    self.assertIn('19,658', lines[-6])
+    self.assertIn('78.6 KB', lines[-6])
 
     # total counts
-    self.assertIn("Total Parameters", lines[-3])
-    self.assertIn("19,850", lines[-3])
-    self.assertIn("79.4 KB", lines[-3])
+    self.assertIn('Total Parameters', lines[-3])
+    self.assertIn('19,850', lines[-3])
+    self.assertIn('79.4 KB', lines[-3])
 
   def test_tabulate_with_sow(self):
     batch_size = 32
@@ -360,17 +359,17 @@ class SummaryTest(absltest.TestCase):
     module = CNN(test_sow=True)
 
     module_repr = module.tabulate(
-        {"dropout": random.key(0), "params": random.key(1)},
-        x,
-        training=True,
-        mutable=True,
-        console_kwargs=CONSOLE_TEST_KWARGS,
-        compute_flops=True,
-        compute_vjp_flops=True,
+      {'dropout': random.key(0), 'params': random.key(1)},
+      x,
+      training=True,
+      mutable=True,
+      console_kwargs=CONSOLE_TEST_KWARGS,
+      compute_flops=True,
+      compute_vjp_flops=True,
     )
 
-    self.assertIn("intermediates", module_repr)
-    self.assertIn("INTERM", module_repr)
+    self.assertIn('intermediates', module_repr)
+    self.assertIn('INTERM', module_repr)
 
   def test_tabulate_with_method(self):
     batch_size = 32
@@ -379,17 +378,17 @@ class SummaryTest(absltest.TestCase):
     module = CNN(test_sow=False)
 
     module_repr = module.tabulate(
-        {"dropout": random.key(0), "params": random.key(1)},
-        x,
-        training=True,
-        method=CNN.cnn_method,
-        console_kwargs=CONSOLE_TEST_KWARGS,
-        compute_flops=True,
-        compute_vjp_flops=True,
+      {'dropout': random.key(0), 'params': random.key(1)},
+      x,
+      training=True,
+      method=CNN.cnn_method,
+      console_kwargs=CONSOLE_TEST_KWARGS,
+      compute_flops=True,
+      compute_vjp_flops=True,
     )
 
-    self.assertIn("(block_method)", module_repr)
-    self.assertIn("(cnn_method)", module_repr)
+    self.assertIn('(block_method)', module_repr)
+    self.assertIn('(cnn_method)', module_repr)
 
   def test_tabulate_function(self):
     """
@@ -403,39 +402,39 @@ class SummaryTest(absltest.TestCase):
     module = CNN(test_sow=False)
 
     module_repr = nn.tabulate(
-        module,
-        {"dropout": random.key(0), "params": random.key(1)},
-        console_kwargs=CONSOLE_TEST_KWARGS,
-        compute_flops=True,
-        compute_vjp_flops=True,
+      module,
+      {'dropout': random.key(0), 'params': random.key(1)},
+      console_kwargs=CONSOLE_TEST_KWARGS,
+      compute_flops=True,
+      compute_vjp_flops=True,
     )(x, training=True)
 
-    lines = module_repr.split("\n")
+    lines = module_repr.split('\n')
 
     # check title
     module_name = module.__class__.__name__
-    self.assertIn(f"{module_name} Summary", lines[1])
+    self.assertIn(f'{module_name} Summary', lines[1])
 
     # check headers are correct
-    self.assertIn("path", lines[3])
-    self.assertIn("module", lines[3])
-    self.assertIn("inputs", lines[3])
-    self.assertIn("outputs", lines[3])
-    self.assertIn("params", lines[3])
-    self.assertIn("flops", lines[3])
-    self.assertIn("batch_stats", lines[3])
+    self.assertIn('path', lines[3])
+    self.assertIn('module', lines[3])
+    self.assertIn('inputs', lines[3])
+    self.assertIn('outputs', lines[3])
+    self.assertIn('params', lines[3])
+    self.assertIn('flops', lines[3])
+    self.assertIn('batch_stats', lines[3])
 
     # collection counts
-    self.assertIn("Total", lines[-6])
-    self.assertIn("192", lines[-6])
-    self.assertIn("768 B", lines[-6])
-    self.assertIn("19,658", lines[-6])
-    self.assertIn("78.6 KB", lines[-6])
+    self.assertIn('Total', lines[-6])
+    self.assertIn('192', lines[-6])
+    self.assertIn('768 B', lines[-6])
+    self.assertIn('19,658', lines[-6])
+    self.assertIn('78.6 KB', lines[-6])
 
     # total counts
-    self.assertIn("Total Parameters", lines[-3])
-    self.assertIn("19,850", lines[-3])
-    self.assertIn("79.4 KB", lines[-3])
+    self.assertIn('Total Parameters', lines[-3])
+    self.assertIn('19,850', lines[-3])
+    self.assertIn('79.4 KB', lines[-3])
 
   def test_lifted_transform(self):
     class LSTM(nn.Module):
@@ -444,35 +443,35 @@ class SummaryTest(absltest.TestCase):
       @nn.compact
       def __call__(self, x):
         carry = nn.LSTMCell(self.features).initialize_carry(
-            random.key(0), x[:, 0].shape
+          random.key(0), x[:, 0].shape
         )
         ScanLSTM = nn.scan(
-            nn.LSTMCell,
-            variable_broadcast="params",
-            split_rngs={"params": False},
-            in_axes=1,
-            out_axes=1,
+          nn.LSTMCell,
+          variable_broadcast='params',
+          split_rngs={'params': False},
+          in_axes=1,
+          out_axes=1,
         )
-        return ScanLSTM(self.features, name="ScanLSTM")(carry, x)
+        return ScanLSTM(self.features, name='ScanLSTM')(carry, x)
 
     lstm = LSTM(features=128)
 
     with jax.check_tracer_leaks(True):
       module_repr = lstm.tabulate(
-          random.key(0),
-          x=jnp.ones((32, 128, 64)),
-          console_kwargs=CONSOLE_TEST_KWARGS,
-          compute_flops=True,
-          compute_vjp_flops=True,
+        random.key(0),
+        x=jnp.ones((32, 128, 64)),
+        console_kwargs=CONSOLE_TEST_KWARGS,
+        compute_flops=True,
+        compute_vjp_flops=True,
       )
 
     lines = module_repr.splitlines()
 
-    self.assertIn("LSTM", lines[5])
-    self.assertIn("ScanLSTM", lines[9])
-    self.assertIn("LSTMCell", lines[9])
-    self.assertIn("ScanLSTM/ii", lines[13])
-    self.assertIn("Dense", lines[13])
+    self.assertIn('LSTM', lines[5])
+    self.assertIn('ScanLSTM', lines[9])
+    self.assertIn('LSTMCell', lines[9])
+    self.assertIn('ScanLSTM/ii', lines[13])
+    self.assertIn('Dense', lines[13])
 
   def test_lifted_transform_no_rename(self):
     class LSTM(nn.Module):
@@ -481,14 +480,14 @@ class SummaryTest(absltest.TestCase):
       @nn.compact
       def __call__(self, x):
         carry = nn.LSTMCell(self.features).initialize_carry(
-            random.key(0), x[:, 0].shape
+          random.key(0), x[:, 0].shape
         )
         ScanLSTM = nn.scan(
-            nn.LSTMCell,
-            variable_broadcast="params",
-            split_rngs={"params": False},
-            in_axes=1,
-            out_axes=1,
+          nn.LSTMCell,
+          variable_broadcast='params',
+          split_rngs={'params': False},
+          in_axes=1,
+          out_axes=1,
         )
         return ScanLSTM(self.features)(carry, x)
 
@@ -496,24 +495,23 @@ class SummaryTest(absltest.TestCase):
 
     with jax.check_tracer_leaks(True):
       module_repr = lstm.tabulate(
-          random.key(0),
-          x=jnp.ones((32, 128, 64)),
-          console_kwargs=CONSOLE_TEST_KWARGS,
-          compute_flops=True,
-          compute_vjp_flops=True,
+        random.key(0),
+        x=jnp.ones((32, 128, 64)),
+        console_kwargs=CONSOLE_TEST_KWARGS,
+        compute_flops=True,
+        compute_vjp_flops=True,
       )
 
     lines = module_repr.splitlines()
 
-    self.assertIn("LSTM", lines[5])
-    self.assertIn("ScanLSTMCell_0", lines[9])
-    self.assertIn("LSTMCell", lines[9])
-    self.assertIn("ScanLSTMCell_0/ii", lines[13])
-    self.assertIn("Dense", lines[13])
+    self.assertIn('LSTM', lines[5])
+    self.assertIn('ScanLSTMCell_0', lines[9])
+    self.assertIn('LSTMCell', lines[9])
+    self.assertIn('ScanLSTMCell_0/ii', lines[13])
+    self.assertIn('Dense', lines[13])
 
   def test_module_reuse(self):
     class ConvBlock(nn.Module):
-
       @nn.compact
       def __call__(self, x):
         x = nn.Conv(32, [3, 3])(x)
@@ -523,7 +521,6 @@ class SummaryTest(absltest.TestCase):
         return x
 
     class CNN(nn.Module):
-
       @nn.compact
       def __call__(self, x):
         block = ConvBlock()
@@ -534,55 +531,55 @@ class SummaryTest(absltest.TestCase):
 
     x = jnp.ones((4, 28, 28, 32))
     module_repr = CNN().tabulate(
-        jax.random.key(0),
-        x=x,
-        show_repeated=True,
-        console_kwargs=CONSOLE_TEST_KWARGS,
-        compute_flops=True,
-        compute_vjp_flops=True,
+      jax.random.key(0),
+      x=x,
+      show_repeated=True,
+      console_kwargs=CONSOLE_TEST_KWARGS,
+      compute_flops=True,
+      compute_vjp_flops=True,
     )
     lines = module_repr.splitlines()
 
     # first call
-    self.assertIn("ConvBlock_0/Conv_0", lines[9])
-    self.assertIn("bias", lines[9])
-    self.assertIn("ConvBlock_0/BatchNorm_0", lines[14])
-    self.assertIn("mean", lines[14])
-    self.assertIn("bias", lines[14])
-    self.assertIn("ConvBlock_0/Dropout_0", lines[19])
+    self.assertIn('ConvBlock_0/Conv_0', lines[9])
+    self.assertIn('bias', lines[9])
+    self.assertIn('ConvBlock_0/BatchNorm_0', lines[14])
+    self.assertIn('mean', lines[14])
+    self.assertIn('bias', lines[14])
+    self.assertIn('ConvBlock_0/Dropout_0', lines[19])
 
     # second call
-    self.assertIn("ConvBlock_0/Conv_0", lines[23])
-    self.assertNotIn("bias", lines[23])
-    self.assertIn("ConvBlock_0/BatchNorm_0", lines[25])
-    self.assertNotIn("mean", lines[25])
-    self.assertNotIn("bias", lines[25])
-    self.assertIn("ConvBlock_0/Dropout_0", lines[27])
+    self.assertIn('ConvBlock_0/Conv_0', lines[23])
+    self.assertNotIn('bias', lines[23])
+    self.assertIn('ConvBlock_0/BatchNorm_0', lines[25])
+    self.assertNotIn('mean', lines[25])
+    self.assertNotIn('bias', lines[25])
+    self.assertIn('ConvBlock_0/Dropout_0', lines[27])
 
     # third call
-    self.assertIn("ConvBlock_0/Conv_0", lines[31])
-    self.assertNotIn("bias", lines[31])
-    self.assertIn("ConvBlock_0/BatchNorm_0", lines[33])
-    self.assertNotIn("mean", lines[33])
-    self.assertNotIn("bias", lines[33])
-    self.assertIn("ConvBlock_0/Dropout_0", lines[35])
+    self.assertIn('ConvBlock_0/Conv_0', lines[31])
+    self.assertNotIn('bias', lines[31])
+    self.assertIn('ConvBlock_0/BatchNorm_0', lines[33])
+    self.assertNotIn('mean', lines[33])
+    self.assertNotIn('bias', lines[33])
+    self.assertIn('ConvBlock_0/Dropout_0', lines[35])
 
     # Test that CNN FLOPs are 3x ConvBlock FLOPs.
-    args = ({"dropout": random.key(0), "params": random.key(1)}, x)
+    args = ({'dropout': random.key(0), 'params': random.key(1)}, x)
     cnn = summary._get_module_table(
-        CNN(),
-        depth=1,
-        show_repeated=True,
-        compute_flops=True,
-        compute_vjp_flops=True,
+      CNN(),
+      depth=1,
+      show_repeated=True,
+      compute_flops=True,
+      compute_vjp_flops=True,
     )(*args, mutable=True)
 
     block = summary._get_module_table(
-        ConvBlock(),
-        depth=1,
-        show_repeated=True,
-        compute_flops=True,
-        compute_vjp_flops=True,
+      ConvBlock(),
+      depth=1,
+      show_repeated=True,
+      compute_flops=True,
+      compute_vjp_flops=True,
     )(*args, mutable=True)
 
     # Total forward/backward FLOPs equal to their sums of sub blocks.
@@ -596,135 +593,129 @@ class SummaryTest(absltest.TestCase):
 
   def test_empty_input(self):
     class EmptyInput(nn.Module):
-
       @nn.compact
       def __call__(self):
         return 1
 
     module = EmptyInput()
     module_repr = module.tabulate(
-        {},
-        console_kwargs=CONSOLE_TEST_KWARGS,
-        compute_flops=True,
-        compute_vjp_flops=True,
+      {},
+      console_kwargs=CONSOLE_TEST_KWARGS,
+      compute_flops=True,
+      compute_vjp_flops=True,
     )
     lines = module_repr.splitlines()
 
     # 1 output and 0 forward / backward FLOPs.
     self.assertRegex(
-        lines[5], r"│\s*│\s*EmptyInput\s*│\s*│\s*1\s*│\s*0\s*│\s*0\s*│"
+      lines[5], r'│\s*│\s*EmptyInput\s*│\s*│\s*1\s*│\s*0\s*│\s*0\s*│'
     )
 
   def test_numpy_scalar(self):
     class Submodule(nn.Module):
-
       def __call__(self, x):
         return x + 1
 
     class EmptyInput(nn.Module):
-
       @nn.compact
       def __call__(self):
         return Submodule()(x=np.pi)
 
     module = EmptyInput()
     module_repr = module.tabulate(
-        {},
-        console_kwargs=CONSOLE_TEST_KWARGS,
-        compute_flops=True,
-        compute_vjp_flops=True,
+      {},
+      console_kwargs=CONSOLE_TEST_KWARGS,
+      compute_flops=True,
+      compute_vjp_flops=True,
     )
     lines = module_repr.splitlines()
 
-    self.assertIn("4.141592", lines[5])
-    self.assertIn("x: 3.141592", lines[7])
-    self.assertIn("4.141592", lines[7])
+    self.assertIn('4.141592', lines[5])
+    self.assertIn('x: 3.141592', lines[7])
+    self.assertIn('4.141592', lines[7])
 
     # 0 forward / backward FLOPs due to precomputed output values.
-    self.assertIn("│ 0     │ 0", lines[5])
-    self.assertIn("│ 0     │ 0", lines[7])
+    self.assertIn('│ 0     │ 0', lines[5])
+    self.assertIn('│ 0     │ 0', lines[7])
 
   def test_partitioned_params(self):
     class Classifier(nn.Module):
-
       @nn.compact
       def __call__(self, x):
         hidden = nn.Dense(
-            features=1024,
-            kernel_init=nn.with_partitioning(
-                nn.initializers.lecun_normal(), (None, "data")
-            ),
-            bias_init=nn.with_partitioning(nn.initializers.zeros, (None,)),
-            name="hidden",
+          features=1024,
+          kernel_init=nn.with_partitioning(
+            nn.initializers.lecun_normal(), (None, 'data')
+          ),
+          bias_init=nn.with_partitioning(nn.initializers.zeros, (None,)),
+          name='hidden',
         )
         x = x / 255.0
         x = x.reshape((x.shape[0], -1))  # flatten
         x = nn.relu(hidden(x))
-        x = nn.Dense(features=10, name="head")(x)
+        x = nn.Dense(features=10, name='head')(x)
         return x
 
     module = Classifier()
     lines = module.tabulate(
-        jax.random.key(0),
-        jnp.empty((1, 28, 28, 1)),
-        console_kwargs=CONSOLE_TEST_KWARGS,
-        compute_flops=True,
-        compute_vjp_flops=True,
+      jax.random.key(0),
+      jnp.empty((1, 28, 28, 1)),
+      console_kwargs=CONSOLE_TEST_KWARGS,
+      compute_flops=True,
+      compute_vjp_flops=True,
     ).splitlines()
-    self.assertIn("P(None,)", lines[7])
-    self.assertIn("P(None, data)", lines[8])
+    self.assertIn('P(None,)', lines[7])
+    self.assertIn('P(None, data)', lines[8])
 
     # Per-layer forward FLOPs:
-    self.assertIn("1606656", lines[7])  # 1 * (28 * 28 * 1) * 1024 * 2 + 1024
-    self.assertIn("20490", lines[12])  #  1 * (1024       ) * 10   * 2 + 10
+    self.assertIn('1606656', lines[7])  # 1 * (28 * 28 * 1) * 1024 * 2 + 1024
+    self.assertIn('20490', lines[12])  #  1 * (1024       ) * 10   * 2 + 10
 
     # Total forward FLOPs: input division + ReLU + two dense layers above.
     # (1 * 28 * 28 * 1) + (1 * 1024) + 1606656 + 20490.
-    self.assertIn("1628954", lines[5])
+    self.assertIn('1628954', lines[5])
 
     # Per-layer backward FLOPs:
 
     # [3x MMs: forward, input cotangent, weight cotangent] 1024 * 784 * 2 * 3
     # + [forward bias addition] 1024
     # + [`mutable=True`: weight and bias sizes] 1024 * 784 + 1024
-    self.assertIn("5621760", lines[7])
+    self.assertIn('5621760', lines[7])
 
     # [3x matmuls: forward, input cotangent, weight cotangent] 1024 * 10 * 2 * 3
     # + [forward bias addition] 10
     # + [`mutable=True`: weight and bias sizes] 1024 * 10 + 10
-    self.assertIn("71700", lines[12])
+    self.assertIn('71700', lines[12])
 
     # Total backward FLOPs: input division + ReLU + two dense layers above.
     # 2 * (1 * 28 * 28 * 1) + 3 * (1 * 1024) + 5621760 + 71700.
-    self.assertIn("5698100", lines[5])
+    self.assertIn('5698100', lines[5])
 
   def test_non_array_variables(self):
     class Metadata(struct.PyTreeNode):
       names: tuple = struct.field(pytree_node=False)
 
     class Foo(nn.Module):
-
       @nn.compact
       def __call__(self):
-        self.sow("foo", "bar", Metadata(("baz", "qux")))
+        self.sow('foo', 'bar', Metadata(('baz', 'qux')))
 
     module = Foo()
     lines = module.tabulate(
-        {},
-        console_kwargs=CONSOLE_TEST_KWARGS,
-        compute_flops=True,
-        compute_vjp_flops=True,
+      {},
+      console_kwargs=CONSOLE_TEST_KWARGS,
+      compute_flops=True,
+      compute_vjp_flops=True,
     ).splitlines()
-    self.assertIn("names", lines[6])
-    self.assertIn("baz", lines[7])
-    self.assertIn("qux", lines[8])
+    self.assertIn('names', lines[6])
+    self.assertIn('baz', lines[7])
+    self.assertIn('qux', lines[8])
 
     # 0 forward and backward FLOPs.
-    self.assertIn("│ 0     │ 0", lines[5])
+    self.assertIn('│ 0     │ 0', lines[5])
 
   def test_tabulate_param_count_and_flops(self):
     class Foo(nn.Module):
-
       @nn.compact
       def __call__(self, x):
         h = nn.Dense(4)(x)
@@ -735,16 +726,15 @@ class SummaryTest(absltest.TestCase):
     x = jnp.ones((16, 9))
 
     rep = module.tabulate(
-        rng,
-        x,
-        console_kwargs=CONSOLE_TEST_KWARGS,
-        compute_flops=True,
-        compute_vjp_flops=True,
+      rng,
+      x,
+      console_kwargs=CONSOLE_TEST_KWARGS,
+      compute_flops=True,
+      compute_vjp_flops=True,
     )
     lines = rep.splitlines()
-    self.assertIn("Total Parameters: 50", lines[-2])
+    self.assertIn('Total Parameters: 50', lines[-2])
 
 
-
-if __name__ == "__main__":
+if __name__ == '__main__':
   absltest.main()

--- a/tests/struct_test.py
+++ b/tests/struct_test.py
@@ -14,16 +14,14 @@
 
 """Tests for flax.struct."""
 
+import dataclasses
 from typing import Any
 
+import jax
 from absl.testing import absltest
-
-import dataclasses
+from jax._src.tree_util import prefix_errors
 
 from flax import struct
-
-import jax
-from jax._src.tree_util import prefix_errors
 
 # Parse absl flags test_srcdir and test_tmpdir.
 jax.config.parse_flags_with_absl()
@@ -37,7 +35,6 @@ class Point:
 
 
 class StructTest(absltest.TestCase):
-
   def test_no_extra_fields(self):
     p = Point(x=1, y=2, meta={})
     with self.assertRaises(dataclasses.FrozenInstanceError):

--- a/tests/tensorboard_test.py
+++ b/tests/tensorboard_test.py
@@ -17,20 +17,21 @@ import itertools
 import pathlib
 import tempfile
 
-from absl.testing import absltest
 import numpy as np
-
-from tensorboard.backend.event_processing import directory_watcher
-from tensorboard.backend.event_processing import event_file_loader
-from tensorboard.util import tensor_util
 import tensorflow as tf
+from absl.testing import absltest
+from tensorboard.backend.event_processing import (
+  directory_watcher,
+  event_file_loader,
+)
+from tensorboard.util import tensor_util
 
 from flax.metrics.tensorboard import SummaryWriter, _flatten_dict
 
 
 def _process_event(event):
   for value in event.summary.value:
-    yield {"wall_time": event.wall_time, "step": event.step, "value": value}
+    yield {'wall_time': event.wall_time, 'step': event.step, 'value': value}
 
 
 def _disk_usage(path: pathlib.Path):
@@ -43,28 +44,27 @@ def _disk_usage(path: pathlib.Path):
       size_bytes += _disk_usage(file)
     return size_bytes
   else:
-    raise NotImplementedError("What filetype is {file}?")
+    raise NotImplementedError('What filetype is {file}?')
 
 
 class TensorboardTest(absltest.TestCase):
-
   def parse_and_return_summary_value(self, path):
     """Parse the event file in the given path and return the
     only summary value."""
     event_value_list = []
     event_file_generator = directory_watcher.DirectoryWatcher(
-        path, event_file_loader.EventFileLoader
+      path, event_file_loader.EventFileLoader
     ).Load()
     event_values = itertools.chain.from_iterable(
-        map(_process_event, event_file_generator)
+      map(_process_event, event_file_generator)
     )
     for value_dict in event_values:
       event_value_list.append(value_dict)
 
     self.assertLen(event_value_list, 1)
-    self.assertEqual(event_value_list[0]["step"], 1)
-    self.assertGreater(event_value_list[0]["wall_time"], 0.0)
-    return event_value_list[0]["value"]
+    self.assertEqual(event_value_list[0]['step'], 1)
+    self.assertGreater(event_value_list[0]['wall_time'], 0.0)
+    return event_value_list[0]['value']
 
   def test_summarywriter_flush_after_close(self):
     log_dir = tempfile.mkdtemp()
@@ -78,27 +78,27 @@ class TensorboardTest(absltest.TestCase):
     summary_writer = SummaryWriter(log_dir=log_dir)
     # Write the scalar and check if the event exists and check data.
     float_value = 99.1232
-    summary_writer.scalar(tag="scalar_test", value=float_value, step=1)
+    summary_writer.scalar(tag='scalar_test', value=float_value, step=1)
 
     summary_value = self.parse_and_return_summary_value(path=log_dir)
-    self.assertEqual(summary_value.tag, "scalar_test")
+    self.assertEqual(summary_value.tag, 'scalar_test')
     self.assertTrue(
-        np.allclose(
-            tensor_util.make_ndarray(summary_value.tensor).item(), float_value
-        )
+      np.allclose(
+        tensor_util.make_ndarray(summary_value.tensor).item(), float_value
+      )
     )
 
   def test_summarywriter_text(self):
     log_dir = tempfile.mkdtemp()
     summary_writer = SummaryWriter(log_dir=log_dir)
-    text = "hello world."
-    summary_writer.text(tag="text_test", textdata=text, step=1)
+    text = 'hello world.'
+    summary_writer.text(tag='text_test', textdata=text, step=1)
 
     summary_value = self.parse_and_return_summary_value(path=log_dir)
-    self.assertEqual(summary_value.tag, "text_test")
+    self.assertEqual(summary_value.tag, 'text_test')
     self.assertEqual(
-        tensor_util.make_ndarray(summary_value.tensor).item().decode("utf-8"),
-        text,
+      tensor_util.make_ndarray(summary_value.tensor).item().decode('utf-8'),
+      text,
     )
 
   def test_summarywriter_image(self):
@@ -106,10 +106,10 @@ class TensorboardTest(absltest.TestCase):
     summary_writer = SummaryWriter(log_dir=log_dir)
     expected_img = np.random.uniform(low=0.0, high=255.0, size=(30, 30, 3))
     expected_img = expected_img.astype(np.uint8)
-    summary_writer.image(tag="image_test", image=expected_img, step=1)
+    summary_writer.image(tag='image_test', image=expected_img, step=1)
     summary_value = self.parse_and_return_summary_value(path=log_dir)
 
-    self.assertEqual(summary_value.tag, "image_test")
+    self.assertEqual(summary_value.tag, 'image_test')
     actual_img = tf.image.decode_image(summary_value.tensor.string_val[2])
     self.assertTrue(np.allclose(actual_img, expected_img))
 
@@ -117,15 +117,15 @@ class TensorboardTest(absltest.TestCase):
     log_dir = tempfile.mkdtemp()
     summary_writer = SummaryWriter(log_dir=log_dir)
     expected_img = np.random.uniform(low=0.0, high=1.0, size=(30, 30, 3))
-    summary_writer.image(tag="image_test", image=expected_img, step=1)
+    summary_writer.image(tag='image_test', image=expected_img, step=1)
     summary_value = self.parse_and_return_summary_value(path=log_dir)
 
     # convert and scale expected_img appropriately to numpy uint8.
     expected_img = tf.image.convert_image_dtype(
-        image=expected_img, dtype=np.uint8
+      image=expected_img, dtype=np.uint8
     )
 
-    self.assertEqual(summary_value.tag, "image_test")
+    self.assertEqual(summary_value.tag, 'image_test')
     actual_img = tf.image.decode_image(summary_value.tensor.string_val[2])
     self.assertTrue(np.allclose(actual_img, expected_img))
 
@@ -134,10 +134,10 @@ class TensorboardTest(absltest.TestCase):
     summary_writer = SummaryWriter(log_dir=log_dir)
     img = np.random.uniform(low=0.0, high=255.0, size=(30, 30))
     img = img.astype(np.uint8)
-    summary_writer.image(tag="2dimage_test", image=img, step=1)
+    summary_writer.image(tag='2dimage_test', image=img, step=1)
     summary_value = self.parse_and_return_summary_value(path=log_dir)
 
-    self.assertEqual(summary_value.tag, "2dimage_test")
+    self.assertEqual(summary_value.tag, '2dimage_test')
     actual_img = tf.image.decode_image(summary_value.tensor.string_val[2])
     # assert the image was increased in dimension
     self.assertEqual(actual_img.shape, (30, 30, 3))
@@ -147,10 +147,10 @@ class TensorboardTest(absltest.TestCase):
     summary_writer = SummaryWriter(log_dir=log_dir)
     img = np.random.uniform(low=0.0, high=255.0, size=(30, 30, 1))
     img = img.astype(np.uint8)
-    summary_writer.image(tag="2dimage_1channel_test", image=img, step=1)
+    summary_writer.image(tag='2dimage_1channel_test', image=img, step=1)
     summary_value = self.parse_and_return_summary_value(path=log_dir)
 
-    self.assertEqual(summary_value.tag, "2dimage_1channel_test")
+    self.assertEqual(summary_value.tag, '2dimage_1channel_test')
     actual_img = tf.image.decode_image(summary_value.tensor.string_val[2])
     # assert the image was increased in dimension
     self.assertEqual(actual_img.shape, (30, 30, 3))
@@ -160,12 +160,12 @@ class TensorboardTest(absltest.TestCase):
     summary_writer = SummaryWriter(log_dir=log_dir)
     expected_img = np.random.uniform(low=0.0, high=255.0, size=(2, 30, 30, 3))
     expected_img = expected_img.astype(np.uint8)
-    summary_writer.image(tag="multiple_images_test", image=expected_img, step=1)
+    summary_writer.image(tag='multiple_images_test', image=expected_img, step=1)
     summary_value = self.parse_and_return_summary_value(path=log_dir)
 
-    self.assertEqual(summary_value.tag, "multiple_images_test")
+    self.assertEqual(summary_value.tag, 'multiple_images_test')
     actual_imgs = [
-        tf.image.decode_image(s) for s in summary_value.tensor.string_val[2:]
+      tf.image.decode_image(s) for s in summary_value.tensor.string_val[2:]
     ]
     self.assertTrue(np.allclose(np.stack(actual_imgs, axis=0), expected_img))
 
@@ -174,12 +174,12 @@ class TensorboardTest(absltest.TestCase):
     summary_writer = SummaryWriter(log_dir=log_dir)
     img = np.random.uniform(low=0.0, high=255.0, size=(2, 30, 30))
     img = img.astype(np.uint8)
-    summary_writer.image(tag="multiple_2dimages_test", image=img, step=1)
+    summary_writer.image(tag='multiple_2dimages_test', image=img, step=1)
     summary_value = self.parse_and_return_summary_value(path=log_dir)
 
-    self.assertEqual(summary_value.tag, "multiple_2dimages_test")
+    self.assertEqual(summary_value.tag, 'multiple_2dimages_test')
     actual_imgs = [
-        tf.image.decode_image(s) for s in summary_value.tensor.string_val[2:]
+      tf.image.decode_image(s) for s in summary_value.tensor.string_val[2:]
     ]
     # assert the images were increased in dimension
     self.assertEqual(np.stack(actual_imgs, axis=0).shape, (2, 30, 30, 3))
@@ -188,48 +188,48 @@ class TensorboardTest(absltest.TestCase):
     log_dir = tempfile.mkdtemp()
     summary_writer = SummaryWriter(log_dir=log_dir)
     expected_audio_samples = np.random.uniform(
-        low=-1.0, high=1.0, size=(2, 48000, 2)
+      low=-1.0, high=1.0, size=(2, 48000, 2)
     )
     summary_writer.audio(
-        tag="audio_test", audiodata=expected_audio_samples, step=1
+      tag='audio_test', audiodata=expected_audio_samples, step=1
     )
 
     summary_value = self.parse_and_return_summary_value(path=log_dir)
-    self.assertEqual(summary_value.tag, "audio_test")
+    self.assertEqual(summary_value.tag, 'audio_test')
 
     # Assert two audio files are parsed.
     self.assertLen(summary_value.tensor.string_val, 2)
 
     # Assert values.
     actual_audio_1 = tf.audio.decode_wav(
-        summary_value.tensor.string_val[0]
+      summary_value.tensor.string_val[0]
     ).audio
     self.assertTrue(
-        np.allclose(expected_audio_samples[0], actual_audio_1, atol=1e-04)
+      np.allclose(expected_audio_samples[0], actual_audio_1, atol=1e-04)
     )
 
     actual_audio_2 = tf.audio.decode_wav(
-        summary_value.tensor.string_val[1]
+      summary_value.tensor.string_val[1]
     ).audio
     self.assertTrue(
-        np.allclose(expected_audio_samples[1], actual_audio_2, atol=1e-04)
+      np.allclose(expected_audio_samples[1], actual_audio_2, atol=1e-04)
     )
 
   def test_summarywriter_audio_sampled_output(self):
     log_dir = tempfile.mkdtemp()
     summary_writer = SummaryWriter(log_dir=log_dir)
     expected_audio_samples = np.random.uniform(
-        low=-1.0, high=1.0, size=(2, 48000, 2)
+      low=-1.0, high=1.0, size=(2, 48000, 2)
     )
     summary_writer.audio(
-        tag="audio_test",
-        audiodata=expected_audio_samples,
-        step=1,
-        max_outputs=1,
+      tag='audio_test',
+      audiodata=expected_audio_samples,
+      step=1,
+      max_outputs=1,
     )
 
     summary_value = self.parse_and_return_summary_value(path=log_dir)
-    self.assertEqual(summary_value.tag, "audio_test")
+    self.assertEqual(summary_value.tag, 'audio_test')
 
     # Assert only the first audio clip is available.
     self.assertLen(summary_value.tensor.string_val, 1)
@@ -238,24 +238,24 @@ class TensorboardTest(absltest.TestCase):
     actual_audio = tf.audio.decode_wav(summary_value.tensor.string_val[0]).audio
 
     self.assertTrue(
-        np.allclose(expected_audio_samples[0], actual_audio, atol=1e-04)
+      np.allclose(expected_audio_samples[0], actual_audio, atol=1e-04)
     )
 
   def test_summarywriter_clipped_audio(self):
     log_dir = tempfile.mkdtemp()
     summary_writer = SummaryWriter(log_dir=log_dir)
     expected_audio_samples = np.random.uniform(
-        low=-2.0, high=2.0, size=(2, 48000, 2)
+      low=-2.0, high=2.0, size=(2, 48000, 2)
     )
     summary_writer.audio(
-        tag="audio_test",
-        audiodata=expected_audio_samples,
-        step=1,
-        max_outputs=1,
+      tag='audio_test',
+      audiodata=expected_audio_samples,
+      step=1,
+      max_outputs=1,
     )
 
     summary_value = self.parse_and_return_summary_value(path=log_dir)
-    self.assertEqual(summary_value.tag, "audio_test")
+    self.assertEqual(summary_value.tag, 'audio_test')
 
     # Assert one audio files is parsed.
     self.assertLen(summary_value.tensor.string_val, 1)
@@ -263,7 +263,7 @@ class TensorboardTest(absltest.TestCase):
     # actual_audio is clipped.
     actual_audio = tf.audio.decode_wav(summary_value.tensor.string_val[0]).audio
     self.assertFalse(
-        np.allclose(expected_audio_samples[0], actual_audio, atol=1e-04)
+      np.allclose(expected_audio_samples[0], actual_audio, atol=1e-04)
     )
 
     clipped_audio = np.clip(np.array(expected_audio_samples[0]), -1, 1)
@@ -274,14 +274,14 @@ class TensorboardTest(absltest.TestCase):
     summary_writer = SummaryWriter(log_dir=log_dir)
     histogram = np.arange(1000)
     # Histogram will be created for 30 (default) bins.
-    summary_writer.histogram(tag="histogram_test", values=histogram, step=1)
+    summary_writer.histogram(tag='histogram_test', values=histogram, step=1)
 
     summary_value = self.parse_and_return_summary_value(path=log_dir)
-    self.assertEqual(summary_value.tag, "histogram_test")
+    self.assertEqual(summary_value.tag, 'histogram_test')
     actual_histogram = tensor_util.make_ndarray(summary_value.tensor)
     self.assertTrue(actual_histogram.shape, (30, 3))
     self.assertTrue(
-        np.allclose(actual_histogram[0], (0.0, 33.3, 34.0), atol=1e-01)
+      np.allclose(actual_histogram[0], (0.0, 33.3, 34.0), atol=1e-01)
     )
 
   def test_summarywriter_histogram_2bins(self):
@@ -289,89 +289,89 @@ class TensorboardTest(absltest.TestCase):
     summary_writer = SummaryWriter(log_dir=log_dir)
     histogram = np.arange(1000)
     summary_writer.histogram(
-        tag="histogram_test", values=histogram, step=1, bins=2
+      tag='histogram_test', values=histogram, step=1, bins=2
     )
 
     summary_value = self.parse_and_return_summary_value(path=log_dir)
-    self.assertEqual(summary_value.tag, "histogram_test")
+    self.assertEqual(summary_value.tag, 'histogram_test')
     actual_histogram = tensor_util.make_ndarray(summary_value.tensor)
     self.assertTrue(actual_histogram.shape, (2, 3))
     self.assertTrue(
-        np.allclose(actual_histogram[0], (0.0, 499.5, 500.0), atol=1e-01)
+      np.allclose(actual_histogram[0], (0.0, 499.5, 500.0), atol=1e-01)
     )
     self.assertTrue(
-        np.allclose(actual_histogram[1], (499.5, 999.0, 500.0), atol=1e-01)
+      np.allclose(actual_histogram[1], (499.5, 999.0, 500.0), atol=1e-01)
     )
 
   def test_flatten_dict(self):
     # Valid types according to https://github.com/tensorflow/tensorboard/blob/1204566da5437af55109f7a4af18f9f8b7c4f864/tensorboard/plugins/hparams/summary_v2.py
     input_hparams = {
-        # Example Invalid Types
-        "None": None,
-        "List": [1, 2, 3],
-        "Tuple": (1, 2, 3),
-        "Complex": complex("1+1j"),
-        "np.complex_": np.complex_("1+1j"),
-        # Valid Python Types
-        "Bool": True,
-        "Int": 1,
-        "Float": 1.0,
-        "Str": "test",
-        # Valid Numpy Types
-        "np.bool_": np.bool_(1),
-        "np.integer": np.int_(1),
-        "np.floating": np.float_(1.0),
-        "np.character": np.str_("test"),
-        # Nested dict to flatten
-        "Nested_Dict": {
-            "None": None,
-            "List": [1, 2, 3],
-            "Tuple": (1, 2, 3),
-            "Complex": complex("1+1j"),
-            "np.complex_": np.complex_("1+1j"),
-            "Bool": True,
-            "Int": 1,
-            "Float": 1.0,
-            "Str": "test",
-            "np.bool_": np.bool_(1),
-            "np.integer": np.int_(1),
-            "np.floating": np.float_(1.0),
-            "np.character": np.str_("test"),
-        },
+      # Example Invalid Types
+      'None': None,
+      'List': [1, 2, 3],
+      'Tuple': (1, 2, 3),
+      'Complex': complex('1+1j'),
+      'np.complex_': np.complex_('1+1j'),
+      # Valid Python Types
+      'Bool': True,
+      'Int': 1,
+      'Float': 1.0,
+      'Str': 'test',
+      # Valid Numpy Types
+      'np.bool_': np.bool_(1),
+      'np.integer': np.int_(1),
+      'np.floating': np.float_(1.0),
+      'np.character': np.str_('test'),
+      # Nested dict to flatten
+      'Nested_Dict': {
+        'None': None,
+        'List': [1, 2, 3],
+        'Tuple': (1, 2, 3),
+        'Complex': complex('1+1j'),
+        'np.complex_': np.complex_('1+1j'),
+        'Bool': True,
+        'Int': 1,
+        'Float': 1.0,
+        'Str': 'test',
+        'np.bool_': np.bool_(1),
+        'np.integer': np.int_(1),
+        'np.floating': np.float_(1.0),
+        'np.character': np.str_('test'),
+      },
     }
 
     result_hparams = _flatten_dict(input_hparams)
 
     expected_hparams = {
-        "None": "None",
-        "List": "[1, 2, 3]",
-        "Tuple": "(1, 2, 3)",
-        "Complex": "(1+1j)",
-        "np.complex_": "(1+1j)",
-        # Valid Python Types
-        "Bool": True,
-        "Int": 1,
-        "Float": 1.0,
-        "Str": "test",
-        # Valid Numpy Types
-        "np.bool_": np.bool_(1),
-        "np.integer": np.int_(1),
-        "np.floating": np.float_(1.0),
-        "np.character": np.str_("test"),
-        # Nested Dict
-        "Nested_Dict.None": "None",
-        "Nested_Dict.List": "[1, 2, 3]",
-        "Nested_Dict.Tuple": "(1, 2, 3)",
-        "Nested_Dict.Complex": "(1+1j)",
-        "Nested_Dict.np.complex_": "(1+1j)",
-        "Nested_Dict.Bool": True,
-        "Nested_Dict.Int": 1,
-        "Nested_Dict.Float": 1.0,
-        "Nested_Dict.Str": "test",
-        "Nested_Dict.np.bool_": np.bool_(1),
-        "Nested_Dict.np.integer": np.int_(1),
-        "Nested_Dict.np.floating": np.float_(1.0),
-        "Nested_Dict.np.character": np.str_("test"),
+      'None': 'None',
+      'List': '[1, 2, 3]',
+      'Tuple': '(1, 2, 3)',
+      'Complex': '(1+1j)',
+      'np.complex_': '(1+1j)',
+      # Valid Python Types
+      'Bool': True,
+      'Int': 1,
+      'Float': 1.0,
+      'Str': 'test',
+      # Valid Numpy Types
+      'np.bool_': np.bool_(1),
+      'np.integer': np.int_(1),
+      'np.floating': np.float_(1.0),
+      'np.character': np.str_('test'),
+      # Nested Dict
+      'Nested_Dict.None': 'None',
+      'Nested_Dict.List': '[1, 2, 3]',
+      'Nested_Dict.Tuple': '(1, 2, 3)',
+      'Nested_Dict.Complex': '(1+1j)',
+      'Nested_Dict.np.complex_': '(1+1j)',
+      'Nested_Dict.Bool': True,
+      'Nested_Dict.Int': 1,
+      'Nested_Dict.Float': 1.0,
+      'Nested_Dict.Str': 'test',
+      'Nested_Dict.np.bool_': np.bool_(1),
+      'Nested_Dict.np.integer': np.int_(1),
+      'Nested_Dict.np.floating': np.float_(1.0),
+      'Nested_Dict.np.character': np.str_('test'),
     }
 
     self.assertDictEqual(result_hparams, expected_hparams)
@@ -379,7 +379,7 @@ class TensorboardTest(absltest.TestCase):
   def test_auto_flush(self):
     tmp_dir = pathlib.Path(self.create_tempdir().full_path)
     summary_writer = SummaryWriter(tmp_dir, auto_flush=True)
-    summary_writer.scalar("metric", 123, 1)
+    summary_writer.scalar('metric', 123, 1)
     filesize_before_flush = _disk_usage(tmp_dir)
     summary_writer.flush()
     filesize_after_flush = _disk_usage(tmp_dir)
@@ -388,12 +388,12 @@ class TensorboardTest(absltest.TestCase):
   def test_no_auto_flush(self):
     tmp_dir = pathlib.Path(self.create_tempdir().full_path)
     summary_writer = SummaryWriter(tmp_dir, auto_flush=False)
-    summary_writer.scalar("metric", 123, 1)
+    summary_writer.scalar('metric', 123, 1)
     filesize_before_flush = _disk_usage(tmp_dir)
     summary_writer.flush()
     filesize_after_flush = _disk_usage(tmp_dir)
     self.assertLess(filesize_before_flush, filesize_after_flush)
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
   absltest.main()

--- a/tests/traceback_util_test.py
+++ b/tests/traceback_util_test.py
@@ -15,16 +15,17 @@
 """Tests for flax.traceback_util."""
 
 import contextlib
-import traceback
 import sys
-from absl.testing import absltest
+import traceback
+
 import jax
+from absl.testing import absltest
 from jax import numpy as jnp
 from jax import random
 from jax._src import traceback_util as jax_traceback_util
+
 from flax import linen as nn
 from flax import traceback_util
-
 
 # pylint: disable=arguments-differ,protected-access, g-wrong-blank-lines
 
@@ -35,15 +36,14 @@ EXPECTED_FILES = (__file__, contextlib.__spec__.origin)
 
 
 class TracebackTest(absltest.TestCase):
-
   def test_exclusion_list(self):
     traceback_util.show_flax_in_tracebacks()
     exclusion_len_wo_flax = len(jax_traceback_util._exclude_paths)
     traceback_util.hide_flax_in_tracebacks()
     exclusion_len_w_flax = len(jax_traceback_util._exclude_paths)
     self.assertLen(
-        traceback_util._flax_exclusions,
-        exclusion_len_w_flax - exclusion_len_wo_flax,
+      traceback_util._flax_exclusions,
+      exclusion_len_w_flax - exclusion_len_wo_flax,
     )
 
   def test_simple_exclusion_tracebackhide(self):
@@ -51,14 +51,12 @@ class TracebackTest(absltest.TestCase):
       return
 
     class Test1(nn.Module):
-
       @nn.remat
       @nn.compact
       def __call__(self, x):
         return Test2()(x)
 
     class Test2(nn.Module):
-
       @nn.jit
       @nn.compact
       def __call__(self, x):
@@ -88,14 +86,12 @@ class TracebackTest(absltest.TestCase):
 
   def test_simple_exclusion_remove_frames(self):
     class Test1(nn.Module):
-
       @nn.remat
       @nn.compact
       def __call__(self, x):
         return Test2()(x)
 
     class Test2(nn.Module):
-
       @nn.jit
       @nn.compact
       def __call__(self, x):
@@ -131,14 +127,12 @@ class TracebackTest(absltest.TestCase):
       return
 
     class Test1(nn.Module):
-
       @nn.remat
       @nn.compact
       def __call__(self, x):
         return Test2()(x)
 
     class Test2(nn.Module):
-
       @nn.jit
       @nn.compact
       def __call__(self, x):
@@ -194,12 +188,12 @@ class TracebackTest(absltest.TestCase):
         filtered_frames_w_flax += 1
 
     self.assertEqual(
-        unfiltered_frames_all + filtered_frames_all,
-        unfiltered_frames_w_flax + filtered_frames_w_flax,
+      unfiltered_frames_all + filtered_frames_all,
+      unfiltered_frames_w_flax + filtered_frames_w_flax,
     )
     self.assertEqual(
-        unfiltered_frames_all + filtered_frames_all,
-        unfiltered_frames_no_flax + filtered_frames_no_flax,
+      unfiltered_frames_all + filtered_frames_all,
+      unfiltered_frames_no_flax + filtered_frames_no_flax,
     )
     self.assertEqual(unfiltered_frames_no_flax, 3)
     self.assertGreater(unfiltered_frames_all, unfiltered_frames_w_flax)

--- a/tests/traverse_util_test.py
+++ b/tests/traverse_util_test.py
@@ -16,21 +16,22 @@
 
 
 import collections
-from absl.testing import absltest
-import numpy as np
-import optax
-import flax
-from flax.core import freeze
-from flax import traverse_util
+
 import jax
 import jax.numpy as jnp
+import numpy as np
+import optax
+from absl.testing import absltest
+
+import flax
+from flax import traverse_util
+from flax.core import freeze
 
 # Parse absl flags test_srcdir and test_tmpdir.
 jax.config.parse_flags_with_absl()
 
 
 class Foo(object):
-
   def __init__(self, foo, bar=None):
     self.foo = foo
     self.bar = bar
@@ -43,7 +44,6 @@ Point = collections.namedtuple('Point', ['x', 'y'])
 
 
 class TraversalTest(absltest.TestCase):
-
   def test_traversal_id(self):
     x = 1
     traversal = traverse_util.t_identity
@@ -104,7 +104,7 @@ class TraversalTest(absltest.TestCase):
     x = [{'foo': 1, 'bar': 2}, {'foo': 3, 'bar': 4}]
     traversal_base = traverse_util.t_identity.each()
     traversal = traversal_base.merge(
-        traverse_util.TraverseItem('foo'), traverse_util.TraverseItem('bar')
+      traverse_util.TraverseItem('foo'), traverse_util.TraverseItem('bar')
     )
     self.assertEqual(list(traversal.iterate(x)), [1, 2, 3, 4])
     y = traversal.update(lambda x: x + x, x)
@@ -152,42 +152,44 @@ class TraversalTest(absltest.TestCase):
     xs = {'foo': 1, 'bar': {'a': 2, 'b': {}}}
     flat_xs = traverse_util.flatten_dict(xs)
     self.assertEqual(
-        flat_xs,
-        {
-            ('foo',): 1,
-            ('bar', 'a'): 2,
-        },
+      flat_xs,
+      {
+        ('foo',): 1,
+        ('bar', 'a'): 2,
+      },
     )
     flat_xs = traverse_util.flatten_dict(freeze(xs))
     self.assertEqual(
-        flat_xs,
-        {
-            ('foo',): 1,
-            ('bar', 'a'): 2,
-        },
+      flat_xs,
+      {
+        ('foo',): 1,
+        ('bar', 'a'): 2,
+      },
     )
     flat_xs = traverse_util.flatten_dict(xs, sep='/')
     self.assertEqual(
-        flat_xs,
-        {
-            'foo': 1,
-            'bar/a': 2,
-        },
+      flat_xs,
+      {
+        'foo': 1,
+        'bar/a': 2,
+      },
     )
 
   def test_unflatten_dict(self):
     expected_xs = {'foo': 1, 'bar': {'a': 2}}
-    xs = traverse_util.unflatten_dict({
+    xs = traverse_util.unflatten_dict(
+      {
         ('foo',): 1,
         ('bar', 'a'): 2,
-    })
+      }
+    )
     self.assertEqual(xs, expected_xs)
     xs = traverse_util.unflatten_dict(
-        {
-            'foo': 1,
-            'bar/a': 2,
-        },
-        sep='/',
+      {
+        'foo': 1,
+        'bar/a': 2,
+      },
+      sep='/',
     )
     self.assertEqual(xs, expected_xs)
 
@@ -195,12 +197,12 @@ class TraversalTest(absltest.TestCase):
     xs = {'foo': 1, 'bar': {'a': 2, 'b': {}}}
     flat_xs = traverse_util.flatten_dict(xs, keep_empty_nodes=True)
     self.assertEqual(
-        flat_xs,
-        {
-            ('foo',): 1,
-            ('bar', 'a'): 2,
-            ('bar', 'b'): traverse_util.empty_node,
-        },
+      flat_xs,
+      {
+        ('foo',): 1,
+        ('bar', 'a'): 2,
+        ('bar', 'b'): traverse_util.empty_node,
+      },
     )
     xs_restore = traverse_util.unflatten_dict(flat_xs)
     self.assertEqual(xs, xs_restore)
@@ -208,21 +210,20 @@ class TraversalTest(absltest.TestCase):
   def test_flatten_dict_is_leaf(self):
     xs = {'foo': {'c': 4}, 'bar': {'a': 2, 'b': {}}}
     flat_xs = traverse_util.flatten_dict(
-        xs, is_leaf=lambda k, x: len(k) == 1 and len(x) == 2
+      xs, is_leaf=lambda k, x: len(k) == 1 and len(x) == 2
     )
     self.assertEqual(
-        flat_xs,
-        {
-            ('foo', 'c'): 4,
-            ('bar',): {'a': 2, 'b': {}},
-        },
+      flat_xs,
+      {
+        ('foo', 'c'): 4,
+        ('bar',): {'a': 2, 'b': {}},
+      },
     )
     xs_restore = traverse_util.unflatten_dict(flat_xs)
     self.assertEqual(xs, xs_restore)
 
 
 class ModelParamTraversalTest(absltest.TestCase):
-
   def test_only_works_on_model_params(self):
     traversal = traverse_util.ModelParamTraversal(lambda *_: True)
     with self.assertRaises(ValueError):
@@ -230,26 +231,26 @@ class ModelParamTraversalTest(absltest.TestCase):
 
   def test_param_selection(self):
     params = {
-        'x': {
-            'kernel': 1,
-            'bias': 2,
-            'y': {
-                'kernel': 3,
-                'bias': 4,
-            },
-            'z': {},
+      'x': {
+        'kernel': 1,
+        'bias': 2,
+        'y': {
+          'kernel': 3,
+          'bias': 4,
         },
+        'z': {},
+      },
     }
     expected_params = {
-        'x': {
-            'kernel': 2,
-            'bias': 2,
-            'y': {
-                'kernel': 6,
-                'bias': 4,
-            },
-            'z': {},
+      'x': {
+        'kernel': 2,
+        'bias': 2,
+        'y': {
+          'kernel': 6,
+          'bias': 4,
         },
+        'z': {},
+      },
     }
     names = []
 
@@ -261,13 +262,13 @@ class ModelParamTraversalTest(absltest.TestCase):
 
     values = list(traversal.iterate(params))
     configs = [
-        (params, expected_params),
-        (flax.core.FrozenDict(params), flax.core.FrozenDict(expected_params)),
+      (params, expected_params),
+      (flax.core.FrozenDict(params), flax.core.FrozenDict(expected_params)),
     ]
     for model, expected_model in configs:
       self.assertEqual(values, [1, 3])
       self.assertEqual(
-          set(names), set(['/x/kernel', '/x/bias', '/x/y/kernel', '/x/y/bias'])
+        set(names), set(['/x/kernel', '/x/bias', '/x/y/kernel', '/x/y/bias'])
       )
       new_model = traversal.update(lambda x: x + x, model)
       self.assertEqual(new_model, expected_model)
@@ -275,50 +276,50 @@ class ModelParamTraversalTest(absltest.TestCase):
   def test_path_value(self):
     params_in = {'a': {'b': 10, 'c': 2}}
     params_out = traverse_util.path_aware_map(
-        lambda path, x: x + 1 if 'b' in path else -x, params_in
+      lambda path, x: x + 1 if 'b' in path else -x, params_in
     )
 
     self.assertEqual(params_out, {'a': {'b': 11, 'c': -2}})
 
   def test_path_aware_map_with_multi_transform(self):
     params = {
-        'linear_1': {'w': jnp.zeros((5, 6)), 'b': jnp.zeros(5)},
-        'linear_2': {'w': jnp.zeros((6, 1)), 'b': jnp.zeros(1)},
+      'linear_1': {'w': jnp.zeros((5, 6)), 'b': jnp.zeros(5)},
+      'linear_2': {'w': jnp.zeros((6, 1)), 'b': jnp.zeros(1)},
     }
     gradients = jax.tree_util.tree_map(jnp.ones_like, params)  # dummy gradients
 
     param_labels = traverse_util.path_aware_map(
-        lambda path, x: 'kernel' if 'w' in path else 'bias', params
+      lambda path, x: 'kernel' if 'w' in path else 'bias', params
     )
     tx = optax.multi_transform(
-        {'kernel': optax.sgd(1.0), 'bias': optax.set_to_zero()}, param_labels
+      {'kernel': optax.sgd(1.0), 'bias': optax.set_to_zero()}, param_labels
     )
     state = tx.init(params)
     updates, new_state = tx.update(gradients, state, params)
     new_params = optax.apply_updates(params, updates)
 
     self.assertTrue(
-        np.allclose(new_params['linear_1']['b'], params['linear_1']['b'])
+      np.allclose(new_params['linear_1']['b'], params['linear_1']['b'])
     )
     self.assertTrue(
-        np.allclose(new_params['linear_2']['b'], params['linear_2']['b'])
+      np.allclose(new_params['linear_2']['b'], params['linear_2']['b'])
     )
     self.assertFalse(
-        np.allclose(new_params['linear_1']['w'], params['linear_1']['w'])
+      np.allclose(new_params['linear_1']['w'], params['linear_1']['w'])
     )
     self.assertFalse(
-        np.allclose(new_params['linear_2']['w'], params['linear_2']['w'])
+      np.allclose(new_params['linear_2']['w'], params['linear_2']['w'])
     )
 
   def test_path_aware_map_with_masked(self):
     params = {
-        'linear_1': {'w': jnp.zeros((5, 6)), 'b': jnp.zeros(5)},
-        'linear_2': {'w': jnp.zeros((6, 1)), 'b': jnp.zeros(1)},
+      'linear_1': {'w': jnp.zeros((5, 6)), 'b': jnp.zeros(5)},
+      'linear_2': {'w': jnp.zeros((6, 1)), 'b': jnp.zeros(1)},
     }
     gradients = jax.tree_util.tree_map(jnp.ones_like, params)  # dummy gradients
 
     params_mask = traverse_util.path_aware_map(
-        lambda path, x: 'w' in path, params
+      lambda path, x: 'w' in path, params
     )
     tx = optax.masked(optax.sgd(1.0), params_mask)
     state = tx.init(params)
@@ -326,22 +327,22 @@ class ModelParamTraversalTest(absltest.TestCase):
     new_params = optax.apply_updates(params, updates)
 
     self.assertTrue(
-        np.allclose(new_params['linear_1']['b'], gradients['linear_1']['b'])
+      np.allclose(new_params['linear_1']['b'], gradients['linear_1']['b'])
     )
     self.assertTrue(
-        np.allclose(new_params['linear_2']['b'], gradients['linear_2']['b'])
+      np.allclose(new_params['linear_2']['b'], gradients['linear_2']['b'])
     )
     self.assertTrue(
-        np.allclose(new_params['linear_1']['w'], -gradients['linear_1']['w'])
+      np.allclose(new_params['linear_1']['w'], -gradients['linear_1']['w'])
     )
     self.assertTrue(
-        np.allclose(new_params['linear_2']['w'], -gradients['linear_2']['w'])
+      np.allclose(new_params['linear_2']['w'], -gradients['linear_2']['w'])
     )
 
   def test_path_aware_map_with_empty_nodes(self):
     params_in = {'a': {'b': 10, 'c': 2}, 'b': {}}
     params_out = traverse_util.path_aware_map(
-        lambda path, x: x + 1 if 'b' in path else -x, params_in
+      lambda path, x: x + 1 if 'b' in path else -x, params_in
     )
 
     self.assertEqual(params_out, {'a': {'b': 11, 'c': -2}, 'b': {}})


### PR DESCRIPTION
Added a [rule](https://github.com/google/flax/pull/3455/files#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R189) to the ruff pre-commit hook that sort imports. 
Added `examples/` as an [exclusion](https://github.com/google/flax/pull/3455/files#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R181) of fixable files for ruff, since sorting imports caused a [seg fault](https://github.com/google/flax/pull/3442).
See a full list of ruff rules [here](https://docs.astral.sh/ruff/rules/#isort-i).

Added [formatting rules](https://github.com/google/flax/pull/3455/files#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R184-R198) to ruff.
Modified [`.pre-commit-config.yaml`](https://github.com/google/flax/pull/3455/files#diff-63a9c44a44acf85fea213a857769990937107cf072831e1a26808cfde9d096b9R38-R45) so that both the linter and formatter auto-fix the code when you run `pre-commit run --all-files`. To manually run the ruff linter and formatter, run `ruff check . --fix` and `ruff format .`, respectively.