### PR TITLE
[nnx] Pytrees are Trees

### DIFF
--- a/flax/experimental/nnx/__init__.py
+++ b/flax/experimental/nnx/__init__.py
@@ -25,7 +25,7 @@ from .nnx.filterlib import All as All
 from .nnx.filterlib import Not as Not
 from .nnx.graph_utils import GraphDef as GraphDef
 from .nnx.helpers import Dict as Dict
-from .nnx.helpers import Sequence as Sequence
+from .nnx.helpers import List as List
 from .nnx.helpers import TrainState as TrainState
 from .nnx.module import GraphDef as GraphDef
 from .nnx.module import M as M

--- a/flax/experimental/nnx/examples/toy_examples/07_transformer.py
+++ b/flax/experimental/nnx/examples/toy_examples/07_transformer.py
@@ -377,7 +377,7 @@ class Decoder(nnx.Module):
         )
       )
     else:
-      self.layers = nnx.Sequence(
+      self.layers = nnx.List(
         DecoderBlock(cfg, rngs=rngs) for _ in range(cfg.layers)
       )
 
@@ -406,7 +406,7 @@ class Decoder(nnx.Module):
       )
       self.layers.update(state)
     else:
-      assert isinstance(self.layers, nnx.Sequence)
+      assert isinstance(self.layers, nnx.List)
       for decoder_block in self.layers:
         x = decoder_block(cfg, x, rngs=rngs)
 

--- a/flax/experimental/nnx/nnx/helpers.py
+++ b/flax/experimental/nnx/nnx/helpers.py
@@ -47,12 +47,12 @@ M = tp.TypeVar('M', bound=Module)
 
 class Dict(Module, tp.Mapping[str, A]):
   @tp.overload
-  def __init__(self, __iterable: tp.Iterable[tp.Tuple[str, A]]):
+  def __init__(self, iterable: tp.Iterable[tp.Tuple[str, A]], /):
     ...
 
   @tp.overload
   def __init__(
-    self, __mapping: tp.Optional[tp.Mapping[str, A]] = None, **kwargs: A
+    self, mapping: tp.Optional[tp.Mapping[str, A]] = None, /, **kwargs: A
   ):
     ...
 
@@ -79,10 +79,10 @@ class Dict(Module, tp.Mapping[str, A]):
     return len(vars(self))
 
 
-class Sequence(Module, tp.Generic[A]):
-  def __init__(self, layers: tp.Iterable[A]):
+class List(Module, tp.Generic[A]):
+  def __init__(self, elems: tp.Iterable[A], /):
     i = 0
-    for i, value in enumerate(layers):
+    for i, value in enumerate(elems):
       setattr(self, str(i), value)
     self._length = i + 1
 
@@ -103,6 +103,7 @@ class Sequence(Module, tp.Generic[A]):
   def __len__(self) -> int:
     return self._length
 
+class Sequential(List):
   def __call__(self, *args, rngs: tp.Optional[Rngs] = None, **kwargs) -> tp.Any:
     output: tp.Any = None
 

--- a/flax/experimental/nnx/nnx/module.py
+++ b/flax/experimental/nnx/nnx/module.py
@@ -514,7 +514,7 @@ class Module(reprlib.Representable, metaclass=ModuleMeta):
   def __init_subclass__(cls, experimental_pytree: bool = False) -> None:
     super().__init_subclass__()
 
-    graph_utils.register_mutable_node_type(
+    graph_utils.register_graph_node_type(
       type=cls,
       flatten=_module_graph_flatten,
       set_key=_module_graph_set_key,

--- a/flax/experimental/nnx/tests/test_module.py
+++ b/flax/experimental/nnx/tests/test_module.py
@@ -132,7 +132,7 @@ class TestModule:
     r1 = nnx.Variable(1)
     r2 = nnx.Variable(2)
 
-    m = m0 = nnx.Dict({'a': nnx.Sequence([r1, r2]), 'b': r1})
+    m = m0 = nnx.Dict({'a': nnx.List([r1, r2]), 'b': r1})
 
     @jax.jit
     def f(state: nnx.State, graphdef: nnx.GraphDef[nnx.Dict[Any]]):
@@ -205,7 +205,7 @@ class TestModule:
     v1 = 3
     m = nnx.Dict(
       {
-        'a': nnx.Sequence([r1, r2, v1]),
+        'a': nnx.List([r1, r2, v1]),
         'b': nnx.Dict({'c': r1, 'd': r2}),
       }
     )
@@ -226,14 +226,14 @@ class TestModule:
     ):
       m = nnx.Dict(
         {
-          'a': nnx.Sequence([r1, r2, v1]),
+          'a': nnx.List([r1, r2, v1]),
           'b': nnx.Dict({'c': r1, 'd': r2}),
         }
       )
 
   def test_clone(self):
     m = nnx.Dict(
-      a=nnx.Sequence([nnx.Param(1), nnx.Param(2), 3]),
+      a=nnx.List([nnx.Param(1), nnx.Param(2), 3]),
       b=nnx.Dict(c=nnx.Param(1), d=nnx.Param(2)),
     )
 

--- a/flax/experimental/nnx/tests/test_partitioning.py
+++ b/flax/experimental/nnx/tests/test_partitioning.py
@@ -22,7 +22,7 @@ from flax.experimental import nnx
 class TestPartitioning:
   def test_partition(self):
     m = nnx.Dict(
-      a=nnx.Sequence([nnx.Param(1), nnx.BatchStat(2)]),
+      a=nnx.List([nnx.Param(1), nnx.BatchStat(2)]),
       b=nnx.Param(2),
       c=100,
     )
@@ -48,7 +48,7 @@ class TestPartitioning:
 
   def test_complete_partitioning(self):
     m = nnx.Dict(
-      a=nnx.Sequence([nnx.Param(1), nnx.Param(2), nnx.Variable(3)]),
+      a=nnx.List([nnx.Param(1), nnx.Param(2), nnx.Variable(3)]),
       b=nnx.Dict(c=nnx.Param(1), d=nnx.BatchStat(2)),
     )
 
@@ -57,7 +57,7 @@ class TestPartitioning:
 
   def test_complete_partitioning_plus_ellipsis(self):
     m = nnx.Dict(
-      a=nnx.Sequence([nnx.Param(1), nnx.Param(2), nnx.Variable(3)]),
+      a=nnx.List([nnx.Param(1), nnx.Param(2), nnx.Variable(3)]),
       b=nnx.Dict(c=nnx.Param(1), d=nnx.BatchStat(2)),
     )
 
@@ -66,7 +66,7 @@ class TestPartitioning:
 
   def test_inclomplete_partition_error(self):
     m = nnx.Dict(
-      a=nnx.Sequence([nnx.Param(1), nnx.Param(2), nnx.Variable(3)]),
+      a=nnx.List([nnx.Param(1), nnx.Param(2), nnx.Variable(3)]),
       b=nnx.Dict(c=nnx.Param(1), d=nnx.BatchStat(2)),
     )
 
@@ -77,7 +77,7 @@ class TestPartitioning:
 
   def test_ellipsis_not_last_error(self):
     m = nnx.Dict(
-      a=nnx.Sequence([nnx.Param(1), nnx.Param(2), nnx.Variable(3)]),
+      a=nnx.List([nnx.Param(1), nnx.Param(2), nnx.Variable(3)]),
       b=nnx.Dict(c=nnx.Param(1), d=nnx.BatchStat(2)),
     )
 
@@ -88,7 +88,7 @@ class TestPartitioning:
 
   def test_update_from(self):
     m = nnx.Dict(
-      a=nnx.Sequence([nnx.Param(1), nnx.BatchStat(3)]),
+      a=nnx.List([nnx.Param(1), nnx.BatchStat(3)]),
       b=nnx.Param(2),
       c=100,
     )
@@ -105,7 +105,7 @@ class TestPartitioning:
 
   def test_update_from_with_array_leaf(self):
     m = nnx.Dict(
-      a=nnx.Sequence([nnx.Param(1), nnx.BatchStat(3)]),
+      a=nnx.List([nnx.Param(1), nnx.BatchStat(3)]),
       b=nnx.Param(2),
       c=nnx.Variable(jax.numpy.array(100)),
     )
@@ -122,7 +122,7 @@ class TestPartitioning:
 
   def test_grad_example(self):
     m = nnx.Dict(
-      a=nnx.Sequence([nnx.Param(1.0), nnx.BatchStat(-10)]),
+      a=nnx.List([nnx.Param(1.0), nnx.BatchStat(-10)]),
       b=nnx.Param(2.0),
       c=100,
     )
@@ -142,7 +142,7 @@ class TestPartitioning:
 
   def test_get_paritition(self):
     m = nnx.Dict(
-      a=nnx.Sequence([nnx.Param(10.0), nnx.Param(20.0)]),
+      a=nnx.List([nnx.Param(10.0), nnx.Param(20.0)]),
       b=nnx.Param(10.0),
       c=7,
       d=5.0,

--- a/flax/experimental/nnx/tests/test_transforms.py
+++ b/flax/experimental/nnx/tests/test_transforms.py
@@ -123,7 +123,7 @@ class TestGrad:
     p2 = nnx.Param(20.0)
 
     m = nnx.Dict(
-      a=nnx.Sequence([p1, p2]),
+      a=nnx.List([p1, p2]),
       b=p1,
       c=7,
       d=5.0,
@@ -155,7 +155,7 @@ class TestGrad:
 
   def test_grad_with_multiple_ref_types(self):
     m = nnx.Dict(
-      a=nnx.Sequence([nnx.Param(10.0), nnx.BatchStat(20.0)]),
+      a=nnx.List([nnx.Param(10.0), nnx.BatchStat(20.0)]),
       b=nnx.Param(10.0),
       c=7,
       d=5.0,
@@ -183,7 +183,7 @@ class TestGrad:
 
   def test_grad_with_type_predicate(self):
     m = nnx.Dict(
-      a=nnx.Sequence([nnx.Param(10.0), nnx.BatchStat(20.0)]),
+      a=nnx.List([nnx.Param(10.0), nnx.BatchStat(20.0)]),
       b=nnx.Param(10.0),
       c=7,
       d=5.0,


### PR DESCRIPTION
# What does this PR do?

* Traversal procedure no longer caches pytree nodes, this reintroduces referential transparency for pytree types.
* `list`, `dict`, and `tuple` are no longer graph nodes, they are they are supported as tree nodes.
### Other changes
* Renames `MutableNodeImpl` to `GraphNodeImpl`.
* Renames `ImmutableNodeImpl` to `PytreeNodeImpl`.
* Renames `Sequence` to `List` for consistency and removes the `__call__` method.
* Created `Sequential` that inherits form `List` and implements `__call__`.