### PR TITLE
add module methods to api docs

### DIFF
--- a/docs/api_reference/flax.linen/module.rst
+++ b/docs/api_reference/flax.linen/module.rst
@@ -5,4 +5,4 @@ Module
 .. currentmodule:: flax.linen
 
 .. autoclass:: Module
-   :members: setup, variable, param, bind, unbind, apply, init, init_with_output, copy, make_rng, sow, variables, Variable, __setattr__, tabulate, is_initializing, perturb
+   :members: setup, variable, param, bind, unbind, apply, init, init_with_output, copy, make_rng, sow, variables, Variable, __setattr__, tabulate, is_initializing, perturb, put_variable, has_variable, has_rng, lazy_init, get_variable, path, is_mutable_collection


### PR DESCRIPTION
Added missing module methods to [api docs](https://flax--3544.org.readthedocs.build/en/3544/api_reference/flax.linen/module.html)