### PR TITLE
Fix cloudpickle sentinel cloning

### DIFF
--- a/flax/linen/module.py
+++ b/flax/linen/module.py
@@ -212,6 +212,13 @@ class _Sentinel:
     del memo
     return self  # Do not copy singleton sentinel.
 
+  def __reduce__(self):
+    return _get_unspecified_parent, ()
+
+
+def _get_unspecified_parent():
+  return _unspecified_parent
+
 
 _unspecified_parent = _Sentinel()
 

--- a/tests/linen/linen_module_test.py
+++ b/tests/linen/linen_module_test.py
@@ -2546,6 +2546,17 @@ class ModuleTest(absltest.TestCase):
     self.assertIs(called[0], bar)
     self.assertIs(called[1], foo)
 
+  def test_cloudpickle_class(self):
+    import cloudpickle
+
+    class MyModule(nn.Module):
+      pass
+
+    a = MyModule()
+
+    UnpickledMyModule = cloudpickle.loads(cloudpickle.dumps(MyModule))
+    b = UnpickledMyModule()
+
   def test_cloudpickle_module(self):
     from cloudpickle import cloudpickle_fast
 


### PR DESCRIPTION
# What does this PR do?

Uses `isinstance` instead of `is` to check for `_Sentinel` instances to avoid non uniqueness issues when using `cloudpickle` (creates a new `_Sentinel` instance for `_unspecified_parent`).