### PR TITLE
[nnx] Rng Variable tags

### DIFF
--- a/flax/experimental/nnx/__init__.py
+++ b/flax/experimental/nnx/__init__.py
@@ -76,6 +76,9 @@ from .nnx.pytreelib import Pytree as Pytree
 from .nnx.pytreelib import TreeNode as TreeNode
 from .nnx.rnglib import Rngs as Rngs
 from .nnx.rnglib import RngStream as RngStream
+from .nnx.rnglib import RngState as RngState
+from .nnx.rnglib import RngKey as RngKey
+from .nnx.rnglib import RngCount as RngCount
 from .nnx.spmd import PARTITION_NAME as PARTITION_NAME
 from .nnx.spmd import get_partition_spec as get_partition_spec
 from .nnx.spmd import get_named_sharding as get_named_sharding

--- a/flax/experimental/nnx/nnx/compatibility.py
+++ b/flax/experimental/nnx/nnx/compatibility.py
@@ -65,7 +65,7 @@ class LinenWrapper(Module):
     self.module = module
 
     _rngs = (
-      {name: stream.key.raw_value for name, stream in rngs._rngs.items()}
+      {name: stream.key.raw_value for name, stream in rngs.items()}
       if rngs
       else {}
     )
@@ -85,9 +85,7 @@ class LinenWrapper(Module):
     self, *args: Any, rngs: tp.Optional[Rngs] = None, **kwargs: Any
   ) -> Any:
     _rngs = (
-      {name: stream.key.value for name, stream in rngs._rngs.items()}
-      if rngs
-      else {}
+      {name: stream.key.value for name, stream in rngs.items()} if rngs else {}
     )
 
     variables = {

--- a/flax/experimental/nnx/nnx/filterlib.py
+++ b/flax/experimental/nnx/nnx/filterlib.py
@@ -26,10 +26,14 @@ Predicate = tp.Callable[[PathParts, tp.Any], bool]
 FilterLiteral = tp.Union[type, str, Predicate, bool, ellipsis, None]
 Filter = tp.Union[FilterLiteral, tuple[FilterLiteral, ...], list[FilterLiteral]]
 
+@tp.runtime_checkable
+class _HasTag(tp.Protocol):
+  tag: str
+
 
 def to_predicate(filter: Filter) -> Predicate:
   if isinstance(filter, str):
-    return AtPath(filter)
+    return WithTag(filter)
   elif isinstance(filter, type):
     return OfType(filter)
   elif isinstance(filter, bool):
@@ -47,11 +51,11 @@ def to_predicate(filter: Filter) -> Predicate:
 
 
 @dataclasses.dataclass
-class AtPath:
-  str_key: str
+class WithTag:
+  tag: str
 
   def __call__(self, path: PathParts, x: tp.Any):
-    return self.str_key in path
+    return isinstance(x, _HasTag) and x.tag == self.tag
 
 
 @dataclasses.dataclass


### PR DESCRIPTION
# What does this PR do?

This PR adds the necessary changes so we can filter `RngState` Variables based on the stream name using `Filter`s, this allows you to manage RNG state a regular graph state but using the previous name-based filter convention.

### Changes
* Adds `RngKey` and `RngCount` Variable types that inherit from `RngState`. `RngKey` is expected to have  a`tag: str` metadata attribute.
* `RngStream.key` is now a `RngKey` and `RngStream.count` is now a `RngCount`. `Rngs` sets `RngKey.tag` as the stream's name.
* `str` filters now create a `WithTag` filter that selects Variables with a `tag` attribute that matches that string.
* Removes `Rngs._rngs`, `RngStreams` are now stored as attributes of `Rngs`.
* Refactors `RngStream.make_rng` to `__call__`.
* `Rngs.__getattr__` and `Rngs.__getitem__` now returns a `RngStream`.