### PR TITLE
Add user-friendly module copy method.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,8 @@ vNext
 -
 -
 -
--
--
+- Add copy() method to Module.  This is a user-friendly version of the internal clone() method with better
+  defaults for common use cases.
 -
 -
 -

--- a/docs/api_reference/flax.linen/module.rst
+++ b/docs/api_reference/flax.linen/module.rst
@@ -5,4 +5,4 @@ Module
 .. currentmodule:: flax.linen
 
 .. autoclass:: Module
-   :members: setup, variable, param, bind, unbind, apply, init, init_with_output, make_rng, sow, variables, Variable, __setattr__, tabulate, is_initializing, perturb
+   :members: setup, variable, param, bind, unbind, apply, init, init_with_output, copy, make_rng, sow, variables, Variable, __setattr__, tabulate, is_initializing, perturb

--- a/flax/linen/module.py
+++ b/flax/linen/module.py
@@ -1434,12 +1434,16 @@ class Module(ModuleBase):
   def clone(
     self: M,
     *,
-    parent: Optional[Union[Scope, 'Module']] = None,
+    parent: Optional[Union[Scope, 'Module', _Sentinel]] = None,
     _deep_clone: Union[bool, weakref.WeakValueDictionary] = False,
     _reset_names: bool = False,
     **updates,
   ) -> M:
     """Creates a clone of this Module, with optionally updated arguments.
+
+    NOTE: end users are encouraged to use the `copy` method.  `clone` is used
+      primarily for internal routines, and `copy` offers simpler arguments and
+      better defaults.
 
     Args:
       parent: The parent of the clone. The clone will have no parent if no
@@ -1502,6 +1506,29 @@ class Module(ModuleBase):
     module = self.__class__(**attrs)
 
     return module
+
+  def copy(
+    self: M,
+    *,
+    parent: Optional[Union[Scope, 'Module', _Sentinel]] = _unspecified_parent,
+    name: Optional[str] = None,
+    **updates,
+  ) -> M:
+    """Creates a copy of this Module, with optionally updated arguments.
+
+    Args:
+      parent: The parent of the copy.  By default the current module is taken
+        as parent if not explicitly specified.
+      name: A new name for the copied Module, by default a new automatic name
+        will be given.
+      **updates: Attribute updates.
+
+    Returns:
+      A copy of the this Module with the updated name, parent, and attributes.
+    """
+    return self.clone(
+      parent=parent, name=name, _deep_clone=True, _reset_names=False, **updates
+    )
 
   @overload
   def variable(


### PR DESCRIPTION
This provides a version of the `Module.clone()` method with simpler arguments and better defaults for allowing copying of modules and the use of existing modules as "templates".  By default `copy` resets `parent` and `name` attributes of the given module, but effectively performs a deep copy of everything "inside".