### PR TITLE
fix typo that breaks syntax highlighting in README.md

### DIFF
--- a/flax/experimental/nnx/README.md
+++ b/flax/experimental/nnx/README.md
@@ -119,7 +119,7 @@ y = model.decode(z)
 
 To interact with JAX NNX provides the [Functional API](https://flax.readthedocs.io/en/latest/experimental/nnx/nnx_basics.html#the-functional-api) which consists of 3 simple methods: `split`, `merge`, and `update`. Using these methods any Module can be lifted to be used in JAX transformations. Here is a simple jitted `forward` function as an example:
 
-```pythonthon
+```python
 state, static = model.split()
 
 @jax.jit


### PR DESCRIPTION
# What does this PR do?

Fixes a typo in NNX Readme file that broke syntax highlighting

## Checklist
- [x] This PR fixes a minor issue (e.g.: typo or small bug) or improves the docs (you can dismiss the other
      checks if that's the case).
- [ ] This change is discussed in a Github issue/
      [discussion](https://github.com/google/flax/discussions) (please add a
      link).
- [ ] The documentation and docstrings adhere to the
      [documentation guidelines](https://github.com/google/flax/blob/main/docs/README.md#how-to-write-code-documentation).
- [ ] This change includes necessary high-coverage tests.
      (No quality testing = no merge!)
