### PR TITLE
[nnx] Fix variable unflatten

### DIFF
--- a/flax/experimental/nnx/nnx/variables.py
+++ b/flax/experimental/nnx/nnx/variables.py
@@ -385,7 +385,10 @@ def _variable_unflatten(
   *,
   cls: type[Variable[A]],
 ) -> Variable[A]:
-  return cls(children[0], **metadata)  # type: ignore
+  variable = object.__new__(cls)
+  variable.value = children[0]
+  vars(variable).update(metadata)
+  return variable
 
 
 jtu.register_pytree_with_keys(


### PR DESCRIPTION
# What does this PR do?

Unflatten a Variable using`object.__new__` instead the constructor to avoid adding / calling hooks.