### PR TITLE
implement Rng.__getattr__

### DIFF
--- a/flax/experimental/nnx/tests/test_rngs.py
+++ b/flax/experimental/nnx/tests/test_rngs.py
@@ -37,7 +37,7 @@ class TestRngs:
 
   def test_fallback_error_no_default(self):
     rngs = nnx.Rngs(some_name=0)
-    with pytest.raises(ValueError, match='No RNG named'):
+    with pytest.raises(AttributeError, match='No RNG named'):
       key = rngs.dropout()
 
   def test_rng_stream(self):


### PR DESCRIPTION
# What does this PR do?

Adds better error type to `Rngs._make_rng` depending on whether `__getitem__` or `__getattr__` is being called.