### PR TITLE
changed pip installs to use quotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ To install some additional dependencies (like `matplotlib`) that are required bu
 by some dependencies, you can use:
 
 ```bash
-pip install flax[all]
+pip install "flax[all]"
 ```
 
 ## What does Flax look like?

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -58,8 +58,8 @@ To contribute code to Flax on GitHub, follow these steps:
    ```bash
    git clone https://github.com/YOUR_USERNAME/flax
    cd flax
-   pip install -e .[all]
-   pip install -e .[testing]
+   pip install -e ".[all]"
+   pip install -e ".[testing]"
    pip install -r docs/requirements.txt
    ```
 

--- a/docs/guides/training_techniques/transfer_learning.ipynb
+++ b/docs/guides/training_techniques/transfer_learning.ipynb
@@ -46,7 +46,7 @@
    "outputs": [],
    "source": [
     "# Note that the Transformers library doesn't use the latest Flax version.\n",
-    "! pip install -q transformers[flax]\n",
+    "! pip install -q \"transformers[flax]\"\n",
     "# Install/upgrade Flax and JAX. For JAX installation with GPU/TPU support,\n",
     "# visit https://github.com/google/jax#installation.\n",
     "! pip install -U -q flax jax jaxlib"

--- a/docs/guides/training_techniques/transfer_learning.md
+++ b/docs/guides/training_techniques/transfer_learning.md
@@ -36,7 +36,7 @@ Depending on your task, some of the content in this guide may be suboptimal. For
 :tags: [skip-execution]
 
 # Note that the Transformers library doesn't use the latest Flax version.
-! pip install -q transformers[flax]
+! pip install -q "transformers[flax]"
 # Install/upgrade Flax and JAX. For JAX installation with GPU/TPU support,
 # visit https://github.com/google/jax#installation.
 ! pip install -U -q flax jax jaxlib


### PR DESCRIPTION
Resolves #3473.

Change pip installs that have square brackets to use quotes to make them compatible with zsh.