### PR TITLE
Guarantee the latest JAX version on CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -118,6 +118,7 @@ jobs:
     - name: Install Flax
       run: |
         venv/bin/python3 -m pip install -e .[all,testing]
+        venv/bin/python3 -m pip install -U jax jaxlib # Ensure we have the latest JAX
     - name: Cached mypy cache
       id: mypy_cache
       uses: actions/cache@v3


### PR DESCRIPTION
# What does this PR do?

Forces an upgrade to JAX before running tests. Solves CI issue in #3623. 