### PR TITLE
add missing docs for module functions

### DIFF
--- a/docs/api_reference/flax.linen/module.rst
+++ b/docs/api_reference/flax.linen/module.rst
@@ -6,3 +6,8 @@ Module
 
 .. autoclass:: Module
    :members: setup, variable, param, bind, unbind, apply, init, init_with_output, copy, make_rng, sow, variables, Variable, __setattr__, tabulate, is_initializing, perturb, put_variable, has_variable, has_rng, lazy_init, get_variable, path, is_mutable_collection
+
+.. autofunction:: apply
+.. autofunction:: init
+.. autofunction:: init_with_output
+.. autofunction:: intercept_methods

--- a/flax/linen/module.py
+++ b/flax/linen/module.py
@@ -331,15 +331,15 @@ def intercept_methods(interceptor: Interceptor):
 
   >>> import flax.linen as nn
   >>> import jax.numpy as jnp
-
+  ...
   >>> class Foo(nn.Module):
   ...   def __call__(self, x):
   ...     return x
-
+  ...
   >>> def my_interceptor1(next_fun, args, kwargs, context):
   ...   print('calling my_interceptor1')
   ...   return next_fun(*args, **kwargs)
-
+  ...
   >>> foo = Foo()
   >>> with nn.intercept_methods(my_interceptor1):
   ...   _ = foo(jnp.ones([1]))
@@ -351,7 +351,7 @@ def intercept_methods(interceptor: Interceptor):
   >>> def my_interceptor2(next_fun, args, kwargs, context):
   ...   print('calling my_interceptor2')
   ...   return next_fun(*args, **kwargs)
-
+  ...
   >>> with nn.intercept_methods(my_interceptor1), \
   ...      nn.intercept_methods(my_interceptor2):
   ...   _ = foo(jnp.ones([1]))


### PR DESCRIPTION
# What does this PR do?

Adds `apply`, `init`, `init_with_output`, and `intercept_methods` to `module.rst`.