### PR TITLE
fix bug in optimizer-api.md

### DIFF
--- a/docs/flip/1009-optimizer-api.md
+++ b/docs/flip/1009-optimizer-api.md
@@ -105,7 +105,7 @@ def train_step(opt_state, variables, inputs, labels, apply_fn, tx_update_fn):
       params)
   updates, new_opt_state = tx_update_fn(grads, opt_state, params)
   new_params = optax.apply_updates(params, updates)
-  new_variables = {**variables, **new_model_state, 'params': params}
+  new_variables = {**variables, **new_model_state, 'params': new_params}
   return new_opt_state, new_variables, loss
 
 


### PR DESCRIPTION

Fix a small bug in the file 1009-optimizer-api.md, where the new variables after updating should be the dict including new_params, not params.

Fixes # (issue)

## Checklist
- [x] This PR fixes a minor issue (e.g.: typo or small bug) or improves the docs (you can dismiss the other
      checks if that's the case).
- [ ] This change is discussed in a Github issue/
      [discussion](https://github.com/google/flax/discussions) (please add a
      link).
- [ ] The documentation and docstrings adhere to the
      [documentation guidelines](https://github.com/google/flax/blob/main/docs/README.md#how-to-write-code-documentation).
- [ ] This change includes necessary high-coverage tests.
      (No quality testing = no merge!)
