### PR TITLE
remove SelfAttention test and warning filter

### DIFF
--- a/examples/lm1b/models.py
+++ b/examples/lm1b/models.py
@@ -243,7 +243,7 @@ class EncoderDecoder1DBlock(nn.Module):
             nn.initializers.ones, ('embed',)
         ),
     )(inputs)
-    x = nn.SelfAttention(
+    x = nn.MultiHeadDotProductAttention(
         num_heads=config.num_heads,
         dtype=config.dtype,
         qkv_features=config.qkv_dim,
@@ -256,7 +256,7 @@ class EncoderDecoder1DBlock(nn.Module):
         dropout_rate=config.attention_dropout_rate,
         deterministic=config.deterministic,
         decode=config.decode,
-    )(x, decoder_mask)
+    )(x, mask=decoder_mask)
     x = nn.Dropout(rate=config.dropout_rate)(
         x, deterministic=config.deterministic
     )

--- a/examples/nlp_seq/models.py
+++ b/examples/nlp_seq/models.py
@@ -173,7 +173,7 @@ class Encoder1DBlock(nn.Module):
     # Attention block.
     assert inputs.ndim == 3
     x = nn.LayerNorm(dtype=config.dtype)(inputs)
-    x = nn.SelfAttention(
+    x = nn.MultiHeadDotProductAttention(
         num_heads=config.num_heads,
         dtype=config.dtype,
         qkv_features=config.qkv_dim,

--- a/examples/wmt/models.py
+++ b/examples/wmt/models.py
@@ -217,7 +217,7 @@ class Encoder1DBlock(nn.Module):
     # Attention block.
     assert inputs.ndim == 3
     x = nn.LayerNorm(dtype=config.dtype)(inputs)
-    x = nn.SelfAttention(
+    x = nn.MultiHeadDotProductAttention(
         num_heads=config.num_heads,
         dtype=config.dtype,
         qkv_features=config.qkv_dim,
@@ -227,7 +227,7 @@ class Encoder1DBlock(nn.Module):
         broadcast_dropout=False,
         dropout_rate=config.attention_dropout_rate,
         deterministic=config.deterministic,
-    )(x, encoder_mask)
+    )(x, mask=encoder_mask)
 
     x = nn.Dropout(rate=config.dropout_rate)(
         x, deterministic=config.deterministic
@@ -270,7 +270,7 @@ class EncoderDecoder1DBlock(nn.Module):
     # Decoder block.
     assert targets.ndim == 3
     x = nn.LayerNorm(dtype=config.dtype)(targets)
-    x = nn.SelfAttention(
+    x = nn.MultiHeadDotProductAttention(
         num_heads=config.num_heads,
         dtype=config.dtype,
         qkv_features=config.qkv_dim,
@@ -281,7 +281,7 @@ class EncoderDecoder1DBlock(nn.Module):
         dropout_rate=config.attention_dropout_rate,
         deterministic=config.deterministic,
         decode=config.decode,
-    )(x, decoder_mask)
+    )(x, mask=decoder_mask)
     x = nn.Dropout(rate=config.dropout_rate)(
         x, deterministic=config.deterministic
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,8 +122,6 @@ filterwarnings = [
     "ignore:`flax.traverse_util.Traversal` will be deprecated.*:DeprecationWarning",
     # Deprecated legacy checkpoint - just want to keep the tests running for a while
     "ignore:Flax Checkpointing will soon be deprecated in favor of Orbax.*:DeprecationWarning",
-    # DeprecationWarning: SelfAttention will be deprecated soon.
-    "ignore:.*SelfAttention will be deprecated soon.*:DeprecationWarning",
     # DeprecationWarning: The inputs_kv arg will be deprecated soon. Use inputs_k and inputs_v instead.
     "ignore:.*The inputs_kv arg will be deprecated soon. Use inputs_k and inputs_v instead.*:DeprecationWarning",
     # DeprecationWarning: the function signature of MultiHeadDotProductAttention's `__call__` method has changed


### PR DESCRIPTION
Since `SelfAttention` is deprecated, remove `SelfAttention` from tests and remove the deprecation warning filter