### PR TITLE
[nnx] Rngs and RngStream inherit from GraphNode

### DIFF
--- a/flax/experimental/nnx/__init__.py
+++ b/flax/experimental/nnx/__init__.py
@@ -20,7 +20,7 @@ from flax.typing import Initializer as Initializer
 
 from .nnx import compatibility as compatibility
 from .nnx import graph_utils as graph_utils
-from .nnx.errors import TraceContextError as TraceContextError
+from .nnx import errors as errors
 from .nnx.filterlib import All as All
 from .nnx.filterlib import Not as Not
 from .nnx.graph_utils import GraphDef as GraphDef

--- a/flax/experimental/nnx/nnx/compatibility.py
+++ b/flax/experimental/nnx/nnx/compatibility.py
@@ -65,7 +65,9 @@ class LinenWrapper(Module):
     self.module = module
 
     _rngs = (
-      {name: stream.key for name, stream in rngs._rngs.items()} if rngs else {}
+      {name: stream.key.raw_value for name, stream in rngs._rngs.items()}
+      if rngs
+      else {}
     )
     # rename default to params
     if 'params' not in _rngs and 'default' in _rngs:
@@ -83,7 +85,9 @@ class LinenWrapper(Module):
     self, *args: Any, rngs: tp.Optional[Rngs] = None, **kwargs: Any
   ) -> Any:
     _rngs = (
-      {name: stream.key for name, stream in rngs._rngs.items()} if rngs else {}
+      {name: stream.key.value for name, stream in rngs._rngs.items()}
+      if rngs
+      else {}
     )
 
     variables = {

--- a/flax/experimental/nnx/nnx/nn/stochastic.py
+++ b/flax/experimental/nnx/nnx/nn/stochastic.py
@@ -14,6 +14,7 @@
 
 from typing import Optional, Sequence
 
+import jax
 import jax.numpy as jnp
 from jax import lax, random
 
@@ -46,7 +47,7 @@ class Dropout(Module):
     *,
     deterministic: Optional[bool] = None,
     rngs: Optional[rnglib.Rngs] = None,
-  ):
+  ) -> jax.Array:
     """Applies a random dropout mask to the input.
 
     Args:

--- a/flax/experimental/nnx/nnx/variables.py
+++ b/flax/experimental/nnx/nnx/variables.py
@@ -227,8 +227,8 @@ class Variable(tp.Generic[A], reprlib.Representable):
 
   def _setattr(self, name: str, value: tp.Any):
     if not self._trace_state.is_valid():
-      raise ValueError(
-        'Cannot mutate Variable from a different trace level'
+      raise nnx.errors.TraceContextError(
+        f'Cannot mutate {type(self).__name__} from a different trace level'
       )
 
     object.__setattr__(self, name, value)

--- a/flax/experimental/nnx/tests/test_module.py
+++ b/flax/experimental/nnx/tests/test_module.py
@@ -41,8 +41,8 @@ class TestModule:
     @jax.jit
     def f():
       with pytest.raises(
-        nnx.TraceContextError,
-        match='Cannot mutate GraphNode from different trace level',
+        nnx.errors.TraceContextError,
+        match="Cannot mutate 'Dict' from different trace level",
       ):
         m.a = 2
 


### PR DESCRIPTION
# What does this PR do?

* `Rngs` and `RngStream` are now `GraphNode`s, this means their state can be more easily tracked by transforms.
* Added a `RngState(Variable)` type.
* `RngStream.key` and `RngStream.count` are now `RngState` variables. This also means that `count` is now a dynamic property.
* Added a general `GraphNode.check_valid_context` method that can be used to check that the GraphNode is in the appropriate context.
* Removed `Rngs._trace_state` and `Rngs.is_valid` in favor of using `GraphNode.check_valid_context`.
* `nnx.jit` no longer has a special rule for `Rngs`, they are just handled as `GraphNode`s if present.

#### other
* Created a `ModuleMeta(GraphNodeMeta)` and passed all dataclass post-init logic (e.g. calling `.setup` or setting `rngs = None`) to `ModuleMeta`.
* Transform combinator metaclasses now inherit from `ModuleMeta`.