### PR TITLE
add compact_name_scope v3

### DIFF
--- a/flax/linen/__init__.py
+++ b/flax/linen/__init__.py
@@ -106,6 +106,7 @@ from .module import (
     Variable as Variable,
     apply as apply,
     compact as compact,
+    compact_name_scope as compact_name_scope,
     disable_named_call as disable_named_call,
     enable_named_call as enable_named_call,
     init_with_output as init_with_output,

--- a/tests/linen/linen_module_test.py
+++ b/tests/linen/linen_module_test.py
@@ -2661,6 +2661,76 @@ class ModuleTest(absltest.TestCase):
     ):
       model.init(jax.random.key(0), jnp.ones((1, 3)))
 
+  def test_compact_name_scope(self):
+    class Foo(nn.Module):
+      @nn.compact_name_scope
+      def up(self, x):
+        return nn.Dense(3)(x)
+
+      @nn.compact_name_scope
+      def down(self, x):
+        return nn.Dense(3)(x)
+
+      @nn.compact
+      def __call__(self, x):
+        return self.up(x) + self.down(x) + nn.Dense(3)(x)
+
+    m = Foo()
+    x = jnp.ones((1, 2))
+
+    self.assertEqual(set(m._compact_name_scope_methods), {'up', 'down'})
+
+    variables = m.init(random.key(0), x)
+    params = variables['params']
+
+    self.assertIn('Dense_0', params)
+    self.assertIn('down', params)
+    self.assertIn('up', params)
+    self.assertIn('Dense_0', params['down'])
+    self.assertIn('Dense_0', params['up'])
+
+    y = m.apply(variables, x)
+    y_up = m.apply(variables, x, method='up')
+    y_down = m.apply(variables, x, method='down')
+
+    assert y.shape == (1, 3)
+    assert y_up.shape == (1, 3)
+    assert y_down.shape == (1, 3)
+
+  def test_compact_name_scope_outside_compact(self):
+    class Foo(nn.Module):
+      @nn.compact_name_scope
+      def up(self, x):
+        return nn.Dense(3)(x)
+
+      @nn.compact_name_scope
+      def down(self, x):
+        return nn.Dense(3)(x)
+
+      def __call__(self, x):
+        return self.up(x) + self.down(x)
+
+    m = Foo()
+    x = jnp.ones((1, 2))
+
+    self.assertEqual(set(m._compact_name_scope_methods), {'up', 'down'})
+
+    variables = m.init(random.key(0), x)
+    params = variables['params']
+
+    self.assertIn('down', params)
+    self.assertIn('up', params)
+    self.assertIn('Dense_0', params['down'])
+    self.assertIn('Dense_0', params['up'])
+
+    y = m.apply(variables, x)
+    y_up = m.apply(variables, x, method='up')
+    y_down = m.apply(variables, x, method='down')
+
+    assert y.shape == (1, 3)
+    assert y_up.shape == (1, 3)
+    assert y_down.shape == (1, 3)
+
 
 class LeakTests(absltest.TestCase):
   def test_tracer_leaks(self):


### PR DESCRIPTION
# What does this PR do?

(Take 3 due to internal pytype bug) 

Adds the `nn.compact_name_scope ` decorator that enables methods to act as compact name scopes as with regular Haiku methods, this makes porting Haiku code easier.