### PR TITLE
Adds GeGLU activation and tests.

### DIFF
--- a/flax/linen/activation.py
+++ b/flax/linen/activation.py
@@ -20,6 +20,7 @@ from typing import Any, Optional
 
 from flax.linen.module import compact
 from flax.linen.module import Module
+from flax.linen.linear import Dense
 
 from jax.nn import celu
 from jax.nn import elu
@@ -99,3 +100,44 @@ class PReLU(Module):
     return jnp.where(
         inputs >= 0, inputs, jnp.asarray(negative_slope, inputs.dtype) * inputs
     )
+
+class GeGLU(Module):
+    """Gated Linear Unit with GELU (GeGLU) activation function.
+
+    GeGLU is a Flax layer that combines a linear transformation with a GELU
+    activation function in a gating mechanism. It is often used in Transformer models
+    to provide non-linear capabilities while preserving a strong linear component.
+
+    Example usage::
+        >>> import flax.linen as nn
+
+        >>> class TransformerBlock(nn.Module):
+        ...   @nn.compact
+        ...   def __call__(self, x):
+        ...     x = nn.Dense(2)(x)
+        ...     x = nn.GeGLU()(x) # initialized
+        ...     return x
+
+    Attributes:
+        features: the number of output features (default: None).
+    """
+    output_dim: int = None
+
+    @compact
+    def __call__(self, inputs: Array) -> Array:
+        """Applies the GeGLU activation to the inputs.
+
+        Args:
+            inputs: the nd-array to apply the GeGLU activation function to.
+
+        Returns:
+            The transformed input.
+        """
+        if self.output_dim is None:
+          output_dim = inputs.shape[-1]
+        else:
+            output_dim = self.output_dim
+
+        x = Dense(output_dim * 2)(inputs)
+        x, gate = x[..., : output_dim], x[..., output_dim :]
+        return x * gelu(gate)

--- a/tests/linen/linen_activation_test.py
+++ b/tests/linen/linen_activation_test.py
@@ -33,6 +33,28 @@ class ActivationTest(parameterized.TestCase):
     y, _ = act.init_with_output(rng, x)
     self.assertEqual(y.shape, x.shape)
 
+  def test_geglu(self):
+    rng = random.key(0)
+    x = jnp.ones((4, 6, 5))
+    act = nn.GeGLU()
+    y, _ = act.init_with_output(rng, x)
+    self.assertEqual(y.shape, x.shape)
+
+  def test_geglu_with_dim_expansion(self):
+    rng = random.key(0)
+    x = jnp.ones((4, 6, 5))
+    act = nn.GeGLU(10)
+    expected_shape = (4, 6, 10)
+    y, _ = act.init_with_output(rng, x)
+    self.assertEqual(y.shape, expected_shape)
+
+  def test_geglu_with_dim_contraction(self):
+    rng = random.key(0)
+    x = jnp.ones((4, 6, 5))
+    act = nn.GeGLU(3)
+    expected_shape = (4, 6, 3)
+    y, _ = act.init_with_output(rng, x)
+    self.assertEqual(y.shape, expected_shape)
 
 if __name__ == '__main__':
   absltest.main()


### PR DESCRIPTION
# What does this PR do?

<!--

This PR adds the GeGLU (Gated Linear Unit with GELU) activation function to the activation module of the Flax library. It is an increasingly popular activation layer which combines a linear transformation with a GELU activation in a gating mechanism, balancing linearity and non-linearity.

GeGLU is parameterised and as such uses Flax's Dense layer and was not part of Jax itself. The implementation allows for an optional output_dim attribute, which can be used to specify the number of output features. This can increase or decrease the -1th dimensions of the results and the code tries to account for that. The tests validate the functionality in three scenarios: standard usage, output dimension expansion, and output dimension contraction, ensuring the layer's reliability in various use cases.
-->

Fixes # (3483)

## Checklist
- [x] This PR adds the GeGLU (Gated Linear Unit with GELU) activation function to the activation module.
- [x] This change is discussed in a Github issue/
      [discussion](https://github.com/google/flax/discussions/3483)
- [x] The documentation and docstrings adhere to the
      [documentation guidelines](https://github.com/google/flax/blob/main/docs/README.md#how-to-write-code-documentation).
- [x] This change includes necessary high-coverage tests.
      (No quality testing = no merge!)
