### PR TITLE
[nnx] improved graph update mechanism

### DIFF
--- a/flax/experimental/nnx/nnx/module.py
+++ b/flax/experimental/nnx/nnx/module.py
@@ -292,7 +292,7 @@ class Module(reprlib.Representable, metaclass=ModuleMeta):
   def split(
     self: M, *filters: filterlib.Filter
   ) -> tuple[State, tpe.Unpack[tuple[State, ...]], GraphDef[M]]:
-    state, graphdef = graph_utils.graph_flatten(self)
+    state, graphdef, _ = graph_utils.graph_flatten(self)
 
     if len(filters) == 0:
       states = (state,)
@@ -520,6 +520,7 @@ class Module(reprlib.Representable, metaclass=ModuleMeta):
       set_key=_module_graph_set_key,
       pop_key=_module_graph_pop_key,
       create_empty=_module_graph_create_empty,
+      clear=_module_graph_clear,
     )
 
     if experimental_pytree:
@@ -588,6 +589,12 @@ def _module_graph_create_empty(cls: tp.Type[M]) -> M:
   module = object.__new__(cls)
   vars(module).update(_module__state=ModuleState())
   return module
+
+def _module_graph_clear(module: Module, cls: tp.Type[M]):
+  module_state = module._module__state
+  module_vars = vars(module)
+  module_vars.clear()
+  module_vars['_module__state'] = module_state
 
 
 def first_from(*args: tp.Optional[A], error_msg: str) -> A:

--- a/flax/experimental/nnx/nnx/reprlib.py
+++ b/flax/experimental/nnx/nnx/reprlib.py
@@ -18,6 +18,9 @@ import threading
 import typing as tp
 from abc import ABC, abstractmethod
 
+A = tp.TypeVar('A')
+B = tp.TypeVar('B')
+
 
 @dataclasses.dataclass
 class ReprContext(threading.local):
@@ -106,3 +109,10 @@ def get_repr(obj: Representable) -> str:
   )
 
   return f'{type_repr}{config.start}{elems}{config.end}'
+
+class MappingReprMixin(tp.Mapping[A, B]):
+  def __nnx_repr__(self):
+    yield Object(type='', value_sep=': ', start='{', end='}')
+
+    for key, value in self.items():
+      yield Attr(repr(key), value)

--- a/flax/experimental/nnx/nnx/variables.py
+++ b/flax/experimental/nnx/nnx/variables.py
@@ -37,6 +37,7 @@ import jax
 import jax.tree_util as jtu
 
 from flax.experimental.nnx.nnx import reprlib, tracers
+from flax.experimental import nnx
 
 A = tp.TypeVar('A')
 B = tp.TypeVar('B')
@@ -243,6 +244,12 @@ class Variable(tp.Generic[A], reprlib.Representable):
     vars_dict = vars(self)
     vars_dict.clear()
     vars_dict.update(vars(other))
+
+  def copy_from_def(self, other: 'nnx.graph_utils.VariableDef', /, value: A):
+    _trace_state = self._trace_state
+    variable_vars = vars(self)
+    variable_vars.clear()
+    variable_vars.update(other.metadata, _trace_state=_trace_state, raw_value=value)
 
   @property
   def value(self) -> A:


### PR DESCRIPTION
# What does this PR do?
Adds a mechanism that allows performing arbitrary mutations on a cloned graph and recreating them on the original graph, this is useful to faithfully update a graph across jax boundaries.

### Changes
* adds `MutableNodeImpl.clear` API to enable `graph_unflatten` to update existing references 
* `graph_flatten` now returns a `ref_to_index: Mapping[Any, int]` that maps the node references to their flatten index.
* `graph_unflatten` now returns a `index_to_ref: dict[int, Any]` maps index flatten references to their node reference.
* `graph_unflatten` now accepts a `ref_cache: dict[int, Any]` that maps flatten indexes to existing node references to use instead of creating new ones. `clear` is used to empty the existing node's state so they can be treated as new nodes during the unflattening process.
