### PR TITLE
added nnx attention equivalence test

### DIFF
--- a/flax/experimental/nnx/nnx/nn/attention.py
+++ b/flax/experimental/nnx/nnx/nn/attention.py
@@ -371,8 +371,20 @@ class MultiHeadAttention(Module):
     if self.normalize_qk:
       # Normalizing query and key projections stabilizes training with higher
       # LR. See ViT-22B paper http://arxiv.org/abs/2302.05442 for analysis.
-      self.query_ln = LayerNorm(self.head_dim, use_bias=False, rngs=rngs)
-      self.key_ln = LayerNorm(self.head_dim, use_bias=False, rngs=rngs)
+      self.query_ln = LayerNorm(
+        self.head_dim,
+        use_bias=False,
+        dtype=self.dtype,
+        param_dtype=self.param_dtype,
+        rngs=rngs,
+      )
+      self.key_ln = LayerNorm(
+        self.head_dim,
+        use_bias=False,
+        dtype=self.dtype,
+        param_dtype=self.param_dtype,
+        rngs=rngs,
+      )
     else:
       self.query_ln = None
       self.key_ln = None

--- a/flax/linen/attention.py
+++ b/flax/linen/attention.py
@@ -459,8 +459,18 @@ class MultiHeadDotProductAttention(Module):
     if self.normalize_qk:
       # Normalizing query and key projections stabilizes training with higher
       # LR. See ViT-22B paper http://arxiv.org/abs/2302.05442 for analysis.
-      query = LayerNorm(name='query_ln', use_bias=False)(query)  # type: ignore[call-arg]
-      key = LayerNorm(name='key_ln', use_bias=False)(key)  # type: ignore[call-arg]
+      query = LayerNorm(
+        name='query_ln',
+        use_bias=False,
+        dtype=self.dtype,
+        param_dtype=self.param_dtype,
+      )(query)  # type: ignore[call-arg]
+      key = LayerNorm(
+        name='key_ln',
+        use_bias=False,
+        dtype=self.dtype,
+        param_dtype=self.param_dtype,
+      )(key)  # type: ignore[call-arg]
 
     # During fast autoregressive decoding, we feed one position at a time,
     # and cache the keys and values step by step.
@@ -494,7 +504,9 @@ class MultiHeadDotProductAttention(Module):
         # update key, value caches with our new 1d spatial slices
         cur_index = cache_index.value
         zero = jnp.array(0, dtype=lax.dtype(cur_index.dtype))
-        indices: tuple[Union[int, jax.Array], ...] = (zero,) * len(batch_dims) + (
+        indices: tuple[Union[int, jax.Array], ...] = (zero,) * len(
+          batch_dims
+        ) + (
           cur_index,
           zero,
           zero,
@@ -699,7 +711,11 @@ class SelfAttention(MultiHeadDotProductAttention):
       DeprecationWarning,
     )
     return super().__call__(
-      inputs_q, mask=mask, deterministic=deterministic, dropout_rng=dropout_rng, sow_weights=sow_weights
+      inputs_q,
+      mask=mask,
+      deterministic=deterministic,
+      dropout_rng=dropout_rng,
+      sow_weights=sow_weights,
     )
 
 
@@ -766,7 +782,9 @@ def make_causal_mask(
   )
 
 
-def combine_masks(*masks: Optional[Array], dtype: Dtype = jnp.float32) -> Optional[Array]:
+def combine_masks(
+  *masks: Optional[Array], dtype: Dtype = jnp.float32
+) -> Optional[Array]:
   """Combine attention masks.
 
   Args:


### PR DESCRIPTION
Added nnx attention equivalence test.

Also passed in user-passed `dtype` and `param_dtype` args into the layer norm layers for both [NNX](https://github.com/google/flax/pull/3687/files#diff-7afe33865dc401f46f1432fd59e26b176385a2f891f8a4241f38e0a45e38d064R377-R378) and [Linen](https://github.com/google/flax/pull/3687/files#diff-819a61a3f034fc520bd15600f64456f88326958dc440198a755ea8fb0514c7bfR465-R466).