### PR TITLE
Add simple argument-only lifted nn.grad function.

### DIFF
--- a/docs/api_reference/flax.linen/transformations.rst
+++ b/docs/api_reference/flax.linen/transformations.rst
@@ -28,6 +28,8 @@ Transformations
   map_variables
   jvp
   vjp
+  grad
+  value_and_grad
   custom_vjp
   while_loop
   cond

--- a/flax/linen/__init__.py
+++ b/flax/linen/__init__.py
@@ -144,6 +144,8 @@ from .transforms import (
     scan as scan,
     switch as switch,
     vjp as vjp,
+    grad as grad,
+    value_and_grad as value_and_grad,
     vmap as vmap,
     while_loop as while_loop,
 )


### PR DESCRIPTION
This function only peforms a lifted value-and-grad operation with respect to the arguments of a function, and does not try to calculate gradients with respect to any variables.  This mirrors the behavior of the haiku grad function, and also easily works in the multi-scope setting (external modules passed in) while avoiding the complexities associated with that case for a more general vjp.
