### PR TITLE
[nnx] Export missing symbols

### DIFF
--- a/flax/experimental/nnx/__init__.py
+++ b/flax/experimental/nnx/__init__.py
@@ -62,6 +62,11 @@ from .nnx.nn.activations import standardize as standardize
 from .nnx.nn.activations import swish as swish
 from .nnx.nn.activations import tanh as tanh
 from .nnx.nn.attention import MultiHeadAttention as MultiHeadAttention
+from .nnx.nn.attention import combine_masks as combine_masks
+from .nnx.nn.attention import dot_product_attention as dot_product_attention
+from .nnx.nn.attention import make_attention_mask as make_attention_mask
+from .nnx.nn.attention import make_causal_mask as make_causal_mask
+from .nnx.nn.initializers import Initializer as Initializer
 from .nnx.nn.linear import Conv as Conv
 from .nnx.nn.linear import Embed as Embed
 from .nnx.nn.linear import Linear as Linear

--- a/flax/experimental/nnx/nnx/nn/initializers.py
+++ b/flax/experimental/nnx/nnx/nn/initializers.py
@@ -15,7 +15,6 @@
 import typing as tp
 
 import jax
-import jax.numpy as jnp
 from jax.nn.initializers import constant as constant
 from jax.nn.initializers import delta_orthogonal as delta_orthogonal
 from jax.nn.initializers import glorot_normal as glorot_normal
@@ -39,13 +38,7 @@ Shape = tp.Sequence[int]
 DTypeLikeInexact = tp.Any
 Array = jax.Array
 
-
-class Initializer(tp.Protocol):
-  @staticmethod
-  def __call__(
-    key: Array, shape: Shape, dtype: DTypeLikeInexact = jnp.float_
-  ) -> Array:
-    ...
+Initializer = jax.nn.initializers.Initializer
 
 
 def zeros_init() -> Initializer:


### PR DESCRIPTION
# What does this PR do?

* Export missing symbols from the `attention` module
* Exports `Initializer`
* Adopts JAX's `Initializer` definition