### PR TITLE
[nnx] add GraphNode base class

### DIFF
--- a/flax/experimental/nnx/__init__.py
+++ b/flax/experimental/nnx/__init__.py
@@ -30,7 +30,9 @@ from .nnx.helpers import TrainState as TrainState
 from .nnx.module import GraphDef as GraphDef
 from .nnx.module import M as M
 from .nnx.module import Module as Module
-from .nnx.module import merge as merge
+from .nnx.graph_utils import merge as merge
+from .nnx.graph_utils import split as split
+from .nnx.graph_utils import update as update
 from .nnx.nn import initializers as initializers
 from .nnx.nn.activations import celu as celu
 from .nnx.nn.activations import elu as elu

--- a/flax/experimental/nnx/examples/toy_examples/06_scan_over_layers.py
+++ b/flax/experimental/nnx/examples/toy_examples/06_scan_over_layers.py
@@ -50,7 +50,7 @@ class ScanMLP(nnx.Module):
 
     # call vmap over create_block, passing the split `params` key
     # and immediately merge to get a Block instance
-    self.layers = nnx.merge(jax.vmap(create_block)(keys))
+    self.layers = nnx.merge(*jax.vmap(create_block)(keys))
 
   def __call__(self, x: jax.Array, *, rngs: nnx.Rngs) -> jax.Array:
     # fork Rngs, split keys into `n_layers`

--- a/flax/experimental/nnx/examples/toy_examples/07_transformer.py
+++ b/flax/experimental/nnx/examples/toy_examples/07_transformer.py
@@ -372,7 +372,7 @@ class Decoder(nnx.Module):
 
     if cfg.scanned:
       self.layers = nnx.merge(
-        jax.vmap(lambda key: DecoderBlock(cfg, rngs=nnx.Rngs(key)).split())(
+        *jax.vmap(lambda key: DecoderBlock(cfg, rngs=nnx.Rngs(key)).split())(
           jax.random.split(rngs.params(), cfg.layers)
         )
       )

--- a/flax/experimental/nnx/nnx/helpers.py
+++ b/flax/experimental/nnx/nnx/helpers.py
@@ -73,7 +73,7 @@ class Dict(Module, tp.Mapping[str, A]):
     super().__setattr__(key, value)
 
   def __iter__(self) -> tp.Iterator[str]:
-    return (k for k in vars(self) if k != '_module__state')
+    return (k for k in vars(self) if k != '_graph_node__state')
 
   def __len__(self) -> int:
     return len(vars(self))

--- a/flax/experimental/nnx/nnx/transforms.py
+++ b/flax/experimental/nnx/nnx/transforms.py
@@ -44,7 +44,8 @@ from flax.experimental.nnx.nnx import (
   spmd,
   variables,
 )
-from flax.experimental.nnx.nnx.module import GraphDef, Module, ModuleMeta
+from flax.experimental.nnx.nnx.graph_utils import GraphNodeMeta
+from flax.experimental.nnx.nnx.module import GraphDef, Module
 from flax.experimental.nnx.nnx.proxy_caller import (
   CallableProxy,
   DelayedAccessor,
@@ -133,7 +134,7 @@ class JITOptions:
     return kwargs
 
 
-class JITMeta(ModuleMeta):
+class JITMeta(GraphNodeMeta):
   def __call__(
     self,
     module_constructor: tp.Callable[..., M],
@@ -383,7 +384,7 @@ class GradOptions:
   return_value: bool
 
 
-class GradMeta(ModuleMeta):
+class GradMeta(GraphNodeMeta):
   def __call__(
     self,
     module_constructor: tp.Callable[..., M],
@@ -639,7 +640,7 @@ class ScanOptions:
   scan_output: bool
 
 
-class ScanMeta(ModuleMeta):
+class ScanMeta(GraphNodeMeta):
   def __call__(
     self,
     module_constructor: tp.Callable[..., M],
@@ -1108,7 +1109,7 @@ def scan(
 # -------------------------------
 
 
-class RematMeta(ModuleMeta):
+class RematMeta(GraphNodeMeta):
   def __call__(
     self,
     module_constructor: tp.Callable[..., M],
@@ -1292,7 +1293,7 @@ class VmapOptions:
   vmap_metadata: tp.Mapping[str, tp.Any]
 
 
-class VmapMeta(ModuleMeta):
+class VmapMeta(GraphNodeMeta):
   def __call__(
     self,
     module_constructor: tp.Callable[..., M],

--- a/flax/experimental/nnx/tests/test_module.py
+++ b/flax/experimental/nnx/tests/test_module.py
@@ -33,7 +33,7 @@ class TestModule:
 
     foo = Foo()
 
-    assert hasattr(foo, '_module__state')
+    assert hasattr(foo, '_graph_node__state')
 
   def test_trace_level(self):
     m = nnx.Dict(a=nnx.Param(1))
@@ -42,7 +42,7 @@ class TestModule:
     def f():
       with pytest.raises(
         nnx.TraceContextError,
-        match='Cannot mutate Module from different trace level',
+        match='Cannot mutate GraphNode from different trace level',
       ):
         m.a = 2
 
@@ -109,7 +109,7 @@ class TestModule:
     m1 = nnx.Dict(a=nnx.Param(1), b=nnx.Param(2))
     m2 = nnx.Dict(x=m1, y=m1, z=nnx.Param(3))
 
-    m3 = nnx.merge(m2.split())
+    m3 = nnx.merge(*m2.split())
 
     assert m3['x'] is m3['y']
     assert m3['x']['a'] is m3['y']['a']
@@ -178,11 +178,11 @@ class TestModule:
     def g(state_and_def):
       nonlocal n
       n += 1
-      m = nnx.merge(state_and_def)
+      m = nnx.merge(*state_and_def)
       m.a.value += 1
       return m.split()
 
-    m2 = nnx.merge(g(m.split()))
+    m2 = nnx.merge(*g(m.split()))
 
     assert n == 1
     assert m2 is not m
@@ -417,7 +417,7 @@ class TestModule:
 
     m2 = m2.clone()  # clone to sort the fields
 
-    with pytest.raises(ValueError, match='Trying to add a new node at path'):
+    with pytest.raises(ValueError, match='Trying to update a node at path'):
       m1.update(m2)
 
   def test_create_abstract(self):

--- a/flax/experimental/nnx/tests/test_spmd.py
+++ b/flax/experimental/nnx/tests/test_spmd.py
@@ -44,7 +44,7 @@ class TestSPMD:
     mesh = Mesh(mesh_utils.create_device_mesh((2, 2)), ('model', 'data'))
 
     with mesh:
-      m: Foo = nnx.merge(create_module())
+      m: Foo = nnx.merge(*create_module())
 
     assert m.w.shape == (8, 2)
     assert m.w.sharding.shard_shape(m.w.shape) == (4, 1)


### PR DESCRIPTION
# What does this PR do?

* Adds `GraphNode` as a base class for `Module` and other types that need a graph flatten/unflatten implementation according to Module's current definition.
* Adds `nnx.split` and `nnx.update` to work with any graph node.
* Redefines `nnx.merge` to match the spread signature returned by `.split`
* Orders the leaves when flattening Module.