### PR TITLE
[nnx] flaglib add get overloads

### DIFF
--- a/flax/experimental/nnx/nnx/flaglib.py
+++ b/flax/experimental/nnx/nnx/flaglib.py
@@ -11,12 +11,15 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import annotations
 
 import dataclasses
 import threading
 import typing as tp
 from contextlib import contextmanager
 from types import MappingProxyType
+
+A = tp.TypeVar('A')
 
 
 @dataclasses.dataclass
@@ -60,7 +63,15 @@ class Flags(tp.Mapping[str, tp.Any]):
     finally:
       FLAGS_CONTEXT.flags_stack.pop()
 
-  def get(self, name: str, default: tp.Any = None) -> tp.Optional[tp.Any]:
+  @tp.overload
+  def get(self, name: str) -> tp.Any:
+    ...
+
+  @tp.overload
+  def get(self, name: str, default: A) -> A:
+    ...
+
+  def get(self, name: str, default: A = None) -> A | None:
     return FLAGS_CONTEXT.flags_stack[-1].get(name, default)
 
 


### PR DESCRIPTION
# What does this PR do?

Adds typing overloads for `flagslib.get`.