### PR TITLE
use note box in make_rng docstring

### DIFF
--- a/flax/linen/module.py
+++ b/flax/linen/module.py
@@ -1893,9 +1893,10 @@ class Module(ModuleBase):
     ``make_rng`` returns a new RNG key, while still guaranteeing full
     reproducibility.
 
-    NOTE: if an invalid name is passed (i.e. no RNG key was passed by
-    the user in ``.init`` or ``.apply`` for this name), then ``name``
-    will default to ``'params'``.
+    .. note::
+      If an invalid name is passed (i.e. no RNG key was passed by
+      the user in ``.init`` or ``.apply`` for this name), then ``name``
+      will default to ``'params'``.
 
     TODO: Link to Flax RNG design note.
 


### PR DESCRIPTION
# What does this PR do?

Uses `.. note:` RST directive in `Module.make_rng` docstring.

<img width="803" alt="Screenshot 2024-03-18 at 11 09 06" src="https://github.com/google/flax/assets/5862228/2cbc5676-8709-4247-a2a3-1809b466d770">
