### PR TITLE
[nnx] split returns graphdef first

### DIFF
--- a/flax/experimental/nnx/docs/demo.ipynb
+++ b/flax/experimental/nnx/docs/demo.ipynb
@@ -223,7 +223,7 @@
     }
    ],
    "source": [
-    "state, static = model.split()\n",
+    "static, state = model.split()\n",
     "\n",
     "# state is a dictionary-like JAX pytree\n",
     "print(f'{state = }'[:500] + '\\n...')\n",
@@ -250,7 +250,7 @@
     }
    ],
    "source": [
-    "state, static = model.split()\n",
+    "static, state = model.split()\n",
     "\n",
     "@jax.jit\n",
     "def forward(static: nnx.GraphDef, state: nnx.State, x: jax.Array):\n",

--- a/flax/experimental/nnx/docs/demo.md
+++ b/flax/experimental/nnx/docs/demo.md
@@ -86,7 +86,7 @@ print(f'{y.shape = }')
 ```{code-cell} ipython3
 :outputId: 9a3f378b-739e-4f45-9968-574651200ede
 
-state, static = model.split()
+static, state = model.split()
 
 # state is a dictionary-like JAX pytree
 print(f'{state = }'[:500] + '\n...')
@@ -98,7 +98,7 @@ print(f'\n{static = }'[:300] + '\n...')
 ```{code-cell} ipython3
 :outputId: 0007d357-152a-449e-bcb9-b1b5a91d2d8d
 
-state, static = model.split()
+static, state = model.split()
 
 @jax.jit
 def forward(static: nnx.GraphDef, state: nnx.State, x: jax.Array):

--- a/flax/experimental/nnx/docs/quick_start.ipynb
+++ b/flax/experimental/nnx/docs/quick_start.ipynb
@@ -344,7 +344,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "params, static = model.split(\"params\")\n",
+    "static, params = model.split(\"params\")\n",
     "\n",
     "\n",
     "@jax.jit\n",
@@ -420,7 +420,7 @@
    "outputs": [],
    "source": [
     "state = nnx.TrainState(\n",
-    "    apply_fn=static.apply,\n",
+    "    static,\n",
     "    params=params,\n",
     "    tx=optax.adam(0.001),\n",
     ")\n",

--- a/flax/experimental/nnx/docs/why.ipynb
+++ b/flax/experimental/nnx/docs/why.ipynb
@@ -305,7 +305,7 @@
    "source": [
     "model = CounterLinear(4, 4, rngs=nnx.Rngs(0))\n",
     "\n",
-    "state, static = model.split()\n",
+    "static, state = model.split()\n",
     "\n",
     "# state is a dictionary-like JAX pytree\n",
     "print(f'{state = }')\n",
@@ -680,7 +680,7 @@
     "model = AnnotatedLinear(4, 8, rngs=nnx.Rngs(0))\n",
     "y = model(jnp.ones((2, 4)))\n",
     "\n",
-    "state, static = model.split()\n",
+    "static, state = model.split()\n",
     "\n",
     "print(f\"{state.variables['kernel'].meta=}\\n{state.variables['kernel'].other_meta=}\")\n",
     "print(f\"{state.variables['bias'].meta=}\\n{state.variables['bias'].other_meta=}\")"
@@ -751,7 +751,7 @@
     "                input_shape=(2, 6, 6, 3),\n",
     "                rngs=nnx.Rngs(0))\n",
     "\n",
-    "state, static = model.split()\n",
+    "static, state = model.split()\n",
     "jax.tree_map(jnp.shape, state)"
    ]
   }

--- a/flax/experimental/nnx/docs/why.md
+++ b/flax/experimental/nnx/docs/why.md
@@ -152,7 +152,7 @@ The `Module.split` method allows you to convert into a `State` dict-like object 
 
 model = CounterLinear(4, 4, rngs=nnx.Rngs(0))
 
-state, static = model.split()
+static, state = model.split()
 
 # state is a dictionary-like JAX pytree
 print(f'{state = }')
@@ -359,7 +359,7 @@ class AnnotatedLinear(nnx.Module):
 model = AnnotatedLinear(4, 8, rngs=nnx.Rngs(0))
 y = model(jnp.ones((2, 4)))
 
-state, static = model.split()
+static, state = model.split()
 
 print(f"{state.variables['kernel'].meta=}\n{state.variables['kernel'].other_meta=}")
 print(f"{state.variables['bias'].meta=}\n{state.variables['bias'].other_meta=}")
@@ -404,6 +404,6 @@ model = Example(in_filters=3,
                 input_shape=(2, 6, 6, 3),
                 rngs=nnx.Rngs(0))
 
-state, static = model.split()
+static, state = model.split()
 jax.tree_map(jnp.shape, state)
 ```

--- a/flax/experimental/nnx/examples/lm1b/utils.py
+++ b/flax/experimental/nnx/examples/lm1b/utils.py
@@ -157,7 +157,7 @@ def setup_initial_state(
 
   with mesh:
     model = constructor(config, rng)
-    params, static = model.split(nnx.Param)
+    static, params = model.split(nnx.Param)
     state = TrainState.create(
       apply_fn=static.apply, params=params, tx=tx, graphdef=static
     )

--- a/flax/experimental/nnx/examples/toy_examples/00_demo.ipynb
+++ b/flax/experimental/nnx/examples/toy_examples/00_demo.ipynb
@@ -103,7 +103,7 @@
     }
    ],
    "source": [
-    "state, graphdef = linear.split()\n",
+    "graphdef, state = linear.split()\n",
     "\n",
     "print(state)\n",
     "print(graphdef)"
@@ -247,7 +247,7 @@
     }
    ],
    "source": [
-    "state, graphdef = linear.split()\n",
+    "graphdef, state = linear.split()\n",
     "\n",
     "print(state)\n",
     "print(graphdef)"
@@ -350,7 +350,7 @@
    ],
    "source": [
     "intermediates = linear.pop(nnx.Intermediate)\n",
-    "state, graphdef = linear.split()\n",
+    "graphdef, state = linear.split()\n",
     "\n",
     "print(intermediates)\n",
     "print(state)"

--- a/flax/experimental/nnx/examples/toy_examples/05_vae.py
+++ b/flax/experimental/nnx/examples/toy_examples/05_vae.py
@@ -113,7 +113,7 @@ class VAE(nnx.Module):
     return nnx.sigmoid(logits)
 
 
-params, static = VAE(
+static, params = VAE(
   din=int(np.prod(image_shape)),
   hidden_size=256,
   latent_size=latent_size,
@@ -133,7 +133,7 @@ state = nnx.TrainState.create(
 def train_step(state: nnx.TrainState[VAE], x: jax.Array, key: jax.Array):
   def loss_fn(params: nnx.State):
     rngs = nnx.Rngs(noise=jax.random.fold_in(key, state.step))
-    logits, (updates, _) = state.apply(params)(x, rngs=rngs)
+    logits, (_, updates) = state.apply(params)(x, rngs=rngs)
 
     losses = updates.extract(Loss)
     kl_loss = sum(jax.tree_util.tree_leaves(losses), 0.0)

--- a/flax/experimental/nnx/examples/toy_examples/06_scan_over_layers.py
+++ b/flax/experimental/nnx/examples/toy_examples/06_scan_over_layers.py
@@ -56,7 +56,7 @@ class ScanMLP(nnx.Module):
     # fork Rngs, split keys into `n_layers`
     keys = rngs.fork(self.n_layers)
     # split Module to get params
-    params, static = self.layers.split(nnx.Param)
+    static, params = self.layers.split(nnx.Param)
 
     def scan_fn(
       x: jax.Array, inputs: Tuple[nnx.State, dict[str, nnx.RngStream]]

--- a/flax/experimental/nnx/examples/toy_examples/07_transformer.py
+++ b/flax/experimental/nnx/examples/toy_examples/07_transformer.py
@@ -389,7 +389,7 @@ class Decoder(nnx.Module):
     if cfg.scanned:
       assert isinstance(self.layers, DecoderBlock)
 
-      state, static = self.layers.split()
+      static, state = self.layers.split()
       rngs, rngsdef = rngs.fork()
       dropout_key = jax.random.split(rngs['dropout'], cfg.layers)
 

--- a/flax/experimental/nnx/examples/toy_examples/08_save_load_checkpoints.py
+++ b/flax/experimental/nnx/examples/toy_examples/08_save_load_checkpoints.py
@@ -47,7 +47,7 @@ def create_and_save(seed: int, path: str):
 
 def load_model(path: str) -> MLP:
   # create that model with abstract shapes
-  state, static = jax.eval_shape(lambda: create_model(0).split())
+  static, state = jax.eval_shape(lambda: create_model(0).split())
   # Load the parameters
   checkpointer = orbax.PyTreeCheckpointer()
   state = checkpointer.restore(f'{path}/state', item=state)

--- a/flax/experimental/nnx/examples/toy_examples/10_quantization.py
+++ b/flax/experimental/nnx/examples/toy_examples/10_quantization.py
@@ -106,7 +106,7 @@ class MLP(nnx.Module):
     return x
 
 
-params, static = MLP(
+static, params = MLP(
   din=np.prod(image_shape), dmid=256, dout=10, rngs=nnx.Rngs(0)
 ).split(nnx.Param)
 
@@ -181,7 +181,7 @@ y_pred = forward(state, x_sample)
 # plot predictions
 figure = plt.figure(figsize=(3 * 5, 3 * 2))
 
-for i in range(10):
+for i in range(5):
   plt.subplot(2, 5, i + 1)
   plt.imshow(x_sample[i].reshape(image_shape), cmap='gray')
   plt.title(f'{y_pred[i]}')
@@ -234,7 +234,7 @@ class QLinear(nnx.Module):
     num_steps: int = 100,
     debug: bool = False,
   ):
-    q_hparams, rest, static = self.split(QHParam, ...)
+    static, q_hparams, rest = self.split(QHParam, ...)
     tx = optax.adam(1e-3)
     opt_state = tx.init(q_hparams)
 
@@ -436,6 +436,8 @@ idxs = np.random.randint(0, len(X_test), size=(100,))
 x_optimize = jnp.asarray(X_test[idxs], dtype=jnp.float32)
 x_optimize = x_optimize.reshape((x_optimize.shape[0], -1))
 print(x_optimize.shape)
-qlinear1.optimize(model.linear1, x_optimize, num_steps=1000, debug=True)
+qlinear1.optimize(model.linear1, x_optimize, num_steps=100, debug=True)
+
+# %%
 
 # %%

--- a/flax/experimental/nnx/nnx/compatibility.py
+++ b/flax/experimental/nnx/nnx/compatibility.py
@@ -38,7 +38,7 @@ class Functional(tp.Generic[M]):
     if rngs is not None:
       kwargs['rngs'] = rngs
     module = self.module_type(*self.args, **self.kwargs, **kwargs)
-    state, graphdef = module.split()
+    graphdef, state = module.split()
     self.graphdef = graphdef
     return state
 

--- a/flax/experimental/nnx/tests/test_graph_utils.py
+++ b/flax/experimental/nnx/tests/test_graph_utils.py
@@ -25,7 +25,7 @@ class TestGraphUtils:
     a = {'a': 1, 'b': nnx.Param(2)}
     g = [a, 3, a, nnx.Param(4)]
 
-    state, static, ref_idx = nnx.graph_utils.graph_flatten(g)
+    static, state, ref_idx = nnx.graph_utils.graph_flatten(g)
 
     state['0']['b'].raw_value = 2
     state['3'].raw_value = 4
@@ -38,7 +38,7 @@ class TestGraphUtils:
     a = nnx.Dict(a=1, b=nnx.Param(2))
     g = nnx.List([a, 3, a, nnx.Param(4)])
 
-    state, static, _ = nnx.graph_utils.graph_flatten(g)
+    static, state, _ = nnx.graph_utils.graph_flatten(g)
     g = static.merge(state)
 
     assert g[0] is g[2]
@@ -47,7 +47,7 @@ class TestGraphUtils:
     a = {'a': 1, 'b': nnx.Param(2)}
     g = [a, 3, a, nnx.Param(4)]
 
-    state, static, _ = nnx.graph_utils.graph_flatten(g)
+    static, state, _ = nnx.graph_utils.graph_flatten(g)
     g = static.merge(state)
 
     assert g[0] is not g[2]
@@ -56,7 +56,7 @@ class TestGraphUtils:
     a = nnx.Dict({'a': 1, 'b': nnx.Param(2)})
     g = nnx.List([a, 3, a, nnx.Param(4)])
 
-    state, static, _ = nnx.graph_utils.graph_flatten(g)
+    static, state, _ = nnx.graph_utils.graph_flatten(g)
     g = static.merge(nnx.State({}))
 
     assert g[0] is g[2]
@@ -67,7 +67,7 @@ class TestGraphUtils:
     a = {'a': 1, 'b': nnx.Param(2)}
     g = [a, 3, a, nnx.Param(4)]
 
-    state, static, _ = nnx.graph_utils.graph_flatten(g)
+    static, state, _ = nnx.graph_utils.graph_flatten(g)
 
     state['0']['b'].raw_value = 3
     nnx.graph_utils.graph_update_dynamic(g, state)
@@ -123,7 +123,7 @@ class TestGraphUtils:
       nnx.BatchNorm(2, rngs=rngs),
     ]
 
-    state, static, _ = nnx.graph_utils.graph_flatten(ls)
+    static, state, _ = nnx.graph_utils.graph_flatten(ls)
 
     assert state['0']['kernel'].raw_value.shape == (2, 2)
     assert state['0']['bias'].raw_value.shape == (2,)
@@ -136,7 +136,7 @@ class TestGraphUtils:
     v = nnx.Param(1)
     g = [v, v]
 
-    state, static, _ = nnx.graph_utils.graph_flatten(g)
+    static, state, _ = nnx.graph_utils.graph_flatten(g)
 
     assert len(state.flat_state()) == 1
 
@@ -154,7 +154,7 @@ class TestGraphUtils:
         self.baz.kernel = self.bar.kernel
 
     node = Foo(rngs=nnx.Rngs(0))
-    state, static, _ = nnx.graph_utils.graph_flatten(node)
+    static, state, _ = nnx.graph_utils.graph_flatten(node)
 
     assert len(state.flat_state()) == 3  # 2 bias + 1 kernel
 
@@ -187,7 +187,7 @@ class TestGraphUtils:
         return self.linear_out(x)
 
     model = Encoder(rngs=nnx.Rngs(0))
-    state, static = model.split()
+    static, state = model.split()
 
     assert len(state.flat_state()) == 1
 
@@ -202,7 +202,7 @@ class TestGraphUtils:
         self.a = nnx.Param(1)
 
     m = Foo()
-    state, static = m.split()
+    static, state = m.split()
 
     assert isinstance(m.a, nnx.Param)
     assert isinstance(state.a, nnx.Param)
@@ -224,7 +224,7 @@ class TestGraphUtils:
         self.b = p
 
     m = Foo()
-    state, static = m.split()
+    static, state = m.split()
 
     assert isinstance(m.a, nnx.Param)
     assert isinstance(m.b, nnx.Param)
@@ -278,7 +278,7 @@ class TestGraphUtils:
 
     m = Foo()
 
-    state, static = m.split()
+    static, state = m.split()
 
     assert 'tree' in state
     assert 'a' in state.tree
@@ -306,13 +306,13 @@ class TestGraphUtils:
     b = m.b
 
     static: nnx.graph_utils.GraphDef[Foo]
-    state, static, ref_out_idx_out = nnx.graph_utils.graph_flatten(m)
+    static, state, ref_out_idx_out = nnx.graph_utils.graph_flatten(m)
 
     @partial(jax.jit, static_argnums=(0,))
     def f_pure(static: nnx.graph_utils.GraphDef[Foo], state):
       m, idx_out_ref_in = nnx.graph_utils.graph_unflatten(static, state)
       f(m)
-      state, static, ref_in_idx_in = nnx.graph_utils.graph_flatten(m)
+      static, state, ref_in_idx_in = nnx.graph_utils.graph_flatten(m)
       idx_out_idx_in = nnx.graph_utils.compose_mapping(
         idx_out_ref_in, ref_in_idx_in
       )
@@ -347,13 +347,13 @@ class TestGraphUtils:
     b = m.b
 
     static: nnx.graph_utils.GraphDef[Foo]
-    state, static, ref_out_idx_out = nnx.graph_utils.graph_flatten(m)
+    static, state, ref_out_idx_out = nnx.graph_utils.graph_flatten(m)
 
     @partial(jax.jit, static_argnums=(0,))
     def f_pure(static: nnx.graph_utils.GraphDef[Foo], state):
       m, idx_out_ref_in = nnx.graph_utils.graph_unflatten(static, state)
       f(m)
-      state, static, ref_in_idx_in = nnx.graph_utils.graph_flatten(m)
+      static, state, ref_in_idx_in = nnx.graph_utils.graph_flatten(m)
       idx_out_idx_in = nnx.graph_utils.compose_mapping(
         idx_out_ref_in, ref_in_idx_in
       )
@@ -385,13 +385,13 @@ class TestGraphUtils:
     m = Foo()
 
     static: nnx.graph_utils.GraphDef[Foo]
-    state, static, ref_out_idx_out = nnx.graph_utils.graph_flatten(m)
+    static, state, ref_out_idx_out = nnx.graph_utils.graph_flatten(m)
 
     @partial(jax.jit, static_argnums=(0,))
     def f_pure(static: nnx.graph_utils.GraphDef[Foo], state):
       m, idx_out_ref_in = nnx.graph_utils.graph_unflatten(static, state)
       f(m)
-      state, static, ref_in_idx_in = nnx.graph_utils.graph_flatten(m)
+      static, state, ref_in_idx_in = nnx.graph_utils.graph_flatten(m)
       idx_out_idx_in = nnx.graph_utils.compose_mapping(
         idx_out_ref_in, ref_in_idx_in
       )

--- a/flax/experimental/nnx/tests/test_helpers.py
+++ b/flax/experimental/nnx/tests/test_helpers.py
@@ -26,7 +26,7 @@ class TestHelpers:
   def test_train_state(self):
     m = nnx.Dict(a=nnx.Param(1), b=nnx.BatchStat(2))
 
-    params, batch_stats, graphdef = m.split(nnx.Param, nnx.BatchStat)
+    graphdef, params, batch_stats = m.split(nnx.Param, nnx.BatchStat)
 
     state = TrainState.create(
       graphdef,
@@ -49,7 +49,7 @@ class TestHelpers:
         return x
 
     module = Foo(rngs=nnx.Rngs(0))
-    params, batch_stats, graphdef = module.split(nnx.Param, nnx.BatchStat)
+    graphdef, params, batch_stats = module.split(nnx.Param, nnx.BatchStat)
 
     state = TrainState.create(
       graphdef,

--- a/flax/experimental/nnx/tests/test_integration.py
+++ b/flax/experimental/nnx/tests/test_integration.py
@@ -115,13 +115,13 @@ class TestIntegration:
       return model.split()
 
     graphdef: nnx.GraphDef[Model]
-    state, graphdef = Model(rngs=nnx.Rngs(0)).split()
+    graphdef, state = Model(rngs=nnx.Rngs(0)).split()
 
     x = np.random.uniform(size=(4, 2))
     y = np.random.uniform(size=(4, 2))
 
     for _i in range(3):
-      state, graphdef = train_step(state, graphdef, x, y)
+      graphdef, state = train_step(state, graphdef, x, y)
 
     model = graphdef.merge(state)
 
@@ -192,12 +192,12 @@ class TestIntegration:
     y = model(x)
     assert model.count.value == 1
 
-    params, counts, graphdef = model.split(nnx.Param, Count)
+    graphdef, params, counts = model.split(nnx.Param, Count)
 
     @jax.jit
     def train_step(params, counts, x, y):
       def loss_fn(params):
-        y_pred, (updates, _) = graphdef.apply(params, counts)(x)
+        y_pred, (_, updates) = graphdef.apply(params, counts)(x)
         loss = jax.numpy.mean((y_pred - y) ** 2)
         return loss, updates.extract(Count)
 
@@ -247,9 +247,9 @@ class TestIntegration:
 
     model = Linear(12, 2, rngs=nnx.Rngs(0))
 
-    state, graphdef = model.split()
+    graphdef, state = model.split()
 
-    y, (state, _) = graphdef.apply(state)(jnp.ones((8, 12)))
+    y, (_, state) = graphdef.apply(state)(jnp.ones((8, 12)))
 
     intermediates, state = state.split(nnx.Intermediate, ...)
 

--- a/flax/experimental/nnx/tests/test_partitioning.py
+++ b/flax/experimental/nnx/tests/test_partitioning.py
@@ -27,7 +27,7 @@ class TestPartitioning:
       c=100,
     )
 
-    params, rest, graphdef = m.split(nnx.Param, ...)
+    graphdef, params, rest = m.split(nnx.Param, ...)
 
     assert len(params) == 2
     assert len(rest) == 1
@@ -93,7 +93,7 @@ class TestPartitioning:
       c=100,
     )
 
-    state = m.split()[0]
+    state = m.split()[1]
     state = jax.tree_map(lambda x: x * 2, state)
 
     m.update(state)
@@ -110,7 +110,7 @@ class TestPartitioning:
       c=nnx.Variable(jax.numpy.array(100)),
     )
 
-    state, graphdef = m.split()
+    graphdef, state = m.split()
     state = jax.tree_map(lambda x: x * 2, state)
 
     m.update(state)

--- a/flax/experimental/nnx/tests/test_spmd.py
+++ b/flax/experimental/nnx/tests/test_spmd.py
@@ -62,7 +62,7 @@ class TestSPMD:
       def __call__(self, x):
         return x @ self.w
 
-    params, graphdef = Foo().split()
+    graphdef, params = Foo().split()
     state = nnx.TrainState.create(
       graphdef,
       params=params,


### PR DESCRIPTION
# What does this PR do?

`nnx.split` now returns a `GraphDef` as the first element, and `nnx.merge` accepts a `GraphDef` as its first argument. Changes a couple of other APIs to be consistent with the new order.