### PR TITLE
Add NNX/Linen API consistency test for `Conv` layer

### DIFF
--- a/flax/experimental/nnx/tests/nn/test_conv.py
+++ b/flax/experimental/nnx/tests/nn/test_conv.py
@@ -1,0 +1,48 @@
+from collections.abc import Sequence
+
+import jax
+from absl.testing import parameterized
+from jax import numpy as jnp
+from jax.lax import Precision
+from numpy.testing import assert_array_equal
+
+from flax import linen
+from flax.experimental import nnx
+
+
+class TestLinenConsistency(parameterized.TestCase):
+
+  @parameterized.product(
+      strides = [None, 1, (2, 3)],
+      padding = ['SAME', 'VALID', 'CIRCULAR', (4, 2)],
+      input_dilation = [1, (2, 3)],
+      kernel_dilation = [1, (2, 3)],
+      feature_group_count = [1, 3],
+      use_bias = [True, False],
+      dtype = [jnp.float32, jnp.float16],
+      param_dtype = [jnp.float32, jnp.float16],
+      precision = [Precision.DEFAULT, Precision.HIGH, Precision.HIGHEST],
+  )
+  def test_nnx_linen_equivalence(self, **kwargs):
+    key = jax.random.key(42)
+    rngs = nnx.Rngs(42)
+    IN_FEATURES = 3
+    OUT_FEATURES = 6
+    INPUT_SHAPE = (24, 9, IN_FEATURES)
+    kwargs["kernel_size"] = (7, 4)
+
+    # Cannot use string padding specification for transpose conv
+    if isinstance(kwargs["input_dilation"], Sequence) or kwargs["input_dilation"] > 1:
+      kwargs["padding"] = (4, 2)
+
+    x = jax.numpy.ones(INPUT_SHAPE)
+    model_nnx = nnx.Conv.create_abstract(IN_FEATURES, OUT_FEATURES, **kwargs, rngs=rngs)
+    model = linen.Conv(OUT_FEATURES, **kwargs)
+    variables = model.init(key, x)
+    model_nnx.kernel = variables['params']['kernel']
+    if kwargs["use_bias"]:
+      model_nnx.bias = variables['params']['bias']
+
+    out_nnx = model_nnx(x)
+    out = model.apply(variables, x)
+    assert_array_equal(out, out_nnx)


### PR DESCRIPTION
# What does this PR do?

Added NNX/Linen API consistency test for Linear/Dense layer

## Checklist
- [ ] This PR fixes a minor issue (e.g.: typo or small bug) or improves the docs (you can dismiss the other
      checks if that's the case).
- [x] This change is discussed in a Github issue/
      [discussion](https://github.com/google/flax/discussions) (please add a
      link).
- [x] The documentation and docstrings adhere to the
      [documentation guidelines](https://github.com/google/flax/blob/main/docs/README.md#how-to-write-code-documentation).
- [x] This change includes necessary high-coverage tests.
      (No quality testing = no merge!)
