### PR TITLE
[nnx] cleanup CallableProxy

### DIFF
--- a/flax/experimental/nnx/nnx/graph_utils.py
+++ b/flax/experimental/nnx/nnx/graph_utils.py
@@ -327,17 +327,17 @@ class GraphDef(tp.Generic[Node], reprlib.Representable):
   def apply(
     self, state: State, *states: State
   ) -> ApplyCaller[tuple[State, 'GraphDef[Node]']]:
-    accessesor = DelayedAccessor()
+    accessor = DelayedAccessor()
 
     def _apply(
-      accessesor, *args, **kwargs
+      accessor: DelayedAccessor, *args, **kwargs
     ) -> tuple[tp.Any, tuple[State, GraphDef[Node]]]:
       module = self.merge(state, *states)
-      fn = accessesor(module)
+      fn = accessor(module)
       out = fn(*args, **kwargs)
       return out, graph_flatten(module)
 
-    return CallableProxy(_apply, accessesor)  # type: ignore
+    return CallableProxy(_apply, accessor)  # type: ignore
 
   def make_empty(self) -> Node:
     return self.merge(State({}))


### PR DESCRIPTION
# What does this PR do?

* `CallableProxy` now create a `DelayedAccessor` by default if no accessor is given.
* Removes the creation of `DelayedAccessors` at many callsites `CallableProxy` is used.