### PR TITLE
Add broadcast of `strides` and `kernel_dilation` to `nn.ConvTranspose`

### DIFF
--- a/tests/linen/linen_linear_test.py
+++ b/tests/linen/linen_linear_test.py
@@ -980,7 +980,7 @@ class LinearTest(parameterized.TestCase):
     conv_module = nn.ConvTranspose(
       features=4,
       use_bias=use_bias,
-      strides=(2, 2),
+      strides=2,
       kernel_size=(6, 6),
       padding='CIRCULAR',
       transpose_kernel=True,


### PR DESCRIPTION
Fixes #3729 and make the API of `nn.Conv` and `nn.ConvTranspose` more consistent.
