### PR TITLE
updated `tree_map`

### DIFF
--- a/docs/guides/converting_and_upgrading/haiku_migration_guide.rst
+++ b/docs/guides/converting_and_upgrading/haiku_migration_guide.rst
@@ -198,7 +198,7 @@ the random dropout masks.
         return optax.softmax_cross_entropy_with_integer_labels(logits, labels).mean()
 
     grads = jax.grad(loss_fn)(params)
-    params = jax.tree_map(lambda p, g: p - 0.1 * g, params, grads)
+    params = jax.tree_util.tree_map(lambda p, g: p - 0.1 * g, params, grads)
 
     return params
 
@@ -214,7 +214,7 @@ the random dropout masks.
         return optax.softmax_cross_entropy_with_integer_labels(logits, labels).mean()
 
     grads = jax.grad(loss_fn)(params)
-    params = jax.tree_map(lambda p, g: p - 0.1 * g, params, grads)
+    params = jax.tree_util.tree_map(lambda p, g: p - 0.1 * g, params, grads)
 
     return params
 
@@ -355,7 +355,7 @@ return value.
       return loss, new_state
 
     grads, new_state = jax.grad(loss_fn, has_aux=True)(params)
-    params = jax.tree_map(lambda p, g: p - 0.1 * g, params, grads)
+    params = jax.tree_util.tree_map(lambda p, g: p - 0.1 * g, params, grads)
 
     return params, new_state
   ---
@@ -371,7 +371,7 @@ return value.
       return loss, updates["batch_stats"]
 
     grads, batch_stats = jax.grad(loss_fn, has_aux=True)(params)
-    params = jax.tree_map(lambda p, g: p - 0.1 * g, params, grads)
+    params = jax.tree_util.tree_map(lambda p, g: p - 0.1 * g, params, grads)
 
     return params, batch_stats
 

--- a/docs/guides/flax_fundamentals/rng_guide.ipynb
+++ b/docs/guides/flax_fundamentals/rng_guide.ipynb
@@ -850,7 +850,7 @@
     "    )\n",
     "    return jnp.mean((y - out) ** 2)\n",
     "  grads = jax.grad(loss)(variables['params'])\n",
-    "  params = jax.tree_map(lambda p, g: p - 1e-3 * g, variables['params'], grads)\n",
+    "  params = jax.tree_util.tree_map(lambda p, g: p - 1e-3 * g, variables['params'], grads)\n",
     "  return {\n",
     "    'params': params,\n",
     "    'other_collection': variables['other_collection'],\n",

--- a/docs/guides/flax_fundamentals/rng_guide.md
+++ b/docs/guides/flax_fundamentals/rng_guide.md
@@ -422,7 +422,7 @@ def update(variables, rng):
     )
     return jnp.mean((y - out) ** 2)
   grads = jax.grad(loss)(variables['params'])
-  params = jax.tree_map(lambda p, g: p - 1e-3 * g, variables['params'], grads)
+  params = jax.tree_util.tree_map(lambda p, g: p - 1e-3 * g, variables['params'], grads)
   return {
     'params': params,
     'other_collection': variables['other_collection'],

--- a/docs/guides/parallel_training/flax_on_pjit.ipynb
+++ b/docs/guides/parallel_training/flax_on_pjit.ipynb
@@ -81,7 +81,7 @@
     "from flax.core import freeze, unfreeze\n",
     "from flax.training import train_state, checkpoints\n",
     "\n",
-    "import optax # Optax for common losses and optimizers. "
+    "import optax # Optax for common losses and optimizers."
    ]
   },
   {
@@ -113,7 +113,7 @@
     "2. Annotate each axis with a name using the `axis_names` parameter in `jax.sharding.Mesh`. A typical way to annotate axis names is `axis_name=('data', 'model')`, where:\n",
     "  * `'data'`: the mesh dimension used for data-parallel sharding of the batch dimension of inputs and activations.\n",
     "  * `'model'`: the mesh dimension used for sharding parameters of the model across devices.\n",
-    "  \n",
+    "\n",
     "3. Make a simple utility function `mesh_sharding` for generating a sharding object from the mesh and any layout."
    ]
   },
@@ -185,8 +185,8 @@
     "  dense_init: Callable = nn.initializers.xavier_normal()\n",
     "  @nn.compact\n",
     "  def __call__(self, x):\n",
-    "    \n",
-    "    y = nn.Dense(self.depth, \n",
+    "\n",
+    "    y = nn.Dense(self.depth,\n",
     "                 kernel_init=nn.with_partitioning(self.dense_init, (None, 'model')),\n",
     "                 use_bias=False,  # or overwrite with `bias_init`\n",
     "                 )(x)\n",
@@ -196,10 +196,10 @@
     "    y = with_sharding_constraint(y, mesh_sharding(PartitionSpec('data', 'model')))\n",
     "\n",
     "    W2 = self.param(\n",
-    "        'W2', \n",
+    "        'W2',\n",
     "        nn.with_partitioning(self.dense_init, ('model', None)),\n",
     "        (self.depth, x.shape[-1]))\n",
-    "    \n",
+    "\n",
     "    z = jnp.dot(y, W2)\n",
     "    # Force a local sharding annotation.\n",
     "    z = with_sharding_constraint(z, mesh_sharding(PartitionSpec('data', None)))\n",
@@ -242,7 +242,7 @@
     "* `flax.linen.scan` can provide faster compilation times.\n",
     "* The for-loop can be faster on runtime.\n",
     "\n",
-    "The code below shows how to apply both methods, and default with the for-loop, so that all the parameters are two-dimensional and you can visualize their sharding. \n",
+    "The code below shows how to apply both methods, and default with the for-loop, so that all the parameters are two-dimensional and you can visualize their sharding.\n",
     "\n",
     "The `flax.linen.scan` code is just to show that this API works with [Flax lifted transforms](https://flax.readthedocs.io/en/latest/developer_notes/lift.html#supported-transformations)."
    ]
@@ -260,7 +260,7 @@
     "  @nn.compact\n",
     "  def __call__(self, x):\n",
     "    if self.use_scan:\n",
-    "      x, _ = nn.scan(DotReluDot, length=self.num_layers, \n",
+    "      x, _ = nn.scan(DotReluDot, length=self.num_layers,\n",
     "                     variable_axes={\"params\": 0},\n",
     "                     split_rngs={\"params\": True},\n",
     "                     metadata_params={nn.PARTITION_NAME: None}\n",
@@ -595,7 +595,7 @@
    "source": [
     "## Inspect the Module output\n",
     "\n",
-    "Note that in the output of `initialized_state`, the `params` `W1` and `W2` are of type [`flax.linen.Partitioned`](https://flax.readthedocs.io/en/latest/api_reference/_autosummary/flax.linen.Partitioned.html). This is a wrapper around the actual `jax.Array` that allows Flax to record the axis names associated with it. \n",
+    "Note that in the output of `initialized_state`, the `params` `W1` and `W2` are of type [`flax.linen.Partitioned`](https://flax.readthedocs.io/en/latest/api_reference/_autosummary/flax.linen.Partitioned.html). This is a wrapper around the actual `jax.Array` that allows Flax to record the axis names associated with it.\n",
     "\n",
     "You can access the raw `jax.Array` by adding `.value` when outside `jit`, or by `.unbox()` when inside."
    ]
@@ -682,7 +682,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "You can use [`jax.tree_map`](https://jax.readthedocs.io/en/latest/_autosummary/jax.tree_util.tree_map.html) to perform mass computation on a dict of boxed params, in the same way as on a dict of JAX arrays."
+    "You can use [`jax.tree_util.tree_map`](https://jax.readthedocs.io/en/latest/_autosummary/jax.tree_util.tree_map.html) to perform mass computation on a dict of boxed params, in the same way as on a dict of JAX arrays."
    ]
   },
   {
@@ -706,10 +706,10 @@
     }
    ],
    "source": [
-    "diff = jax.tree_map(\n",
-    "    lambda a, b: a - b, \n",
+    "diff = jax.tree_util.tree_map(\n",
+    "    lambda a, b: a - b,\n",
     "    initialized_state.params['DotReluDot_0'], initialized_state.params['DotReluDot_0'])\n",
-    "print(jax.tree_map(jnp.shape, diff))\n",
+    "print(jax.tree_util.tree_map(jnp.shape, diff))\n",
     "diff_array = diff['Dense_0']['kernel'].value\n",
     "print(type(diff_array))\n",
     "print(diff_array.shape)"
@@ -720,7 +720,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Compile the train step and inference \n",
+    "## Compile the train step and inference\n",
     "\n",
     "Create a `jit`ted training step as follows:"
    ]
@@ -731,7 +731,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "@functools.partial(jax.jit, in_shardings=(state_sharding, x_sharding), \n",
+    "@functools.partial(jax.jit, in_shardings=(state_sharding, x_sharding),\n",
     "                   out_shardings=state_sharding)\n",
     "def train_step(state, x):\n",
     "  # A fake loss function.\n",
@@ -893,7 +893,7 @@
     }
    ],
    "source": [
-    "@functools.partial(jax.jit, in_shardings=(state_sharding, x_sharding), \n",
+    "@functools.partial(jax.jit, in_shardings=(state_sharding, x_sharding),\n",
     "                   out_shardings=x_sharding)\n",
     "def apply_fn(state, x):\n",
     "  return state.apply_fn({'params': state.params}, x)\n",
@@ -932,7 +932,7 @@
     "%%timeit\n",
     "\n",
     "def block_all(xs):\n",
-    "  jax.tree_map(lambda x: x.block_until_ready(), xs)\n",
+    "  jax.tree_util.tree_map(lambda x: x.block_until_ready(), xs)\n",
     "  return xs\n",
     "\n",
     "with mesh:\n",
@@ -946,7 +946,7 @@
    "source": [
     "## Logical axis annotation\n",
     "\n",
-    "JAX's automatic SPMD encourages users to explore different sharding layouts to find the optimal one. To this end, in Flax you actually can annotate the dimensions of any data with more descriptive axis names (not just device mesh axis names like `'data'` and `'model'`). \n",
+    "JAX's automatic SPMD encourages users to explore different sharding layouts to find the optimal one. To this end, in Flax you actually can annotate the dimensions of any data with more descriptive axis names (not just device mesh axis names like `'data'` and `'model'`).\n",
     "\n",
     "The `LogicalDotReluDot` and `LogicalMLP` Module definition below are similar to the Modules you created earlier, except for the following:\n",
     "\n",
@@ -965,8 +965,8 @@
     "  depth: int\n",
     "  dense_init: Callable = nn.initializers.xavier_normal()\n",
     "  @nn.compact\n",
-    "  def __call__(self, x):    \n",
-    "    y = nn.Dense(self.depth, \n",
+    "  def __call__(self, x):\n",
+    "    y = nn.Dense(self.depth,\n",
     "                 kernel_init=nn.with_logical_partitioning(self.dense_init, ('embed', 'hidden')),\n",
     "                 use_bias=False,  # or overwrite with `bias_init`\n",
     "                 )(x)\n",
@@ -976,7 +976,7 @@
     "    y = with_sharding_constraint(y, mesh_sharding(PartitionSpec('data', 'model')))\n",
     "\n",
     "    W2 = self.param(\n",
-    "        'W2', \n",
+    "        'W2',\n",
     "        nn.with_logical_partitioning(self.dense_init, ('hidden', 'embed')),\n",
     "        (self.depth, x.shape[-1]))\n",
     "\n",
@@ -992,7 +992,7 @@
     "  @nn.compact\n",
     "  def __call__(self, x):\n",
     "    if self.use_scan:\n",
-    "      x, _ = nn.scan(LogicalDotReluDot, length=self.num_layers, \n",
+    "      x, _ = nn.scan(LogicalDotReluDot, length=self.num_layers,\n",
     "                    variable_axes={\"params\": 0},\n",
     "                    split_rngs={\"params\": True},\n",
     "                    metadata_params={nn.PARTITION_NAME: 'layer'}\n",
@@ -1039,11 +1039,11 @@
     "logical_abstract_variables = jax.eval_shape(\n",
     "    functools.partial(init_fn, model=logical_model, optimizer=optimizer), k, x)\n",
     "logical_state_spec = nn.get_partition_spec(logical_abstract_variables)\n",
-    "print('annotations are logical, not mesh-specific: ', \n",
+    "print('annotations are logical, not mesh-specific: ',\n",
     "      logical_state_spec.params['LogicalDotReluDot_0']['Dense_0']['kernel'])\n",
     "\n",
     "logical_state_sharding = nn.logical_to_mesh_sharding(logical_state_spec, mesh, rules)\n",
-    "print('sharding annotations are mesh-specific: ', \n",
+    "print('sharding annotations are mesh-specific: ',\n",
     "      logical_state_sharding.params['LogicalDotReluDot_0']['Dense_0']['kernel'].spec)"
    ]
   },

--- a/docs/guides/training_techniques/use_checkpointing.ipynb
+++ b/docs/guides/training_techniques/use_checkpointing.ipynb
@@ -19,7 +19,7 @@
     "*  [`jax.sharding`](https://jax.readthedocs.io/en/latest/notebooks/Distributed_arrays_and_automatic_parallelization.html)-based API to save and load in multi-host scenarios\n",
     "\n",
     "---\n",
-    "**_Ongoing migration to Orbax:_** \n",
+    "**_Ongoing migration to Orbax:_**\n",
     "\n",
     "After July 30 2023, Flax's legacy `flax.training.checkpoints` API will be deprecated in favor of [Orbax](https://github.com/google/orbax).\n",
     "\n",
@@ -30,7 +30,7 @@
     "   * **Migrating your code to Orbax (Recommended)**: Migrate your API calls to `orbax.checkpoint` API by following this [migration guide](https://flax.readthedocs.io/en/latest/guides/converting_and_upgrading/orbax_upgrade_guide.html).\n",
     "\n",
     "   * **Automatically use the Orbax backend**: Add `flax.config.update('flax_use_orbax_checkpointing', True)` to your project, which will let your `flax.training.checkpoints` calls automatically use the Orbax backend to save your checkpoints.\n",
-    "     \n",
+    "\n",
     "     * **Scheduled flip**: This will become the default mode after **May 2023** (tentative date).\n",
     "\n",
     "     * Visit [Orbax-as-backend troubleshooting section](https://flax.readthedocs.io/en/latest/guides/training_techniques/use_checkpointing.html#orbax-as-backend-troubleshooting) if you meet any issue in the automatic migration.\n",
@@ -186,7 +186,7 @@
     "    params=variables['params'],\n",
     "    tx=tx)\n",
     "# Perform a simple gradient update similar to the one during a normal training workflow.\n",
-    "state = state.apply_gradients(grads=jax.tree_map(jnp.ones_like, state.params))\n",
+    "state = state.apply_gradients(grads=jax.tree_util.tree_map(jnp.ones_like, state.params))\n",
     "\n",
     "# Some arbitrary nested pytree with a dictionary and a NumPy array.\n",
     "config = {'dimensions': np.array([5, 3])}\n",
@@ -233,7 +233,7 @@
    "id": "07d4de1a",
    "metadata": {},
    "source": [
-    "Next, to use versioning and automatic bookkeeping features, you need to wrap `orbax.checkpoint.CheckpointManager` over `orbax.checkpoint.PyTreeCheckpointer`. \n",
+    "Next, to use versioning and automatic bookkeeping features, you need to wrap `orbax.checkpoint.CheckpointManager` over `orbax.checkpoint.PyTreeCheckpointer`.\n",
     "\n",
     "In addition, provide `orbax.checkpoint.CheckpointManagerOptions` that customizes your needs, such as how often and on what criteria you prefer old checkpoints be deleted. See [documentation](https://github.com/google/orbax/blob/main/docs/checkpoint.md#checkpointmanager) for a full list of options offered.\n",
     "\n",
@@ -407,7 +407,7 @@
     "\n",
     "Note that with the migration to Orbax in progress, `flax.training.checkpointing.restore_checkpoint` can automatically identify whether a checkpoint is saved in the legacy Flax format or with an Orbax backend, and restore the pytree correctly. Therefore, adding `flax.config.update('flax_use_orbax_checkpointing', True)` won't hurt your ability to restore old checkpoints.\n",
     "\n",
-    "Here's how to restore checkpoints using the legacy API: "
+    "Here's how to restore checkpoints using the legacy API:"
    ]
   },
   {
@@ -502,7 +502,7 @@
    "source": [
     "empty_state = train_state.TrainState.create(\n",
     "    apply_fn=model.apply,\n",
-    "    params=jax.tree_map(np.zeros_like, variables['params']),  # values of the tree leaf doesn't matter\n",
+    "    params=jax.tree_util.tree_map(np.zeros_like, variables['params']),  # values of the tree leaf doesn't matter\n",
     "    tx=tx,\n",
     ")\n",
     "empty_config = {'dimensions': np.array([0, 0])}\n",
@@ -687,7 +687,7 @@
    "source": [
     "### Scenario 1: When a reference object is partial\n",
     "\n",
-    "If your reference object is a subtree of your checkpoint, the restoration will ignore the additional field(s) and restore a checkpoint with the same structure as the reference. \n",
+    "If your reference object is a subtree of your checkpoint, the restoration will ignore the additional field(s) and restore a checkpoint with the same structure as the reference.\n",
     "\n",
     "Like in the example below, the `batch_stats` field in `CustomTrainState` was ignored, and the checkpoint was restored as a `TrainState`.\n",
     "\n",

--- a/docs/guides/training_techniques/use_checkpointing.md
+++ b/docs/guides/training_techniques/use_checkpointing.md
@@ -23,7 +23,7 @@ Orbax provides a variety of features for saving and loading model data, which yo
 *  [`jax.sharding`](https://jax.readthedocs.io/en/latest/notebooks/Distributed_arrays_and_automatic_parallelization.html)-based API to save and load in multi-host scenarios
 
 ---
-**_Ongoing migration to Orbax:_** 
+**_Ongoing migration to Orbax:_**
 
 After July 30 2023, Flax's legacy `flax.training.checkpoints` API will be deprecated in favor of [Orbax](https://github.com/google/orbax).
 
@@ -34,7 +34,7 @@ After July 30 2023, Flax's legacy `flax.training.checkpoints` API will be deprec
    * **Migrating your code to Orbax (Recommended)**: Migrate your API calls to `orbax.checkpoint` API by following this [migration guide](https://flax.readthedocs.io/en/latest/guides/converting_and_upgrading/orbax_upgrade_guide.html).
 
    * **Automatically use the Orbax backend**: Add `flax.config.update('flax_use_orbax_checkpointing', True)` to your project, which will let your `flax.training.checkpoints` calls automatically use the Orbax backend to save your checkpoints.
-     
+
      * **Scheduled flip**: This will become the default mode after **May 2023** (tentative date).
 
      * Visit [Orbax-as-backend troubleshooting section](https://flax.readthedocs.io/en/latest/guides/training_techniques/use_checkpointing.html#orbax-as-backend-troubleshooting) if you meet any issue in the automatic migration.
@@ -103,7 +103,7 @@ state = train_state.TrainState.create(
     params=variables['params'],
     tx=tx)
 # Perform a simple gradient update similar to the one during a normal training workflow.
-state = state.apply_gradients(grads=jax.tree_map(jnp.ones_like, state.params))
+state = state.apply_gradients(grads=jax.tree_util.tree_map(jnp.ones_like, state.params))
 
 # Some arbitrary nested pytree with a dictionary and a NumPy array.
 config = {'dimensions': np.array([5, 3])}
@@ -128,7 +128,7 @@ save_args = orbax_utils.save_args_from_target(ckpt)
 orbax_checkpointer.save('/tmp/flax_ckpt/orbax/single_save', ckpt, save_args=save_args)
 ```
 
-Next, to use versioning and automatic bookkeeping features, you need to wrap `orbax.checkpoint.CheckpointManager` over `orbax.checkpoint.PyTreeCheckpointer`. 
+Next, to use versioning and automatic bookkeeping features, you need to wrap `orbax.checkpoint.CheckpointManager` over `orbax.checkpoint.PyTreeCheckpointer`.
 
 In addition, provide `orbax.checkpoint.CheckpointManagerOptions` that customizes your needs, such as how often and on what criteria you prefer old checkpoints be deleted. See [documentation](https://github.com/google/orbax/blob/main/docs/checkpoint.md#checkpointmanager) for a full list of options offered.
 
@@ -184,7 +184,7 @@ checkpoint_manager.restore(step)
 
 Note that with the migration to Orbax in progress, `flax.training.checkpointing.restore_checkpoint` can automatically identify whether a checkpoint is saved in the legacy Flax format or with an Orbax backend, and restore the pytree correctly. Therefore, adding `flax.config.update('flax_use_orbax_checkpointing', True)` won't hurt your ability to restore old checkpoints.
 
-Here's how to restore checkpoints using the legacy API: 
+Here's how to restore checkpoints using the legacy API:
 
 ```python outputId="85ffceca-f38d-46b8-e567-d9d38b7885f9"
 raw_restored = checkpoints.restore_checkpoint(ckpt_dir='/tmp/flax_ckpt/flax-checkpointing', target=None)
@@ -206,7 +206,7 @@ Note: Data that was a JAX NumPy array (`jnp.array`) format will be restored as a
 ```python outputId="110c6b6e-fe42-4179-e5d8-6b92d355e11b"
 empty_state = train_state.TrainState.create(
     apply_fn=model.apply,
-    params=jax.tree_map(np.zeros_like, variables['params']),  # values of the tree leaf doesn't matter
+    params=jax.tree_util.tree_map(np.zeros_like, variables['params']),  # values of the tree leaf doesn't matter
     tx=tx,
 )
 empty_config = {'dimensions': np.array([0, 0])}
@@ -267,7 +267,7 @@ Below are examples of a few common scenarios.
 
 ### Scenario 1: When a reference object is partial
 
-If your reference object is a subtree of your checkpoint, the restoration will ignore the additional field(s) and restore a checkpoint with the same structure as the reference. 
+If your reference object is a subtree of your checkpoint, the restoration will ignore the additional field(s) and restore a checkpoint with the same structure as the reference.
 
 Like in the example below, the `batch_stats` field in `CustomTrainState` was ignored, and the checkpoint was restored as a `TrainState`.
 

--- a/flax/experimental/nnx/docs/quick_start.ipynb
+++ b/flax/experimental/nnx/docs/quick_start.ipynb
@@ -267,7 +267,7 @@
     }
    ],
    "source": [
-    "jax.tree_map(jnp.shape, model.extract(nnx.Param))"
+    "jax.tree_util.tree_map(jnp.shape, model.extract(nnx.Param))"
    ]
   },
   {
@@ -318,7 +318,7 @@
     "\n",
     "  loss, grads = nnx.value_and_grad(loss_fn, wrt=\"params\")(model)\n",
     "  params = model.extract(\"params\")\n",
-    "  params = jax.tree_map(lambda w, g: w - 0.001 * g, params, grads)\n",
+    "  params = jax.tree_util.tree_map(lambda w, g: w - 0.001 * g, params, grads)\n",
     "\n",
     "  model.update(params)\n",
     "  print(f\"Step {step}: loss={loss:.4f}\")"
@@ -354,7 +354,7 @@
     "    return optax.softmax_cross_entropy_with_integer_labels(logits, y).mean()\n",
     "\n",
     "  loss, grads = jax.value_and_grad(loss_fn)(params)\n",
-    "  params = jax.tree_map(lambda w, g: w - 0.001 * g, params, grads)\n",
+    "  params = jax.tree_util.tree_map(lambda w, g: w - 0.001 * g, params, grads)\n",
     "\n",
     "  return loss, params"
    ]

--- a/flax/experimental/nnx/docs/tiny_nnx.ipynb
+++ b/flax/experimental/nnx/docs/tiny_nnx.ipynb
@@ -399,7 +399,7 @@
     "y = module(x, train=True, rngs=Rngs(random.key(1)))\n",
     "\n",
     "state, graphdef = module.split()\n",
-    "print(\"state =\", jax.tree_map(jnp.shape, state))\n",
+    "print(\"state =\", jax.tree_util.tree_map(jnp.shape, state))\n",
     "print(\"graphdef =\", graphdef)"
    ]
   },
@@ -442,8 +442,8 @@
     "# merge\n",
     "state = State({**params, **batch_stats})\n",
     "\n",
-    "print(\"params =\", jax.tree_map(jnp.shape, params))\n",
-    "print(\"batch_stats =\", jax.tree_map(jnp.shape, batch_stats))"
+    "print(\"params =\", jax.tree_util.tree_map(jnp.shape, params))\n",
+    "print(\"batch_stats =\", jax.tree_util.tree_map(jnp.shape, batch_stats))"
    ]
   }
  ],

--- a/flax/experimental/nnx/docs/why.ipynb
+++ b/flax/experimental/nnx/docs/why.ipynb
@@ -439,7 +439,7 @@
     "\n",
     "print(f'{y.shape = }')\n",
     "print(f'{ensemble.models.count = }')\n",
-    "print(f'state = {jax.tree_map(jnp.shape, ensemble.get_state())}')"
+    "print(f'state = {jax.tree_util.tree_map(jnp.shape, ensemble.get_state())}')"
    ]
   },
   {
@@ -752,7 +752,7 @@
     "                rngs=nnx.Rngs(0))\n",
     "\n",
     "static, state = model.split()\n",
-    "jax.tree_map(jnp.shape, state)"
+    "jax.tree_util.tree_map(jnp.shape, state)"
    ]
   }
  ],

--- a/flax/experimental/nnx/docs/why.md
+++ b/flax/experimental/nnx/docs/why.md
@@ -243,7 +243,7 @@ y = ensemble(x)
 
 print(f'{y.shape = }')
 print(f'{ensemble.models.count = }')
-print(f'state = {jax.tree_map(jnp.shape, ensemble.get_state())}')
+print(f'state = {jax.tree_util.tree_map(jnp.shape, ensemble.get_state())}')
 ```
 
 #### Convenience lifted transforms
@@ -405,5 +405,5 @@ model = Example(in_filters=3,
                 rngs=nnx.Rngs(0))
 
 static, state = model.split()
-jax.tree_map(jnp.shape, state)
+jax.tree_util.tree_map(jnp.shape, state)
 ```

--- a/flax/experimental/nnx/examples/lm1b/train.py
+++ b/flax/experimental/nnx/examples/lm1b/train.py
@@ -582,7 +582,7 @@ def train_and_evaluate(config: default.Config, workdir: str):
       # Shard data to devices and do a training step.
       with jax.profiler.StepTraceAnnotation('train', step_num=step):
         batch = next(train_iter)
-        batch = jax.tree_map(lambda x: jnp.asarray(x), batch)
+        batch = jax.tree_util.tree_map(lambda x: jnp.asarray(x), batch)
         state, metrics = jit_train_step(
           state, batch, learning_rate_fn, 0.0, dropout_rngs
         )

--- a/flax/experimental/nnx/examples/lm1b/utils.py
+++ b/flax/experimental/nnx/examples/lm1b/utils.py
@@ -161,7 +161,7 @@ def setup_initial_state(
     state = TrainState.create(
       apply_fn=static.apply, params=params, tx=tx, graphdef=static
     )
-    state = jax.tree_map(_to_array, state)
+    state = jax.tree_util.tree_map(_to_array, state)
     state_spec = nnx.get_partition_spec(state)
     state = jax.lax.with_sharding_constraint(state, state_spec)
 

--- a/flax/experimental/nnx/examples/toy_examples/01_functional_api.py
+++ b/flax/experimental/nnx/examples/toy_examples/01_functional_api.py
@@ -75,7 +75,7 @@ def train_step(params, counts, batch):
 
   grad, counts = jax.grad(loss_fn, has_aux=True)(params)
   #                          |-------- sgd ---------|
-  params = jax.tree_map(lambda w, g: w - 0.1 * g, params, grad)
+  params = jax.tree_util.tree_map(lambda w, g: w - 0.1 * g, params, grad)
 
   return params, counts
 

--- a/flax/experimental/nnx/examples/toy_examples/06_scan_over_layers.py
+++ b/flax/experimental/nnx/examples/toy_examples/06_scan_over_layers.py
@@ -83,5 +83,5 @@ x = jnp.ones((3, 10))
 model.set_attributes(deterministic=False)
 y = model(x, rngs=nnx.Rngs(dropout=1))
 
-print(jax.tree_map(jnp.shape, model.get_state()))
+print(jax.tree_util.tree_map(jnp.shape, model.get_state()))
 print(y.shape)

--- a/flax/experimental/nnx/examples/toy_examples/09_parameter_surgery.py
+++ b/flax/experimental/nnx/examples/toy_examples/09_parameter_surgery.py
@@ -52,5 +52,5 @@ is_trainable = lambda path, node: (
 # split the parameters into trainable and non-trainable parameters
 trainable_params, non_trainable, static = model.split(is_trainable, ...)
 
-print('trainable_params =', jax.tree_map(jax.numpy.shape, trainable_params))
-print('non_trainable = ', jax.tree_map(jax.numpy.shape, non_trainable))
+print('trainable_params =', jax.tree_util.tree_map(jax.numpy.shape, trainable_params))
+print('non_trainable = ', jax.tree_util.tree_map(jax.numpy.shape, non_trainable))

--- a/flax/experimental/nnx/examples/toy_examples/10_quantization.py
+++ b/flax/experimental/nnx/examples/toy_examples/10_quantization.py
@@ -166,7 +166,7 @@ for epoch in range(epochs):
     state, loss = train_step(state, x_batch, y_batch)
 
   metrics = eval_step(state, X_test, Y_test)
-  metrics = jax.tree_map(lambda x: x.item(), metrics)
+  metrics = jax.tree_util.tree_map(lambda x: x.item(), metrics)
   print(f'Epoch {epoch} - {metrics}')
 
 # %%
@@ -238,7 +238,7 @@ class QLinear(nnx.Module):
     tx = optax.adam(1e-3)
     opt_state = tx.init(q_hparams)
 
-    print(jax.tree_map(lambda x: x.shape, q_hparams))
+    print(jax.tree_util.tree_map(lambda x: x.shape, q_hparams))
 
     @jax.jit
     def optimization_step(

--- a/flax/experimental/nnx/ideas/shape_inference.py
+++ b/flax/experimental/nnx/ideas/shape_inference.py
@@ -150,12 +150,12 @@ print('test Linear')
 # eager
 m1 = Linear(din=32, dout=10, rngs=nnx.Rngs(params=0))
 y = m1(x=jnp.ones((1, 32)))
-print(jax.tree_map(jnp.shape, m1.get_state()))
+print(jax.tree_util.tree_map(jnp.shape, m1.get_state()))
 
 # lazy
 m2 = Linear(dout=10)
 y = m2.init(x=jnp.ones((1, 32)), rngs=nnx.Rngs(params=0))
-print(jax.tree_map(jnp.shape, m2.get_state()))
+print(jax.tree_util.tree_map(jnp.shape, m2.get_state()))
 
 # usage
 y1 = m1(x=jnp.ones((1, 32)))
@@ -199,7 +199,7 @@ MLP = nnx.Scan(
 mlp = MLP(din=10, dout=10, rngs=nnx.Rngs(params=0))
 y, _ = mlp.call(jnp.ones((1, 10)), None, train=True, rngs=nnx.Rngs(dropout=1))
 print(f'{y.shape=}')
-print('state =', jax.tree_map(jnp.shape, mlp.get_state()))
+print('state =', jax.tree_util.tree_map(jnp.shape, mlp.get_state()))
 print()
 
 # lazy
@@ -207,4 +207,4 @@ mlp = MLP(dout=10)
 mlp.init(jnp.ones((1, 10)), None, train=False, rngs=nnx.Rngs(params=0))
 y, _ = mlp.call(jnp.ones((1, 10)), None, train=True, rngs=nnx.Rngs(dropout=1))
 print(f'{y.shape=}')
-print('state =', jax.tree_map(jnp.shape, mlp.get_state()))
+print('state =', jax.tree_util.tree_map(jnp.shape, mlp.get_state()))

--- a/flax/experimental/nnx/nnx/graph_utils.py
+++ b/flax/experimental/nnx/nnx/graph_utils.py
@@ -1069,7 +1069,7 @@ def extract_graph_nodes(pytree: A, /) -> tuple[A, tuple[tp.Any, ...]]:
       return GraphNodeIndex(index)
     return x
 
-  return jax.tree_map(_maybe_extract, pytree), tuple(nodes)
+  return jax.tree_util.tree_map(_maybe_extract, pytree), tuple(nodes)
 
 
 def insert_graph_nodes(pytree: A, nodes: tuple[tp.Any, ...], /) -> A:
@@ -1080,7 +1080,7 @@ def insert_graph_nodes(pytree: A, nodes: tuple[tp.Any, ...], /) -> A:
       return nodes[x.index]
     return x
 
-  return jax.tree_map(
+  return jax.tree_util.tree_map(
     _maybe_insert, pytree, is_leaf=lambda x: isinstance(x, GraphNodeIndex)
   )
 

--- a/flax/experimental/nnx/nnx/nn/linear.py
+++ b/flax/experimental/nnx/nnx/nn/linear.py
@@ -117,12 +117,12 @@ class LinearGeneral(Module):
     >>> # output features (4, 5)
     >>> layer = nn.LinearGeneral(features=(4, 5))
     >>> params = layer.init(jax.random.key(0), jnp.ones((1, 3)))
-    >>> jax.tree_map(jnp.shape, params)
+    >>> jax.tree_util.tree_map(jnp.shape, params)
     {'params': {'bias': (4, 5), 'kernel': (3, 4, 5)}}
     >>> # apply transformation on the the second and last axes
     >>> layer = nn.LinearGeneral(features=(4, 5), axis=(1, -1))
     >>> params = layer.init(jax.random.key(0), jnp.ones((1, 3, 6, 7)))
-    >>> jax.tree_map(jnp.shape, params)
+    >>> jax.tree_util.tree_map(jnp.shape, params)
     {'params': {'bias': (4, 5), 'kernel': (3, 7, 4, 5)}}
 
   Attributes:
@@ -195,7 +195,7 @@ class LinearGeneral(Module):
         * np.prod(shape[n_batch_axis : n_in_features + n_batch_axis]),
         np.prod(shape[-n_out_features:]),
       )
-      flat_shape = jax.tree_map(int, flat_shape)
+      flat_shape = jax.tree_util.tree_map(int, flat_shape)
       kernel = self.kernel_init(rng, flat_shape, dtype)
       if isinstance(kernel, variables.VariableMetadata):
         kernel.raw_value = jnp.reshape(kernel.raw_value, shape)

--- a/flax/experimental/nnx/nnx/spmd.py
+++ b/flax/experimental/nnx/nnx/spmd.py
@@ -56,7 +56,7 @@ def add_axis(
       x.add_axis(axis_name, index)
     return x
 
-  return jax.tree_map(
+  return jax.tree_util.tree_map(
     _add_axis, state, is_leaf=lambda x: isinstance(x, variables.Variable)
   )
 
@@ -75,7 +75,7 @@ def remove_axis(
       x.remove_axis(axis_name, index)
     return x
 
-  return jax.tree_map(
+  return jax.tree_util.tree_map(
     _remove_axis, state, is_leaf=lambda x: isinstance(x, variables.Variable)
   )
 
@@ -107,7 +107,7 @@ def get_partition_spec(tree: A) -> A:
 
     return _maybe_replicate(x)
 
-  return jax.tree_map(
+  return jax.tree_util.tree_map(
     f,
     tree,
     is_leaf=lambda x: isinstance(x, variables.Variable)
@@ -117,7 +117,7 @@ def get_partition_spec(tree: A) -> A:
 
 def get_named_sharding(tree: A, mesh: jax.sharding.Mesh) -> A:
   spec = get_partition_spec(tree)
-  sharding = jax.tree_map(lambda p: jax.sharding.NamedSharding(mesh, p), spec)
+  sharding = jax.tree_util.tree_map(lambda p: jax.sharding.NamedSharding(mesh, p), spec)
   return sharding
 
 

--- a/flax/experimental/nnx/nnx/transforms.py
+++ b/flax/experimental/nnx/nnx/transforms.py
@@ -957,7 +957,7 @@ def scan_apply(
     args,
     is_leaf=lambda x: x is None,
   )
-  broadcast_args = jax.tree_map(
+  broadcast_args = jax.tree_util.tree_map(
     lambda axis, node: node if axis is None else None,
     options.in_args_axes,
     args,

--- a/flax/experimental/nnx/tests/test_helpers.py
+++ b/flax/experimental/nnx/tests/test_helpers.py
@@ -64,6 +64,6 @@ class TestHelpers:
     assert y.shape == (1, 4)
 
     # fake gradient
-    grads = jax.tree_map(jnp.ones_like, state.params)
+    grads = jax.tree_util.tree_map(jnp.ones_like, state.params)
     # test apply_gradients
     state = state.apply_gradients(grads)

--- a/flax/experimental/nnx/tests/test_integration.py
+++ b/flax/experimental/nnx/tests/test_integration.py
@@ -204,7 +204,7 @@ class TestIntegration:
       # compute gradient
       grads, counts = jax.grad(loss_fn, has_aux=True)(params)
       # SGD update
-      params = jax.tree_map(lambda w, g: w - 0.1 * g, params, grads)
+      params = jax.tree_util.tree_map(lambda w, g: w - 0.1 * g, params, grads)
 
       return params, counts
 

--- a/flax/experimental/nnx/tests/test_module.py
+++ b/flax/experimental/nnx/tests/test_module.py
@@ -53,14 +53,14 @@ class TestModule:
 
     static, state = m.split()
 
-    state = jax.tree_map(lambda x: x + 1, state)
+    state = jax.tree_util.tree_map(lambda x: x + 1, state)
 
   def test_split_2(self):
     m = nnx.Dict(a=nnx.Param(1))
 
     empty, some, static = m.split(None, ...)
 
-    some = jax.tree_map(lambda x: x + 1, some)
+    some = jax.tree_util.tree_map(lambda x: x + 1, some)
 
   def test_split_merge(self):
     m = nnx.Dict(a=nnx.Param(1))
@@ -516,7 +516,7 @@ class TestModulePytree:
 
     m = Foo()
 
-    m = jax.tree_map(lambda x: x + 1, m)
+    m = jax.tree_util.tree_map(lambda x: x + 1, m)
 
     assert m.node.value == 2
     assert m.static == 1

--- a/flax/experimental/nnx/tests/test_partitioning.py
+++ b/flax/experimental/nnx/tests/test_partitioning.py
@@ -94,7 +94,7 @@ class TestPartitioning:
     )
 
     state = m.split()[1]
-    state = jax.tree_map(lambda x: x * 2, state)
+    state = jax.tree_util.tree_map(lambda x: x * 2, state)
 
     m.update(state)
 
@@ -111,7 +111,7 @@ class TestPartitioning:
     )
 
     graphdef, state = m.split()
-    state = jax.tree_map(lambda x: x * 2, state)
+    state = jax.tree_util.tree_map(lambda x: x * 2, state)
 
     m.update(state)
 

--- a/flax/experimental/nnx/tests/test_pytree.py
+++ b/flax/experimental/nnx/tests/test_pytree.py
@@ -34,7 +34,7 @@ class TestPytree:
     leaves = jax.tree_util.tree_leaves(pytree)
     assert leaves == [3]
 
-    pytree = jax.tree_map(lambda x: x * 2, pytree)
+    pytree = jax.tree_util.tree_map(lambda x: x * 2, pytree)
     assert pytree.x == 2
     assert pytree.y.value == 6
 
@@ -58,7 +58,7 @@ class TestPytree:
     leaves = jax.tree_util.tree_leaves(pytree)
     assert leaves == [3]
 
-    pytree = jax.tree_map(lambda x: x * 2, pytree)
+    pytree = jax.tree_util.tree_map(lambda x: x * 2, pytree)
     assert pytree.x == 2
     assert pytree.y.value == 6
 
@@ -185,7 +185,7 @@ class TestPytree:
 
     pytree = A(a=1)
 
-    pytree = jax.tree_map(lambda x: x * 2, pytree)
+    pytree = jax.tree_util.tree_map(lambda x: x * 2, pytree)
 
   def test_deterministic_order(self):
     class A(nnx.Pytree):
@@ -218,7 +218,7 @@ class TestMutablePytree:
     leaves = jax.tree_util.tree_leaves(pytree)
     assert leaves == [3]
 
-    pytree = jax.tree_map(lambda x: x * 2, pytree)
+    pytree = jax.tree_util.tree_map(lambda x: x * 2, pytree)
     assert pytree.x == 2
     assert pytree.y.value == 6
 
@@ -252,7 +252,7 @@ class TestMutablePytree:
     leaves = jax.tree_util.tree_leaves(pytree)
     assert leaves == [3]
 
-    pytree = jax.tree_map(lambda x: x * 2, pytree)
+    pytree = jax.tree_util.tree_map(lambda x: x * 2, pytree)
     assert pytree.x == 2
     assert pytree.y.value == 6
 

--- a/flax/experimental/nnx/tests/test_variable.py
+++ b/flax/experimental/nnx/tests/test_variable.py
@@ -26,7 +26,7 @@ class TestVariable:
     r1 = nnx.Variable(1)
     assert r1.raw_value == 1
 
-    r2 = jax.tree_map(lambda x: x + 1, r1)
+    r2 = jax.tree_util.tree_map(lambda x: x + 1, r1)
 
     assert r1.raw_value == 1
     assert r2.raw_value == 2

--- a/flax/linen/linear.py
+++ b/flax/linen/linear.py
@@ -294,7 +294,7 @@ class Einsum(Module):
 
     >>> layer = nn.Einsum((5, 6, 7), 'abc,cde->abde')
     >>> variables = layer.init(jax.random.key(0), jnp.ones((3, 4, 5)))
-    >>> jax.tree_map(jnp.shape, variables)
+    >>> jax.tree_util.tree_map(jnp.shape, variables)
     {'params': {'bias': (6, 7), 'kernel': (5, 6, 7)}}
 
   Attributes:


### PR DESCRIPTION
Updated `jax.tree_map` to `jax.tree_util.tree_map`. As of [JAX 0.4.26](https://jax.readthedocs.io/en/latest/changelog.html#jax-0-4-26-april-3-2024), `jax.tree_map` is deprecated. We should switch to `jax.tree.map` when the [JAX minimum version](https://github.com/google/flax/blob/main/pyproject.toml#L17) is >=0.4.26 for Flax.

Additional context:
* JAX PR that added the `jax.tree` module: https://github.com/google/jax/pull/19588
* JAX PR that deprecated `jax.tree_map`: https://github.com/google/jax/pull/19930