### PR TITLE
[nnx] non-str State keys

### DIFF
--- a/flax/experimental/nnx/nnx/filterlib.py
+++ b/flax/experimental/nnx/nnx/filterlib.py
@@ -14,7 +14,7 @@
 
 import builtins
 import dataclasses
-from flax.typing import Path
+from flax.typing import PathParts
 import typing as tp
 
 if tp.TYPE_CHECKING:
@@ -22,7 +22,7 @@ if tp.TYPE_CHECKING:
 else:
   ellipsis = tp.Any
 
-Predicate = tp.Callable[[Path, tp.Any], bool]
+Predicate = tp.Callable[[PathParts, tp.Any], bool]
 FilterLiteral = tp.Union[type, str, Predicate, bool, ellipsis, None]
 Filter = tp.Union[FilterLiteral, tuple[FilterLiteral, ...], list[FilterLiteral]]
 
@@ -48,17 +48,17 @@ def to_predicate(filter: Filter) -> Predicate:
 
 @dataclasses.dataclass
 class AtPath:
-  path: str
+  str_key: str
 
-  def __call__(self, path: Path, x: tp.Any):
-    return self.path == path
+  def __call__(self, path: PathParts, x: tp.Any):
+    return self.str_key in path
 
 
 @dataclasses.dataclass
 class OfType:
   type: type
 
-  def __call__(self, path: Path, x: tp.Any):
+  def __call__(self, path: PathParts, x: tp.Any):
     return isinstance(x, self.type)
 
 
@@ -68,7 +68,7 @@ class Any:
       to_predicate(collection_filter) for collection_filter in filters
     )
 
-  def __call__(self, path: Path, x: tp.Any):
+  def __call__(self, path: PathParts, x: tp.Any):
     return any(predicate(path, x) for predicate in self.predicates)
 
 
@@ -78,7 +78,7 @@ class All:
       to_predicate(collection_filter) for collection_filter in filters
     )
 
-  def __call__(self, path: Path, x: tp.Any):
+  def __call__(self, path: PathParts, x: tp.Any):
     return all(predicate(path, x) for predicate in self.predicates)
 
 
@@ -86,15 +86,15 @@ class Not:
   def __init__(self, collection_filter: Filter):
     self.predicate = to_predicate(collection_filter)
 
-  def __call__(self, path: Path, x: tp.Any):
+  def __call__(self, path: PathParts, x: tp.Any):
     return not self.predicate(path, x)
 
 
 class Everything:
-  def __call__(self, path: Path, x: tp.Any):
+  def __call__(self, path: PathParts, x: tp.Any):
     return True
 
 
 class Nothing:
-  def __call__(self, path: Path, x: tp.Any):
+  def __call__(self, path: PathParts, x: tp.Any):
     return False

--- a/flax/experimental/nnx/nnx/module.py
+++ b/flax/experimental/nnx/nnx/module.py
@@ -36,7 +36,7 @@ from flax.experimental.nnx.nnx.proxy_caller import (
 from flax.experimental.nnx.nnx.rnglib import Rngs
 from flax.experimental.nnx.nnx.state import State
 from flax.experimental.nnx.nnx.variables import Variable
-from flax.typing import Path
+from flax.typing import Path, PathParts
 
 A = tp.TypeVar('A')
 B = tp.TypeVar('B')
@@ -298,7 +298,7 @@ class Module(graph_utils.GraphNode, metaclass=ModuleMeta):
       reduced_value = reduce_fn(init_fn(), value)
       setattr(self, name, variable_type(reduced_value))
 
-  def modules(self) -> tp.Iterator[tuple[Path, Module]]:
+  def modules(self) -> tp.Iterator[tuple[PathParts, Module]]:
     for path, value in graph_utils.iter_nodes(self):
       if isinstance(value, Module):
         yield path, value

--- a/flax/experimental/nnx/nnx/rnglib.py
+++ b/flax/experimental/nnx/nnx/rnglib.py
@@ -183,7 +183,8 @@ class Rngs(GraphNode, tp.Mapping[str, tp.Callable[[], jax.Array]]):
 
     for name, stream in self._rngs.items():
       for predicate, pattern in predicate_pattern:
-        if predicate(name, stream):
+        stream_path = (name,)
+        if predicate(stream_path, stream):
           fork = stream.fork(pattern)
           if pattern is None:
             broadcasts[name] = fork

--- a/flax/experimental/nnx/tests/nn/test_attention.py
+++ b/flax/experimental/nnx/tests/nn/test_attention.py
@@ -69,11 +69,12 @@ class TestMultiHeadAttention:
 
     _ = module(x, True)
     intermediates = module.pop(nnx.Intermediate)
-    assert intermediates['attention_layers/0/attention_weights'].raw_value[
+    # assert intermediates['attention_layers/0/attention_weights'].raw_value[
+    assert intermediates['attention_layers'][0]['attention_weights'].raw_value[
       0
     ].shape == (4, 8, 6, 6)
-    assert 'attention_layers/1/attention_weights' not in intermediates
-    assert intermediates['attention_layers/2/attention_weights'].raw_value[
+    assert 1 not in intermediates['attention_layers']
+    assert intermediates['attention_layers'][2]['attention_weights'].raw_value[
       0
     ].shape == (4, 8, 6, 6)
 

--- a/flax/experimental/nnx/tests/test_graph_utils.py
+++ b/flax/experimental/nnx/tests/test_graph_utils.py
@@ -27,8 +27,8 @@ class TestGraphUtils:
 
     static, state, ref_idx = nnx.graph_utils.graph_flatten(g)
 
-    state['0']['b'].raw_value = 2
-    state['3'].raw_value = 4
+    state[0]['b'].raw_value = 2
+    state[3].raw_value = 4
 
     assert len(ref_idx) == 2
     assert a['b'] in ref_idx
@@ -69,7 +69,7 @@ class TestGraphUtils:
 
     static, state, _ = nnx.graph_utils.graph_flatten(g)
 
-    state['0']['b'].raw_value = 3
+    state[0]['b'].raw_value = 3
     nnx.graph_utils.graph_update_dynamic(g, state)
 
     assert g[0]['b'].raw_value == 3
@@ -125,12 +125,12 @@ class TestGraphUtils:
 
     static, state, _ = nnx.graph_utils.graph_flatten(ls)
 
-    assert state['0']['kernel'].raw_value.shape == (2, 2)
-    assert state['0']['bias'].raw_value.shape == (2,)
-    assert state['1']['scale'].raw_value.shape == (2,)
-    assert state['1']['bias'].raw_value.shape == (2,)
-    assert state['1']['mean'].raw_value.shape == (2,)
-    assert state['1']['var'].raw_value.shape == (2,)
+    assert state[0]['kernel'].raw_value.shape == (2, 2)
+    assert state[0]['bias'].raw_value.shape == (2,)
+    assert state[1]['scale'].raw_value.shape == (2,)
+    assert state[1]['bias'].raw_value.shape == (2,)
+    assert state[1]['mean'].raw_value.shape == (2,)
+    assert state[1]['var'].raw_value.shape == (2,)
 
   def test_shared_variables(self):
     v = nnx.Param(1)

--- a/flax/experimental/nnx/tests/test_module.py
+++ b/flax/experimental/nnx/tests/test_module.py
@@ -649,11 +649,11 @@ class TestModuleDef:
     modules = list(module.modules())
 
     assert len(modules) == 3
-    assert modules[0][0] == ''
+    assert modules[0][0] == ()
     assert isinstance(modules[0][1], Foo)
-    assert modules[1][0] == 'submodules/0/a'
+    assert modules[1][0] == ('submodules', 0, 'a')
     assert isinstance(modules[1][1], nnx.Linear)
-    assert modules[2][0] == 'submodules/1/b'
+    assert modules[2][0] == ('submodules', 1, 'b')
     assert isinstance(modules[2][1], nnx.Conv)
 
   def test_array_in_module(self):

--- a/flax/experimental/nnx/tests/test_partitioning.py
+++ b/flax/experimental/nnx/tests/test_partitioning.py
@@ -33,11 +33,11 @@ class TestPartitioning:
     assert len(rest) == 1
 
     # check params
-    assert params['a']['0'].raw_value == m.a[0].value
+    assert params['a'][0].raw_value == m.a[0].value
     assert params['b'].raw_value == m.b.value
 
     # check rest
-    assert rest['a']['1'].raw_value == m.a[1].value
+    assert rest['a'][1].raw_value == m.a[1].value
 
     m2 = graphdef.merge(params, rest)
 
@@ -152,8 +152,8 @@ class TestPartitioning:
     assert vars(m.a)['0'] is not vars(m)['b']
 
     state = m.extract(nnx.Variable)
-    assert state['a']['0'].raw_value == m.a[0].value
-    assert state['a']['1'].raw_value == m.a[1].value
+    assert state['a'][0].raw_value == m.a[0].value
+    assert state['a'][1].raw_value == m.a[1].value
     assert state['b'].raw_value == m.b.value
     assert state.b is not state.a[0]
     assert len(state.flat_state()) == 3

--- a/flax/experimental/nnx/tests/test_transforms.py
+++ b/flax/experimental/nnx/tests/test_transforms.py
@@ -340,10 +340,10 @@ class TestGrad:
 
     assert m.a[0] is m.b
     assert isinstance(grads, nnx.State)
-    assert grads['a']['0'].raw_value == 2.0
-    assert isinstance(grads.a['0'], nnx.Variable)
-    assert grads['a']['1'].raw_value == 1.0
-    assert isinstance(grads.a['1'], nnx.Variable)
+    assert grads['a'][0].raw_value == 2.0
+    assert isinstance(grads.a[0], nnx.Variable)
+    assert grads['a'][1].raw_value == 1.0
+    assert isinstance(grads.a[1], nnx.Variable)
     assert len(grads.flat_state()) == 2
 
     m.update(grads)
@@ -371,8 +371,8 @@ class TestGrad:
     grads = f(m)
 
     assert isinstance(grads, nnx.State)
-    assert grads['a']['0'].raw_value == 1.0
-    assert isinstance(grads.a['0'], nnx.Param)
+    assert grads['a'][0].raw_value == 1.0
+    assert isinstance(grads.a[0], nnx.Param)
     assert len(grads) == 2
 
     m.update(grads)
@@ -399,8 +399,8 @@ class TestGrad:
     grads = f(m)
 
     assert isinstance(grads, nnx.State)
-    assert grads['a']['1'].raw_value == 1.0
-    assert isinstance(grads.a['1'], nnx.BatchStat)
+    assert grads['a'][1].raw_value == 1.0
+    assert isinstance(grads.a[1], nnx.BatchStat)
     assert len(grads) == 1
 
     m.update(grads)

--- a/flax/typing.py
+++ b/flax/typing.py
@@ -17,8 +17,10 @@ from typing import (
   Callable,
   Dict,
   Generic,
+  Hashable,
   Mapping,
   Optional,
+  Protocol,
   Sequence,
   Tuple,
   TypeVar,
@@ -38,9 +40,16 @@ PRNGKey = jax.Array
 RNGSequences = Dict[str, PRNGKey]
 Dtype = Union[jax.typing.DTypeLike, Any]
 Shape = Sequence[int]
+K = TypeVar('K')
+
+
+class Key(Hashable, Protocol):
+  def __lt__(self: K, value: K, /) -> bool:
+    ...
+
 
 Path = str
-PathParts = Tuple[str, ...]
+PathParts = Tuple[Key, ...]
 
 Leaf = Any
 


### PR DESCRIPTION
# What does this PR do?

* Graph node can now emit non-string keys, this helps to sort int keys such as to from `list` and `tuple`. In general they can emit any type that implement the `Key` protocol, which is any `Hashable` object that also implements `__lt__`.
* `State` now contains `Key` keys.
* `State.flat_state` now returns a `dict[tuple[Key, ...], Any]` instead of `dict[str, Any]` with keys as `/` separated strings.
* `State.from_flat_path` now creates a `State` from a `dict[tuple[Key, ...], Any]`.
* `_graph_node_*` functions are now methods of `GraphNode`.
* `List` now emits `int` keys. To implement the graph node protocol correctly it overrides a couple of `_graph_node_*` methods.
* Fixed `graph_pop` bug.