### PR TITLE
Add git fetch upstream to contributing doc.

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -107,6 +107,7 @@ To contribute code to Flax on GitHub, follow these steps:
    Then sync your code with the main repository:
 
    ```bash
+   git fetch upstream
    git rebase upstream/main
    ```
 


### PR DESCRIPTION
In the [contributing doc](https://flax.readthedocs.io/en/latest/contributing.html), change
```bash
git rebase upstream/main
```
to
```bash
git fetch upstream
git rebase upstream/main
```
This ensures that users fetch `upstream` before rebasing. I had to do this for #3712 and prior PRs. It also matches [JAX's contributing doc](https://jax.readthedocs.io/en/latest/contributing.html).