### PR TITLE
[nnx] always fold_in on fork + new ForkedKeys return type

### DIFF
--- a/flax/experimental/nnx/nnx/transforms.py
+++ b/flax/experimental/nnx/nnx/transforms.py
@@ -774,9 +774,10 @@ def scan_init(
     if not isinstance(rngs, rnglib.Rngs):
       raise TypeError(f'Expected a Rngs, got {type(rngs).__name__}')
 
-    split_keys, broadcast_keys = rngs.fork(
+    forked_rngs = rngs.fork(
       {filterlib.Not(options.broadcast_rngs): options.length}
     )
+    split_keys, broadcast_keys = forked_rngs.splits, forked_rngs.broadcasts
 
     if split_keys and options.length is None:
       raise ValueError('Cannot split RNGs without specifying a length')
@@ -910,9 +911,8 @@ def scan_apply(
   if rngs is not None:
     if not isinstance(rngs, rnglib.Rngs):
       raise TypeError(f'Expected a Rngs, got {type(rngs).__name__}')
-    split_keys, broadcast_keys = rngs.fork(
-      {filterlib.Not(options.broadcast_rngs): length}
-    )
+    forked_rngs = rngs.fork({filterlib.Not(options.broadcast_rngs): length})
+    split_keys, broadcast_keys = forked_rngs.splits, forked_rngs.broadcasts
   else:
     split_keys = None
     broadcast_keys = None
@@ -1413,9 +1413,10 @@ def vmap_init(
   if rngs is not None:
     if not isinstance(rngs, rnglib.Rngs):
       raise TypeError(f'Expected a Rngs, got {type(rngs).__name__}')
-    split_keys, broadcast_keys = rngs.fork(
+    forked_rngs = rngs.fork(
       {filterlib.Not(options.broadcast_rngs): options.axis_size}
     )
+    split_keys, broadcast_keys = forked_rngs.splits, forked_rngs.broadcasts
     if split_keys and options.axis_size is None:
       raise ValueError('Cannot split RNGs without specifying a length')
   else:
@@ -1522,9 +1523,8 @@ def vmap_apply(
     if not isinstance(rngs, rnglib.Rngs):
       raise TypeError(f'Expected a Rngs, got {type(rngs).__name__}')
 
-    split_keys, broadcast_keys = rngs.fork(
-      {filterlib.Not(options.broadcast_rngs): axis_size}
-    )
+    forked_rngs = rngs.fork({filterlib.Not(options.broadcast_rngs): axis_size})
+    split_keys, broadcast_keys = forked_rngs.splits, forked_rngs.broadcasts
   else:
     split_keys = None
     broadcast_keys = None


### PR DESCRIPTION
# What does this PR do?

* `Rngs.fork` now returns a single `ForkedKeys` type instead of different types depending on the `overload` (overloads are removed).  `ForkedKeys` is a `Mapping[str, Array]` with the keys, and contains `.splits` and `.broadcasts` attributes of type `dict[str, Array]` for cases when you need to tell apart the splits from the broadcasts.
* `Rngs.fork` now folds all keys so there is no need to maintain / propagate hashable data.
* Because of the previous `RngStream.counts: list[int]` is replaced with `RngStream.count: int`.

