### PR TITLE
format linen_linear_test.py

### DIFF
--- a/tests/linen/linen_linear_test.py
+++ b/tests/linen/linen_linear_test.py
@@ -994,7 +994,15 @@ class LinearTest(parameterized.TestCase):
     conv_int = module(features=4, kernel_size=3)
     conv_seq = module(features=4, kernel_size=(3,))
     x = jnp.ones((8, 3))
-    self.assertTrue(jax.tree_util.tree_all(jax.tree_map(lambda x, y: (x==y).all(), conv_int.init(random.key(0), x), conv_seq.init(random.key(0), x))))
+    self.assertTrue(
+      jax.tree_util.tree_all(
+        jax.tree_map(
+          lambda x, y: (x == y).all(),
+          conv_int.init(random.key(0), x),
+          conv_seq.init(random.key(0), x),
+        )
+      )
+    )
 
   def test_embed(self):
     rng = dict(params=random.key(0))


### PR DESCRIPTION
Formatted `linen_linear_test.py` since the line too long after #3537