### PR TITLE
Fix Tabulate's compute_flops

### DIFF
--- a/flax/linen/summary.py
+++ b/flax/linen/summary.py
@@ -336,6 +336,8 @@ def tabulate(
 def _get_flops(fn, *args, **kwargs):
   e = jax.jit(fn).lower(*args, **kwargs)
   cost = e.cost_analysis()
+  if cost is None:
+    return 0
   flops = int(cost['flops']) if 'flops' in cost else 0
   return flops
 


### PR DESCRIPTION
# What does this PR do?

Returns `0` when cost analysis is not available.