### PR TITLE
Fix example of restoring checkpoint in use_checkpointing.ipynb

### DIFF
--- a/docs/guides/training_techniques/use_checkpointing.ipynb
+++ b/docs/guides/training_techniques/use_checkpointing.ipynb
@@ -944,7 +944,7 @@
     "# Add/remove fields as needed.\n",
     "raw_state_dict['model']['batch_stats'] = np.flip(np.arange(10))\n",
     "# Restore the classes with correct target now\n",
-    "flax.serialization.from_state_dict(custom_target, raw_state_dict)"
+    "custom_target = flax.serialization.from_state_dict(custom_target, raw_state_dict)"
    ]
   },
   {


### PR DESCRIPTION
# What does this PR do?

This is a minor issue. In the example of how to restore a partial checkpoint when calling `flax.serialization.from_state_dict` we better to assign the return value to the custom_target. Otherwise the state is not updated.

## Checklist
- [x] This PR fixes a minor issue (e.g.: typo or small bug) or improves the docs (you can dismiss the other
      checks if that's the case).
- [ ] This change is discussed in a Github issue/
      [discussion](https://github.com/google/flax/discussions) (please add a
      link).
- [ ] The documentation and docstrings adhere to the
      [documentation guidelines](https://github.com/google/flax/blob/main/docs/README.md#how-to-write-code-documentation).
- [ ] This change includes necessary high-coverage tests.
      (No quality testing = no merge!)
