### PR TITLE
disabled ruff formatter

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,5 +41,6 @@ repos:
     # Run the Ruff linter.
     - id: ruff
       args: [--fix, --exit-non-zero-on-fix]
-    # Run the Ruff formatter.
-    - id: ruff-format
+    # Disable Ruff formatter for now
+    # # Run the Ruff formatter.
+    # - id: ruff-format

--- a/docs/api_reference/flax.cursor.rst
+++ b/docs/api_reference/flax.cursor.rst
@@ -6,38 +6,6 @@ The Cursor API allows for mutability of pytrees. This API provides a more
 ergonomic solution to making partial-updates of deeply nested immutable
 data structures, compared to making many nested ``dataclasses.replace`` calls.
 
-Regular::
-  >>> a = 3
-  >>> b = 4
-  >>> a + b
-  >>> a + c
-
-.. doctest::
-  :pyversion: > 3.10
-  >>> a = 3
-  >>> b = 4
-  >>> a + b
-  >>> a + c
-
-.. doctest::
-  >>> a = 3
-  >>> b = 4
-  >>> a + b
-  >>> a + c
-
-.. doctest::
-  :pyversion: > 3.10
-  a = 3
-  b = 4
-  a + b
-  a + c
-
-.. doctest::
-  a = 3
-  b = 4
-  a + b
-  a + c
-
 To illustrate, consider the example below::
 
   from flax.cursor import cursor

--- a/docs/api_reference/flax.cursor.rst
+++ b/docs/api_reference/flax.cursor.rst
@@ -6,6 +6,38 @@ The Cursor API allows for mutability of pytrees. This API provides a more
 ergonomic solution to making partial-updates of deeply nested immutable
 data structures, compared to making many nested ``dataclasses.replace`` calls.
 
+Regular::
+  >>> a = 3
+  >>> b = 4
+  >>> a + b
+  >>> a + c
+
+.. doctest::
+  :pyversion: > 3.10
+  >>> a = 3
+  >>> b = 4
+  >>> a + b
+  >>> a + c
+
+.. doctest::
+  >>> a = 3
+  >>> b = 4
+  >>> a + b
+  >>> a + c
+
+.. doctest::
+  :pyversion: > 3.10
+  a = 3
+  b = 4
+  a + b
+  a + c
+
+.. doctest::
+  a = 3
+  b = 4
+  a + b
+  a + c
+
 To illustrate, consider the example below::
 
   from flax.cursor import cursor


### PR DESCRIPTION
Disabled ruff formatter for now because hanging indent can't be configured separately from regular indent, whereas the internal Google formatter has 4 space hanging indent and 2 space regular indent.

Original PR: #3455
Feature request for `ruff`: https://github.com/astral-sh/ruff/issues/3907