### PR TITLE
[nnx] add qkv_features back to MHA

### DIFF
--- a/flax/experimental/nnx/nnx/nn/attention.py
+++ b/flax/experimental/nnx/nnx/nn/attention.py
@@ -292,6 +292,7 @@ class MultiHeadAttention(Module):
     self,
     num_heads: int,
     in_features: int,
+    qkv_features: int | None = None,
     out_features: int | None = None,
     *,
     dtype: Dtype | None = None,
@@ -315,6 +316,9 @@ class MultiHeadAttention(Module):
   ):
     self.num_heads = num_heads
     self.in_features = in_features
+    self.qkv_features = (
+      qkv_features if qkv_features is not None else in_features
+    )
     self.out_features = (
       out_features if out_features is not None else in_features
     )
@@ -335,13 +339,13 @@ class MultiHeadAttention(Module):
     self.qkv_dot_general_cls = qkv_dot_general_cls
     self.out_dot_general_cls = out_dot_general_cls
 
-    if self.out_features % self.num_heads != 0:
+    if self.qkv_features % self.num_heads != 0:
       raise ValueError(
-        f"'out_features' ({self.out_features}) must be divisible by "
+        f'Memory dimension ({self.qkv_features}) must be divisible by '
         f"'num_heads' heads ({self.num_heads})."
       )
 
-    self.head_dim = self.out_features // self.num_heads
+    self.head_dim = self.qkv_features // self.num_heads
 
     linear_general = functools.partial(
       LinearGeneral,

--- a/flax/experimental/nnx/tests/nn/test_attention.py
+++ b/flax/experimental/nnx/tests/nn/test_attention.py
@@ -19,7 +19,13 @@ from flax.experimental import nnx
 
 class TestMultiHeadAttention:
   def test_basic(self):
-    module = nnx.MultiHeadAttention(2, 3, 6, rngs=nnx.Rngs(0))
+    module = nnx.MultiHeadAttention(
+      num_heads=2,
+      in_features=3,
+      qkv_features=6,
+      out_features=6,
+      rngs=nnx.Rngs(0),
+    )
     y = module(jnp.ones((1, 7, 3)))
     assert y.shape == (1, 7, 6)
 


### PR DESCRIPTION
# What does this PR do?

Fixes #3564. Adds `qkv_features` back to `MultiHeadAttention`.