### PR TITLE
Expose `nnx.GraphNode`

### DIFF
--- a/flax/experimental/nnx/__init__.py
+++ b/flax/experimental/nnx/__init__.py
@@ -24,10 +24,10 @@ from .nnx.errors import TraceContextError as TraceContextError
 from .nnx.filterlib import All as All
 from .nnx.filterlib import Not as Not
 from .nnx.graph_utils import GraphDef as GraphDef
+from .nnx.graph_utils import GraphNode as GraphNode
 from .nnx.helpers import Dict as Dict
 from .nnx.helpers import List as List
 from .nnx.helpers import TrainState as TrainState
-from .nnx.module import GraphDef as GraphDef
 from .nnx.module import M as M
 from .nnx.module import Module as Module
 from .nnx.graph_utils import merge as merge


### PR DESCRIPTION
Expose `nnx.GraphNode`.

Also deleted duplicate import of [`GraphDef`](https://github.com/google/flax/pull/3796/files#diff-a850c3ae82319e126fa3e81971ab22623c5a7cec98922c3f0bc649839dde0b54L30) from `nnx.module` since it's already imported from [`graph_utils`](https://github.com/google/flax/pull/3796/files#diff-a850c3ae82319e126fa3e81971ab22623c5a7cec98922c3f0bc649839dde0b54R26) directly.