### PR TITLE
Improve clarity of loss calculation in parallel_training guide

### DIFF
--- a/docs/guides/parallel_training/ensembling.rst
+++ b/docs/guides/parallel_training/ensembling.rst
@@ -105,7 +105,7 @@ Next we simply do the same for the functions ``apply_model()`` and
 ``update_model()``. To compute the average loss of the ensemble, we take the
 average of the individual losses. Similarly, to compute the predictions from
 the ensemble, we take the average of the individual probabilities. We use
-|jax.lax.pmean()|_ to computethe average *across devices*. This also requires
+|jax.lax.pmean()|_ to compute the average *across devices*. This also requires
 us to specify the ``axis_name`` to both |jax.pmap()|_ and |jax.lax.pmean()|_.
 
 .. codediff::

--- a/docs/guides/parallel_training/ensembling.rst
+++ b/docs/guides/parallel_training/ensembling.rst
@@ -102,10 +102,11 @@ will be scalar values. For more details see `JIT mechanics: tracing and static
 variables`_.
 
 Next we simply do the same for the functions ``apply_model()`` and
-``update_model()``. To compute the predictions from the ensemble, we take the
-average of the individual probabilities. We use |jax.lax.pmean()|_ to compute
-the average *across devices*. This also requires us to specify the
-``axis_name`` to both |jax.pmap()|_ and |jax.lax.pmean()|_.
+``update_model()``. To compute the average loss of the ensemble, we take the
+average of the individual losses. Similarly, to compute the predictions from
+the ensemble, we take the average of the individual probabilities. We use
+|jax.lax.pmean()|_ to computethe average *across devices*. This also requires
+us to specify the ``axis_name`` to both |jax.pmap()|_ and |jax.lax.pmean()|_.
 
 .. codediff::
   :title_left: Single-model

--- a/docs/guides/parallel_training/ensembling.rst
+++ b/docs/guides/parallel_training/ensembling.rst
@@ -140,6 +140,7 @@ the average *across devices*. This also requires us to specify the
 
     grad_fn = jax.value_and_grad(loss_fn, has_aux=True)
     (loss, logits), grads = grad_fn(state.params)
+    loss = jax.lax.pmean(loss, axis_name='ensemble')  #!
     probs = jax.lax.pmean(jax.nn.softmax(logits), axis_name='ensemble')  #!
     accuracy = jnp.mean(jnp.argmax(probs, -1) == labels)  #!
     return grads, loss, accuracy


### PR DESCRIPTION
# What does this PR do?

Introduce a `pmean` of the losses to improve clarity. 

## Details:
Thanks for creating this great guide!

The guide currently may lead to confusion in the handling of the ensemble loss calculation. The individual losses are returned from `apply_model` *without averaging*, then later unreplicated:

In `train_epoch`:
> `epoch_loss.append(jax_utils.unreplicate(loss))`

In the final code box:
>  ` _, test_loss, test_accuracy = jax_utils.unreplicate(apply_model(state, test_ds['image'], test_ds['label']))`

The use of `unreplicate` mean that only the loss of one model (the model on device 0) will be reported in the train and test losses. This may lead to users who follow this example unknowingly introducing bugs into their adapted versions. 

## Other Solutions
This could potentially be fixed in other ways (e.g. averaging outside of `apply_model`, or explicitly stating that this is the loss of only one model) - but I thought this was the simplest fix. Happy to take other suggestions!

## Checklist
- [x] This PR fixes a minor issue (e.g.: typo or small bug) or improves the docs (you can dismiss the other
      checks if that's the case).