### PR TITLE
renamed attention layer to MultiHeadAttention

### DIFF
--- a/docs/api_reference/flax.linen/layers.rst
+++ b/docs/api_reference/flax.linen/layers.rst
@@ -88,6 +88,10 @@ Attention
 
 .. flax_module::
   :module: flax.linen
+  :class: MultiHeadAttention
+
+.. flax_module::
+  :module: flax.linen
   :class: MultiHeadDotProductAttention
 
 .. autofunction:: dot_product_attention_weights
@@ -148,6 +152,7 @@ Recurrent
   Sequential
   Dropout
   SelfAttention
+  MultiHeadAttention
   MultiHeadDotProductAttention
   RNNCellBase
   LSTMCell

--- a/examples/linen_design_test/attention_simple.py
+++ b/examples/linen_design_test/attention_simple.py
@@ -153,7 +153,7 @@ def concise_vmap(module, in_axes, out_axes, axis_size=None, **var_specs):
   )
 
 
-class MultiHeadDotProductAttention(Module):
+class MultiHeadAttention(Module):
   qkv_features: Optional[int] = None
   out_features: Optional[int] = None
   attn_module: Callable = SoftmaxAttn
@@ -201,7 +201,7 @@ class MultiHeadDotProductAttention(Module):
 if __name__ == '__main__':
   inputs = jnp.ones((8, 97, 256))
   rngs = {'params': random.key(0), 'dropout': random.key(1)}
-  model = MultiHeadDotProductAttention(
+  model = MultiHeadAttention(
       broadcast_dropout=False,
       qkv_features=256,
       out_features=256,

--- a/examples/lm1b/models.py
+++ b/examples/lm1b/models.py
@@ -243,7 +243,7 @@ class EncoderDecoder1DBlock(nn.Module):
             nn.initializers.ones, ('embed',)
         ),
     )(inputs)
-    x = nn.MultiHeadDotProductAttention(
+    x = nn.MultiHeadAttention(
         num_heads=config.num_heads,
         dtype=config.dtype,
         qkv_features=config.qkv_dim,

--- a/examples/nlp_seq/models.py
+++ b/examples/nlp_seq/models.py
@@ -173,7 +173,7 @@ class Encoder1DBlock(nn.Module):
     # Attention block.
     assert inputs.ndim == 3
     x = nn.LayerNorm(dtype=config.dtype)(inputs)
-    x = nn.MultiHeadDotProductAttention(
+    x = nn.MultiHeadAttention(
         num_heads=config.num_heads,
         dtype=config.dtype,
         qkv_features=config.qkv_dim,

--- a/examples/wmt/models.py
+++ b/examples/wmt/models.py
@@ -217,7 +217,7 @@ class Encoder1DBlock(nn.Module):
     # Attention block.
     assert inputs.ndim == 3
     x = nn.LayerNorm(dtype=config.dtype)(inputs)
-    x = nn.MultiHeadDotProductAttention(
+    x = nn.MultiHeadAttention(
         num_heads=config.num_heads,
         dtype=config.dtype,
         qkv_features=config.qkv_dim,
@@ -270,7 +270,7 @@ class EncoderDecoder1DBlock(nn.Module):
     # Decoder block.
     assert targets.ndim == 3
     x = nn.LayerNorm(dtype=config.dtype)(targets)
-    x = nn.MultiHeadDotProductAttention(
+    x = nn.MultiHeadAttention(
         num_heads=config.num_heads,
         dtype=config.dtype,
         qkv_features=config.qkv_dim,
@@ -289,7 +289,7 @@ class EncoderDecoder1DBlock(nn.Module):
 
     # Encoder-Decoder block.
     y = nn.LayerNorm(dtype=config.dtype)(x)
-    y = nn.MultiHeadDotProductAttention(
+    y = nn.MultiHeadAttention(
         num_heads=config.num_heads,
         dtype=config.dtype,
         qkv_features=config.qkv_dim,

--- a/flax/core/nn/attention.py
+++ b/flax/core/nn/attention.py
@@ -411,9 +411,9 @@ def multi_head_dot_product_attention(
   return out
 
 
-# TODO(flax-dev): Consider refactoring MultiHeadDotProductAttention and moving
+# TODO(flax-dev): Consider refactoring MultiHeadAttention and moving
 # causal_mask and cache support into this class instead.
-# SelfAttention = MultiHeadDotProductAttention.partial(inputs_kv=None)
+# SelfAttention = MultiHeadAttention.partial(inputs_kv=None)
 
 
 def make_padding_mask(

--- a/flax/linen/__init__.py
+++ b/flax/linen/__init__.py
@@ -61,7 +61,7 @@ from .activation import (
     tanh as tanh,
 )
 from .attention import (
-    MultiHeadDotProductAttention as MultiHeadDotProductAttention,
+    MultiHeadAttention as MultiHeadAttention,
     SelfAttention as SelfAttention,
     combine_masks as combine_masks,
     dot_product_attention_weights as dot_product_attention_weights,
@@ -151,3 +151,22 @@ from .transforms import (
     while_loop as while_loop,
 )
 # pylint: enable=g-multiple-import
+
+
+# aliasing the deprecated MultiHeadDotProductAttention to MultiHeadAttention and raising a DeprecationWarning
+import typing as _typing
+if _typing.TYPE_CHECKING:
+  from .attention import MultiHeadAttention as MultiHeadDotProductAttention
+else:
+  def __getattr__(attr):
+    if attr == 'MultiHeadDotProductAttention':
+      import _warnings
+      _warnings.warn(
+        'flax.linen.MultiHeadDotProductAttention is deprecated. Use flax.linen.MultiHeadAttention instead.',
+        DeprecationWarning,
+        stacklevel=2,
+      )
+      del _warnings
+      return MultiHeadAttention
+    raise AttributeError(f"module '{__name__}' has no attribute '{attr}'")
+del _typing

--- a/flax/linen/attention.py
+++ b/flax/linen/attention.py
@@ -213,7 +213,7 @@ def dot_product_attention(
   )
 
 
-class MultiHeadDotProductAttention(Module):
+class MultiHeadAttention(Module):
   """Multi-head dot-product attention.
 
   Example usage::
@@ -221,7 +221,7 @@ class MultiHeadDotProductAttention(Module):
     >>> import flax.linen as nn
     >>> import jax
 
-    >>> layer = nn.MultiHeadDotProductAttention(num_heads=8, qkv_features=16)
+    >>> layer = nn.MultiHeadAttention(num_heads=8, qkv_features=16)
     >>> key1, key2, key3, key4, key5, key6 = jax.random.split(jax.random.key(0), 6)
     >>> shape = (4, 3, 2, 5)
     >>> q, k, v = jax.random.uniform(key1, shape), jax.random.uniform(key2, shape), jax.random.uniform(key3, shape)
@@ -247,8 +247,8 @@ class MultiHeadDotProductAttention(Module):
     ...
     ...   @nn.compact
     ...   def __call__(self, x, dropout_rng=None):
-    ...     out1 = nn.MultiHeadDotProductAttention(**self.attention_kwargs)(x, dropout_rng=dropout_rng)
-    ...     out2 = nn.MultiHeadDotProductAttention(**self.attention_kwargs)(x, dropout_rng=dropout_rng)
+    ...     out1 = nn.MultiHeadAttention(**self.attention_kwargs)(x, dropout_rng=dropout_rng)
+    ...     out2 = nn.MultiHeadAttention(**self.attention_kwargs)(x, dropout_rng=dropout_rng)
     ...     return out1, out2
     >>> module = Module(attention_kwargs)
     >>> variables = module.init({'params': key1, 'dropout': key2}, q)
@@ -418,7 +418,7 @@ class MultiHeadDotProductAttention(Module):
           'to the `inputs_v` arg, when you may have intended '
           'to pass it to the `mask` arg. As of Flax version '
           '0.7.4, the function signature of '
-          "MultiHeadDotProductAttention's `__call__` method "
+          "MultiHeadAttention's `__call__` method "
           'has changed to `__call__(inputs_q, inputs_k=None, '
           'inputs_v=None, *, inputs_kv=None, mask=None, '
           'deterministic=None)`. Use the kwarg `mask` instead. '
@@ -571,14 +571,14 @@ class MultiHeadDotProductAttention(Module):
     return out
 
 
-class SelfAttention(MultiHeadDotProductAttention):
+class SelfAttention(MultiHeadAttention):
   """Self-attention special case of multi-head dot-product attention.
-  This layer is deprecated in favor of ``MultiHeadDotProductAttention``.
+  This layer is deprecated in favor of ``MultiHeadAttention``.
 
   Example usage::
     >>> import flax.linen as nn
     >>> import jax, jax.numpy as jnp
-    >>> layer = nn.MultiHeadDotProductAttention(num_heads=8, qkv_features=16)
+    >>> layer = nn.MultiHeadAttention(num_heads=8, qkv_features=16)
     >>> variables = layer.init(jax.random.key(0), jnp.ones((4, 3, 2, 5)))
   """
 
@@ -608,7 +608,7 @@ class SelfAttention(MultiHeadDotProductAttention):
     """
     warnings.warn(
       'SelfAttention will be deprecated soon. Use '
-      '`MultiHeadDotProductAttention.__call__(inputs_q)` instead. '
+      '`MultiHeadAttention.__call__(inputs_q)` instead. '
       'See https://github.com/google/flax/discussions/3389 '
       'for more information.',
       DeprecationWarning,

--- a/flax/linen/combinators.py
+++ b/flax/linen/combinators.py
@@ -56,7 +56,7 @@ class Sequential(Module):
     ...
     ...   @nn.compact
     ...   def __call__(self, query, key_value):
-    ...     output = nn.MultiHeadDotProductAttention(
+    ...     output = nn.MultiHeadAttention(
     ...       num_heads=self.num_heads, qkv_features=self.qkv_features)(query,
     ...                                                                 key_value)
     ...     output = nn.Dense(self.qkv_features)(output)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,8 +128,8 @@ filterwarnings = [
     "ignore:Flax Checkpointing will soon be deprecated in favor of Orbax.*:DeprecationWarning",
     # DeprecationWarning: The inputs_kv arg will be deprecated soon. Use inputs_k and inputs_v instead.
     "ignore:.*The inputs_kv arg will be deprecated soon. Use inputs_k and inputs_v instead.*:DeprecationWarning",
-    # DeprecationWarning: the function signature of MultiHeadDotProductAttention's `__call__` method has changed
-    "ignore:.*the function signature of MultiHeadDotProductAttention's `__call__` method has changed.*:DeprecationWarning",
+    # DeprecationWarning: the function signature of MultiHeadAttention's `__call__` method has changed
+    "ignore:.*the function signature of MultiHeadAttention's `__call__` method has changed.*:DeprecationWarning",
     # DeprecationWarning: ml_dtypes.float8_e4m3b11 is deprecated.
     "ignore:.*ml_dtypes.float8_e4m3b11 is deprecated.*:DeprecationWarning",
     # DeprecationWarning: jax.config.define_bool_state is deprecated. Please use other libraries for configuration instead.

--- a/tests/linen/linen_attention_test.py
+++ b/tests/linen/linen_attention_test.py
@@ -33,7 +33,7 @@ class AttentionTest(parameterized.TestCase):
   def test_multihead_self_attention(self):
     rng = random.key(0)
     x = jnp.ones((4, 6, 5))
-    sa_module = nn.MultiHeadDotProductAttention(
+    sa_module = nn.MultiHeadAttention(
       num_heads=8,
       qkv_features=16,
       kernel_init=initializers.ones,
@@ -47,7 +47,7 @@ class AttentionTest(parameterized.TestCase):
   def test_dtype_infer(self):
     rng = random.key(0)
     x = jnp.ones((4, 6, 5), jnp.complex64)
-    sa_module = nn.MultiHeadDotProductAttention(
+    sa_module = nn.MultiHeadAttention(
       num_heads=8,
       qkv_features=16,
       kernel_init=initializers.ones,
@@ -61,7 +61,7 @@ class AttentionTest(parameterized.TestCase):
   def test_multihead_encoder_decoder_attention(self):
     rng = random.key(0)
     q = jnp.ones((4, 2, 3, 5))
-    sa_module = nn.MultiHeadDotProductAttention(
+    sa_module = nn.MultiHeadAttention(
       num_heads=8,
       qkv_features=16,
       kernel_init=initializers.ones,
@@ -74,7 +74,7 @@ class AttentionTest(parameterized.TestCase):
   def test_multihead_self_attention_w_dropout(self):
     rng = random.key(0)
     x = jnp.ones((4, 2, 3, 5))
-    sa_module = nn.MultiHeadDotProductAttention(
+    sa_module = nn.MultiHeadAttention(
       num_heads=8,
       qkv_features=16,
       kernel_init=initializers.ones,
@@ -93,10 +93,10 @@ class AttentionTest(parameterized.TestCase):
 
       @nn.compact
       def __call__(self, x, dropout_rng=None):
-        a = nn.MultiHeadDotProductAttention(**self.attention_kwargs)(
+        a = nn.MultiHeadAttention(**self.attention_kwargs)(
           x, x, dropout_rng=dropout_rng
         )
-        b = nn.MultiHeadDotProductAttention(**self.attention_kwargs)(
+        b = nn.MultiHeadAttention(**self.attention_kwargs)(
           x, x, dropout_rng=dropout_rng
         )
         return a, b
@@ -132,7 +132,7 @@ class AttentionTest(parameterized.TestCase):
   def test_multihead_self_attention_w_dropout_disabled(self):
     rng = random.key(0)
     x = jnp.ones((4, 2, 3, 5))
-    sa_module0 = nn.MultiHeadDotProductAttention(
+    sa_module0 = nn.MultiHeadAttention(
       num_heads=8,
       qkv_features=16,
       kernel_init=initializers.ones,
@@ -149,7 +149,7 @@ class AttentionTest(parameterized.TestCase):
     y3 = sa_module0.apply(vs, x, rngs=rngs1)
     y4 = sa_module0.apply(vs, x, rngs=rngs2)
     np.testing.assert_allclose(y3, y4)
-    sa_module1 = nn.MultiHeadDotProductAttention(
+    sa_module1 = nn.MultiHeadAttention(
       num_heads=8,
       qkv_features=16,
       kernel_init=initializers.ones,
@@ -159,7 +159,7 @@ class AttentionTest(parameterized.TestCase):
     y5 = sa_module1.apply(vs, x, deterministic=True, rngs=rngs1)
     y6 = sa_module1.apply(vs, x, deterministic=True, rngs=rngs2)
     np.testing.assert_allclose(y5, y6)
-    sa_module2 = nn.MultiHeadDotProductAttention(
+    sa_module2 = nn.MultiHeadAttention(
       num_heads=8,
       qkv_features=16,
       kernel_init=initializers.ones,
@@ -192,7 +192,7 @@ class AttentionTest(parameterized.TestCase):
     inputs = random.normal(
       key1, (bs,) + spatial_shape + (num_heads * num_features,)
     )
-    module = nn.MultiHeadDotProductAttention(
+    module = nn.MultiHeadAttention(
       num_heads=num_heads,
       qkv_features=num_heads * num_features,
       precision=lax.Precision.HIGHEST,
@@ -233,7 +233,7 @@ class AttentionTest(parameterized.TestCase):
     input_shape = (1, length, dim)
     inputs = random.normal(rng2, input_shape)
 
-    module = nn.MultiHeadDotProductAttention(
+    module = nn.MultiHeadAttention(
       num_heads=num_heads,
       kernel_init=jax.nn.initializers.ones,
       deterministic=False,
@@ -273,7 +273,7 @@ class AttentionTest(parameterized.TestCase):
     key1, key2 = random.split(random.key(0), 2)
     query = random.uniform(key1, (3, 5))
     key_value = random.uniform(key1, (9, 5))
-    module = nn.MultiHeadDotProductAttention(
+    module = nn.MultiHeadAttention(
       num_heads=8,
       qkv_features=16,
       kernel_init=initializers.ones,
@@ -326,7 +326,7 @@ class AttentionTest(parameterized.TestCase):
     input_shape = (1, length, dim)
     query = key = random.normal(rng2, input_shape)
 
-    module = nn.MultiHeadDotProductAttention(
+    module = nn.MultiHeadAttention(
       num_heads=num_heads,
       kernel_init=jax.nn.initializers.ones,
       deterministic=False,
@@ -338,7 +338,7 @@ class AttentionTest(parameterized.TestCase):
     module.apply(initial_vars, query, key, mask=causal_mask)
     with self.assertWarnsRegex(
       DeprecationWarning,
-      "the function signature of MultiHeadDotProductAttention's `__call__` method has changed",
+      "the function signature of MultiHeadAttention's `__call__` method has changed",
     ):
       with self.assertRaises(errors.ScopeParamShapeError):
         module.apply(initial_vars, query, key, causal_mask)
@@ -352,11 +352,11 @@ class AttentionTest(parameterized.TestCase):
 
       @nn.compact
       def __call__(self, x, sow_weights=False):
-        x = nn.MultiHeadDotProductAttention(**self.attention_kwargs)(
+        x = nn.MultiHeadAttention(**self.attention_kwargs)(
           x, sow_weights=sow_weights
         )
-        x = nn.MultiHeadDotProductAttention(**self.attention_kwargs)(x)
-        x = nn.MultiHeadDotProductAttention(**self.attention_kwargs)(
+        x = nn.MultiHeadAttention(**self.attention_kwargs)(x)
+        x = nn.MultiHeadAttention(**self.attention_kwargs)(
           x, sow_weights=sow_weights
         )
         return x
@@ -375,16 +375,14 @@ class AttentionTest(parameterized.TestCase):
       v, x, mutable=['intermediates'], sow_weights=True
     )
     self.assertEqual(
-      intermediates['intermediates']['MultiHeadDotProductAttention_0'][
+      intermediates['intermediates']['MultiHeadAttention_0'][
         'attention_weights'
       ][0].shape,
       (4, 8, 6, 6),
     )
-    self.assertNotIn(
-      'MultiHeadDotProductAttention_1', intermediates['intermediates']
-    )
+    self.assertNotIn('MultiHeadAttention_1', intermediates['intermediates'])
     self.assertEqual(
-      intermediates['intermediates']['MultiHeadDotProductAttention_2'][
+      intermediates['intermediates']['MultiHeadAttention_2'][
         'attention_weights'
       ][0].shape,
       (4, 8, 6, 6),
@@ -393,6 +391,42 @@ class AttentionTest(parameterized.TestCase):
       v, x, mutable=['intermediates'], sow_weights=False
     )
     self.assertNotIn('intermediates', intermediates)
+
+  def test_multihead_alias(self):
+    rng = random.key(0)
+    x = jnp.ones((4, 6, 5))
+    module1 = nn.MultiHeadAttention(
+      num_heads=8,
+      qkv_features=16,
+      kernel_init=initializers.ones,
+      bias_init=initializers.zeros,
+      deterministic=False,
+    )
+    with self.assertWarnsRegex(
+      DeprecationWarning,
+      'flax.linen.MultiHeadDotProductAttention is deprecated. Use flax.linen.MultiHeadAttention instead.',
+    ):
+      module2 = nn.MultiHeadDotProductAttention(
+        num_heads=8,
+        qkv_features=16,
+        kernel_init=initializers.ones,
+        bias_init=initializers.zeros,
+        deterministic=False,
+      )
+      self.assertIsInstance(module2, nn.MultiHeadAttention)
+      self.assertEqual(module1, module2)
+    y1, v1 = module1.init_with_output(rng, x)
+    y2, v2 = module2.init_with_output(rng, x)
+    self.assertTrue(
+      jax.tree_util.tree_all(jax.tree_map(lambda x, y: (x == y).all(), v1, v2))
+    )
+    self.assertTrue((y1 == y2).all())
+
+    with self.assertRaisesRegex(
+      AttributeError,
+      "module 'flax.linen' has no attribute 'non_existent_attribute'",
+    ):
+      _ = nn.non_existent_attribute
 
 
 if __name__ == '__main__':

--- a/tests/linen/linen_combinators_test.py
+++ b/tests/linen/linen_combinators_test.py
@@ -56,7 +56,7 @@ class AttentionTuple(nn.Module):
 
   @nn.compact
   def __call__(self, query, key_value):
-    output = nn.MultiHeadDotProductAttention(
+    output = nn.MultiHeadAttention(
       num_heads=self.num_heads, qkv_features=self.qkv_features
     )(query, key_value)
     return output, key_value
@@ -68,7 +68,7 @@ class AttentionDict(nn.Module):
 
   @nn.compact
   def __call__(self, query, key_value):
-    output = nn.MultiHeadDotProductAttention(
+    output = nn.MultiHeadAttention(
       num_heads=self.num_heads, qkv_features=self.qkv_features
     )(query, key_value)
     return dict(query=output, key_value=key_value)

--- a/tests/linen/linen_test.py
+++ b/tests/linen/linen_test.py
@@ -442,20 +442,20 @@ class NormalizationTest(parameterized.TestCase):
     {
       'model_index': 2,
       'key_paths': {
-        'MultiHeadDotProductAttention_0/key/bias/u',
-        'MultiHeadDotProductAttention_0/key/kernel/u',
-        'MultiHeadDotProductAttention_0/out/kernel/u',
-        'MultiHeadDotProductAttention_0/query/bias/u',
-        'MultiHeadDotProductAttention_0/query/kernel/u',
-        'MultiHeadDotProductAttention_0/value/bias/u',
-        'MultiHeadDotProductAttention_0/value/kernel/u',
-        'MultiHeadDotProductAttention_0/key/bias/sigma',
-        'MultiHeadDotProductAttention_0/key/kernel/sigma',
-        'MultiHeadDotProductAttention_0/out/kernel/sigma',
-        'MultiHeadDotProductAttention_0/query/bias/sigma',
-        'MultiHeadDotProductAttention_0/query/kernel/sigma',
-        'MultiHeadDotProductAttention_0/value/bias/sigma',
-        'MultiHeadDotProductAttention_0/value/kernel/sigma',
+        'MultiHeadAttention_0/key/bias/u',
+        'MultiHeadAttention_0/key/kernel/u',
+        'MultiHeadAttention_0/out/kernel/u',
+        'MultiHeadAttention_0/query/bias/u',
+        'MultiHeadAttention_0/query/kernel/u',
+        'MultiHeadAttention_0/value/bias/u',
+        'MultiHeadAttention_0/value/kernel/u',
+        'MultiHeadAttention_0/key/bias/sigma',
+        'MultiHeadAttention_0/key/kernel/sigma',
+        'MultiHeadAttention_0/out/kernel/sigma',
+        'MultiHeadAttention_0/query/bias/sigma',
+        'MultiHeadAttention_0/query/kernel/sigma',
+        'MultiHeadAttention_0/value/bias/sigma',
+        'MultiHeadAttention_0/value/kernel/sigma',
       },
     },
   )
@@ -485,7 +485,7 @@ class NormalizationTest(parameterized.TestCase):
       def __call__(self, x, train):
         a = nn.Dense(4)(x)
         b = nn.Dense(4)(x)
-        x = nn.SpectralNorm(nn.attention.MultiHeadDotProductAttention(4))(
+        x = nn.SpectralNorm(nn.attention.MultiHeadAttention(4))(
           a, b, update_stats=train
         )
         x = nn.Dense(4)(x)
@@ -721,10 +721,10 @@ class NormalizationTest(parameterized.TestCase):
     {
       'model_index': 2,
       'key_paths': {
-        'MultiHeadDotProductAttention_0/key/kernel/scale',
-        'MultiHeadDotProductAttention_0/out/kernel/scale',
-        'MultiHeadDotProductAttention_0/query/kernel/scale',
-        'MultiHeadDotProductAttention_0/value/kernel/scale',
+        'MultiHeadAttention_0/key/kernel/scale',
+        'MultiHeadAttention_0/out/kernel/scale',
+        'MultiHeadAttention_0/query/kernel/scale',
+        'MultiHeadAttention_0/value/kernel/scale',
       },
     },
   )
@@ -758,7 +758,7 @@ class NormalizationTest(parameterized.TestCase):
       def __call__(self, x):
         a = nn.Dense(4)(x)
         b = nn.Dense(4)(x)
-        x = nn.WeightNorm(nn.attention.MultiHeadDotProductAttention(4))(a, b)
+        x = nn.WeightNorm(nn.attention.MultiHeadAttention(4))(a, b)
         x = nn.Dense(4)(x)
         return x
 


### PR DESCRIPTION
Renamed attention layer `nn.MultiHeadDotProductAttention` to `nn.MultiHeadAttention`. This is requested in [#1737](https://github.com/google/flax/discussions/1737#discussioncomment-7568103).

`MultiHeadDotProductAttention` can still be used, but a [`DeprecationWarning`](https://github.com/google/flax/pull/3552/files#diff-b7e399166c22f33b2518396c1cf200fd4c84b9ab3fca1ac754928b4f1794b3dfR157-R167) will be thrown.

Also added a [test](https://github.com/google/flax/pull/3552/files#diff-ffc73f4960d444a491d3b1ed16a242fb0359a42084c397bdc549dfacb4c5feccR395-R429) to check the alias and deprecation warning is working properly.