### PR TITLE
[nnx] switch to nested State representation

### DIFF
--- a/flax/experimental/nnx/examples/00_demo.ipynb
+++ b/flax/experimental/nnx/examples/00_demo.ipynb
@@ -2,9 +2,16 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "A Google TPU may be present on this machine, but either a TPU-enabled jaxlib or libtpu is not installed. Falling back to cpu.\n"
+     ]
+    },
     {
      "name": "stdout",
      "output_type": "stream",
@@ -48,7 +55,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [
     {
@@ -56,24 +63,21 @@
      "output_type": "stream",
      "text": [
       "State({\n",
-      "  'b': Param(\n",
-      "    value=Array([0., 0.], dtype=float32)\n",
-      "  ),\n",
-      "  'w': Param(\n",
-      "    value=Array([[0.31696808, 0.55285215],\n",
-      "           [0.31418085, 0.7399571 ]], dtype=float32)\n",
-      "  )\n",
+      "  'w': Array([[0.31696808, 0.55285215],\n",
+      "         [0.31418085, 0.7399571 ]], dtype=float32),\n",
+      "  'b': Array([0., 0.], dtype=float32)\n",
       "})\n",
       "GraphDef(\n",
       "  type=Linear,\n",
       "  index=0,\n",
+      "  subgraphs=(),\n",
       "  static_fields=(('din', 2), ('dout', 2)),\n",
-      "  variables=(('b', Param(\n",
+      "  variables=(('w', Param(\n",
       "      value=Empty\n",
-      "    )), ('w', Param(\n",
+      "    )), ('b', Param(\n",
       "      value=Empty\n",
       "    ))),\n",
-      "  submodules=()\n",
+      "  metadata=<class '__main__.Linear'>\n",
       ")\n"
      ]
     }
@@ -87,7 +91,40 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "State({\n",
+       "  'linear': {\n",
+       "    'w': Array([[0.31696808, 0.55285215],\n",
+       "           [0.31418085, 0.7399571 ]], dtype=float32),\n",
+       "    'b': Array([0., 0.], dtype=float32)\n",
+       "  }\n",
+       "})"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "class Nested(nnx.Module):\n",
+    "    def __init__(self, din: int, dout: int, *, rngs: nnx.Rngs):\n",
+    "        self.linear = Linear(din, dout, rngs=rngs)\n",
+    "    \n",
+    "module = Nested(2, 2, rngs=nnx.Rngs(0))\n",
+    "\n",
+    "state, static = module.split()\n",
+    "state"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
@@ -129,7 +166,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -137,26 +174,23 @@
      "output_type": "stream",
      "text": [
       "State({\n",
-      "  'b': Param(\n",
-      "    value=Array([0., 0.], dtype=float32)\n",
-      "  ),\n",
-      "  'w': Param(\n",
-      "    value=Array([[0.31696808, 0.55285215],\n",
-      "           [0.31418085, 0.7399571 ]], dtype=float32)\n",
-      "  )\n",
+      "  'w': Array([[0.31696808, 0.55285215],\n",
+      "         [0.31418085, 0.7399571 ]], dtype=float32),\n",
+      "  'b': Array([0., 0.], dtype=float32)\n",
       "})\n",
       "GraphDef(\n",
       "  type=Linear,\n",
       "  index=0,\n",
+      "  subgraphs=(\n",
+      "    ('submodule', 0)\n",
+      "  ),\n",
       "  static_fields=(('din', 2), ('dout', 2)),\n",
-      "  variables=(('b', Param(\n",
+      "  variables=(('w', Param(\n",
       "      value=Empty\n",
-      "    )), ('w', Param(\n",
+      "    )), ('b', Param(\n",
       "      value=Empty\n",
       "    ))),\n",
-      "  submodules=(\n",
-      "    ('submodule', 0)\n",
-      "  )\n",
+      "  metadata=<class '__main__.Linear'>\n",
       ")\n"
      ]
     }
@@ -170,7 +204,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -179,7 +213,7 @@
        "True"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -192,7 +226,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -235,7 +269,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
@@ -243,19 +277,14 @@
      "output_type": "stream",
      "text": [
       "State({\n",
-      "  'y': Intermediate(\n",
-      "    value=Array([[0.63114893, 1.2928092 ],\n",
-      "           [0.63114893, 1.2928092 ]], dtype=float32)\n",
-      "  )\n",
+      "  'y': Array([[0.63114893, 1.2928092 ],\n",
+      "         [0.63114893, 1.2928092 ]], dtype=float32)\n",
       "})\n",
       "State({\n",
-      "  'b': Param(\n",
-      "    value=Array([0., 0.], dtype=float32)\n",
-      "  ),\n",
-      "  'w': Param(\n",
-      "    value=Array([[0.31696808, 0.55285215],\n",
-      "           [0.31418085, 0.7399571 ]], dtype=float32)\n",
-      "  )\n",
+      "  'w': Array([[0.31696808, 0.55285215],\n",
+      "         [0.31418085, 0.7399571 ]], dtype=float32),\n",
+      "  'b': Array([0., 0.], dtype=float32),\n",
+      "  'y': Empty\n",
       "})\n"
      ]
     }
@@ -267,6 +296,13 @@
     "print(intermediates)\n",
     "print(state)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -280,7 +316,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.16"
+   "version": "3.9.18"
   }
  },
  "nbformat": 4,

--- a/flax/experimental/nnx/nnx/state.py
+++ b/flax/experimental/nnx/nnx/state.py
@@ -75,7 +75,9 @@ class State(tp.MutableMapping[Key, tp.Any], reprlib.Representable):
   def variables(self) -> dict[Key, dict[str, tp.Any] | tp.Any]:
     return self._mapping
 
-  def __getitem__(self, key: Key) -> Leaf | State:
+  def __getitem__(self, key: Key | int) -> Leaf | State:
+    if isinstance(key, int):
+      key = str(key)
     value = self._mapping[key]
     if isinstance(value, Variable):
       return value.value
@@ -87,7 +89,9 @@ class State(tp.MutableMapping[Key, tp.Any], reprlib.Representable):
 
     return self[key]
 
-  def __setitem__(self, key: Key, value: Leaf | State) -> None:
+  def __setitem__(self, key: Key | int, value: Leaf | State) -> None:
+    if isinstance(key, int):
+      key = str(key)
     if isinstance(value, State):
       self._mapping[key] = value._mapping
     else:

--- a/flax/experimental/nnx/nnx/state.py
+++ b/flax/experimental/nnx/nnx/state.py
@@ -32,6 +32,7 @@ import typing as tp
 import jax
 import jax.tree_util as jtu
 
+from flax import traverse_util
 from flax.experimental.nnx.nnx import filterlib, reprlib
 from flax.experimental.nnx.nnx.variables import Variable
 
@@ -39,37 +40,70 @@ A = tp.TypeVar('A')
 
 Leaf = tp.Any
 Path = str
-StateDict = dict[Path, tp.Any]
-StateMapping = tp.Mapping[Path, tp.Any]
+Key = str
+FlatState = dict[Path, Variable[Leaf]]
 
 
-class State(tp.MutableMapping[Path, Leaf], reprlib.Representable):
-  __slots__ = ('_mapping',)
+class NestedStateRepr(reprlib.Representable):
+  def __init__(self, state: State):
+    self.state = state
 
+  def __nnx_repr__(self):
+    yield reprlib.Object('', value_sep=': ', start='{', end='}')
+
+    for r in self.state.__nnx_repr__():
+      if isinstance(r, reprlib.Object):
+        continue
+      yield r
+
+
+class State(tp.MutableMapping[Key, tp.Any], reprlib.Representable):
   def __init__(
     self,
-    __input: tp.Union[
-      tp.Mapping[Path, Variable[Leaf]],
-      tp.Iterator[tp.Tuple[Path, Variable[Leaf]]],
+    mapping: tp.Union[
+      tp.Mapping[Key, tp.Any],
+      tp.Iterator[tp.Tuple[Key, tp.Any]],
     ],
     /,
   ):
-    self._mapping = dict(__input)
+    if tp.TYPE_CHECKING:
+      self._mapping = dict(mapping)
+    else:
+      super().__setattr__('_mapping', dict(mapping))
 
   @property
-  def variables(self) -> dict[Path, Variable[Leaf]]:
+  def variables(self) -> dict[Key, Variable[Leaf] | dict[str, tp.Any]]:
     return self._mapping
 
-  def __getitem__(self, __key: Path) -> Leaf:
-    return self._mapping[__key].value
+  def __getitem__(self, key: Key) -> Leaf | State:
+    value = self._mapping[key]
+    if isinstance(value, Variable):
+      return value.value
+    return State(value)
 
-  def __setitem__(self, __key: Path, __value: Leaf) -> None:
-    self._mapping[__key] = self._mapping[__key].replace(value=__value)
+  def __getattr__(self, key: Key) -> Leaf | State:
+    if '_mapping' not in vars(self) or key not in self._mapping:
+      raise AttributeError(f'No attribute {key} in State')
 
-  def __delitem__(self, __key: Path) -> None:
-    del self._mapping[__key]
+    return self[key]
 
-  def __iter__(self) -> tp.Iterator[Path]:
+  def __setitem__(self, key: Key, value: Leaf | State) -> None:
+    if isinstance(value, State):
+      self._mapping[key] = value._mapping
+    else:
+      if not isinstance(self._mapping[key], Variable):
+        raise ValueError(
+          f'Trying to set key {key} to a leaf value '
+          f'but current value is not a Variable: {self._mapping[key]}.'
+        )
+      self._mapping[key].value = value
+
+  __setattr__ = __setitem__
+
+  def __delitem__(self, key: Key) -> None:
+    del self._mapping[key]
+
+  def __iter__(self) -> tp.Iterator[Key]:
     return iter(self._mapping)
 
   def __len__(self) -> int:
@@ -79,7 +113,17 @@ class State(tp.MutableMapping[Path, Leaf], reprlib.Representable):
     yield reprlib.Object(type(self), value_sep=': ', start='({', end='})')
 
     for k, v in self.items():
+      if isinstance(v, State):
+        v = NestedStateRepr(v)
       yield reprlib.Attr(repr(k), v)
+
+  def flat_state(self) -> dict[Key, Variable[Leaf]]:
+    return traverse_util.flatten_dict(self._mapping, sep='/')  # type: ignore
+
+  @classmethod
+  def from_flat_path(cls, flat_state: FlatState) -> State:
+    nested_state = traverse_util.unflatten_dict(flat_state, sep='/')
+    return cls(nested_state)
 
   @tp.overload
   def split(self, first: filterlib.Filter, /) -> 'State':
@@ -108,9 +152,9 @@ class State(tp.MutableMapping[Path, Leaf], reprlib.Representable):
       )
 
     if len(states) == 1:
-      states = State(states[0])
+      states = states[0]
     else:
-      states = tuple(State(state) for state in states)
+      states = tuple(states)
     return states
 
   @tp.overload
@@ -142,9 +186,9 @@ class State(tp.MutableMapping[Path, Leaf], reprlib.Representable):
     assert len(states) == len(filters) + 1
 
     if len(states) == 1:
-      states = State(states[0])
+      states = states[0]
     else:
-      states = tuple(State(state) for state in states)
+      states = tuple(states)
 
     return states
 
@@ -155,12 +199,12 @@ class State(tp.MutableMapping[Path, Leaf], reprlib.Representable):
     if len(states) == 1:
       return states[0]
 
-    new_state: StateDict = {}
+    new_state: FlatState = {}
 
     for state in states:
-      new_state.update(state.variables)
+      new_state.update(state.flat_state())
 
-    return State(new_state)
+    return State.from_flat_path(new_state)
 
   def __or__(self, other: 'State') -> 'State':
     if not other:
@@ -171,16 +215,11 @@ class State(tp.MutableMapping[Path, Leaf], reprlib.Representable):
     if not other:
       return self
 
-    # create new State via __new__ to avoid __init__ sorting
     _mapping = {k: v for k, v in self._mapping.items() if k not in other}
-    state = object.__new__(State)
-    state._mapping = _mapping
-    return state
+    return State(_mapping)
 
 
-def _state_flatten_with_keys(
-  x: State,
-):
+def _state_flatten_with_keys(x: State):
   items = sorted(x._mapping.items(), key=lambda item: item[0])
   children = tuple((jtu.DictKey(key), value) for key, value in items)
   return children, tuple(x._mapping.keys())
@@ -206,9 +245,9 @@ jax.tree_util.register_pytree_with_keys(
 
 
 def _split_state(
-  state: StateMapping,
+  state: State,
   *filters: filterlib.Filter,
-) -> tp.Tuple[StateDict, ...]:
+) -> tp.Tuple[State, ...]:
   for i, filter_ in enumerate(filters):
     if filter_ is ... and i != len(filters) - 1:
       raise ValueError(
@@ -217,24 +256,21 @@ def _split_state(
       )
   predicates = tuple(map(filterlib.to_predicate, filters))
 
+  flat_state = state.flat_state()
+
   # we have n + 1 states, where n is the number of predicates
   # the last state is for values that don't match any predicate
-  states: tp.Tuple[StateDict, ...] = tuple(
+  flat_states: tp.Tuple[FlatState, ...] = tuple(
     {} for _ in range(len(predicates) + 1)
   )
 
-  if isinstance(state, State):
-    items = state._mapping.items()
-  else:
-    items = state.items()
-
-  for path, value in items:
+  for path, value in flat_state.items():
     for i, predicate in enumerate(predicates):
       if predicate(path, value):
-        states[i][path] = value
+        flat_states[i][path] = value
         break
     else:
       # if we didn't break, set leaf to last state
-      states[-1][path] = value
+      flat_states[-1][path] = value
 
-  return states
+  return tuple(State.from_flat_path(flat_state) for flat_state in flat_states)

--- a/flax/experimental/nnx/nnx/state.py
+++ b/flax/experimental/nnx/nnx/state.py
@@ -72,7 +72,7 @@ class State(tp.MutableMapping[Key, tp.Any], reprlib.Representable):
       super().__setattr__('_mapping', dict(mapping))
 
   @property
-  def variables(self) -> dict[Key, Variable[Leaf] | dict[str, tp.Any]]:
+  def variables(self) -> dict[Key, dict[str, tp.Any] | tp.Any]:
     return self._mapping
 
   def __getitem__(self, key: Key) -> Leaf | State:

--- a/flax/experimental/nnx/tests/test_graph_utils.py
+++ b/flax/experimental/nnx/tests/test_graph_utils.py
@@ -24,7 +24,7 @@ class TestGraphUtils:
 
     state, static = nnx.graph_utils.graph_flatten(g)
 
-    state['0/b'] = 2
+    state['0']['b'] = 2
     state['3'] = 4
 
   def test_unflatten(self):
@@ -53,7 +53,7 @@ class TestGraphUtils:
 
     state, static = nnx.graph_utils.graph_flatten(g)
 
-    state['0/b'] = 3
+    state['0']['b'] = 3
     nnx.graph_utils.graph_update_dynamic(g, state)
 
     assert g[0]['b'].value == 3
@@ -109,9 +109,9 @@ class TestGraphUtils:
 
     state, static = nnx.graph_utils.graph_flatten(ls)
 
-    assert state['0/kernel'].shape == (2, 2)
-    assert state['0/bias'].shape == (2,)
-    assert state['1/scale'].shape == (2,)
-    assert state['1/bias'].shape == (2,)
-    assert state['1/mean'].shape == (2,)
-    assert state['1/var'].shape == (2,)
+    assert state['0']['kernel'].shape == (2, 2)
+    assert state['0']['bias'].shape == (2,)
+    assert state['1']['scale'].shape == (2,)
+    assert state['1']['bias'].shape == (2,)
+    assert state['1']['mean'].shape == (2,)
+    assert state['1']['var'].shape == (2,)

--- a/flax/experimental/nnx/tests/test_module.py
+++ b/flax/experimental/nnx/tests/test_module.py
@@ -227,7 +227,7 @@ class TestModule:
     )
 
     p, graphdef = m.split()
-    assert len(p) == 4
+    assert len(p.flat_state()) == 4
     assert len(jax.tree_util.tree_leaves(p)) == 4
 
   def test_deref_array_attributes_not_allowed(self):

--- a/flax/experimental/nnx/tests/test_partitioning.py
+++ b/flax/experimental/nnx/tests/test_partitioning.py
@@ -33,11 +33,11 @@ class TestPartitioning:
     assert len(rest) == 1
 
     # check params
-    assert params['a/0'] == m.a[0]
+    assert params['a']['0'] == m.a[0]
     assert params['b'] == m.b
 
     # check rest
-    assert rest['a/1'] == m.a[1]
+    assert rest['a']['1'] == m.a[1]
 
     m2 = graphdef.merge(params, rest)
 
@@ -152,8 +152,8 @@ class TestPartitioning:
     assert vars(m.a)['0'] is not vars(m)['b']
 
     state = m.extract(nnx.Variable)
-    assert state['a/0'] == m.a[0]
-    assert state['a/1'] == m.a[1]
+    assert state['a']['0'] == m.a[0]
+    assert state['a']['1'] == m.a[1]
     assert state['b'] == m.b
-    assert state.variables['b'] is not state.variables['a/0']
-    assert len(state) == 3
+    assert state.variables['b'] is not state.variables['a']['0']
+    assert len(state.flat_state()) == 3

--- a/flax/experimental/nnx/tests/test_state.py
+++ b/flax/experimental/nnx/tests/test_state.py
@@ -35,3 +35,16 @@ class StateTest(TestCase):
     assert state.variables['a'].value == 3
     assert isinstance(state.variables['b']['c'], nnx.Param)
     assert state.variables['b']['c'].value == 4
+
+  def test_integer_access(self):
+    class Foo(nnx.Module):
+      def __init__(self, *, rngs: nnx.Rngs):
+        self.layers = [nnx.Linear(1, 2, rngs=rngs), nnx.Linear(2, 3, rngs=rngs)]
+
+    module = Foo(rngs=nnx.Rngs(0))
+    state = module.get_state()
+
+    assert module.layers[0].kernel.shape == (1, 2)
+    assert state.layers[0].kernel.shape == (1, 2)
+    assert module.layers[1].kernel.shape == (2, 3)
+    assert state.layers[1].kernel.shape == (2, 3)

--- a/flax/experimental/nnx/tests/test_state.py
+++ b/flax/experimental/nnx/tests/test_state.py
@@ -1,0 +1,37 @@
+from absl.testing.absltest import TestCase
+
+from flax.experimental import nnx
+
+
+class StateTest(TestCase):
+  def test_create_state(self):
+    state = nnx.State({'a': nnx.Param(1), 'b': {'c': nnx.Param(2)}})
+
+    assert state['a'] == 1
+    assert state['b']['c'] == 2
+
+  def test_get_attr(self):
+    state = nnx.State({'a': nnx.Param(1), 'b': {'c': nnx.Param(2)}})
+
+    assert state.a == 1
+    assert state.b.c == 2
+
+  def test_set_attr(self):
+    state = nnx.State({'a': nnx.Param(1), 'b': {'c': nnx.Param(2)}})
+
+    state.a = 3
+    state.b.c = 4
+
+    assert state['a'] == 3
+    assert state['b']['c'] == 4
+
+  def test_set_attr_variables(self):
+    state = nnx.State({'a': nnx.Param(1), 'b': {'c': nnx.Param(2)}})
+
+    state.a = 3
+    state.b.c = 4
+
+    assert isinstance(state.variables['a'], nnx.Param)
+    assert state.variables['a'].value == 3
+    assert isinstance(state.variables['b']['c'], nnx.Param)
+    assert state.variables['b']['c'].value == 4

--- a/flax/experimental/nnx/tests/test_transforms.py
+++ b/flax/experimental/nnx/tests/test_transforms.py
@@ -137,13 +137,13 @@ class TestGrad:
     grads = f(m)
 
     assert isinstance(grads, nnx.State)
-    assert grads['a/0'] == 1.0
-    assert isinstance(grads.variables['a/0'], nnx.Variable)
-    assert grads['a/1'] == 1.0
-    assert isinstance(grads.variables['a/1'], nnx.Variable)
+    assert grads['a']['0'] == 1.0
+    assert isinstance(grads.variables['a']['0'], nnx.Variable)
+    assert grads['a']['1'] == 1.0
+    assert isinstance(grads.variables['a']['1'], nnx.Variable)
     assert grads['b'] == 1.0
     assert isinstance(grads.variables['b'], nnx.Variable)
-    assert len(grads) == 3
+    assert len(grads.flat_state()) == 3
 
     m.update(grads)
 
@@ -169,8 +169,8 @@ class TestGrad:
     grads = f(m)
 
     assert isinstance(grads, nnx.State)
-    assert grads['a/0'] == 1.0
-    assert isinstance(grads.variables['a/0'], nnx.Param)
+    assert grads['a']['0'] == 1.0
+    assert isinstance(grads.variables['a']['0'], nnx.Param)
     assert len(grads) == 2
 
     m.update(grads)
@@ -197,8 +197,8 @@ class TestGrad:
     grads = f(m)
 
     assert isinstance(grads, nnx.State)
-    assert grads['a/1'] == 1.0
-    assert isinstance(grads.variables['a/1'], nnx.BatchStat)
+    assert grads['a']['1'] == 1.0
+    assert isinstance(grads.variables['a']['1'], nnx.BatchStat)
     assert len(grads) == 1
 
     m.update(grads)
@@ -482,28 +482,34 @@ class TestScan:
 
     # test sharding layers axes is set
     variables = m.get_state().variables
-    assert variables['scan_module/linear/kernel'].value.shape == (5, 3, 3)
-    assert variables['scan_module/linear/kernel'].sharding == (
+    assert variables['scan_module']['linear']['kernel'].value.shape == (5, 3, 3)
+    assert variables['scan_module']['linear']['kernel'].sharding == (
       'layers',
       'din',
       'dout',
     )
-    assert variables['scan_module/linear/bias'].value.shape == (5, 3)
-    assert variables['scan_module/linear/bias'].sharding == ('layers', 'dout')
+    assert variables['scan_module']['linear']['bias'].value.shape == (5, 3)
+    assert variables['scan_module']['linear']['bias'].sharding == (
+      'layers',
+      'dout',
+    )
 
     x = jnp.ones((1, 3))
     y, out = m(x, None)
 
     # test sharding axes is preserved
     variables = m.get_state().variables
-    assert variables['scan_module/linear/kernel'].value.shape == (5, 3, 3)
-    assert variables['scan_module/linear/kernel'].sharding == (
+    assert variables['scan_module']['linear']['kernel'].value.shape == (5, 3, 3)
+    assert variables['scan_module']['linear']['kernel'].sharding == (
       'layers',
       'din',
       'dout',
     )
-    assert variables['scan_module/linear/bias'].value.shape == (5, 3)
-    assert variables['scan_module/linear/bias'].sharding == ('layers', 'dout')
+    assert variables['scan_module']['linear']['bias'].value.shape == (5, 3)
+    assert variables['scan_module']['linear']['bias'].sharding == (
+      'layers',
+      'dout',
+    )
 
   def test_type_error_less_than_one_args(self):
     class Block(nnx.Module):


### PR DESCRIPTION
# What does this PR do?

Uses a nested representation instead of a flattened path representation. 

```python
State({
  'linear': {
    'kernel': Array([[0.31696808, 0.55285215],
           [0.31418085, 0.7399571 ]], dtype=float32),
    'bias': Array([0., 0.], dtype=float32)
  }
})
```
The PR also implements `State.__getattr__` and `State.__setattr__` to allow for a more natural access mechanism. In particular, since paths are preserved exactly from the corresponding `Module`, you get the exact same access syntax.

```python
# getattr
model.linear.kernel == state.linear.kernel
# getitem
model.linear.kernel == state['linear']['kernel']
```
Integer access is also allowed keep the 1-1 access correspondence with `list` and `tuple` nodes:
```python
class Foo(nnx.Module):
  def __init__(self, *, rngs: nnx.Rngs):
    self.layers = [
      nnx.Linear(1, 2, rngs=rngs),
      nnx.Linear(2, 3, rngs=rngs),
    ]

model = Foo(rngs=nnx.Rngs(0))
state = model.get_state()

assert model.layers[0].kernel.shape == (1, 2)
assert state.layers[0].kernel.shape == (1, 2)
assert model.layers[1].kernel.shape == (2, 3)
assert state.layers[1].kernel.shape == (2, 3)
```