### PR TITLE
Add `kw_only` struct.dataclass test

### DIFF
--- a/tests/struct_test.py
+++ b/tests/struct_test.py
@@ -92,6 +92,25 @@ class StructTest(absltest.TestCase):
     class A(struct.PyTreeNode):
       a: int
 
+  # TODO(marcuschiam): Uncomment when Flax upgrades to Python 3.10.
+  # def test_kw_only(self):
+  #   @struct.dataclass
+  #   class A:
+  #     a: int = 1
+
+  #   with self.assertRaisesRegex(TypeError, "non-default argument 'b' follows default argument"):
+  #     @struct.dataclass
+  #     class B(A):
+  #       b: int
+
+  #   @functools.partial(struct.dataclass, kw_only=True)
+  #   class B(A):
+  #     b: int
+
+  #   obj = B(b=2)
+  #   self.assertEqual(obj.a, 1)
+  #   self.assertEqual(obj.b, 2)
+
 
 if __name__ == '__main__':
   absltest.main()


### PR DESCRIPTION
In #3617, A user requested to allow a `kw_only` argument to be passed into the `flax.struct.dataclass` decorator.
#3645 allows general `kwargs` to be passed into the `flax.struct.dataclass` decorator, originally with the intention of allowing the `slots` argument to be passed, but this will also solve #3617 as well.

This PR adds a test to make sure `kw_only` is working as intended. It is currently commented out because `kw_only` is only supported in python 3.10 or greater, but Flax currently supports Python 3.9 or greater. This test was tested locally and passed on python 3.10. This test will be commented back in once Flax upgrades its minimum python version to 3.10.

~This PR also [enforces `frozen=True`](https://github.com/google/flax/pull/3651/files#diff-99b09b7db6644aaccda9ec75198369c2e578cbed72b921c440ea972417ce3089R107-R112) for the `struct.dataclass` decorator, otherwise a `ValueError` will be raised.~
^ Removing frozen enforcement, because a lot of internal tests rely on mutable `struct.dataclass`.