### PR TITLE
[nnx] Fix graph_utils bug

### DIFF
--- a/flax/experimental/nnx/nnx/graph_utils.py
+++ b/flax/experimental/nnx/nnx/graph_utils.py
@@ -147,6 +147,9 @@ class _HashableMapping(tp.Mapping[HA, HB], tp.Hashable):
   def __init__(self, mapping: tp.Mapping[HA, HB] | tp.Iterable[tuple[HA, HB]]):
     self._mapping = dict(mapping)
 
+  def __contains__(self, key: object) -> bool:
+    return key in self._mapping
+
   def __getitem__(self, key: HA) -> HB:
     return self._mapping[key]
 
@@ -422,7 +425,7 @@ def _graph_flatten(
       if variable_id in id_to_index:
         variables.append((key, id_to_index[variable_id]))
       else:
-        flat_state[str_path] = value
+        flat_state[str_path] = value.copy()
         variable_index = id_to_index[variable_id] = len(id_to_index)
         variables.append(
           (key, VariableDef.from_variable(value, variable_index))
@@ -522,6 +525,8 @@ def _graph_unflatten(
                 f'Expected a Variable of type {variable_def.type} '
                 f'for {key!r}, but got a Variable of type {type(value)}.'
               )
+            assert isinstance(value, Variable)
+            value = value.copy()
             new_state[key] = value
             index_to_node[variable_def.index] = value
 

--- a/flax/experimental/nnx/nnx/variables.py
+++ b/flax/experimental/nnx/nnx/variables.py
@@ -253,6 +253,13 @@ class Variable(
     return value
 
   def copy_from(self, other: 'Variable[A]') -> None:
+    if not self.is_equivalent(other):
+      raise ValueError(
+        f'Cannot copy from incompatible container, '
+        f'expected {type(self).__name__}, got {type(other).__name__}'
+      )
+    if self is other:
+      return
     vars_dict = vars(self)
     vars_dict.clear()
     vars_dict.update(vars(other))

--- a/flax/experimental/nnx/tests/test_graph_utils.py
+++ b/flax/experimental/nnx/tests/test_graph_utils.py
@@ -180,3 +180,53 @@ class TestGraphUtils:
     y = model(x)
 
     assert y.shape == (2, 10)
+
+  def test_state_variables_not_shared_with_graph(self):
+    class Foo(nnx.Module):
+      def __init__(self):
+        self.a = nnx.Param(1)
+
+    m = Foo()
+    state, static = m.split()
+
+    assert isinstance(m.variables.a, nnx.Param)
+    assert isinstance(state.variables['a'], nnx.Param)
+    assert m.variables.a is not state.variables['a']
+    assert m.a == state.a
+
+    m2 = static.merge(state)
+
+    assert isinstance(m2.variables.a, nnx.Param)
+    assert isinstance(state.variables['a'], nnx.Param)
+    assert m2.variables.a is not state.variables['a']
+    assert m2.a == state.a
+
+  def test_shared_state_variables_not_shared_with_graph(self):
+    class Foo(nnx.Module):
+      def __init__(self):
+        p = nnx.Param(1)
+        self.a = p
+        self.b = p
+
+    m = Foo()
+    state, static = m.split()
+
+    assert isinstance(m.variables.a, nnx.Param)
+    assert isinstance(m.variables.b, nnx.Param)
+    assert isinstance(state.variables['a'], nnx.Param)
+    assert 'b' not in state
+    assert m.variables.a is not state.variables['a']
+    assert m.variables.b is not state.variables['a']
+    assert m.a == state.a
+    assert m.b == state.a
+
+    m2 = static.merge(state)
+
+    assert isinstance(m2.variables.a, nnx.Param)
+    assert isinstance(m2.variables.b, nnx.Param)
+    assert isinstance(state.variables['a'], nnx.Param)
+    assert m2.variables.a is not state.variables['a']
+    assert m2.variables.b is not state.variables['a']
+    assert m2.a == state.a
+    assert m2.b == state.a
+    assert m2.a is m2.b


### PR DESCRIPTION
# What does this PR do?

* Fixes a bug in flatten/unflatten logic in `graph_utils`, `Variable`s were not being copied which is a problem in new Reference semantics.