### PR TITLE
added flax.typing

### DIFF
--- a/flax/core/__init__.py
+++ b/flax/core/__init__.py
@@ -38,7 +38,6 @@ from .meta import (
     unbox as unbox,
 )
 from .scope import (
-    Array as Array,
     DenyList as DenyList,
     Scope as Scope,
     apply as apply,
@@ -50,4 +49,8 @@ from .tracers import (
     check_trace_level as check_trace_level,
     current_trace as current_trace,
     trace_level as trace_level,
+)
+
+from flax.typing import (
+    Array as Array,
 )

--- a/flax/core/meta.py
+++ b/flax/core/meta.py
@@ -23,12 +23,13 @@ to keep track of how variables should be partitioned with ``jax.pjit``.
 
 import abc
 import functools
-from typing import Any, Callable, Dict, Generic, Optional, Tuple, TypeVar, Union
+from typing import Any, Callable, Dict, Generic, Optional, TypeVar
 
 import jax
 from jax.experimental import maps
 
 from flax import errors, struct
+from flax.typing import LogicalNames
 
 A = TypeVar('A')
 B = TypeVar('B')
@@ -170,7 +171,6 @@ def replace_boxed(tree: Any, updates: Any) -> Any:
 
 
 PARTITION_NAME = 'partition_name'
-LogicalNames = Tuple[Union[str, None], ...]
 
 
 def _global_mesh_defined() -> bool:

--- a/flax/core/scope.py
+++ b/flax/core/scope.py
@@ -47,6 +47,17 @@ from flax import config as config
 from flax import configurations as legacy_config  # only for flax_lazy_rng
 from flax import errors, struct, traceback_util
 from flax.ids import uuid
+from flax.typing import (
+  PRNGKey,
+  Array,
+  RNGSequences,
+  Collection,
+  MutableCollection,
+  VariableDict,
+  FrozenVariableDict as FrozenVariableDict,
+  MutableVariableDict,
+  PRNGFoldable
+)
 
 from . import meta, partial_eval, tracers
 from .frozen_dict import FrozenDict, freeze, unfreeze
@@ -54,11 +65,6 @@ from .frozen_dict import FrozenDict, freeze, unfreeze
 traceback_util.register_exclusion(__file__)
 
 T = TypeVar('T')
-
-PRNGKey = Any
-Array = Any
-
-RNGSequences = Dict[str, PRNGKey]
 
 
 Filter = Union[bool, str, typing.Collection[str], 'DenyList']
@@ -70,16 +76,12 @@ Filter = Union[bool, str, typing.Collection[str], 'DenyList']
 @dataclasses.dataclass(frozen=True, eq=True)
 class DenyList:
   """DenyList represents an opt-out based mutability filter.
-
   DenyList can be used to make every collection mutable except the ones
   defined in the given filter.
   To for example make everything but the params collection mutable::
-
     nn.apply(fn, mutable=nn.DenyList(["params"]))
-
   Attributes:
     deny: The filter representing the collections that are not mutable.
-
   """
 
   deny: Filter
@@ -87,15 +89,6 @@ class DenyList:
 
 CollectionFilter = Filter
 PRNGSequenceFilter = Filter
-
-Collection = Mapping[str, Any]
-MutableCollection = Dict[str, Any]
-
-VariableDict = Mapping[str, Collection]
-FrozenVariableDict = FrozenDict[str, Collection]
-MutableVariableDict = Dict[str, MutableCollection]
-
-PRNGFoldable = Union[int, str]
 
 
 class LazyRng(struct.PyTreeNode):
@@ -431,7 +424,7 @@ class Scope:
   def __init__(
     self,
     variables: MutableVariableDict,
-    rngs: Optional[Dict[str, Union[PRNGKey, LazyRng]]] = None,
+    rngs: Optional[Union[RNGSequences, Dict[str, LazyRng]]] = None,
     name: Optional[str] = None,
     mutable: CollectionFilter = False,
     parent: Optional['Scope'] = None,

--- a/flax/cursor.py
+++ b/flax/cursor.py
@@ -48,7 +48,7 @@ class AccessType(enum.Enum):
 @dataclasses.dataclass
 class ParentKey(Generic[A]):
   parent: 'Cursor[A]'
-  key: Any
+  key: Key
   access_type: AccessType
 
 

--- a/flax/experimental/nnx/__init__.py
+++ b/flax/experimental/nnx/__init__.py
@@ -16,6 +16,7 @@ from flax.linen.pooling import avg_pool as avg_pool
 from flax.linen.pooling import max_pool as max_pool
 from flax.linen.pooling import min_pool as min_pool
 from flax.linen.pooling import pool as pool
+from flax.typing import Initializer as Initializer
 
 from .nnx import compatibility as compatibility
 from .nnx.dataclasses import dataclass as dataclass
@@ -66,7 +67,6 @@ from .nnx.nn.attention import combine_masks as combine_masks
 from .nnx.nn.attention import dot_product_attention as dot_product_attention
 from .nnx.nn.attention import make_attention_mask as make_attention_mask
 from .nnx.nn.attention import make_causal_mask as make_causal_mask
-from .nnx.nn.initializers import Initializer as Initializer
 from .nnx.nn.linear import Conv as Conv
 from .nnx.nn.linear import Embed as Embed
 from .nnx.nn.linear import Linear as Linear

--- a/flax/experimental/nnx/nnx/filterlib.py
+++ b/flax/experimental/nnx/nnx/filterlib.py
@@ -14,6 +14,7 @@
 
 import builtins
 import dataclasses
+from flax.typing import Path
 import typing as tp
 
 if tp.TYPE_CHECKING:
@@ -21,7 +22,6 @@ if tp.TYPE_CHECKING:
 else:
   ellipsis = tp.Any
 
-Path = str
 Predicate = tp.Callable[[Path, tp.Any], bool]
 FilterLiteral = tp.Union[type, str, Predicate, bool, ellipsis, None]
 Filter = tp.Union[FilterLiteral, tuple[FilterLiteral, ...], list[FilterLiteral]]

--- a/flax/experimental/nnx/nnx/graph_utils.py
+++ b/flax/experimental/nnx/nnx/graph_utils.py
@@ -28,14 +28,13 @@ from flax.experimental.nnx.nnx.proxy_caller import (
 )
 from flax.experimental.nnx.nnx.state import State
 from flax.experimental.nnx.nnx.variables import EMPTY, Empty, Variable
+from flax.typing import Path, PathParts
 
 HA = tp.TypeVar('HA', bound=tp.Hashable)
 HB = tp.TypeVar('HB', bound=tp.Hashable)
 
 Index = int
 Names = tp.Sequence[int]
-PathParts = tuple[str, ...]
-Path = str
 Node = tp.TypeVar('Node')
 Leaf = tp.TypeVar('Leaf')
 AuxData = tp.TypeVar('AuxData')

--- a/flax/experimental/nnx/nnx/module.py
+++ b/flax/experimental/nnx/nnx/module.py
@@ -43,15 +43,13 @@ from flax.experimental.nnx.nnx.proxy_caller import (
 from flax.experimental.nnx.nnx.rnglib import Rngs
 from flax.experimental.nnx.nnx.state import State
 from flax.experimental.nnx.nnx.variables import Variable
+from flax.typing import Path
 
 A = tp.TypeVar('A')
 B = tp.TypeVar('B')
 M = tp.TypeVar('M', bound='Module')
 S = tp.TypeVar('S', bound=tp.Union[State, tuple[State, ...]])
 V = tp.TypeVar('V', bound=variableslib.Variable[tp.Any])
-
-Path = str
-PathParts = tuple[str, ...]
 
 StateMapping = tp.Mapping[Path, tp.Any]
 

--- a/flax/experimental/nnx/nnx/nn/attention.py
+++ b/flax/experimental/nnx/nnx/nn/attention.py
@@ -17,7 +17,7 @@
 from __future__ import annotations
 
 import functools
-from typing import Any, Callable, Optional, Tuple, overload
+from typing import Any, Callable, Optional, overload
 
 import jax
 import jax.numpy as jnp
@@ -30,16 +30,18 @@ from flax.experimental.nnx.nnx.module import Module, first_from
 from flax.experimental.nnx.nnx.nn import initializers
 from flax.experimental.nnx.nnx.nn.dtypes import promote_dtype
 from flax.experimental.nnx.nnx.nn.linear import (
-  DotGeneralT,
   LinearGeneral,
-  PrecisionLike,
   default_kernel_init,
 )
 from flax.experimental.nnx.nnx.nn.normalization import LayerNorm
-
-Array = jax.Array
-Shape = Tuple[int, ...]
-Dtype = Any
+from flax.typing import (
+  Array,
+  Dtype,
+  Shape,
+  Initializer,
+  PrecisionLike,
+  DotGeneralT,
+)
 
 
 def dot_product_attention_weights(
@@ -301,8 +303,8 @@ class MultiHeadAttention(Module):
     dropout_rate: float = 0.0,
     deterministic: bool | None = None,
     precision: PrecisionLike = None,
-    kernel_init: initializers.Initializer = default_kernel_init,
-    bias_init: initializers.Initializer = initializers.zeros_init(),
+    kernel_init: Initializer = default_kernel_init,
+    bias_init: Initializer = initializers.zeros_init(),
     use_bias: bool = True,
     attention_fn: Callable[..., Array] = dot_product_attention,
     decode: bool | None = None,

--- a/flax/experimental/nnx/nnx/nn/dtypes.py
+++ b/flax/experimental/nnx/nnx/nn/dtypes.py
@@ -12,14 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Optional
-
+from typing import Optional
+from flax.typing import Dtype
 from jax import numpy as jnp
 from typing_extensions import TypeVarTuple, Unpack
 
 T = TypeVarTuple('T')
-Dtype = Any
-Array = Any
 
 
 def canonicalize_dtype(

--- a/flax/experimental/nnx/nnx/nn/initializers.py
+++ b/flax/experimental/nnx/nnx/nn/initializers.py
@@ -14,7 +14,6 @@
 
 import typing as tp
 
-import jax
 from jax.nn.initializers import constant as constant
 from jax.nn.initializers import delta_orthogonal as delta_orthogonal
 from jax.nn.initializers import glorot_normal as glorot_normal
@@ -33,12 +32,9 @@ from jax.nn.initializers import variance_scaling as variance_scaling
 from jax.nn.initializers import xavier_normal as xavier_normal
 from jax.nn.initializers import xavier_uniform as xavier_uniform
 from jax.nn.initializers import zeros as zeros
+from flax.typing import Initializer
 
-Shape = tp.Sequence[int]
-DTypeLikeInexact = tp.Any
-Array = jax.Array
-
-Initializer = jax.nn.initializers.Initializer
+DtypeLikeInexact = tp.Any
 
 
 def zeros_init() -> Initializer:

--- a/flax/experimental/nnx/nnx/nn/linear.py
+++ b/flax/experimental/nnx/nnx/nn/linear.py
@@ -39,24 +39,19 @@ from flax.experimental import nnx
 from flax.experimental.nnx.nnx import rnglib, variables
 from flax.experimental.nnx.nnx.module import Module
 from flax.experimental.nnx.nnx.nn import dtypes, initializers
+from flax.typing import (
+  Array,
+  Dtype,
+  Initializer,
+  PrecisionLike,
+  DotGeneralT,
+  ConvGeneralDilatedT,
+  PaddingLike,
+  LaxPadding,
+)
 
-Array = jax.Array
-KeyArray = jax.Array
-Shape = tp.Tuple[int, ...]
-Dtype = tp.Any  # this could be a real type?
 Axis = int
 Size = int
-PrecisionLike = tp.Union[
-  None,
-  str,
-  lax.Precision,
-  tp.Tuple[str, str],
-  tp.Tuple[lax.Precision, lax.Precision],
-]
-ConvGeneralDilatedT = tp.Callable[..., Array]
-PaddingLike = tp.Union[str, int, tp.Sequence[tp.Union[int, tp.Tuple[int, int]]]]
-LaxPadding = tp.Union[str, tp.Sequence[tp.Tuple[int, int]]]
-DotGeneralT = tp.Callable[..., Array]
 
 
 default_kernel_init = initializers.lecun_normal()
@@ -152,8 +147,8 @@ class LinearGeneral(Module):
     use_bias: bool = True,
     dtype: Dtype | None = None,
     param_dtype: Dtype = jnp.float32,
-    kernel_init: initializers.Initializer = default_kernel_init,
-    bias_init: initializers.Initializer = initializers.zeros_init(),
+    kernel_init: Initializer = default_kernel_init,
+    bias_init: Initializer = initializers.zeros_init(),
     precision: PrecisionLike = None,
     # Deprecated. Will be removed.
     dot_general: DotGeneralT | None = None,
@@ -310,12 +305,8 @@ class Linear(Module):
     dtype: tp.Optional[Dtype] = None,
     param_dtype: Dtype = jnp.float32,
     precision: PrecisionLike = None,
-    kernel_init: tp.Callable[
-      [KeyArray, Shape, Dtype], Array
-    ] = default_kernel_init,
-    bias_init: tp.Callable[
-      [KeyArray, Shape, Dtype], Array
-    ] = initializers.zeros_init(),
+    kernel_init: Initializer = default_kernel_init,
+    bias_init: Initializer = initializers.zeros_init(),
     dot_general: DotGeneralT = lax.dot_general,
     rngs: rnglib.Rngs,
   ):
@@ -420,12 +411,8 @@ class Conv(Module):
     dtype: tp.Optional[Dtype] = None,
     param_dtype: Dtype = jnp.float32,
     precision: PrecisionLike = None,
-    kernel_init: tp.Callable[
-      [KeyArray, Shape, Dtype], Array
-    ] = default_kernel_init,
-    bias_init: tp.Callable[
-      [KeyArray, Shape, Dtype], Array
-    ] = initializers.zeros_init(),
+    kernel_init: Initializer = default_kernel_init,
+    bias_init: Initializer = initializers.zeros_init(),
     conv_general_dilated: ConvGeneralDilatedT = lax.conv_general_dilated,
     rngs: rnglib.Rngs,
   ):
@@ -566,7 +553,7 @@ class Conv(Module):
     )
 
     if self.use_bias:
-      bias = bias.reshape((1,) * (y.ndim - bias.ndim) + bias.shape)
+      bias = bias.reshape((1,) * (y.ndim - bias.ndim) + bias.shape)  # type: ignore
       y += bias
 
     if num_batch_dimensions != 1:
@@ -607,9 +594,7 @@ class Embed(Module):
     *,
     dtype: tp.Optional[Dtype] = None,
     param_dtype: Dtype = jnp.float32,
-    embedding_init: tp.Callable[
-      [KeyArray, Shape, Dtype], Array
-    ] = default_embed_init,
+    embedding_init: Initializer = default_embed_init,
     rngs: rnglib.Rngs,
   ):
     self.embedding = nnx.Param(

--- a/flax/experimental/nnx/nnx/nn/normalization.py
+++ b/flax/experimental/nnx/nnx/nn/normalization.py
@@ -14,7 +14,6 @@
 
 import typing as tp
 
-import jax
 import jax.numpy as jnp
 from jax import lax
 
@@ -22,13 +21,12 @@ from flax.experimental import nnx
 from flax.experimental.nnx.nnx import flaglib, rnglib
 from flax.experimental.nnx.nnx.module import Module, first_from
 from flax.experimental.nnx.nnx.nn import dtypes, initializers
-
-KeyArray = jax.Array
-Array = jax.Array
-Shape = tp.Tuple[int, ...]
-Dtype = tp.Any  # this could be a real type?
-
-Axes = tp.Union[int, tp.Any]
+from flax.typing import (
+  Array,
+  Dtype,
+  Initializer,
+  Axes,
+)
 
 
 def _canonicalize_axes(rank: int, axes: Axes) -> tp.Tuple[int, ...]:
@@ -116,7 +114,7 @@ def _normalize(
   bias: tp.Optional[Array],
   reduction_axes: Axes,
   feature_axes: Axes,
-  dtype: Dtype,
+  dtype: tp.Optional[Dtype],
   epsilon: float,
 ):
   """ "Normalizes the input of a normalization layer and optionally applies a learned scale and bias.
@@ -201,12 +199,8 @@ class BatchNorm(Module):
     param_dtype: Dtype = jnp.float32,
     use_bias: bool = True,
     use_scale: bool = True,
-    bias_init: tp.Callable[
-      [KeyArray, Shape, Dtype], Array
-    ] = initializers.zeros_init(),
-    scale_init: tp.Callable[
-      [KeyArray, Shape, Dtype], Array
-    ] = initializers.ones_init(),
+    bias_init: Initializer = initializers.zeros_init(),
+    scale_init: Initializer = initializers.ones_init(),
     axis_name: tp.Optional[str] = None,
     axis_index_groups: tp.Any = None,
     rngs: rnglib.Rngs,
@@ -334,12 +328,8 @@ class LayerNorm(Module):
     param_dtype: Dtype = jnp.float32,
     use_bias: bool = True,
     use_scale: bool = True,
-    bias_init: tp.Callable[
-      [KeyArray, Shape, Dtype], Array
-    ] = initializers.zeros_init(),
-    scale_init: tp.Callable[
-      [KeyArray, Shape, Dtype], Array
-    ] = initializers.ones_init(),
+    bias_init: Initializer = initializers.zeros_init(),
+    scale_init: Initializer = initializers.ones_init(),
     reduction_axes: Axes = -1,
     feature_axes: Axes = -1,
     axis_name: tp.Optional[str] = None,

--- a/flax/experimental/nnx/nnx/spmd.py
+++ b/flax/experimental/nnx/nnx/spmd.py
@@ -22,16 +22,17 @@ from jax.sharding import Mesh, PartitionSpec
 from flax.experimental.nnx.nnx import variables
 from flax.experimental.nnx.nnx.pytreelib import TreeNode
 from flax.experimental.nnx.nnx.state import State
+from flax.typing import (
+  Array,
+  ArrayPytree,  # pylint: disable=invalid-name
+  PartitionSpecPytree,  # pylint: disable=invalid-name
+  Sharding,
+)
 
-# Real types and dummy aliases for documentation
-Array = tp.Any  # pylint: disable=invalid-name
-ArrayPytree = tp.Any  # pylint: disable=invalid-name
-PartitionSpecPytree = tp.Any  # pylint: disable=invalid-name
 
 A = tp.TypeVar('A')
 F = tp.TypeVar('F', bound=tp.Callable[..., tp.Any])
 PARTITION_NAME = 'partition_name'
-Sharding = tuple[tp.Optional[str], ...]
 
 
 @tp.runtime_checkable

--- a/flax/experimental/nnx/nnx/state.py
+++ b/flax/experimental/nnx/nnx/state.py
@@ -35,11 +35,10 @@ import jax.tree_util as jtu
 from flax import traverse_util
 from flax.experimental.nnx.nnx import filterlib, reprlib
 from flax.experimental.nnx.nnx.variables import Variable
+from flax.typing import Path, Leaf
 
 A = tp.TypeVar('A')
 
-Leaf = tp.Any
-Path = str
 Key = str
 FlatState = dict[Path, Variable[Leaf]]
 

--- a/flax/experimental/nnx/nnx/transforms.py
+++ b/flax/experimental/nnx/nnx/transforms.py
@@ -51,6 +51,7 @@ from flax.experimental.nnx.nnx.proxy_caller import (
   DelayedAccessor,
 )
 from flax.experimental.nnx.nnx.state import State
+from flax.typing import Leaf
 
 A = tp.TypeVar('A')
 C = tp.TypeVar('C')
@@ -61,7 +62,6 @@ M = tp.TypeVar('M', bound=Module)
 N = tp.TypeVar('N', bound=Module)
 
 AxisName = tp.Hashable
-Leaf = tp.Any
 Leaves = tp.List[Leaf]
 
 

--- a/flax/experimental/nnx/nnx/variables.py
+++ b/flax/experimental/nnx/nnx/variables.py
@@ -37,12 +37,12 @@ import jax
 import jax.tree_util as jtu
 
 from flax.experimental.nnx.nnx import reprlib
+from flax.typing import Sharding
 
 A = tp.TypeVar('A')
 B = tp.TypeVar('B')
 F = tp.TypeVar('F', bound=tp.Callable[..., tp.Any])
 V = tp.TypeVar('V', bound='Variable[Any]')
-Sharding = tp.Tuple[tp.Optional[str], ...]
 GetValueHook = tp.Callable[['Variable[A]', A], A]
 SetValueHook = tp.Callable[['Variable[A]', A], A]
 CreateValueHook = tp.Callable[['Variable[A]', A], A]

--- a/flax/linen/activation.py
+++ b/flax/linen/activation.py
@@ -21,6 +21,7 @@ from typing import Any, Optional
 from flax.linen.module import compact
 from flax.linen.module import Module
 from flax.linen.linear import Dense
+from flax.typing import Array, Dtype
 
 from jax.nn import celu
 from jax.nn import elu
@@ -53,9 +54,6 @@ normalize = standardize
 
 # pylint: enable=unused-import
 
-
-Array = Any
-Dtype = Any
 
 
 class PReLU(Module):

--- a/flax/linen/attention.py
+++ b/flax/linen/attention.py
@@ -16,7 +16,7 @@
 
 import functools
 import warnings
-from typing import Any, Callable, Optional, Tuple, Union, overload
+from typing import Any, Callable, Optional, Union, overload
 
 import jax
 import jax.numpy as jnp
@@ -26,17 +26,19 @@ from flax.linen import initializers
 from flax.linen.dtypes import promote_dtype
 from flax.linen.linear import (
   DenseGeneral,
-  DotGeneralT,
-  PrecisionLike,
   default_kernel_init,
 )
 from flax.linen.module import Module, compact, merge_param
 from flax.linen.normalization import LayerNorm
-
-PRNGKey = jax.Array
-Shape = Tuple[int, ...]
-Dtype = Any
-Array = Any
+from flax.typing import (
+  Array,
+  PRNGKey,
+  Dtype,
+  Shape as Shape,
+  Initializer,
+  PrecisionLike,
+  DotGeneralT,
+)
 
 
 def dot_product_attention_weights(
@@ -296,10 +298,8 @@ class MultiHeadDotProductAttention(Module):
   dropout_rate: float = 0.0
   deterministic: Optional[bool] = None
   precision: PrecisionLike = None
-  kernel_init: Callable[[PRNGKey, Shape, Dtype], Array] = default_kernel_init
-  bias_init: Callable[
-    [PRNGKey, Shape, Dtype], Array
-  ] = initializers.zeros_init()
+  kernel_init: Initializer = default_kernel_init
+  bias_init: Initializer = initializers.zeros_init()
   use_bias: bool = True
   attention_fn: Callable[..., Array] = dot_product_attention
   decode: bool = False
@@ -329,7 +329,7 @@ class MultiHeadDotProductAttention(Module):
     self,
     inputs_q: Array,
     *,
-    inputs_kv: Array = None,
+    inputs_kv: Optional[Array] = None,
     mask: Optional[Array] = None,
     deterministic: Optional[bool] = None,
     dropout_rng: Optional[PRNGKey] = None,
@@ -766,7 +766,7 @@ def make_causal_mask(
   )
 
 
-def combine_masks(*masks: Optional[Array], dtype: Dtype = jnp.float32) -> Array:
+def combine_masks(*masks: Optional[Array], dtype: Dtype = jnp.float32) -> Optional[Array]:
   """Combine attention masks.
 
   Args:

--- a/flax/linen/dtypes.py
+++ b/flax/linen/dtypes.py
@@ -28,11 +28,8 @@
 """APIs for handling dtypes in Linen Modules."""
 
 from typing import Any, List, Optional
-
+from flax.typing import Dtype
 from jax import numpy as jnp
-
-Dtype = Any
-Array = Any
 
 
 def canonicalize_dtype(
@@ -67,7 +64,7 @@ def canonicalize_dtype(
   return dtype
 
 
-def promote_dtype(*args, dtype=None, inexact=True) -> List[Array]:
+def promote_dtype(*args, dtype=None, inexact=True) -> List[Any]:
   """ "Promotes input arguments to a specified or inferred dtype.
 
   All args are cast to the same dtype. See ``canonicalize_dtype`` for how

--- a/flax/linen/initializers.py
+++ b/flax/linen/initializers.py
@@ -16,7 +16,6 @@
 
 # pylint: disable=unused-import
 # re-export initializer functions from jax.nn
-from jax.nn.initializers import Initializer as Initializer
 from jax.nn.initializers import constant as constant
 from jax.nn.initializers import delta_orthogonal as delta_orthogonal
 from jax.nn.initializers import glorot_normal as glorot_normal
@@ -36,6 +35,7 @@ from jax.nn.initializers import variance_scaling as variance_scaling
 from jax.nn.initializers import xavier_normal as xavier_normal
 from jax.nn.initializers import xavier_uniform as xavier_uniform
 from jax.nn.initializers import zeros as zeros
+from flax.typing import Initializer as Initializer
 
 # pylint: enable=unused-import
 

--- a/flax/linen/module.py
+++ b/flax/linen/module.py
@@ -60,19 +60,19 @@ from flax.core.frozen_dict import FrozenDict
 from flax.core.scope import (
   CollectionFilter,
   DenyList,
-  FrozenVariableDict,
   Variable,
-  VariableDict,
   union_filters,
 )
 from flax.ids import FlaxId, uuid
 from flax.linen import kw_only_dataclasses
+from flax.typing import (
+  RNGSequences,
+  PRNGKey,
+  FrozenVariableDict,
+  VariableDict,
+)
 
 traceback_util.register_exclusion(__file__)
-
-KeyArray = jax.Array
-RNGSequences = Dict[str, KeyArray]
-Array = Any  # pylint: disable=invalid-name
 
 
 T = TypeVar('T')
@@ -1758,7 +1758,7 @@ class Module(ModuleBase):
       raise ValueError("Can't query for RNGs on unbound modules")
     return self.scope.has_rng(name)
 
-  def make_rng(self, name: str = 'default') -> KeyArray:
+  def make_rng(self, name: str = 'default') -> PRNGKey:
     """Returns a new RNG key from a given RNG sequence for this Module.
 
     The new RNG key is split from the previous one. Thus, every call to
@@ -2018,7 +2018,7 @@ class Module(ModuleBase):
   @traceback_util.api_boundary
   def init_with_output(
     self,
-    rngs: Union[KeyArray, RNGSequences],
+    rngs: Union[PRNGKey, RNGSequences],
     *args,
     method: Union[Callable[..., Any], str, None] = None,
     mutable: CollectionFilter = DenyList('intermediates'),
@@ -2055,7 +2055,7 @@ class Module(ModuleBase):
     if not isinstance(rngs, dict):
       if not core.scope._is_valid_rng(rngs):
         raise errors.InvalidRngError(
-          'RNGs should be of shape (2,) or KeyArray in Module '
+          'RNGs should be of shape (2,) or PRNGKey in Module '
           f'{self.__class__.__name__}, but rngs are: {rngs}'
         )
       rngs = {'params': rngs}
@@ -2082,7 +2082,7 @@ class Module(ModuleBase):
   @traceback_util.api_boundary
   def init(
     self,
-    rngs: Union[KeyArray, RNGSequences],
+    rngs: Union[PRNGKey, RNGSequences],
     *args,
     method: Union[Callable[..., Any], str, None] = None,
     mutable: CollectionFilter = DenyList('intermediates'),
@@ -2189,7 +2189,7 @@ class Module(ModuleBase):
   @traceback_util.api_boundary
   def lazy_init(
     self,
-    rngs: Union[KeyArray, RNGSequences],
+    rngs: Union[PRNGKey, RNGSequences],
     *args,
     method: Optional[Callable[..., Any]] = None,
     mutable: CollectionFilter = DenyList('intermediates'),
@@ -2460,7 +2460,7 @@ class Module(ModuleBase):
 
   def tabulate(
     self,
-    rngs: Union[KeyArray, RNGSequences],
+    rngs: Union[PRNGKey, RNGSequences],
     *args,
     depth: Optional[int] = None,
     show_repeated: bool = False,
@@ -2590,7 +2590,7 @@ class Module(ModuleBase):
 
   def module_paths(
     self,
-    rngs: Union[KeyArray, RNGSequences],
+    rngs: Union[PRNGKey, RNGSequences],
     *args,
     show_repeated: bool = False,
     mutable: CollectionFilter = DenyList('intermediates'),

--- a/flax/linen/normalization.py
+++ b/flax/linen/normalization.py
@@ -16,7 +16,7 @@
 
 import dataclasses
 import functools
-from typing import Any, Callable, Iterable, Optional, Sequence, Tuple, Union
+from typing import Any, Iterable, Optional, Tuple
 
 import jax
 import jax.numpy as jnp
@@ -24,12 +24,14 @@ from jax import lax
 from jax.nn import initializers
 
 from flax.linen import dtypes, module, transforms
-
-PRNGKey = Any
-Array = Any
-Shape = Tuple[int, ...]
-Dtype = Any  # this could be a real type?
-Axes = Union[int, Sequence[int]]
+from flax.typing import (
+  Array,
+  PRNGKey as PRNGKey,
+  Dtype,
+  Shape as Shape,
+  Initializer,
+  Axes,
+)
 
 field = dataclasses.field
 canonicalize_dtype = dtypes.canonicalize_dtype
@@ -145,13 +147,13 @@ def _normalize(
   var: Array,
   reduction_axes: Axes,
   feature_axes: Axes,
-  dtype: Dtype,
+  dtype: Optional[Dtype],
   param_dtype: Dtype,
   epsilon: float,
   use_bias: bool,
   use_scale: bool,
-  bias_init: Callable[[PRNGKey, Shape, Dtype], Array],
-  scale_init: Callable[[PRNGKey, Shape, Dtype], Array],
+  bias_init: Initializer,
+  scale_init: Initializer,
 ):
   """Normalizes the input of a normalization layer and optionally applies a learned scale and bias.
 
@@ -291,8 +293,8 @@ class BatchNorm(Module):
   param_dtype: Dtype = jnp.float32
   use_bias: bool = True
   use_scale: bool = True
-  bias_init: Callable[[PRNGKey, Shape, Dtype], Array] = initializers.zeros
-  scale_init: Callable[[PRNGKey, Shape, Dtype], Array] = initializers.ones
+  bias_init: Initializer = initializers.zeros
+  scale_init: Initializer = initializers.ones
   axis_name: Optional[str] = None
   axis_index_groups: Any = None
   use_fast_variance: bool = True
@@ -438,8 +440,8 @@ class LayerNorm(Module):
   param_dtype: Dtype = jnp.float32
   use_bias: bool = True
   use_scale: bool = True
-  bias_init: Callable[[PRNGKey, Shape, Dtype], Array] = initializers.zeros
-  scale_init: Callable[[PRNGKey, Shape, Dtype], Array] = initializers.ones
+  bias_init: Initializer = initializers.zeros
+  scale_init: Initializer = initializers.ones
   reduction_axes: Axes = -1
   feature_axes: Axes = -1
   axis_name: Optional[str] = None
@@ -534,7 +536,7 @@ class RMSNorm(Module):
   dtype: Optional[Dtype] = None
   param_dtype: Dtype = jnp.float32
   use_scale: bool = True
-  scale_init: Callable[[PRNGKey, Shape, Dtype], Array] = initializers.ones
+  scale_init: Initializer = initializers.ones
   reduction_axes: Axes = -1
   feature_axes: Axes = -1
   axis_name: Optional[str] = None
@@ -654,8 +656,8 @@ class GroupNorm(Module):
   param_dtype: Dtype = jnp.float32
   use_bias: bool = True
   use_scale: bool = True
-  bias_init: Callable[[PRNGKey, Shape, Dtype], Array] = initializers.zeros
-  scale_init: Callable[[PRNGKey, Shape, Dtype], Array] = initializers.ones
+  bias_init: Initializer = initializers.zeros
+  scale_init: Initializer = initializers.ones
   reduction_axes: Optional[Axes] = None
   axis_name: Optional[str] = None
   axis_index_groups: Any = None
@@ -824,8 +826,8 @@ class InstanceNorm(Module):
   param_dtype: Dtype = jnp.float32
   use_bias: bool = True
   use_scale: bool = True
-  bias_init: Callable[[PRNGKey, Shape, Dtype], Array] = initializers.zeros
-  scale_init: Callable[[PRNGKey, Shape, Dtype], Array] = initializers.ones
+  bias_init: Initializer = initializers.zeros
+  scale_init: Initializer = initializers.ones
   feature_axes: Axes = -1
   axis_name: Optional[str] = None
   axis_index_groups: Any = None
@@ -1232,7 +1234,7 @@ class WeightNorm(Module):
   dtype: Optional[Dtype] = None
   param_dtype: Dtype = jnp.float32
   use_scale: bool = True
-  scale_init: Callable[[PRNGKey, Shape, Dtype], Array] = initializers.ones
+  scale_init: Initializer = initializers.ones
   feature_axes: Optional[Axes] = -1
   variable_filter: Optional[Iterable] = dataclasses.field(
     default_factory=lambda: {'kernel'}

--- a/flax/linen/partitioning.py
+++ b/flax/linen/partitioning.py
@@ -37,27 +37,35 @@ from flax import linen as nn
 from flax import struct
 from flax.core.frozen_dict import freeze
 from flax.core.frozen_dict import unfreeze
-from flax.core.lift import In as ScanIn  # pylint: disable=unused-import
-from flax.core.lift import Out as ScanOut  # pylint: disable=unused-import
+from flax.core.scope import (
+  CollectionFilter as CollectionFilter,
+  PRNGSequenceFilter as PRNGSequenceFilter,
+)
 from flax.linen.spmd import _axis_rules  # pylint: disable=unused-import
 from flax.linen.spmd import _AxisRules  # pylint: disable=unused-import
 from flax.linen.spmd import _is_logical_spec
 from flax.linen.spmd import _with_sharding_constraint  # pylint: disable=unused-import
-from flax.linen.spmd import Array  # pylint: disable=unused-import
-from flax.linen.spmd import ArrayPytree  # pylint: disable=unused-import
 from flax.linen.spmd import get_logical_axis_rules as get_axis_rules  # pylint: disable=unused-import
 from flax.linen.spmd import logical_axis_rules as axis_rules  # pylint: disable=unused-import
 from flax.linen.spmd import logical_to_mesh  # pylint: disable=unused-import
 from flax.linen.spmd import logical_to_mesh_axes  # pylint: disable=unused-import
-from flax.linen.spmd import LogicalPartitionSpec  # pylint: disable=unused-import
-from flax.linen.spmd import LogicalPartitionSpecPytree
-from flax.linen.spmd import LogicalRules  # pylint: disable=unused-import
-from flax.linen.spmd import PartitionSpecPytree  # pylint: disable=unused-import
 from flax.linen.spmd import RulesFallback
 from flax.linen.spmd import set_logical_axis_rules as set_axis_rules  # pylint: disable=unused-import
 from flax.linen.spmd import with_logical_constraint as with_sharding_constraint
 from flax.traverse_util import flatten_dict
 from flax.traverse_util import unflatten_dict
+from flax.typing import (
+  Array,
+  In as ScanIn,  # pylint: disable=unused-import
+  Out as ScanOut,  # pylint: disable=unused-import
+  InOutAxis,
+  InOutScanAxis,
+  LogicalRules,  # pylint: disable=unused-import
+  ArrayPytree,  # pylint: disable=unused-import
+  LogicalPartitionSpec,  # pylint: disable=unused-import
+  LogicalPartitionSpecPytree,
+  PartitionSpecPytree,  # pylint: disable=unused-import
+)
 import jax
 
 
@@ -403,11 +411,11 @@ def _add_axis_to_metadata(fn, axis_pos, axis_name, axis_col='params_axes'):
 def scan_with_axes(
     target: 'flax.linen.transforms.Target',
     variable_axes: Mapping[
-        flax.core.lift.CollectionFilter, flax.core.lift.InOutScanAxis
+        CollectionFilter, InOutScanAxis
     ] = {},
-    variable_broadcast: flax.core.lift.CollectionFilter = False,
-    variable_carry: flax.core.lift.CollectionFilter = False,
-    split_rngs: Mapping[flax.core.lift.PRNGSequenceFilter, bool] = {},
+    variable_broadcast: CollectionFilter = False,
+    variable_carry: CollectionFilter = False,
+    split_rngs: Mapping[PRNGSequenceFilter, bool] = {},
     in_axes=0,
     out_axes=0,
     length: Optional[int] = None,
@@ -459,9 +467,9 @@ def scan_with_axes(
 def vmap_with_axes(
     target: 'flax.linen.transforms.Target',
     variable_axes: Mapping[
-        flax.core.lift.CollectionFilter, flax.core.lift.InOutAxis
+        CollectionFilter, InOutAxis
     ],
-    split_rngs: Mapping[flax.core.lift.PRNGSequenceFilter, bool] = {},
+    split_rngs: Mapping[PRNGSequenceFilter, bool] = {},
     in_axes=0,
     out_axes=0,
     axis_size: Optional[int] = None,

--- a/flax/linen/recurrent.py
+++ b/flax/linen/recurrent.py
@@ -38,19 +38,23 @@ from jax import numpy as jnp
 from jax import random
 from typing_extensions import Protocol
 
-from flax.core import lift
 from flax.core.frozen_dict import FrozenDict
+from flax.core.scope import CollectionFilter, PRNGSequenceFilter
 from flax.linen import initializers, transforms
 from flax.linen.activation import sigmoid, tanh
 from flax.linen.dtypes import promote_dtype
-from flax.linen.linear import Conv, Dense, PrecisionLike, default_kernel_init
+from flax.linen.linear import Conv, Dense, default_kernel_init
 from flax.linen.module import Module, compact, nowrap
+from flax.typing import (
+  Array,
+  PRNGKey,
+  Dtype,
+  InOutScanAxis,
+  Initializer,
+  PrecisionLike,
+)
 
 A = TypeVar('A')
-PRNGKey = jax.Array
-Shape = Tuple[int, ...]
-Dtype = Any  # this could be a real type?
-Array = jax.Array
 Carry = Any
 CarryHistory = Any
 Output = Any
@@ -126,12 +130,12 @@ class LSTMCell(RNNCellBase):
   features: int
   gate_fn: Callable[..., Any] = sigmoid
   activation_fn: Callable[..., Any] = tanh
-  kernel_init: initializers.Initializer = default_kernel_init
-  recurrent_kernel_init: initializers.Initializer = initializers.orthogonal()
-  bias_init: initializers.Initializer = initializers.zeros_init()
+  kernel_init: Initializer = default_kernel_init
+  recurrent_kernel_init: Initializer = initializers.orthogonal()
+  bias_init: Initializer = initializers.zeros_init()
   dtype: Optional[Dtype] = None
   param_dtype: Dtype = jnp.float32
-  carry_init: initializers.Initializer = initializers.zeros_init()
+  carry_init: Initializer = initializers.zeros_init()
 
   @compact
   def __call__(self, carry, inputs):
@@ -205,10 +209,8 @@ class DenseParams(Module):
   use_bias: bool = True
   param_dtype: Dtype = jnp.float32
   precision: PrecisionLike = None
-  kernel_init: Callable[[PRNGKey, Shape, Dtype], Array] = default_kernel_init
-  bias_init: Callable[
-    [PRNGKey, Shape, Dtype], Array
-  ] = initializers.zeros_init()
+  kernel_init: Initializer = default_kernel_init
+  bias_init: Initializer = initializers.zeros_init()
 
   @compact
   def __call__(self, inputs: Array) -> Tuple[Array, Optional[Array]]:
@@ -275,12 +277,12 @@ class OptimizedLSTMCell(RNNCellBase):
   features: int
   gate_fn: Callable[..., Any] = sigmoid
   activation_fn: Callable[..., Any] = tanh
-  kernel_init: initializers.Initializer = default_kernel_init
-  recurrent_kernel_init: initializers.Initializer = initializers.orthogonal()
-  bias_init: initializers.Initializer = initializers.zeros_init()
+  kernel_init: Initializer = default_kernel_init
+  recurrent_kernel_init: Initializer = initializers.orthogonal()
+  bias_init: Initializer = initializers.zeros_init()
   dtype: Optional[Dtype] = None
   param_dtype: Dtype = jnp.float32
-  carry_init: initializers.Initializer = initializers.zeros_init()
+  carry_init: Initializer = initializers.zeros_init()
 
   @compact
   def __call__(
@@ -434,12 +436,12 @@ class GRUCell(RNNCellBase):
   features: int
   gate_fn: Callable[..., Any] = sigmoid
   activation_fn: Callable[..., Any] = tanh
-  kernel_init: initializers.Initializer = default_kernel_init
-  recurrent_kernel_init: initializers.Initializer = initializers.orthogonal()
-  bias_init: initializers.Initializer = initializers.zeros_init()
+  kernel_init: Initializer = default_kernel_init
+  recurrent_kernel_init: Initializer = initializers.orthogonal()
+  bias_init: Initializer = initializers.zeros_init()
   dtype: Optional[Dtype] = None
   param_dtype: Dtype = jnp.float32
-  carry_init: initializers.Initializer = initializers.zeros_init()
+  carry_init: Initializer = initializers.zeros_init()
 
   @compact
   def __call__(self, carry, inputs):
@@ -552,13 +554,13 @@ class MGUCell(RNNCellBase):
   features: int
   gate_fn: Callable[..., Any] = sigmoid
   activation_fn: Callable[..., Any] = tanh
-  kernel_init: initializers.Initializer = default_kernel_init
-  recurrent_kernel_init: initializers.Initializer = initializers.orthogonal()
-  forget_bias_init: initializers.Initializer = initializers.ones_init()
-  activation_bias_init: initializers.Initializer = initializers.zeros_init()
+  kernel_init: Initializer = default_kernel_init
+  recurrent_kernel_init: Initializer = initializers.orthogonal()
+  forget_bias_init: Initializer = initializers.ones_init()
+  activation_bias_init: Initializer = initializers.zeros_init()
   dtype: Optional[Dtype] = None
   param_dtype: Dtype = jnp.float32
-  carry_init: initializers.Initializer = initializers.zeros_init()
+  carry_init: Initializer = initializers.zeros_init()
 
   @compact
   def __call__(self, carry, inputs):
@@ -684,7 +686,7 @@ class ConvLSTMCell(RNNCellBase):
   use_bias: bool = True
   dtype: Optional[Dtype] = None
   param_dtype: Dtype = jnp.float32
-  carry_init: initializers.Initializer = initializers.zeros_init()
+  carry_init: Initializer = initializers.zeros_init()
 
   @compact
   def __call__(self, carry, inputs):
@@ -863,11 +865,11 @@ class RNN(Module):
   keep_order: bool = False
   unroll: int = 1
   variable_axes: Mapping[
-    lift.CollectionFilter, lift.InOutScanAxis
+    CollectionFilter, InOutScanAxis
   ] = FrozenDict()
-  variable_broadcast: lift.CollectionFilter = 'params'
-  variable_carry: lift.CollectionFilter = False
-  split_rngs: Mapping[lift.PRNGSequenceFilter, bool] = FrozenDict(
+  variable_broadcast: CollectionFilter = 'params'
+  variable_carry: CollectionFilter = False
+  split_rngs: Mapping[PRNGSequenceFilter, bool] = FrozenDict(
     {'params': False}
   )
 

--- a/flax/linen/spmd.py
+++ b/flax/linen/spmd.py
@@ -38,14 +38,14 @@ from jax.experimental import maps
 
 from flax import struct
 from flax.core import meta
-
-# Real types and dummy aliases for documentation
-LogicalRules = Sequence[Tuple[str, Union[str, Tuple[str], None]]]
-Array = Any  # pylint: disable=invalid-name
-ArrayPytree = Any  # pylint: disable=invalid-name
-LogicalPartitionSpec = Any  # pylint: disable=invalid-name
-LogicalPartitionSpecPytree = Any  # pylint: disable=invalid-name
-PartitionSpecPytree = Any  # pylint: disable=invalid-name
+from flax.typing import (
+  Array,
+  LogicalNames,
+  LogicalRules,
+  ArrayPytree,  # pylint: disable=invalid-name
+  LogicalPartitionSpec,  # pylint: disable=unused-import
+  LogicalPartitionSpecPytree,  # pylint: disable=invalid-name
+  )
 
 
 # Dynamic Axis Mapping Context
@@ -319,7 +319,7 @@ class LogicallyPartitioned(meta.Partitioned):
 
 def with_logical_partitioning(
   fn: Callable[..., Any],
-  names: meta.LogicalNames,
+  names: LogicalNames,
   mesh: Optional[jax.sharding.Mesh] = None,
   rules: Optional[LogicalRules] = None,
 ) -> Callable[..., LogicallyPartitioned]:

--- a/flax/linen/stochastic.py
+++ b/flax/linen/stochastic.py
@@ -16,13 +16,11 @@
 
 from typing import Optional, Sequence
 
-import jax
 import jax.numpy as jnp
 from jax import lax, random
 
 from flax.linen.module import Module, compact, merge_param
-
-KeyArray = jax.Array
+from flax.typing import PRNGKey
 
 
 class Dropout(Module):
@@ -69,7 +67,7 @@ class Dropout(Module):
     self,
     inputs,
     deterministic: Optional[bool] = None,
-    rng: Optional[KeyArray] = None,
+    rng: Optional[PRNGKey] = None,
   ):
     """Applies a random dropout mask to the input.
 

--- a/flax/linen/summary.py
+++ b/flax/linen/summary.py
@@ -46,14 +46,16 @@ from flax.core import meta, unfreeze
 from flax.core.scope import (
   CollectionFilter,
   DenyList,
-  FrozenVariableDict,
   LazyRng,
-  MutableVariableDict,
 )
-
-PRNGKey = Any  # pylint: disable=invalid-name
-RNGSequences = Dict[str, PRNGKey]
-Array = Any  # pylint: disable=invalid-name
+from flax.typing import (
+  Array,
+  PRNGKey,
+  RNGSequences,
+  FrozenVariableDict,
+  MutableVariableDict,
+  LogicalNames,
+)
 
 
 class _ValueRepresentation(ABC):
@@ -85,7 +87,7 @@ class _ArrayRepresentation(_ValueRepresentation):
 @dataclasses.dataclass
 class _PartitionedArrayRepresentation(_ValueRepresentation):
   array_representation: _ArrayRepresentation
-  names: meta.LogicalNames
+  names: LogicalNames
 
   @classmethod
   def from_partitioned(

--- a/flax/training/dynamic_scale.py
+++ b/flax/training/dynamic_scale.py
@@ -22,8 +22,7 @@ import jax.numpy as jnp
 from jax import lax
 
 from flax import struct
-
-Array = Any
+from flax.typing import Array
 
 
 class DynamicScaleResult(NamedTuple):
@@ -82,8 +81,8 @@ class DynamicScale(struct.PyTreeNode):
   growth_factor: float = struct.field(pytree_node=False, default=2.0)
   backoff_factor: float = struct.field(pytree_node=False, default=0.5)
   growth_interval: int = struct.field(pytree_node=False, default=2000)
-  fin_steps: Array = 0
-  scale: Array = 65536.0
+  fin_steps: int = 0
+  scale: float = 65536.0
   minimum_scale: Optional[float] = struct.field(
     pytree_node=False, default=jnp.finfo(jnp.float32).tiny
   )

--- a/flax/traverse_util.py
+++ b/flax/traverse_util.py
@@ -57,16 +57,15 @@ import abc
 import copy
 import dataclasses
 import warnings
-from typing import Any, Callable, Tuple
+from typing import Any, Callable
 
 import jax
 
 import flax
 from flax.core.scope import VariableDict
+from flax.typing import PathParts
 
 from . import struct
-
-Path = Tuple[str, ...]
 
 
 # the empty node is a struct.dataclass to be compatible with JAX.
@@ -178,7 +177,7 @@ def unflatten_dict(xs, sep=None):
 
 
 def path_aware_map(
-  f: Callable[[Path, Any], Any], nested_dict: VariableDict
+  f: Callable[[PathParts, Any], Any], nested_dict: VariableDict
 ) -> VariableDict:
   """A map function that operates over nested dictionary structures while taking
   the path to each leaf into account.

--- a/flax/typing.py
+++ b/flax/typing.py
@@ -1,0 +1,105 @@
+from typing import (
+  Any,
+  Callable,
+  Dict,
+  Generic,
+  Mapping,
+  Optional,
+  Sequence,
+  Tuple,
+  TypeVar,
+  Union,
+)
+
+import jax
+from flax.core import FrozenDict
+
+import dataclasses
+
+
+# General
+
+Array = Union[jax.Array, Any]
+PRNGKey = jax.Array
+RNGSequences = Dict[str, PRNGKey]
+Dtype = Union[jax.typing.DTypeLike, Any]
+Shape = Sequence[int]
+
+Path = str
+PathParts = Tuple[str, ...]
+
+Leaf = Any
+
+
+# Linear
+
+PrecisionLike = Union[
+  None,
+  str,
+  jax.lax.Precision,
+  Tuple[str, str],
+  Tuple[jax.lax.Precision, jax.lax.Precision],
+]
+DotGeneralT = Callable[..., Array]
+ConvGeneralDilatedT = Callable[..., Array]
+
+PaddingLike = Union[str, int, Sequence[Union[int, Tuple[int, int]]]]
+LaxPadding = Union[str, Sequence[Tuple[int, int]]]
+
+
+# Initializers
+
+Initializer = Union[jax.nn.initializers.Initializer, Callable[..., Any]]
+
+
+# Collections
+
+Collection = Mapping[str, Any]
+MutableCollection = Dict[str, Any]
+
+
+# Dicts
+
+VariableDict = Mapping[str, Collection]
+FrozenVariableDict = FrozenDict[str, Collection]
+MutableVariableDict = Dict[str, MutableCollection]
+
+PRNGFoldable = Union[int, str]
+
+
+# Axes
+
+T = TypeVar('T')
+
+@dataclasses.dataclass(frozen=True)
+class In(Generic[T]):
+  """Specifies a variable collection should only be lifted as input."""
+
+  axis: T
+
+@dataclasses.dataclass(frozen=True)
+class Out(Generic[T]):
+  """Specifies a variable collection should only be lifted as output."""
+
+  axis: T
+
+Axis = Optional[int]
+InOutAxis = Union[Axis, In[Axis], Out[Axis]]
+
+ScanAxis = int
+InOutScanAxis = Union[ScanAxis, In[ScanAxis], Out[ScanAxis]]
+
+Axes = Union[int, Sequence[int]]
+
+
+# SPMD
+
+LogicalNames = Tuple[Union[str, None], ...]
+
+LogicalRules = Sequence[Tuple[str, Union[str, Tuple[str], None]]]
+ArrayPytree = Any  # pylint: disable=invalid-name
+LogicalPartitionSpec = Any  # pylint: disable=invalid-name
+LogicalPartitionSpecPytree = Any  # pylint: disable=invalid-name
+PartitionSpecPytree = Any  # pylint: disable=invalid-name
+
+Sharding = Tuple[Optional[str], ...]


### PR DESCRIPTION
Added [`flax/typing.py`](https://github.com/google/flax/pull/3624/files#diff-f06fb18c99233972846e0a2db5c4ee574ac4b6b632e7ee1fe2bdc57d8901277dR1-R132) file to unify typing annotations.

Few things to note:
* [`Filter`](https://github.com/google/flax/pull/3624/files#diff-f06fb18c99233972846e0a2db5c4ee574ac4b6b632e7ee1fe2bdc57d8901277dR59) is defined [differently in NNX](https://github.com/google/flax/blob/7b0f6537f48ec016ad021b963e53564836c2c041/flax/experimental/nnx/nnx/filterlib.py#L27), so I did not unify NNX's definition under the `flax.typing` definition
* [`Axis`](https://github.com/google/flax/pull/3624/files#diff-f06fb18c99233972846e0a2db5c4ee574ac4b6b632e7ee1fe2bdc57d8901277dR113) is defined [differently in NNX](https://github.com/google/flax/blob/7b0f6537f48ec016ad021b963e53564836c2c041/flax/experimental/nnx/nnx/nn/linear.py#L55), so I did not unify NNX's definition under the `flax.typing` definition
* In addition to regular JAX initializers, `Partitioned` objects can also be used as [`kernel_init` and `bias_init` arguments](https://github.com/google/flax/blob/7b0f6537f48ec016ad021b963e53564836c2c041/examples/lm1b/models.py#L189-L192). Currently to accommodate this, the `Initializer` type annotation is [`Union[jax.nn.initializers.Initializer, Callable[..., Any]]`](https://github.com/google/flax/pull/3624/files#diff-f06fb18c99233972846e0a2db5c4ee574ac4b6b632e7ee1fe2bdc57d8901277dR54). The more correct annotation would be `Union[jax.nn.initializers.Initializer, Callable[..., Partitioned[Any]]]`, but then the linter will complain about code that tries to call `Array` methods or access `Array` attributes like `.reshape` and `.shape` on the initialized `kernel` or `bias` since `Partitioned[Any]` does not have any of these methods or attributes. The linter will also complain about functions that take in the initialized `kernel` or `bias` as an input argument, because they expect an `Array` and not `Partitioned[Any]`.