### PR TITLE
fixed error doc formatting

### DIFF
--- a/flax/errors.py
+++ b/flax/errors.py
@@ -224,6 +224,7 @@ class ScopeCollectionNotFound(FlaxError):
   collection.
 
   There are two common causes:
+
   1. | The collection was not passed to ``apply`` correctly.
      | For example, you might have used ``module.apply(params, ...)`` instead
      | of ``module.apply({'params': params}, ...)``.


### PR DESCRIPTION
Fixed error doc formatting. View [here](https://flax--3587.org.readthedocs.build/en/3587/api_reference/flax.errors.html#flax.errors.ScopeCollectionNotFound).