### PR TITLE
[nnx] Add missing import on why.ipynb

### DIFF
--- a/flax/experimental/nnx/docs/why.ipynb
+++ b/flax/experimental/nnx/docs/why.ipynb
@@ -34,7 +34,8 @@
    "source": [
     "from functools import partial\n",
     "import jax\n",
-    "from jax import random, numpy as jnp"
+    "from jax import random, numpy as jnp\n",
+    "from flax.experimental import nnx"
    ]
   },
   {

--- a/flax/experimental/nnx/docs/why.md
+++ b/flax/experimental/nnx/docs/why.md
@@ -33,6 +33,7 @@ We'd love to hear from any of our users about their thoughts on these ideas.
 from functools import partial
 import jax
 from jax import random, numpy as jnp
+from flax.experimental import nnx
 ```
 
 ### NNX is Pythonic


### PR DESCRIPTION
# What does this PR do?

* Adds missing import to `why.ipynb`