### PR TITLE
added Einsum layer to NNX

### DIFF
--- a/flax/experimental/nnx/__init__.py
+++ b/flax/experimental/nnx/__init__.py
@@ -65,6 +65,7 @@ from .nnx.nn.linear import Conv as Conv
 from .nnx.nn.linear import Embed as Embed
 from .nnx.nn.linear import Linear as Linear
 from .nnx.nn.linear import LinearGeneral as LinearGeneral
+from .nnx.nn.linear import Einsum as Einsum
 from .nnx.nn.normalization import BatchNorm as BatchNorm
 from .nnx.nn.normalization import LayerNorm as LayerNorm
 from .nnx.nn.normalization import RMSNorm as RMSNorm


### PR DESCRIPTION
Unlike the Linen implementation, the NNX implementation of the `Einsum` layer requires an explicit [`bias_shape`](https://github.com/google/flax/pull/3741/files#diff-66832bf05a8eff953cecd238affae58842fefeb11741c6e11285c51ad3375cf0R395) to be passed at construction time since the bias param is instantiated during construction time and requires that information. During call time, the `broadcasted_bias_shape` is inferred by passing the `inputs`, `kernel` and `einsum_str` as arguments to [`opt_einsum.parser.parse_einsum_input`](https://github.com/dgasmith/opt_einsum/blob/master/opt_einsum/parser.py#L265) (similar to the [Linen implementation](https://github.com/google/flax/blob/main/flax/linen/linear.py#L391)).

~~The NNX implementation of the `Einsum` layer requires an explicit [`input_shape`](https://github.com/google/flax/pull/3741/files#diff-66832bf05a8eff953cecd238affae58842fefeb11741c6e11285c51ad3375cf0R395) to be passed at construction time since the bias param is instantiated during construction time and requires that information. A dummy array is constructed using [`jax.ShapeDtypeStruct`](https://jax.readthedocs.io/en/latest/_autosummary/jax.ShapeDtypeStruct.html#jax.ShapeDtypeStruct)) and is passed to [`opt_einsum.parser.parse_einsum_input`](https://github.com/dgasmith/opt_einsum/blob/master/opt_einsum/parser.py#L265) (in the case of the Linen implementation, [both arrays are provided during call time](https://github.com/google/flax/blob/main/flax/linen/linear.py#L391)).~~

While both implementations allow `einsum_str` to be passed during construction and call time, the bias shape can be determined either by the `einsum_str` passed in constructor or call time because of lazy init in Linen, while the bias shape is **_always_** determined by the `einsum_str` passed **_in construction time_** in NNX (meaning **_it must always be passed during construction time_**). NNX allows the option to pass in a different `einsum_str` during call time which will take precedence over the constructor `einsum_str`, but the bias shape is never determined at call time, since it's already been instantiated.

Another difference to note is that the Linen implementation has a construction signature of `Einsum(kernel_shape,  einsum_str=None, ...)` while the NNX implementation has a construction signature of `Einsum(einsum_str, kernel_shape, bias_shape=None, ...)`. `einsum_str` can be `None` in Linen, since it can also be passed as an argument during call time, whereas an `einsum_str` **_must be passed_** in the NNX implementation during construction time.