### PR TITLE
Add .editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,32 @@
+root = true
+
+[*.{bash,css,md,py,rst,sh,toml,txt}]
+indent_style = space
+end_of_line = lf
+trim_trailing_whitespace = true
+insert_final_newline = true
+max_line_length = 79
+
+[*.bash]
+indent_size = 4
+
+[*.css]
+indent_size = 2
+
+[*.md]
+indent_size = 2
+
+[*.py]
+indent_size = 2
+
+[*.rst]
+indent_size = 2
+
+[*.sh]
+indent_size = 4
+
+[*.toml]
+indent_size = 4
+
+[*.txt]
+indent_size = 4


### PR DESCRIPTION
This file helps non-Googler contributors who have their editors set up differently for different projects.  Most modern editors will automatically use the Google style when they see this file:
* (most importantly) 2 character indent size,
* 79 character maximum line length,
* spaces instead of tabs,
* linux line endings, and
* no extraneous whitespace.