### PR TITLE
Fix promotion bug in MultiHeadDotProductAttention:

### DIFF
--- a/flax/linen/attention.py
+++ b/flax/linen/attention.py
@@ -493,10 +493,11 @@ class MultiHeadDotProductAttention(Module):
           )
         # update key, value caches with our new 1d spatial slices
         cur_index = cache_index.value
-        indices: tuple[Union[int, jax.Array], ...] = (0,) * len(batch_dims) + (
+        zero = jnp.array(0, dtype=lax.dtype(cur_index.dtype))
+        indices: tuple[Union[int, jax.Array], ...] = (zero,) * len(batch_dims) + (
           cur_index,
-          0,
-          0,
+          zero,
+          zero,
         )
         key = lax.dynamic_update_slice(cached_key.value, key, indices)
         value = lax.dynamic_update_slice(cached_value.value, value, indices)


### PR DESCRIPTION
If x64 is enabled, autoregressive decoding would lead to dynamic slicing errors

Changes:
 * Add explicit types for dynamic_slice arguments
 * Add test for autoregressive decoding with x64 enabled

Please refer to the test case to recreate.

# What does this PR do?

<!--

Great, you are contributing to Flax!

But... please read the following carefully so we can make sure your PR is merged
easily.

Replace this text block with a description of the change and which issue it
fixes (if applicable). Please also include relevant motivation/context.

Once you're done, someone in the Flax team will review your PR shortly. They may
suggest changes to make the code even better. If no one reviewed your PR after a
week has passed, don't hesitate to post a new comment @-mentioning the same
persons (sometimes notifications get lost).
-->

Fixes # (issue)

## Checklist
- [x] This PR fixes a minor issue (e.g.: typo or small bug) or improves the docs (you can dismiss the other
      checks if that's the case).
- [ ] This change is discussed in a Github issue/
      [discussion](https://github.com/google/flax/discussions) (please add a
      link).
- [x] The documentation and docstrings adhere to the
      [documentation guidelines](https://github.com/google/flax/blob/main/docs/README.md#how-to-write-code-documentation).
- [x] This change includes necessary high-coverage tests.
      (No quality testing = no merge!)
