### PR TITLE
removed getattr/setattr unboxing magic from `nnx.Pytree`

### DIFF
--- a/flax/experimental/nnx/nnx/helpers.py
+++ b/flax/experimental/nnx/nnx/helpers.py
@@ -165,16 +165,16 @@ class TrainState(pytreelib.Pytree, tp.Generic[M]):
     states = (state, *states)
 
     _states = (
-      getattr(self, state) if isinstance(state, str) else state
+      getattr(self, state).value if isinstance(state, str) else state.value
       for state in states
     )
 
     return self.graphdef.apply(*_states)
 
   def apply_gradients(self, grads: State, **kwargs) -> 'TrainState[M]':
-    updates, opt_state = self.tx.update(grads, self.opt_state, self.params)
+    updates, opt_state = self.tx.update(grads, self.opt_state.value, self.params.value)
     params = optax.apply_updates(self.params, updates)  # type: ignore
-    step = self.step + 1
+    step = self.step.replace(value=self.step.value + 1)
     return self.replace(
       params=params,
       opt_state=opt_state,

--- a/flax/experimental/nnx/nnx/pytreelib.py
+++ b/flax/experimental/nnx/nnx/pytreelib.py
@@ -80,12 +80,6 @@ class Pytree(reprlib.Representable, metaclass=PytreeMeta):
 
   if not tp.TYPE_CHECKING:
 
-    def __getattribute__(self, name: str) -> tp.Any:
-      value = object.__getattribute__(self, name)
-      if isinstance(value, variables.Variable):
-        return value.raw_value
-      return value
-
     def __setattr__(self, name: str, value: tp.Any) -> None:
       self._setattr(name, value)
 
@@ -103,29 +97,14 @@ class Pytree(reprlib.Representable, metaclass=PytreeMeta):
         f'{type(self)} is immutable, trying to update field {name}'
       )
 
-    if name in vars_dict:
-      if isinstance(variable := vars_dict[name], variables.Variable):
-        if isinstance(value, variables.Variable):
-          if type(value) != type(variable):
-            raise ValueError(
-              f"Trying to assign a Variable of type '{type(value).__name__}' "
-              f"to the Module attribute '{name}' of a different type "
-              f"'{type(variable).__name__}'."
-            )
-          vars_dict[name] = value
-        else:
-          variable.value = value
-      else:
-        vars_dict[name] = value
-    else:
-      if isinstance(value, (jax.Array, np.ndarray, State)):
-        raise ValueError(
-          f"Trying to assign a '{type(value).__name__}' to the Module"
-          f" attribute '{name}'. This is not supported. Non-hashable "
-          'objects are not valid static state in JAX. Please wrap '
-          'the value in a Variable type instead.'
-        )
-      vars_dict[name] = value
+    if isinstance(value, (jax.Array, np.ndarray, State)):
+      raise ValueError(
+        f"Trying to assign a '{type(value).__name__}' to the Module"
+        f" attribute '{name}'. This is not supported. Non-hashable "
+        'objects are not valid static state in JAX. Please wrap '
+        'the value in a Variable type instead.'
+      )
+    vars_dict[name] = value
 
   def __init_subclass__(cls, mutable: bool = False):
     super().__init_subclass__()

--- a/flax/experimental/nnx/tests/test_pytree.py
+++ b/flax/experimental/nnx/tests/test_pytree.py
@@ -36,11 +36,11 @@ class TestPytree:
 
     pytree = jax.tree_map(lambda x: x * 2, pytree)
     assert pytree.x == 2
-    assert pytree.y == 6
+    assert pytree.y.value == 6
 
     pytree = pytree.replace(x=3)
     assert pytree.x == 3
-    assert pytree.y == 6
+    assert pytree.y.value == 6
 
     with pytest.raises(
       AttributeError, match='is immutable, trying to update field'
@@ -60,11 +60,11 @@ class TestPytree:
 
     pytree = jax.tree_map(lambda x: x * 2, pytree)
     assert pytree.x == 2
-    assert pytree.y == 6
+    assert pytree.y.value == 6
 
     pytree = pytree.replace(x=3)
     assert pytree.x == 3
-    assert pytree.y == 6
+    assert pytree.y.value == 6
 
     with pytest.raises(AttributeError, match='cannot assign to field'):
       pytree.x = 4
@@ -79,7 +79,7 @@ class TestPytree:
 
     @jax.jit
     def f(m: Foo):
-      return m.a + m.b
+      return m.a.value + m.b
 
     assert f(module) == 3
 
@@ -101,16 +101,16 @@ class TestPytree:
 
     assert state_dict == {
       'bar': {
-        'b': 2,
+        'b': nnx.Variable(2),
       },
-      'c': 3,
+      'c': nnx.TreeNode(3),
     }
 
-    state_dict['bar']['b'] = 5
+    state_dict['bar']['b'] = nnx.Variable(5)
 
     foo = serialization.from_state_dict(foo, state_dict)
 
-    assert foo.bar.b == 5
+    assert foo.bar.b == nnx.Variable(5)
 
     del state_dict['bar']['b']
 
@@ -220,11 +220,11 @@ class TestMutablePytree:
 
     pytree = jax.tree_map(lambda x: x * 2, pytree)
     assert pytree.x == 2
-    assert pytree.y == 6
+    assert pytree.y.value == 6
 
     pytree = pytree.replace(x=3)
     assert pytree.x == 3
-    assert pytree.y == 6
+    assert pytree.y.value == 6
 
     # test mutation
     pytree.x = 4
@@ -254,11 +254,11 @@ class TestMutablePytree:
 
     pytree = jax.tree_map(lambda x: x * 2, pytree)
     assert pytree.x == 2
-    assert pytree.y == 6
+    assert pytree.y.value == 6
 
     pytree = pytree.replace(x=3)
     assert pytree.x == 3
-    assert pytree.y == 6
+    assert pytree.y.value == 6
 
     # test mutation
     pytree.x = 4

--- a/flax/experimental/nnx/tests/test_spmd.py
+++ b/flax/experimental/nnx/tests/test_spmd.py
@@ -70,10 +70,10 @@ class TestSPMD:
     )
     state_spec = nnx.get_partition_spec(state)
 
-    assert state_spec.params['w'].raw_value == PartitionSpec('row', 'col')
-    assert state_spec.opt_state[0].mu['w'].raw_value == PartitionSpec(
+    assert state_spec.params.value['w'].raw_value == PartitionSpec('row', 'col')
+    assert state_spec.opt_state.value[0].mu.value['w'].raw_value == PartitionSpec(
       'row', 'col'
     )
-    assert state_spec.opt_state[0].nu['w'].raw_value == PartitionSpec(
+    assert state_spec.opt_state.value[0].nu.value['w'].raw_value == PartitionSpec(
       'row', 'col'
     )


### PR DESCRIPTION
removed `getattr`/`setattr` unboxing magic from `nnx.Pytree`, after #3720.