### PR TITLE
Make fp8 scaling factors scalar

### DIFF
--- a/flax/linen/fp8_ops.py
+++ b/flax/linen/fp8_ops.py
@@ -161,7 +161,7 @@ class Fp8DotGeneralOp(module.Module):
     scale_args = (
       initializers.ones_init(),
       random.PRNGKey(0),
-      (1,),
+      (),
       jnp.float32,
     )
     amax_history_args = (


### PR DESCRIPTION
The original design of Fp8 scaling factors is of shape (1,) which could result in a fusion pattern of convert->bitcast->convert if bf16 is used as wider type. The fused kernel is run on GPU with block and grid of size <<<1,1,1,>>> which is inefficient. Since cublasLt Fp8 gemm only takes Fp32 typed scales, this change could avoid the above issue with the help of `SimplifyFPConversions` pass.
