### PR TITLE
Adding links to FLAX tutorials

### DIFF
--- a/docs/examples/community_examples.rst
+++ b/docs/examples/community_examples.rst
@@ -76,12 +76,12 @@ Tutorials
       - Author
       - Task type
       - Reference
-    * - `Graph Convolutional Network (GCN) <https://github.com/mashaan14/YouTube-channel/blob/main/notebooks/2024_03_21_jraph_GCN.ipynb>`
-      - `@mashaan14 <https://github.com/mashaan14>`
+    * - `Graph Convolutional Network (GCN) <https://github.com/mashaan14/YouTube-channel/blob/main/notebooks/2024_03_21_jraph_GCN.ipynb>`__
+      - `@mashaan14 <https://github.com/mashaan14>`__
       - Node Classification
       - https://arxiv.org/abs/1609.02907
-    * - `Graph Attention Networks <https://github.com/mashaan14/YouTube-channel/blob/main/notebooks/2024_03_18_jraph_GAT.ipynb>`
-      - `@mashaan14 <https://github.com/mashaan14>`
+    * - `Graph Attention Networks <https://github.com/mashaan14/YouTube-channel/blob/main/notebooks/2024_03_18_jraph_GAT.ipynb>`__
+      - `@mashaan14 <https://github.com/mashaan14>`__
       - Node Classification
       - https://arxiv.org/abs/1710.10903
 

--- a/docs/examples/community_examples.rst
+++ b/docs/examples/community_examples.rst
@@ -76,10 +76,14 @@ Tutorials
       - Author
       - Task type
       - Reference
-    * -
-      -
-      -
-      -
+    * - `Graph Convolutional Network (GCN) <https://github.com/mashaan14/YouTube-channel/blob/main/notebooks/2024_03_21_jraph_GCN.ipynb>`
+      - `@mashaan14 <https://github.com/mashaan14>`
+      - Node Classification
+      - https://arxiv.org/abs/1609.02907
+    * - `Graph Attention Networks <https://github.com/mashaan14/YouTube-channel/blob/main/notebooks/2024_03_18_jraph_GAT.ipynb>`
+      - `@mashaan14 <https://github.com/mashaan14>`
+      - Node Classification
+      - https://arxiv.org/abs/1710.10903
 
 Contributing policy
 *******************


### PR DESCRIPTION
# What does this PR do?

This PR adds links to two tutorials I created using FLAX and Jraph libraries. These are Graph Neural Network tutorials. I've also added links to papers on arxiv.

Fixes # (issue)
Adding links to FLAX tutorials.

## Checklist
- [X] This PR fixes a minor issue (e.g.: typo or small bug) or improves the docs (you can dismiss the other
      checks if that's the case).
- [ ] This change is discussed in a Github issue/
      [discussion](https://github.com/google/flax/discussions) (please add a
      link).
- [ ] The documentation and docstrings adhere to the
      [documentation guidelines](https://github.com/google/flax/blob/main/docs/README.md#how-to-write-code-documentation).
- [ ] This change includes necessary high-coverage tests.
      (No quality testing = no merge!)
