### PR TITLE
[nnx] refactor GraphDef

### DIFF
--- a/flax/experimental/nnx/__init__.py
+++ b/flax/experimental/nnx/__init__.py
@@ -35,6 +35,8 @@ from .nnx.module import Module as Module
 from .nnx.graph_utils import merge as merge
 from .nnx.graph_utils import split as split
 from .nnx.graph_utils import update as update
+from .nnx.graph_utils import clone as clone
+from .nnx.graph_utils import pop as pop
 from .nnx.nn import initializers as initializers
 from .nnx.nn.activations import celu as celu
 from .nnx.nn.activations import elu as elu

--- a/flax/experimental/nnx/nnx/state.py
+++ b/flax/experimental/nnx/nnx/state.py
@@ -77,7 +77,7 @@ class State(tp.MutableMapping[Key, tp.Any], reprlib.Representable):
       super().__setattr__('_mapping', dict(mapping))
 
   @property
-  def raw_mapping(self) -> dict[Key, dict[str, tp.Any] | tp.Any]:
+  def raw_mapping(self) -> dict[Key, dict[Key, tp.Any] | tp.Any]:
     return self._mapping
 
   def __getitem__(self, key: Key) -> State | StateLeaf:

--- a/flax/experimental/nnx/nnx/transforms.py
+++ b/flax/experimental/nnx/nnx/transforms.py
@@ -559,7 +559,7 @@ def grad_apply(options: GradOptions, f, args: tuple[tp.Any, ...]):
     _args = list(args)
     for i, graph_node in diff_graph_nodes.items():
       diff_state: State = _args[i]
-      graph_utils.graph_update_dynamic(graph_node, diff_state)
+      graph_utils.update(graph_node, diff_state)
       _args[i] = graph_node
 
     out = f(*_args)
@@ -592,7 +592,7 @@ def grad_apply(options: GradOptions, f, args: tuple[tp.Any, ...]):
     else:
       out, updates = out
 
-  graph_utils.graph_update_dynamic((input_nodes, out_nodes), updates)
+  graph_utils.update((input_nodes, out_nodes), updates)
   return out
 
 
@@ -922,7 +922,7 @@ def scan_init(
       for state, index in zip(axes_states, options.variable_axes.values())
     ]
 
-  module = graphdef.merge(*axes_states, carry_state)
+  module = graph_utils.merge(graphdef, *axes_states, carry_state)
 
   return module
 
@@ -1558,7 +1558,7 @@ def vmap_init(
       for state, index in zip(axes_states, options.variable_axes.values())
     ]
 
-  module = graphdef.merge(*axes_states, carry_state)
+  module = graph_utils.merge(graphdef, *axes_states, carry_state)
   return module
 
 


### PR DESCRIPTION
# What does this PR do?

Renames `GraphDef` to `NodeDef` and creates a new `GraphDef` dataclass defined as:

```python
@dataclasses.dataclass(frozen=True)
class GraphDef(tp.Generic[Node], reprlib.Representable):
  nodedef: NodeDef[Node]
  flatten_ref_to_index: RefMap[tp.Any, Index] | None
  idx_mapping: dict[Index, Index] | None 
```
where `flatten_ref_to_index` can store the flatten indexes, and `idx_mapping` can store the index mapping for `GraphDef.update`. More importantly, `flatten_ref_to_index` is *opaque* meaning that its not included in the hash and eq calculations, and its dropped when flattening `GraphDef` as a pytree.