### PR TITLE
re-factored features arg

### DIFF
--- a/flax/experimental/nnx/tests/nn/test_attention.py
+++ b/flax/experimental/nnx/tests/nn/test_attention.py
@@ -43,7 +43,7 @@ class TestMultiHeadAttention:
 
     module = Model(
       dict(
-        features_in=8,
+        in_features=8,
         num_heads=8,
         kernel_init=nnx.initializers.ones(),
         bias_init=nnx.initializers.zeros(),


### PR DESCRIPTION
Standardized feature args to `in_features` and `out_features`, since NNX uses both [`in/out_features`](https://github.com/google/flax/blob/main/flax/experimental/nnx/nnx/nn/linear.py#L306-L307) and [`features_in/out`](https://github.com/google/flax/blob/main/flax/experimental/nnx/nnx/nn/linear.py#L147-L148), while Linen only uses `in/out_features`.