### PR TITLE
Improved Rigor of `PReLU` Test

### DIFF
--- a/tests/linen/linen_activation_test.py
+++ b/tests/linen/linen_activation_test.py
@@ -18,7 +18,7 @@ import jax
 import jax.numpy as jnp
 from absl.testing import absltest
 from jax import random
-from jax._src.test_util import JaxTestCase
+from numpy.testing import assert_array_almost_equal, assert_array_equal
 
 from flax import linen as nn
 
@@ -26,7 +26,7 @@ from flax import linen as nn
 jax.config.parse_flags_with_absl()
 
 
-class ActivationTest(JaxTestCase):
+class ActivationTest(absltest.TestCase):
   def test_prelu(self):
     rng = random.key(0)
     key, skey_1, skey_2 = jax.random.split(rng, 3)
@@ -38,8 +38,8 @@ class ActivationTest(JaxTestCase):
     expected_negative_slope = jnp.array(act.negative_slope_init, dtype=jnp.float32)
 
     self.assertEqual(y.shape, x.shape)
-    self.assertArraysAllClose(expected_y, y)
-    self.assertArraysEqual(init_negative_slope, expected_negative_slope)
+    assert_array_almost_equal(expected_y, y)
+    assert_array_equal(init_negative_slope, expected_negative_slope)
 
 
 if __name__ == '__main__':

--- a/tests/linen/linen_activation_test.py
+++ b/tests/linen/linen_activation_test.py
@@ -16,8 +16,9 @@
 
 import jax
 import jax.numpy as jnp
-from absl.testing import absltest, parameterized
+from absl.testing import absltest
 from jax import random
+from jax._src.test_util import JaxTestCase
 
 from flax import linen as nn
 
@@ -25,13 +26,20 @@ from flax import linen as nn
 jax.config.parse_flags_with_absl()
 
 
-class ActivationTest(parameterized.TestCase):
+class ActivationTest(JaxTestCase):
   def test_prelu(self):
     rng = random.key(0)
-    x = jnp.ones((4, 6, 5))
+    key, skey_1, skey_2 = jax.random.split(rng, 3)
+    x = jax.random.uniform(skey_1, (4, 6, 5)) - 0.5
     act = nn.PReLU()
-    y, _ = act.init_with_output(rng, x)
+    y, params = act.init_with_output(skey_2, x)
+    expected_y = jnp.where(x < 0, x*act.negative_slope_init, x)
+    init_negative_slope = params['params']['negative_slope']
+    expected_negative_slope = jnp.array(act.negative_slope_init, dtype=jnp.float32)
+
     self.assertEqual(y.shape, x.shape)
+    self.assertArraysAllClose(expected_y, y)
+    self.assertArraysEqual(init_negative_slope, expected_negative_slope)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
# What does this PR do?
Improves the rigor of the existing `PReLU` activation unit test by checking for correctness in produced output, as well as verifying that the correct parameter dictionary is produced upon initialization

Fixes # (issue)

## Checklist
- [ ] This PR fixes a minor issue (e.g.: typo or small bug) or improves the docs (you can dismiss the other
      checks if that's the case).
- [x] This change is discussed in a Github issue/
      [discussion](https://github.com/google/flax/discussions) (please add a
      link).
- [x] The documentation and docstrings adhere to the
      [documentation guidelines](https://github.com/google/flax/blob/main/docs/README.md#how-to-write-code-documentation).
- [x] This change includes necessary high-coverage tests.
      (No quality testing = no merge!)

cc: @chiamp 
