### PR TITLE
bump version number to 0.8.1

### DIFF
--- a/flax/version.py
+++ b/flax/version.py
@@ -13,4 +13,4 @@
 # limitations under the License.
 
 """Current Flax version at head on Github."""
-__version__ = '0.8.0'
+__version__ = '0.8.1'


### PR DESCRIPTION
bump version number to `0.8.1`, after the [`0.8.0` release](https://github.com/google/flax/releases/tag/v0.8.0).