### PR TITLE
added InstanceNorm

### DIFF
--- a/docs/api_reference/flax.linen/layers.rst
+++ b/docs/api_reference/flax.linen/layers.rst
@@ -58,6 +58,10 @@ Normalization
 
 .. flax_module::
   :module: flax.linen
+  :class: InstanceNorm
+
+.. flax_module::
+  :module: flax.linen
   :class: SpectralNorm
 
 .. flax_module::

--- a/flax/linen/__init__.py
+++ b/flax/linen/__init__.py
@@ -118,6 +118,7 @@ from .module import (
 from .normalization import (
     BatchNorm as BatchNorm,
     GroupNorm as GroupNorm,
+    InstanceNorm as InstanceNorm,
     LayerNorm as LayerNorm,
     RMSNorm as RMSNorm,
     SpectralNorm as SpectralNorm,

--- a/tests/linen/linen_test.py
+++ b/tests/linen/linen_test.py
@@ -431,6 +431,61 @@ class NormalizationTest(parameterized.TestCase):
     np.testing.assert_allclose(y1, y2, rtol=1e-4)
 
   @parameterized.parameters(
+    {'channel_axes': -1},
+    {'channel_axes': (1, 2)},
+    {'channel_axes': (1, 2, 3)},
+    {'channel_axes': -1, 'use_fast_variance': False},
+  )
+  def test_instance_norm(self, channel_axes, use_fast_variance=True):
+    rng = random.key(0)
+    key1, key2 = random.split(rng)
+    e = 1e-5
+    x = random.normal(key1, (2, 3, 4, 5))
+    if not use_fast_variance:
+      x += 1e4  # This blows up fast variance, but should work otherwise.
+    model_cls = nn.InstanceNorm(
+      use_bias=False,
+      use_scale=False,
+      epsilon=e,
+      channel_axes=channel_axes,
+      use_fast_variance=use_fast_variance,
+    )
+    y, _ = model_cls.init_with_output(key2, x)
+    self.assertEqual(x.dtype, y.dtype)
+    self.assertEqual(x.shape, y.shape)
+
+    canonicalized_channel_axes = [
+      i if i >= 0 else (x.ndim + i)
+      for i in (
+        channel_axes if isinstance(channel_axes, tuple) else (channel_axes,)
+      )
+    ]
+    reduction_axes = [
+      i for i in range(1, x.ndim) if i not in canonicalized_channel_axes
+    ]
+    y_one_liner = (
+      x - x.mean(axis=reduction_axes, keepdims=True)
+    ) * jax.lax.rsqrt(x.var(axis=reduction_axes, keepdims=True) + e)
+
+    np.testing.assert_allclose(y_one_liner, y, atol=1e-6)
+
+  @parameterized.parameters(
+    {'channel_axes': 0},
+    {'channel_axes': -4},
+    {'channel_axes': (0, 3)},
+    {'channel_axes': (2, -4)},
+  )
+  def test_instance_norm_raise_error(self, channel_axes):
+    with self.assertRaisesRegex(
+      ValueError,
+      'The channel axes cannot include the leading dimension '
+      'as this is assumed to be the batch axis.',
+    ):
+      x = jax.random.normal(jax.random.key(0), (2, 3, 4, 5))
+      layer = nn.InstanceNorm(channel_axes=channel_axes)
+      _ = layer.init(jax.random.key(1), x)
+
+  @parameterized.parameters(
     {
       'model_index': 0,
       'key_paths': {'Dense_1/kernel/u', 'Dense_1/kernel/sigma'},


### PR DESCRIPTION
Added InstanceNorm. See the [API reference](https://flax--3652.org.readthedocs.build/en/3652/api_reference/flax.linen/layers.html#flax.linen.InstanceNorm) for more details.

Resolves #3622.

Alternative implementations:
* have `InstanceNorm` subclass `LayerNorm` and derive the `feature_axes` and `reduction_axes` from the `channel_axes` argument in `InstanceNorm`, and then pass them into `LayerNorm`
* create a base normalization layer, and have both `InstanceNorm` and `LayerNorm` subclass it