### PR TITLE
re-factored nnx initializers

### DIFF
--- a/flax/experimental/nnx/nnx/nn/attention.py
+++ b/flax/experimental/nnx/nnx/nn/attention.py
@@ -301,7 +301,7 @@ class MultiHeadAttention(Module):
     deterministic: bool | None = None,
     precision: PrecisionLike = None,
     kernel_init: initializers.Initializer = default_kernel_init,
-    bias_init: initializers.Initializer = initializers.zeros(),
+    bias_init: initializers.Initializer = initializers.zeros_init(),
     use_bias: bool = True,
     attention_fn: Callable[..., Array] = dot_product_attention,
     decode: bool = False,

--- a/flax/experimental/nnx/nnx/nn/initializers.py
+++ b/flax/experimental/nnx/nnx/nn/initializers.py
@@ -46,12 +46,12 @@ class Initializer(tp.Protocol):
     ...
 
 
-def zeros() -> Initializer:
+def zeros_init() -> Initializer:
   """Builds an initializer that returns a constant array full of zeros.
 
   >>> import jax, jax.numpy as jnp
-  >>> from flax.linen.initializers import zeros_init
-  >>> zeros_initializer = zeros_init()
+  >>> from flax.experimental.nnx import initializers
+  >>> zeros_initializer = initializers.zeros_init()
   >>> zeros_initializer(jax.random.key(42), (2, 3), jnp.float32)
   Array([[0., 0., 0.],
          [0., 0., 0.]], dtype=float32)
@@ -59,12 +59,12 @@ def zeros() -> Initializer:
   return jax.nn.initializers.zeros
 
 
-def ones() -> Initializer:
+def ones_init() -> Initializer:
   """Builds an initializer that returns a constant array full of ones.
 
   >>> import jax, jax.numpy as jnp
-  >>> from flax.linen.initializers import ones_init
-  >>> ones_initializer = ones_init()
+  >>> from flax.experimental.nnx import initializers
+  >>> ones_initializer = initializers.ones_init()
   >>> ones_initializer(jax.random.key(42), (3, 2), jnp.float32)
   Array([[1., 1.],
          [1., 1.],

--- a/flax/experimental/nnx/nnx/nn/linear.py
+++ b/flax/experimental/nnx/nnx/nn/linear.py
@@ -153,7 +153,7 @@ class LinearGeneral(Module):
     dtype: Dtype | None = None,
     param_dtype: Dtype = jnp.float32,
     kernel_init: initializers.Initializer = default_kernel_init,
-    bias_init: initializers.Initializer = initializers.zeros(),
+    bias_init: initializers.Initializer = initializers.zeros_init(),
     precision: PrecisionLike = None,
     # Deprecated. Will be removed.
     dot_general: DotGeneralT | None = None,
@@ -315,7 +315,7 @@ class Linear(Module):
     ] = default_kernel_init,
     bias_init: tp.Callable[
       [KeyArray, Shape, Dtype], Array
-    ] = initializers.zeros(),
+    ] = initializers.zeros_init(),
     dot_general: DotGeneralT = lax.dot_general,
     rngs: rnglib.Rngs,
   ):
@@ -425,7 +425,7 @@ class Conv(Module):
     ] = default_kernel_init,
     bias_init: tp.Callable[
       [KeyArray, Shape, Dtype], Array
-    ] = initializers.zeros(),
+    ] = initializers.zeros_init(),
     conv_general_dilated: ConvGeneralDilatedT = lax.conv_general_dilated,
     rngs: rnglib.Rngs,
   ):

--- a/flax/experimental/nnx/nnx/nn/normalization.py
+++ b/flax/experimental/nnx/nnx/nn/normalization.py
@@ -203,10 +203,10 @@ class BatchNorm(Module):
     use_scale: bool = True,
     bias_init: tp.Callable[
       [KeyArray, Shape, Dtype], Array
-    ] = initializers.zeros(),
+    ] = initializers.zeros_init(),
     scale_init: tp.Callable[
       [KeyArray, Shape, Dtype], Array
-    ] = initializers.ones(),
+    ] = initializers.ones_init(),
     axis_name: tp.Optional[str] = None,
     axis_index_groups: tp.Any = None,
     rngs: rnglib.Rngs,
@@ -335,10 +335,10 @@ class LayerNorm(Module):
     use_scale: bool = True,
     bias_init: tp.Callable[
       [KeyArray, Shape, Dtype], Array
-    ] = initializers.zeros(),
+    ] = initializers.zeros_init(),
     scale_init: tp.Callable[
       [KeyArray, Shape, Dtype], Array
-    ] = initializers.ones(),
+    ] = initializers.ones_init(),
     reduction_axes: Axes = -1,
     feature_axes: Axes = -1,
     axis_name: tp.Optional[str] = None,

--- a/flax/experimental/nnx/tests/nn/test_attention.py
+++ b/flax/experimental/nnx/tests/nn/test_attention.py
@@ -45,8 +45,8 @@ class TestMultiHeadAttention:
       dict(
         features_in=8,
         num_heads=8,
-        kernel_init=nnx.initializers.ones(),
-        bias_init=nnx.initializers.zeros(),
+        kernel_init=nnx.initializers.ones_init(),
+        bias_init=nnx.initializers.zeros_init(),
         deterministic=False,
       ),
       rng,

--- a/flax/experimental/nnx/tests/test_transforms.py
+++ b/flax/experimental/nnx/tests/test_transforms.py
@@ -453,7 +453,7 @@ class TestScan:
             sharding=('din', 'dout'),
           ),
           bias_init=nnx.with_metadata(
-            nnx.initializers.zeros(),
+            nnx.initializers.zeros_init(),
             sharding=('dout',),
           ),
           rngs=rngs,


### PR DESCRIPTION
Re-naming `zeros` and `ones` initializers to `zeros_init` and `ones_init`, so that it's consistent with Linen initializers and users won't be confused between NNX `zeros/ones` and JAX `zeros/ones` since they have different function signatures.

See also #2002 and #2790.