### PR TITLE
make make_rng default to 'params'

### DIFF
--- a/flax/core/scope.py
+++ b/flax/core/scope.py
@@ -743,11 +743,11 @@ class Scope:
     """Returns true if a PRNGSequence with name `name` exists."""
     return name in self.rngs
 
-  def make_rng(self, name: str = 'default') -> PRNGKey:
+  def make_rng(self, name: str = 'params') -> PRNGKey:
     """Generates A PRNGKey from a PRNGSequence with name `name`."""
     if not self.has_rng(name):
-      if self.has_rng('default'):
-        name = 'default'
+      if self.has_rng('params'):
+        name = 'params'
       else:
         raise errors.InvalidRngError(f'{self.name} needs PRNG for "{name}"')
     self._check_valid()

--- a/flax/linen/module.py
+++ b/flax/linen/module.py
@@ -1883,12 +1883,16 @@ class Module(ModuleBase):
       raise ValueError("Can't query for RNGs on unbound modules")
     return self.scope.has_rng(name)
 
-  def make_rng(self, name: str = 'default') -> PRNGKey:
+  def make_rng(self, name: str = 'params') -> PRNGKey:
     """Returns a new RNG key from a given RNG sequence for this Module.
 
     The new RNG key is split from the previous one. Thus, every call to
     ``make_rng`` returns a new RNG key, while still guaranteeing full
     reproducibility.
+
+    NOTE: if an invalid name is passed (i.e. no RNG key was passed by
+    the user in ``.init`` or ``.apply`` for this name), then ``name``
+    will default to ``'params'``.
 
     TODO: Link to Flax RNG design note.
 


### PR DESCRIPTION
Following #3669. 

The Flax team has decided to switch the default `make_rng` name to `'params'` instead of `'default'`.

This would have the following effect (see the original proposal with `'default'` in #3668):
* Make self.make_rng(name='params') callable without explicitly passing in a string name, in which it would default to the 'params' RNG stream
  * This would allow the user to pass in a single RNG mapping (e.g. {'params': random.key(0)}) to .init() and .apply() that self.make_rng('other_rng_stream') will use as the RNG seed if, for example, {'other_rng_stream': random.key(1)} wasn't in the RNG mapping that was passed into .init() or .apply()