### PR TITLE
added nnx api reference

### DIFF
--- a/docs/api_reference/flax.experimental.nnx/index.rst
+++ b/docs/api_reference/flax.experimental.nnx/index.rst
@@ -1,0 +1,15 @@
+flax.experimental.nnx
+------------------------
+
+Experimental API. See the `NNX page <https://flax.readthedocs.io/en/latest/experimental/nnx/index.html>`__ for more details.
+
+.. toctree::
+  :maxdepth: 3
+
+  module
+  nn/index
+  rnglib
+  spmd
+  transforms
+  variables
+

--- a/docs/api_reference/flax.experimental.nnx/module.rst
+++ b/docs/api_reference/flax.experimental.nnx/module.rst
@@ -1,0 +1,10 @@
+Module
+------------------------
+
+.. automodule:: flax.experimental.nnx
+.. currentmodule:: flax.experimental.nnx
+
+.. autoclass:: Module
+   :members:
+
+.. autofunction:: merge

--- a/docs/api_reference/flax.experimental.nnx/nn/activations.rst
+++ b/docs/api_reference/flax.experimental.nnx/nn/activations.rst
@@ -1,0 +1,30 @@
+Activation functions
+------------------------
+
+.. automodule:: flax.experimental.nnx
+.. currentmodule:: flax.experimental.nnx
+
+.. autofunction:: celu
+.. autofunction:: elu
+.. autofunction:: gelu
+.. autofunction:: glu
+.. autofunction:: hard_sigmoid
+.. autofunction:: hard_silu
+.. autofunction:: hard_swish
+.. autofunction:: hard_tanh
+.. autofunction:: leaky_relu
+.. autofunction:: log_sigmoid
+.. autofunction:: log_softmax
+.. autofunction:: logsumexp
+.. autofunction:: one_hot
+.. autofunction:: relu
+.. autofunction:: relu6 as relu6,
+.. autofunction:: selu
+.. autofunction:: sigmoid
+.. autofunction:: silu
+.. autofunction:: soft_sign
+.. autofunction:: softmax
+.. autofunction:: softplus
+.. autofunction:: standardize
+.. autofunction:: swish
+.. autofunction:: tanh

--- a/docs/api_reference/flax.experimental.nnx/nn/attention.rst
+++ b/docs/api_reference/flax.experimental.nnx/nn/attention.rst
@@ -1,0 +1,13 @@
+Attention
+------------------------
+
+.. automodule:: flax.experimental.nnx
+.. currentmodule:: flax.experimental.nnx
+
+.. autoclass:: MultiHeadAttention
+   :members:
+
+.. autofunction:: combine_masks
+.. autofunction:: dot_product_attention
+.. autofunction:: make_attention_mask
+.. autofunction:: make_causal_mask

--- a/docs/api_reference/flax.experimental.nnx/nn/index.rst
+++ b/docs/api_reference/flax.experimental.nnx/nn/index.rst
@@ -1,0 +1,15 @@
+flax.experimental.nnx.nnx.nn
+----------------------------
+
+Experimental API. See the `NNX page <https://flax.readthedocs.io/en/latest/experimental/nnx/index.html>`__ for more details.
+
+.. toctree::
+  :maxdepth: 3
+
+  activations
+  attention
+  initializers
+  linear
+  normalization
+  stochastic
+

--- a/docs/api_reference/flax.experimental.nnx/nn/initializers.rst
+++ b/docs/api_reference/flax.experimental.nnx/nn/initializers.rst
@@ -1,8 +1,8 @@
 Initializers
 ------------------------
 
-.. automodule:: flax.linen.initializers
-.. currentmodule:: flax.linen.initializers
+.. automodule:: flax.experimental.nnx.initializers
+.. currentmodule:: flax.experimental.nnx.initializers
 
 .. autofunction:: constant
 .. autofunction:: delta_orthogonal
@@ -25,31 +25,3 @@ Initializers
 .. autofunction:: xavier_uniform
 .. autofunction:: zeros
 .. autofunction:: zeros_init
-
-**Summary**
-
-.. autosummary::
-  :toctree: _autosummary
-
-  constant
-  delta_orthogonal
-  glorot_normal
-  glorot_uniform
-  he_normal
-  he_uniform
-  kaiming_normal
-  kaiming_uniform
-  lecun_normal
-  lecun_uniform
-  normal
-  truncated_normal
-  ones
-  ones_init
-  orthogonal
-  uniform
-  standardize
-  variance_scaling
-  xavier_normal
-  xavier_uniform
-  zeros
-  zeros_init

--- a/docs/api_reference/flax.experimental.nnx/nn/linear.rst
+++ b/docs/api_reference/flax.experimental.nnx/nn/linear.rst
@@ -1,0 +1,18 @@
+Linear
+------------------------
+
+NNX linear layer classes.
+
+.. automodule:: flax.experimental.nnx
+.. currentmodule:: flax.experimental.nnx
+
+.. autoclass:: Conv
+   :members:
+.. autoclass:: Embed
+   :members:
+.. autoclass:: Linear
+   :members:
+.. autoclass:: LinearGeneral
+   :members:
+.. autoclass:: Einsum
+   :members:

--- a/docs/api_reference/flax.experimental.nnx/nn/normalization.rst
+++ b/docs/api_reference/flax.experimental.nnx/nn/normalization.rst
@@ -1,0 +1,12 @@
+Normalization
+------------------------
+
+.. automodule:: flax.experimental.nnx
+.. currentmodule:: flax.experimental.nnx
+
+.. autoclass:: BatchNorm
+   :members:
+.. autoclass:: LayerNorm
+   :members:
+.. autoclass:: RMSNorm
+   :members:

--- a/docs/api_reference/flax.experimental.nnx/nn/stochastic.rst
+++ b/docs/api_reference/flax.experimental.nnx/nn/stochastic.rst
@@ -1,0 +1,8 @@
+Stochastic
+------------------------
+
+.. automodule:: flax.experimental.nnx
+.. currentmodule:: flax.experimental.nnx
+
+.. autoclass:: Dropout
+   :members:

--- a/docs/api_reference/flax.experimental.nnx/rnglib.rst
+++ b/docs/api_reference/flax.experimental.nnx/rnglib.rst
@@ -1,0 +1,10 @@
+RNG
+------------------------
+
+.. automodule:: flax.experimental.nnx
+.. currentmodule:: flax.experimental.nnx
+
+.. autoclass:: Rngs
+   :members:
+.. autoclass:: RngStream
+   :members:

--- a/docs/api_reference/flax.experimental.nnx/spmd.rst
+++ b/docs/api_reference/flax.experimental.nnx/spmd.rst
@@ -1,0 +1,10 @@
+SPMD
+------------------------
+
+.. automodule:: flax.experimental.nnx
+.. currentmodule:: flax.experimental.nnx
+
+.. autofunction:: get_partition_spec
+.. autofunction:: get_named_sharding
+.. autofunction:: with_partitioning
+.. autofunction:: with_sharding_constraint

--- a/docs/api_reference/flax.experimental.nnx/transforms.rst
+++ b/docs/api_reference/flax.experimental.nnx/transforms.rst
@@ -1,0 +1,21 @@
+Transformations
+------------------------
+
+.. automodule:: flax.experimental.nnx
+.. currentmodule:: flax.experimental.nnx
+
+.. autoclass:: JIT
+   :members:
+.. autoclass:: Remat
+   :members:
+.. autoclass:: Scan
+   :members:
+.. autoclass:: Vmap
+   :members:
+
+.. autofunction:: grad
+.. autofunction:: jit
+.. autofunction:: remat
+.. autofunction:: scan
+.. autofunction:: value_and_grad
+.. autofunction:: vmap

--- a/docs/api_reference/flax.experimental.nnx/variables.rst
+++ b/docs/api_reference/flax.experimental.nnx/variables.rst
@@ -1,0 +1,24 @@
+Variables
+------------------------
+
+.. automodule:: flax.experimental.nnx
+.. currentmodule:: flax.experimental.nnx
+
+.. autoclass:: BatchStat
+   :members:
+.. autoclass:: Cache
+   :members:
+.. autoclass:: Empty
+   :members:
+.. autoclass:: Intermediate
+   :members:
+.. autoclass:: Param
+   :members:
+.. autoclass:: Rng
+   :members:
+.. autoclass:: Variable
+   :members:
+.. autoclass:: VariableMetadata
+   :members:
+
+.. autofunction:: with_metadata

--- a/docs/api_reference/index.rst
+++ b/docs/api_reference/index.rst
@@ -8,6 +8,7 @@ API Reference
    flax.core.frozen_dict
    flax.cursor
    flax.errors
+   flax.experimental.nnx/index
    flax.jax_utils
    flax.linen/index
    flax.serialization

--- a/flax/experimental/nnx/nnx/module.py
+++ b/flax/experimental/nnx/nnx/module.py
@@ -220,7 +220,7 @@ class Module(reprlib.Representable, metaclass=ModuleMeta):
       module.update(state, *states)
 
     However, thanks to dead code elimination the resulting constructor will only
-    initialize the subset of ``Variable``s that were part of the given state(s).
+    initialize the subset of ``Variable``'s that were part of the given state(s).
 
     Example::
 
@@ -478,7 +478,7 @@ class Module(reprlib.Representable, metaclass=ModuleMeta):
       >>> block.dropout.deterministic, block.batch_norm.use_running_average
       (True, True)
 
-    ``Filter``s can be used to set the attributes of specific Modules::
+    ``Filter``'s can be used to set the attributes of specific Modules::
 
       >>> block = Block(2, 5, rngs=nnx.Rngs(0))
       >>> block.set_attributes(nnx.Dropout, deterministic=True, use_running_average=True)
@@ -610,5 +610,6 @@ def first_from(*args: tp.Optional[A], error_msg: str) -> A:
 def merge(
   state_and_def: tuple[tpe.Unpack[tuple[State, ...]], GraphDef[M]],
 ) -> M:
+  # TODO: add docstring of example usage
   *states, graphdef = state_and_def
   return graphdef.merge(*states)

--- a/flax/experimental/nnx/nnx/nn/initializers.py
+++ b/flax/experimental/nnx/nnx/nn/initializers.py
@@ -27,6 +27,7 @@ from jax.nn.initializers import lecun_uniform as lecun_uniform
 from jax.nn.initializers import normal as normal
 from jax.nn.initializers import ones as ones
 from jax.nn.initializers import orthogonal as orthogonal
+from jax.nn.initializers import truncated_normal as truncated_normal
 from jax.nn.initializers import uniform as uniform
 from jax.nn.initializers import variance_scaling as variance_scaling
 from jax.nn.initializers import xavier_normal as xavier_normal


### PR DESCRIPTION
Added [nnx api reference](https://flax--3762.org.readthedocs.build/en/3762/api_reference/flax.experimental.nnx/index.html). More docstrings to be added later.