### PR TITLE
added geglu activation and tests

### DIFF
--- a/flax/linen/__init__.py
+++ b/flax/linen/__init__.py
@@ -32,6 +32,7 @@ from ..core.meta import (
     with_partitioning as with_partitioning,
 )
 from .activation import (
+    GeGLU as GeGLU,
     PReLU as PReLU,
     celu as celu,
     elu as elu,

--- a/flax/linen/activation.py
+++ b/flax/linen/activation.py
@@ -20,6 +20,7 @@ from typing import Any, Optional
 
 from flax.linen.module import compact
 from flax.linen.module import Module
+from flax.linen.linear import Dense
 
 from jax.nn import celu
 from jax.nn import elu
@@ -99,3 +100,44 @@ class PReLU(Module):
     return jnp.where(
         inputs >= 0, inputs, jnp.asarray(negative_slope, inputs.dtype) * inputs
     )
+
+class GeGLU(Module):
+    """Gated Linear Unit with GELU (GeGLU) activation function.
+
+    GeGLU is a Flax layer that combines a linear transformation with a GELU
+    activation function in a gating mechanism. It is often used in Transformer models
+    to provide non-linear capabilities while preserving a strong linear component.
+
+    Example usage::
+        >>> import flax.linen as nn
+
+        >>> class TransformerBlock(nn.Module):
+        ...   @nn.compact
+        ...   def __call__(self, x):
+        ...     x = nn.Dense(2)(x)
+        ...     x = nn.GeGLU()(x) # initialized
+        ...     return x
+
+    Attributes:
+        features: the number of output features (default: None).
+    """
+    output_dim: int = None
+
+    @compact
+    def __call__(self, inputs: Array) -> Array:
+        """Applies the GeGLU activation to the inputs.
+
+        Args:
+            inputs: the nd-array to apply the GeGLU activation function to.
+
+        Returns:
+            The transformed input.
+        """
+        if self.output_dim is None:
+          output_dim = inputs.shape[-1]
+        else:
+            output_dim = self.output_dim
+
+        x = Dense(output_dim * 2)(inputs)
+        x, gate = x[..., : output_dim], x[..., output_dim :]
+        return x * gelu(gate)

--- a/flax/linen/activation.py
+++ b/flax/linen/activation.py
@@ -121,7 +121,7 @@ class GeGLU(Module):
     Attributes:
         features: the number of output features (default: None).
     """
-    output_dim: int = None
+    output_dim: int = -1
 
     @compact
     def __call__(self, inputs: Array) -> Array:
@@ -133,7 +133,7 @@ class GeGLU(Module):
         Returns:
             The transformed input.
         """
-        if self.output_dim is None:
+        if self.output_dim == -1:
           output_dim = inputs.shape[-1]
         else:
             output_dim = self.output_dim

--- a/tests/linen/linen_activation_test.py
+++ b/tests/linen/linen_activation_test.py
@@ -14,12 +14,13 @@
 
 """Tests for flax.linen.activation."""
 
-from absl.testing import absltest
-from flax import linen as nn
 import jax
-from jax import random
 import jax.numpy as jnp
 import numpy as np
+from absl.testing import absltest
+from jax import random
+
+from flax import linen as nn
 
 # Parse absl flags test_srcdir and test_tmpdir.
 jax.config.parse_flags_with_absl()
@@ -42,6 +43,32 @@ class ActivationTest(absltest.TestCase):
     self.assertEqual(y.shape, x.shape)
     np.testing.assert_array_almost_equal(expected_y, y)
     np.testing.assert_array_equal(init_negative_slope, expected_negative_slope)
+
+  def test_geglu(self):
+    rng = random.key(0)
+    x = jnp.array([[0.123,0.234], [0.456,0.789]])
+    act = nn.GeGLU()
+    expected_result = jnp.array([[0.00024275, -0.00208032],
+                                [0.00336634, -0.02307648]])
+    y, _ = act.init_with_output(rng, x)
+    np.testing.assert_array_almost_equal(y, expected_result)
+
+  def test_geglu_with_dim_expansion(self):
+    rng = random.key(0)
+    x = jnp.array([[0.123,0.234], [0.456,0.789]])
+    act = nn.GeGLU(3)
+    expected_result = jnp.array([[-0.02157649, -0.00018928, -0.01176354],
+                                [-0.08777858,  0.00258885, -0.18744925]])
+    y, _ = act.init_with_output(rng, x)
+    np.testing.assert_array_almost_equal(y, expected_result)
+
+  def test_geglu_with_dim_contraction(self):
+    rng = random.key(0)
+    x = jnp.array([[0.123,0.234], [0.456,0.789]])
+    act = nn.GeGLU(1)
+    expected_result = jnp.array([[0.00224223], [0.0307451 ]])
+    y, _ = act.init_with_output(rng, x)
+    np.testing.assert_array_almost_equal(y, expected_result)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
# What does this PR do?

<!--

Great, you are contributing to Flax!

But... please read the following carefully so we can make sure your PR is merged
easily.

Replace this text block with a description of the change and which issue it
fixes (if applicable). Please also include relevant motivation/context.

Once you're done, someone in the Flax team will review your PR shortly. They may
suggest changes to make the code even better. If no one reviewed your PR after a
week has passed, don't hesitate to post a new comment @-mentioning the same
persons (sometimes notifications get lost).
-->

Fixes # (3483)

This PR adds the GeGLU (Gated Linear Unit with GELU) activation function to the activation module of the Flax library. It is an increasingly popular activation layer which combines a linear transformation with a GELU activation in a gating mechanism, balancing linearity and non-linearity.

GeGLU is parameterised and as such uses Flax's Dense layer and was not part of Jax itself. The implementation allows for an optional output_dim attribute, which can be used to specify the number of output features. This can increase or decrease the -1th dimensions of the results and the code tries to account for that. The tests validate the functionality in three scenarios: standard usage, output dimension expansion, and output dimension contraction, ensuring the layer's reliability in various use cases.

## Checklist
- [x] This PR adds GeGLU activation and tests.
- [x] This change is discussed in a Github issue/
      [discussion](https://github.com/google/flax/discussions/3483)
- [x] The documentation and docstrings adhere to the
      [documentation guidelines](https://github.com/google/flax/blob/main/docs/README.md#how-to-write-code-documentation).
- [x] This change includes necessary high-coverage tests.
      (No quality testing = no merge!)
