### PR TITLE
Add module_paths method to docs

### DIFF
--- a/docs/api_reference/flax.linen/module.rst
+++ b/docs/api_reference/flax.linen/module.rst
@@ -5,7 +5,7 @@ Module
 .. currentmodule:: flax.linen
 
 .. autoclass:: Module
-   :members: setup, variable, param, bind, unbind, apply, init, init_with_output, copy, make_rng, sow, variables, Variable, __setattr__, tabulate, is_initializing, perturb, put_variable, has_variable, has_rng, lazy_init, get_variable, path, is_mutable_collection
+   :members: setup, variable, param, bind, unbind, apply, init, init_with_output, copy, make_rng, sow, variables, Variable, __setattr__, tabulate, module_paths, is_initializing, perturb, put_variable, has_variable, has_rng, lazy_init, get_variable, path, is_mutable_collection
 
 .. autofunction:: apply
 .. autofunction:: init


### PR DESCRIPTION
# What does this PR do?

Adds the missing reference to `Module.module_paths` in the docs.