### PR TITLE
[nnx] refactor graph_utils

### DIFF
--- a/flax/experimental/nnx/__init__.py
+++ b/flax/experimental/nnx/__init__.py
@@ -33,8 +33,11 @@ from .nnx.helpers import TrainState as TrainState
 from .nnx.module import M as M
 from .nnx.module import Module as Module
 from .nnx.graph_utils import merge as merge
+from .nnx.graph_utils import UpdateContext as UpdateContext
 from .nnx.graph_utils import split as split
 from .nnx.graph_utils import update as update
+from .nnx.graph_utils import clone as clone
+from .nnx.graph_utils import pop as pop
 from .nnx.nn import initializers as initializers
 from .nnx.nn.activations import celu as celu
 from .nnx.nn.activations import elu as elu

--- a/flax/experimental/nnx/examples/toy_examples/09_parameter_surgery.py
+++ b/flax/experimental/nnx/examples/toy_examples/09_parameter_surgery.py
@@ -52,5 +52,10 @@ is_trainable = lambda path, node: (
 # split the parameters into trainable and non-trainable parameters
 trainable_params, non_trainable, static = model.split(is_trainable, ...)
 
-print('trainable_params =', jax.tree_util.tree_map(jax.numpy.shape, trainable_params))
-print('non_trainable = ', jax.tree_util.tree_map(jax.numpy.shape, non_trainable))
+print(
+  'trainable_params =',
+  jax.tree_util.tree_map(jax.numpy.shape, trainable_params),
+)
+print(
+  'non_trainable = ', jax.tree_util.tree_map(jax.numpy.shape, non_trainable)
+)

--- a/flax/experimental/nnx/nnx/graph_utils.py
+++ b/flax/experimental/nnx/nnx/graph_utils.py
@@ -37,8 +37,13 @@ from flax.experimental.nnx.nnx.proxy_caller import (
   CallableProxy,
   DelayedAccessor,
 )
-from flax.experimental.nnx.nnx.state import State, StateLeaf, is_state_leaf
-from flax.experimental.nnx.nnx.variables import EMPTY, Empty, Variable
+from flax.experimental.nnx.nnx.state import (
+  FlatState,
+  State,
+  StateLeaf,
+  is_state_leaf,
+)
+from flax.experimental.nnx.nnx.variables import EMPTY, Variable
 from flax.typing import PathParts, Key
 
 A = tp.TypeVar('A')
@@ -99,8 +104,11 @@ class _HashById(tp.Hashable, tp.Generic[A]):
 class RefMap(tp.MutableMapping[A, B], reprlib.MappingReprMixin[A, B]):
   """A mapping that uses object id as the hash for the keys."""
 
-  def __init__(self):
+  def __init__(
+    self, mapping: tp.Mapping[A, B] | tp.Iterable[tuple[A, B]] = (), /
+  ):
     self._mapping: dict[_HashById[A], B] = {}
+    self.update(mapping)
 
   def __getitem__(self, key: A) -> B:
     return self._mapping[_HashById(key)]
@@ -122,6 +130,7 @@ class RefMap(tp.MutableMapping[A, B], reprlib.MappingReprMixin[A, B]):
 
   def __str__(self) -> str:
     return repr(self)
+
 
 
 @dataclasses.dataclass(frozen=True)
@@ -314,20 +323,19 @@ class VariableDef(reprlib.Representable):
       and self._metadata == other._metadata
     )
 
+@dataclasses.dataclass(frozen=True)
+class NodeDef(tp.Generic[Node], reprlib.Representable):
+  type: tp.Type[Node]
+  index: int
+  attributes: tuple[Key, ...]
+  subgraphs: _HashableMapping[Key, tp.Union['NodeDef[tp.Any]', int]]
+  static_fields: _HashableMapping[Key, tp.Any]
+  variables: _HashableMapping[Key, VariableDef | int]
+  metadata: tp.Any
 
-class GraphDef(tp.Generic[Node], reprlib.Representable):
-  __slots__ = (
-    '_type',
-    '_index',
-    '_attributes',
-    '_subgraphs',
-    '_static_fields',
-    '_variables',
-    '_metadata',
-  )
-
-  def __init__(
-    self,
+  @classmethod
+  def create(
+    cls,
     type: tp.Type[Node],
     index: int,
     attributes: tuple[Key, ...],
@@ -336,60 +344,49 @@ class GraphDef(tp.Generic[Node], reprlib.Representable):
     variables: tp.Iterable[tuple[Key, VariableDef | int]],
     metadata: tp.Any,
   ):
-    self._type: type[Node] = type
-    self._index = index
-    self._attributes = attributes
-    self._subgraphs = _HashableMapping(subgraphs)
-    self._static_fields = _HashableMapping(static_fields)
-    self._variables = _HashableMapping(variables)
-    self._metadata = metadata
+    return cls(
+      type=type,
+      index=index,
+      attributes=attributes,
+      subgraphs=_HashableMapping(subgraphs),
+      static_fields=_HashableMapping(static_fields),
+      variables=_HashableMapping(variables),
+      metadata=metadata,
+    )
 
   def __nnx_repr__(self):
     yield reprlib.Object(type=type(self))
 
-    yield reprlib.Attr('type', self._type.__name__)
-    yield reprlib.Attr('index', self._index)
-    yield reprlib.Attr('attributes', self._attributes)
-    yield reprlib.Attr('subgraphs', _MappingRepr(self._subgraphs))
-    yield reprlib.Attr('static_fields', _MappingRepr(self._static_fields))
-    yield reprlib.Attr('variables', _MappingRepr(self._variables))
-    yield reprlib.Attr('metadata', self._metadata)
+    yield reprlib.Attr('type', self.type.__name__)
+    yield reprlib.Attr('index', self.index)
+    yield reprlib.Attr('attributes', self.attributes)
+    yield reprlib.Attr('subgraphs', _MappingRepr(self.subgraphs))
+    yield reprlib.Attr('static_fields', _MappingRepr(self.static_fields))
+    yield reprlib.Attr('variables', _MappingRepr(self.variables))
+    yield reprlib.Attr('metadata', self.metadata)
 
-  def __hash__(self) -> int:
-    return hash((self._type, self._subgraphs))
 
-  def __eq__(self, other: tp.Any) -> bool:
-    if not isinstance(other, GraphDef):
-      return False
-    return self._type == other._type and self._subgraphs == other._subgraphs
+@dataclasses.dataclass(frozen=True)
+class GraphDef(tp.Generic[Node], reprlib.Representable):
+  nodedef: NodeDef[Node]
+  index_mapping: dict[Index, Index] | None
 
-  @property
-  def type(self) -> tp.Type[Node]:
-    return self._type
+  def __nnx_repr__(self):
+    yield reprlib.Object(type=type(self))
 
-  @property
-  def index(self) -> int:
-    return self._index
+    yield reprlib.Attr('nodedef', self.nodedef)
+    yield reprlib.Attr('index_mapping', self.index_mapping)
 
-  @property
-  def attributes(self) -> tuple[str, ...]:
-    return self._attributes
+  def __deepcopy__(self, memo=None):
+    nodedef = deepcopy(self.nodedef, memo)
+    index_mapping = deepcopy(self.index_mapping, memo)
+    return GraphDef(nodedef, index_mapping)
 
-  @property
-  def subgraphs(self):
-    return self._subgraphs
+  def __hash__(self):
+    return hash(self.nodedef)
 
-  @property
-  def static_fields(self):
-    return self._static_fields
-
-  @property
-  def variables(self):
-    return self._variables
-
-  @property
-  def metadata(self) -> tp.Any:
-    return self._metadata
+  def __eq__(self, other):
+    return isinstance(other, GraphDef) and self.nodedef == other.nodedef
 
   def merge(self, state: State, /, *states: State) -> Node:
     if states:
@@ -404,7 +401,7 @@ class GraphDef(tp.Generic[Node], reprlib.Representable):
     def _apply(
       accessor: DelayedAccessor, *args, **kwargs
     ) -> tuple[tp.Any, tuple[GraphDef[Node], State]]:
-      module = self.merge(state, *states)
+      module = merge(self, state, *states)
       fn = accessor(module)
       out = fn(*args, **kwargs)
       return out, graph_flatten(module)[:2]
@@ -412,88 +409,83 @@ class GraphDef(tp.Generic[Node], reprlib.Representable):
     return CallableProxy(_apply, accessor)  # type: ignore
 
   def make_empty(self) -> Node:
-    return self.merge(State({}))
+    return merge(self, State({}))
 
 
-def _gradphdef_flatten(graphdef: GraphDef[tp.Any]):
-  return (), (
-    graphdef._type,
-    graphdef._index,
-    graphdef._attributes,
-    graphdef._subgraphs,
-    graphdef._static_fields,
-    graphdef._variables,
-    graphdef._metadata,
-  )
+def _graphdef_flatten(graphdef: GraphDef[Node]):
+  # refmap is opaque, we don't propagate it
+  static = (graphdef.nodedef, graphdef.index_mapping)
+  return (), static
 
 
 def _graphdef_unflatten(
-  metadata: tuple[
-    tp.Type[Node],
-    int,
-    tuple[Key, ...],
-    tuple[tuple[Key, GraphDef[Node] | int], ...],
-    tuple[tuple[Key, tp.Any], ...],
-    tuple[tuple[Key, Variable[Empty] | int], ...],
-    tp.Any,
-  ],
-  _,
-) -> GraphDef[Node]:
-  return GraphDef(*metadata)
+  static: tuple[NodeDef[Node], dict[Index, Index] | None], _nodes: tuple[()]
+):
+  nodedef, index_mapping = static
+  return GraphDef(nodedef, index_mapping)
 
 
 jax.tree_util.register_pytree_node(
-  GraphDef, _gradphdef_flatten, _graphdef_unflatten
+  GraphDef,
+  _graphdef_flatten,
+  _graphdef_unflatten,
 )
 
 
 def graph_flatten(
   x: Node,
   /,
-) -> tuple[GraphDef[Node], State, tp.Mapping[tp.Any, Index]]:
-  ref_to_index = RefMap[tp.Any, Index]()
+  *,
+  idxmap: dict[Index, tp.Any] | None = None,
+) -> tuple[GraphDef[Node], State, RefMap[tp.Any, Index]]:
+  refmap = RefMap[tp.Any, Index]()
   flat_state: dict[PathParts, StateLeaf] = {}
-  graphdef = _graph_flatten((), ref_to_index, flat_state, x)
-  assert not isinstance(graphdef, int)
-  return graphdef, State.from_flat_path(flat_state), ref_to_index
+  nodedef = _graph_flatten((), refmap, flat_state, x)
+  assert not isinstance(nodedef, int)
+  if idxmap is not None:
+    index_to_index = compose_mapping(idxmap, refmap)
+  else:
+    index_to_index = None
+  graphdef = GraphDef(nodedef, index_to_index)
+  return graphdef, State.from_flat_path(flat_state), refmap
 
 
 def _graph_flatten(
   path: PathParts,
-  ref_to_index: RefMap[tp.Any, Index],
+  refmap: RefMap[tp.Any, Index],
   flat_state: dict[PathParts, StateLeaf],
   node: Node,
-) -> GraphDef[Node] | int:
+) -> NodeDef[Node] | int:
   if not is_node(node):
     raise RuntimeError(f'Unsupported type: {type(node)}, this is a bug.')
 
-  if node in ref_to_index:
-    return ref_to_index[node]
+  if node in refmap:
+    return refmap[node]
 
   node_impl = get_node_impl(node)
 
   # only cache graph nodes
   if isinstance(node_impl, GraphNodeImpl):
-    index = len(ref_to_index)
-    ref_to_index[node] = index
+    index = len(refmap)
+    refmap[node] = index
   else:
     index = -1
 
-  subgraphs: list[tuple[Key, tp.Union[GraphDef[Node], int]]] = []
+  subgraphs: list[tuple[Key, tp.Union[NodeDef[Node], int]]] = []
   static_fields: list[tuple[Key, tp.Any]] = []
   variables: list[tuple[Key, VariableDef | int]] = []
 
   values, metadata = node_impl.flatten(node)
   for key, value in values:
     if is_node(value):
-      graphdef = _graph_flatten((*path, key), ref_to_index, flat_state, value)
-      subgraphs.append((key, graphdef))
+      nodedef = _graph_flatten((*path, key), refmap, flat_state, value)
+      subgraphs.append((key, nodedef))
     elif isinstance(value, Variable):
-      if value in ref_to_index:
-        variables.append((key, ref_to_index[value]))
+      if value in refmap:
+        variables.append((key, refmap[value]))
       else:
         flat_state[(*path, key)] = value.copy()
-        variable_index = ref_to_index[value] = len(ref_to_index)
+        variable_index = refmap[value] = len(refmap)
         variables.append(
           (key, VariableDef.from_variable(value, variable_index))
         )
@@ -502,7 +494,7 @@ def _graph_flatten(
     else:
       static_fields.append((key, value))
 
-  graphdef = GraphDef(
+  nodedef = NodeDef.create(
     type=node_impl.type,
     index=index,
     attributes=tuple(key for key, _ in values),
@@ -511,7 +503,7 @@ def _graph_flatten(
     variables=variables,
     metadata=metadata,
   )
-  return graphdef
+  return nodedef
 
 
 def graph_unflatten(
@@ -519,12 +511,12 @@ def graph_unflatten(
   state: State,
   /,
   *,
-  ref_cache: dict[Index, tp.Any] | None = None,
+  idxmap: dict[Index, tp.Any] | None = None,
 ) -> tuple[Node, dict[Index, tp.Any]]:
   """Unflattens a graphdef into a node with the given state.
 
   Args:
-    graphdef: A GraphDef instance.
+    graphdef: A NodeDef instance.
     state: A State instance.
     ref_cache: A mapping from indexes to existing nodes that can be reused.
       When an reference is reused, ``GraphNodeImpl.clear`` is called to leave the
@@ -533,20 +525,22 @@ def graph_unflatten(
       specified by the graphdef.
   """
   index_to_ref: dict[Index, tp.Any] = {}
-  node = _graph_unflatten(graphdef, state.raw_mapping, index_to_ref, ref_cache)
+  node = _graph_unflatten(
+    graphdef.nodedef, state.raw_mapping, index_to_ref, idxmap
+  )
   return node, index_to_ref
 
 
 def _graph_unflatten(
-  graphdef: tp.Union[GraphDef[Node], int],
-  state: dict[str, StateLeaf | dict[str, tp.Any]],
+  nodedef: tp.Union[NodeDef[Node], int],
+  state: dict[Key, StateLeaf | dict[Key, tp.Any]],
   index_to_ref: dict[Index, tp.Any],
-  ref_cache: dict[Index, tp.Any] | None,
+  idxmap: dict[Index, tp.Any] | None,
 ) -> Node:
   """Recursive helper for graph_unflatten.
 
   Args:
-    graphdef: A GraphDef instance or an index to a node in the cache.
+    nodedef: A NodeDef instance or an index to a node in the cache.
     state: A mapping from attribute names to variables or subgraphs.
     index_to_ref: A mapping from indexes to nodes that have been traversed.
       If a node is already in the cache, it won't be traversed again.
@@ -554,31 +548,31 @@ def _graph_unflatten(
       When an reference is reused, ``GraphNodeImpl.clear`` is called to leave the
       object in an empty state and then filled by the unflatten process, as a result
       existing graph nodes are mutated to have the new content/topology
-      specified by the graphdef.
+      specified by the nodedef.
   """
-  if isinstance(graphdef, int):
-    return index_to_ref[graphdef]
+  if isinstance(nodedef, int):
+    return index_to_ref[nodedef]
 
-  if not is_node_type(graphdef.type):
-    raise RuntimeError(f'Unsupported type: {graphdef.type}, this is a bug.')
+  if not is_node_type(nodedef.type):
+    raise RuntimeError(f'Unsupported type: {nodedef.type}, this is a bug.')
 
-  if graphdef.index in index_to_ref:
-    raise RuntimeError(f'GraphDef index {graphdef.index} already used.')
+  if nodedef.index in index_to_ref:
+    raise RuntimeError(f'NodeDef index {nodedef.index} already used.')
 
-  node_impl = get_node_impl_for_type(graphdef.type)
+  node_impl = get_node_impl_for_type(nodedef.type)
 
   def _get_children():
     children: dict[str, StateLeaf | Node] = {}
 
-    for key in graphdef.attributes:
-      if key in graphdef.static_fields:
-        children[key] = graphdef.static_fields[key]
+    for key in nodedef.attributes:
+      if key in nodedef.static_fields:
+        children[key] = nodedef.static_fields[key]
       elif key not in state:
         # TODO(cgarcia): maybe we shouldn't support unflattening with missing keys?
         # if key is not present create an empty types
-        if key in graphdef.subgraphs:
+        if key in nodedef.subgraphs:
           # if the key is a subgraph we create an empty node
-          subgraphdef = graphdef.subgraphs[key]
+          subgraphdef = nodedef.subgraphs[key]
           if isinstance(subgraphdef, int):
             # subgraph exists, take it from the cache
             children[key] = index_to_ref[subgraphdef]
@@ -586,17 +580,17 @@ def _graph_unflatten(
             # create an empty node and add it to the cache
             substate = {}
             node = children[key] = _graph_unflatten(
-              subgraphdef, substate, index_to_ref, ref_cache
+              subgraphdef, substate, index_to_ref, idxmap
             )
-        elif key in graphdef.variables:
-          variable_def = graphdef.variables[key]
+        elif key in nodedef.variables:
+          variable_def = nodedef.variables[key]
           if isinstance(variable_def, int):
             # variable exists, take it from the cache
             children[key] = index_to_ref[variable_def]
           else:
             # create an empty variable and add it to the cache
-            if ref_cache is not None and variable_def.index in ref_cache:
-              node = ref_cache[variable_def.index]
+            if idxmap is not None and variable_def.index in idxmap:
+              node = idxmap[variable_def.index]
               if type(node) != variable_def.type:
                 raise ValueError(
                   f'Expected a node of type {variable_def.type.__name__} for '
@@ -613,23 +607,23 @@ def _graph_unflatten(
           raise RuntimeError(f'Unknown static field: {key!r}')
       else:
         value = state[key]
-        if key in graphdef.subgraphs:
+        if key in nodedef.subgraphs:
           if is_state_leaf(value):
             raise ValueError(
               f'Expected a subgraph for {key!r}, but got a Variable.'
             )
           assert isinstance(value, dict)
-          subgraphdef = graphdef.subgraphs[key]
+          subgraphdef = nodedef.subgraphs[key]
 
           if isinstance(subgraphdef, int):
             node = index_to_ref[subgraphdef]
           else:
             node = children[key] = _graph_unflatten(
-              subgraphdef, value, index_to_ref, ref_cache
+              subgraphdef, value, index_to_ref, idxmap
             )
 
-        elif key in graphdef.variables:
-          variable_def = graphdef.variables[key]
+        elif key in nodedef.variables:
+          variable_def = nodedef.variables[key]
           if isinstance(variable_def, int):
             children[key] = index_to_ref[variable_def]
           else:
@@ -639,8 +633,8 @@ def _graph_unflatten(
                 f'for {key!r}, but got a Variable of type {type(value)}.'
               )
             assert isinstance(value, Variable)
-            if ref_cache is not None and variable_def.index in ref_cache:
-              variable = ref_cache[variable_def.index]
+            if idxmap is not None and variable_def.index in idxmap:
+              variable = idxmap[variable_def.index]
               if type(variable) != variable_def.type:
                 raise ValueError(
                   f'Expected a Variable of type {variable_def.type} for '
@@ -654,7 +648,7 @@ def _graph_unflatten(
             index_to_ref[variable_def.index] = variable
         elif is_state_leaf(value):
           children[key] = value
-    for new_key in set(state) - set(graphdef.attributes):
+    for new_key in set(state) - set(nodedef.attributes):
       raise ValueError(f'Unknown key: {new_key!r}')
 
     return children
@@ -662,24 +656,24 @@ def _graph_unflatten(
   if isinstance(node_impl, GraphNodeImpl):
     # we create an empty node first and add it to the index
     # this avoids infinite recursion when there is a reference cycle
-    if ref_cache is not None and graphdef.index in ref_cache:
-      node = ref_cache[graphdef.index]
-      if type(node) != graphdef.type:
+    if idxmap is not None and nodedef.index in idxmap:
+      node = idxmap[nodedef.index]
+      if type(node) != nodedef.type:
         raise ValueError(
-          f'Expected a node of type {graphdef.type} for index '
-          f'{graphdef.index}, but got a node of type {type(node)}.'
+          f'Expected a node of type {nodedef.type} for index '
+          f'{nodedef.index}, but got a node of type {type(node)}.'
         )
-      node_impl.clear(node, graphdef.metadata)
+      node_impl.clear(node, nodedef.metadata)
     else:
-      node = node_impl.create_empty(graphdef.metadata)
-    index_to_ref[graphdef.index] = node
+      node = node_impl.create_empty(nodedef.metadata)
+    index_to_ref[nodedef.index] = node
     children = _get_children()
     node_impl.init(node, tuple(children.items()))
   else:
     # if the node type does not support the creation of an empty object it means
     # that it cannot reference itself, so we can create its children first
     children = _get_children()
-    node = node_impl.unflatten(tuple(children.items()), graphdef.metadata)
+    node = node_impl.unflatten(tuple(children.items()), nodedef.metadata)
 
   return node
 
@@ -716,7 +710,11 @@ def _graph_pop(
   for name, value in node_dict.items():
     if is_node(value):
       _graph_pop(
-        value, id_to_index, (*path_parts, name), flat_states, predicates
+        node=value,
+        id_to_index=id_to_index,
+        path_parts=(*path_parts, name),
+        flat_states=flat_states,
+        predicates=predicates,
       )
       continue
     elif not is_state_leaf(value):
@@ -743,23 +741,7 @@ def _graph_pop(
       pass
 
 
-def graph_update_dynamic(
-  node: tp.Any,
-  updates: State | tp.Sequence[State],
-) -> None:
-  if not is_node(node):
-    raise ValueError(f'Unsupported type: {type(node)}')
-
-  if isinstance(updates, State):
-    new_states = (updates,)
-  else:
-    new_states = updates
-
-  for state in new_states:
-    _graph_update_dynamic(node, state.raw_mapping)
-
-
-def _graph_update_dynamic(node: tp.Any, state: dict[str, tp.Any]):
+def _graph_update_dynamic(node: tp.Any, state: dict[Key, tp.Any]):
   if not is_node(node):
     raise RuntimeError(f'Unsupported type: {type(node)}')
 
@@ -812,7 +794,14 @@ class _StaticModuleStatus(enum.Enum):
   NEW = enum.auto()
   UPDATED = enum.auto()
 
+# TODO(cgarciae): remove once transform init are reimplemented
+def update_from(node: Node, updates: Node) -> None:
+  graph_update_static(node, updates)
+  _, state = split(updates)
+  update(node, state)
 
+
+# TODO(cgarciae): remove once transform init are reimplemented
 def graph_update_static(node: Node, updates: Node) -> None:
   cache: dict[int, _StaticModuleStatus] = {}
   _graph_update_static(node, updates, cache, _StaticModuleStatus.UPDATED, ())
@@ -902,15 +891,116 @@ def _graph_update_static(
 
       node_impl.set_key(node, name, value_updates)
 
+@dataclasses.dataclass
+class UpdateContext:
+  refmap: RefMap[tp.Any, Index] | None = None
+  idxmap: dict[Index, tp.Any] | None = None
+
+  # define context manager to clean up refmap and idxmap
+  # on exit
+  def __enter__(self):
+    return self
+
+  def __exit__(self, *args, **kwargs):
+    self.refmap = None
+    self.idxmap = None
+
+  # define hash and eq to make this an opaque object
+  def __hash__(self):
+    return 0
+
+  def __eq__(self, other):
+    return isinstance(other, UpdateContext)
+
+  @tp.overload
+  def split(self, graph_node: A, /) -> tuple[GraphDef[A], State]:
+    ...
+
+  @tp.overload
+  def split(
+    self, graph_node: A, first: filterlib.Filter, /
+  ) -> tuple[GraphDef[A], State]:
+    ...
+
+  @tp.overload
+  def split(
+    self,
+    graph_node: A,
+    first: filterlib.Filter,
+    second: filterlib.Filter,
+    /,
+    *filters: filterlib.Filter,
+  ) -> tuple[GraphDef[A], State, tpe.Unpack[tuple[State, ...]]]:
+    ...
+
+  def split(
+    self, node: A, *filters: filterlib.Filter
+  ) -> tuple[GraphDef[A], State, tpe.Unpack[tuple[State, ...]]]:
+    if self.refmap is not None and self.idxmap is None:
+      raise ValueError(
+        "'merge' was not called in-between the first and second call to 'split'"
+      )
+    graphdef, state, refmap = graph_flatten(node, idxmap=self.idxmap)
+
+    if len(filters) == 0:
+      states = (state,)
+    elif len(filters) == 1:
+      states = (state.split(filters[0]),)
+    else:
+      states = state.split(filters[0], filters[1], *filters[2:])
+
+    if self.refmap is None:
+      self.refmap = refmap
+
+    return graphdef, states[0], *states[1:]
+
+  def merge(
+    self,
+    graphdef: GraphDef[A],
+    state: State,
+    *states: State,
+  ) -> A:
+    # TODO: add docstring of example usage
+    if states:
+      state = State.merge(state, *states)
+
+    node, self.idxmap = graph_unflatten(graphdef, state)
+    return node
+
+  def update(
+    self,
+    new_graphdef: GraphDef[A],
+    state: State,
+    /,
+    *states: State,
+  ):
+    if self.refmap is None:
+      raise ValueError('Cannot update a graphdef without refmap.')
+    if new_graphdef.index_mapping is None:
+      raise ValueError('Cannot update a graphdef without index_mapping.')
+
+    if states:
+      state = State.merge(state, *states)
+
+    index_to_ref = compose_mapping_reversed(
+      self.refmap, new_graphdef.index_mapping
+    )
+    return graph_unflatten(new_graphdef, state, idxmap=index_to_ref)[0]
+
+
+jax.tree_util.register_static(UpdateContext)
+
 
 @tp.overload
-def split(graph_node: A) -> tuple[GraphDef[A], State]:
+def split(graph_node: A, /) -> tuple[GraphDef[A], State]:
   ...
 
 
 @tp.overload
 def split(
-  graph_node: A, first: filterlib.Filter, /
+  graph_node: A,
+  first: filterlib.Filter,
+  /,
 ) -> tuple[GraphDef[A], State]:
   ...
 
@@ -927,9 +1017,9 @@ def split(
 
 
 def split(
-  graph_node: A, *filters: filterlib.Filter
+  node: A, *filters: filterlib.Filter
 ) -> tuple[GraphDef[A], State, tpe.Unpack[tuple[State, ...]]]:
-  graphdef, state, _ = graph_flatten(graph_node)
+  graphdef, state, _ = graph_flatten(node)
 
   if len(filters) == 0:
     states = (state,)
@@ -946,58 +1036,98 @@ def merge(
   state: State,
   *states: State,
 ) -> A:
-  # TODO: add docstring of example usage
-  return graphdef.merge(state, *states)
-
-
-def update(graph_node: A, update: Updates[A], /, *updates: Updates[A]) -> None:
-  updates = (update, *updates)
-
-  # find states and module_update
-  leaves = jax.tree_util.tree_leaves(
-    updates, is_leaf=lambda x: isinstance(x, (GraphDef, State))
-  )
-  states: list[State] = []
-  module_update: tp.Optional[A] = None
-
-  for leaf in leaves:
-    if is_graph_node(leaf) or isinstance(leaf, GraphDef):
-      if module_update is not None:
-        raise ValueError(
-          'Expected only one GraphDef or GraphNode in the updates'
-        )
-
-      if is_graph_node(leaf):
-        if not isinstance(leaf, type(graph_node)):
-          raise ValueError(
-            'Expected a GraphNode of the same type as the input, '
-            f'got {type(leaf).__name__} instead.'
-          )
-        module_update = leaf
-        states.append(split(leaf)[1])
-      elif isinstance(leaf, GraphDef):
-        module_update = leaf.make_empty()
-      else:
-        raise ValueError(
-          'Expected a GraphDef or graph node, got' f' {type(leaf).__name__}'
-        )
-    elif isinstance(leaf, State):
-      states.append(leaf)
-    else:
-      raise ValueError(
-        'Expected a GraphDef, GraphNode or State, got' f' {type(leaf).__name__}'
-      )
-
-  if module_update is not None:
-    graph_update_static(graph_node, module_update)
-
   if states:
-    graph_update_dynamic(graph_node, states)
+    state = State.merge(state, *states)
+
+  node, _ = graph_unflatten(graphdef, state)
+  return node
+
+
+def update(node, state: State, *states: State) -> None:
+  if states:
+    state = State.merge(state, *states)
+
+  _graph_update_dynamic(node, state.raw_mapping)
+
+
+@tp.overload
+def extract(node, first: filterlib.Filter, /) -> State:
+  ...
+
+
+@tp.overload
+def extract(
+  node,
+  first: filterlib.Filter,
+  second: filterlib.Filter,
+  /,
+  *filters: filterlib.Filter,
+) -> tuple[State, ...]:
+  ...
+
+
+def extract(
+  node,
+  first: filterlib.Filter,
+  /,
+  *filters: filterlib.Filter,
+) -> tp.Union[State, tuple[State, ...]]:
+  state = graph_flatten(node)[1]
+
+  if len(filters) == 0:
+    states = state.extract(first)
+  else:
+    states = state.extract(first, filters[0], *filters[1:])
+
+  return states
+
+
+@tp.overload
+def pop(
+  node,
+  filter: filterlib.Filter,
+  /,
+) -> State:
+  ...
+
+
+@tp.overload
+def pop(
+  node,
+  filter: filterlib.Filter,
+  filter2: filterlib.Filter,
+  /,
+  *filters: filterlib.Filter,
+) -> tuple[State, ...]:
+  ...
+
+
+def pop(node, *filters: filterlib.Filter) -> tp.Union[State, tuple[State, ...]]:
+  if len(filters) == 0:
+    raise ValueError('Expected at least one filter')
+
+  id_to_index: dict[int, Index] = {}
+  path_parts: PathParts = ()
+  predicates = tuple(filterlib.to_predicate(filter) for filter in filters)
+  flat_states: tuple[FlatState, ...] = tuple({} for _ in predicates)
+  _graph_pop(
+    node=node,
+    id_to_index=id_to_index,
+    path_parts=path_parts,
+    flat_states=flat_states,
+    predicates=predicates,
+  )
+  states = tuple(State.from_flat_path(flat_state) for flat_state in flat_states)
+
+  if len(states) == 1:
+    return states[0]
+  else:
+    return states
 
 
 def clone(node: Node) -> Node:
-  static, state, _ = graph_flatten(node)
-  return static.merge(state)
+  static, state = split(node)
+  return merge(static, state)
 
 
 def iter_nodes(node: tp.Any) -> tp.Iterator[tuple[PathParts, tp.Any]]:
@@ -1157,10 +1287,10 @@ class GraphNode(reprlib.Representable, metaclass=GraphNodeMeta):
       raise errors.TraceContextError(error_msg)
 
   def __deepcopy__(self: G, memo=None) -> G:
-    graphdef, state, _ = graph_utils.graph_flatten(self)
+    graphdef, state = graph_utils.split(self)
     graphdef = deepcopy(graphdef)
     state = deepcopy(state)
-    return graphdef.merge(state)
+    return merge(graphdef, state)
 
   def __hash__(self) -> int:
     return hash(self._graph_node__state.id)

--- a/flax/experimental/nnx/nnx/module.py
+++ b/flax/experimental/nnx/nnx/module.py
@@ -20,7 +20,6 @@ from functools import partial
 
 import jax
 import jax.tree_util as jtu
-import typing_extensions as tpe
 
 from flax.experimental.nnx.nnx import (
   filterlib,
@@ -144,13 +143,13 @@ class Module(graph_utils.GraphNode, metaclass=ModuleMeta):
 
       def _partial_init_constructor():
         module = constructor(*args, **lift_rngs(kwargs))
-        module.update(*states)
-        return module.split()
+        graph_utils.update(module, *states)
+        return graph_utils.split(module)
 
       graphdef: GraphDef[M]
       state: State
       graphdef, state = jax.jit(_partial_init_constructor)()
-      module = graphdef.merge(state)
+      module = graph_utils.merge(graphdef, state)
       return module
 
     return CallableProxy(_partial_init)  # type: ignore
@@ -182,11 +181,11 @@ class Module(graph_utils.GraphNode, metaclass=ModuleMeta):
     return graph_utils.split(self, *filters)
 
   def get_state(self) -> State:
-    _, state = self.split()
+    _, state = graph_utils.split(self)
     return state
 
   def get_graphdef(self: M) -> GraphDef[M]:
-    graphdef, _ = self.split()
+    graphdef, _ = graph_utils.split(self)
     return graphdef
 
   @tp.overload
@@ -252,17 +251,15 @@ class Module(graph_utils.GraphNode, metaclass=ModuleMeta):
   @property
   def apply(self: M) -> ApplyCaller[M]:
     def _apply(accessor: DelayedAccessor, *args, **kwargs) -> tuple[tp.Any, M]:
-      module = self.clone()
+      module = graph_utils.clone(self)
       fn = accessor(module)
       out = fn(*args, **kwargs)
       return out, module
 
     return CallableProxy(_apply)  # type: ignore
 
-  def update(
-    self: M, update: graph_utils.Updates[M], /, *updates: graph_utils.Updates[M]
-  ) -> None:
-    graph_utils.update(self, update, *updates)
+  def update(self, state: State, *states: State) -> None:
+    graph_utils.update(self, state, *states)
 
   def sow(
     self,
@@ -368,7 +365,7 @@ class Module(graph_utils.GraphNode, metaclass=ModuleMeta):
 # Pytree Definition
 # -------------------------
 def _module_flatten(module: Module, *, with_keys: bool):
-  graphdef, state = module.split()
+  graphdef, state = graph_utils.split(module)
   key_values = sorted(state.raw_mapping.items())
   keys = tuple(key for key, _ in key_values)
 

--- a/flax/experimental/nnx/nnx/spmd.py
+++ b/flax/experimental/nnx/nnx/spmd.py
@@ -106,7 +106,7 @@ def get_partition_spec(tree: A) -> A:
 
     return _maybe_replicate(x)
 
-  return jax.tree_map(
+  return jax.tree_util.tree_map(
     f, tree, is_leaf=lambda x: isinstance(x, variables.Variable)
   )
 

--- a/flax/experimental/nnx/nnx/state.py
+++ b/flax/experimental/nnx/nnx/state.py
@@ -77,7 +77,7 @@ class State(tp.MutableMapping[Key, tp.Any], reprlib.Representable):
       super().__setattr__('_mapping', dict(mapping))
 
   @property
-  def raw_mapping(self) -> dict[Key, dict[str, tp.Any] | tp.Any]:
+  def raw_mapping(self) -> dict[Key, dict[Key, tp.Any] | tp.Any]:
     return self._mapping
 
   def __getitem__(self, key: Key) -> State | StateLeaf:

--- a/flax/experimental/nnx/tests/test_graph_utils.py
+++ b/flax/experimental/nnx/tests/test_graph_utils.py
@@ -25,21 +25,22 @@ class TestGraphUtils:
     a = {'a': 1, 'b': nnx.Param(2)}
     g = [a, 3, a, nnx.Param(4)]
 
-    static, state, ref_idx = nnx.graph_utils.graph_flatten(g)
+    static, state, refmap = nnx.graph_utils.graph_flatten(g)
+    assert refmap is not None
 
     state[0]['b'].raw_value = 2
     state[3].raw_value = 4
 
-    assert len(ref_idx) == 2
-    assert a['b'] in ref_idx
-    assert g[3] in ref_idx
+    assert len(refmap) == 2
+    assert a['b'] in refmap
+    assert g[3] in refmap
 
   def test_unflatten(self):
     a = nnx.Dict(a=1, b=nnx.Param(2))
     g = nnx.List([a, 3, a, nnx.Param(4)])
 
-    static, state, _ = nnx.graph_utils.graph_flatten(g)
-    g = static.merge(state)
+    static, state = nnx.split(g)
+    g = nnx.merge(static, state)
 
     assert g[0] is g[2]
 
@@ -47,8 +48,8 @@ class TestGraphUtils:
     a = {'a': 1, 'b': nnx.Param(2)}
     g = [a, 3, a, nnx.Param(4)]
 
-    static, state, _ = nnx.graph_utils.graph_flatten(g)
-    g = static.merge(state)
+    static, state = nnx.split(g)
+    g = nnx.merge(static, state)
 
     assert g[0] is not g[2]
 
@@ -56,7 +57,7 @@ class TestGraphUtils:
     a = nnx.Dict({'a': 1, 'b': nnx.Param(2)})
     g = nnx.List([a, 3, a, nnx.Param(4)])
 
-    static, state, _ = nnx.graph_utils.graph_flatten(g)
+    static, state = nnx.split(g)
     g = static.merge(nnx.State({}))
 
     assert g[0] is g[2]
@@ -67,10 +68,10 @@ class TestGraphUtils:
     a = {'a': 1, 'b': nnx.Param(2)}
     g = [a, 3, a, nnx.Param(4)]
 
-    static, state, _ = nnx.graph_utils.graph_flatten(g)
+    static, state = nnx.split(g)
 
     state[0]['b'].raw_value = 3
-    nnx.graph_utils.graph_update_dynamic(g, state)
+    nnx.graph_utils.update(g, state)
 
     assert g[0]['b'].raw_value == 3
     assert g[2]['b'].raw_value == 3
@@ -123,7 +124,7 @@ class TestGraphUtils:
       nnx.BatchNorm(2, rngs=rngs),
     ]
 
-    static, state, _ = nnx.graph_utils.graph_flatten(ls)
+    static, state = nnx.split(ls)
 
     assert state[0]['kernel'].raw_value.shape == (2, 2)
     assert state[0]['bias'].raw_value.shape == (2,)
@@ -136,7 +137,7 @@ class TestGraphUtils:
     v = nnx.Param(1)
     g = [v, v]
 
-    static, state, _ = nnx.graph_utils.graph_flatten(g)
+    static, state = nnx.split(g)
 
     assert len(state.flat_state()) == 1
 
@@ -154,7 +155,7 @@ class TestGraphUtils:
         self.baz.kernel = self.bar.kernel
 
     node = Foo(rngs=nnx.Rngs(0))
-    static, state, _ = nnx.graph_utils.graph_flatten(node)
+    static, state = nnx.split(node)
 
     assert len(state.flat_state()) == 3  # 2 bias + 1 kernel
 
@@ -282,7 +283,7 @@ class TestGraphUtils:
 
     assert 'tree' in state
     assert 'a' in state.tree
-    assert static.subgraphs['tree'].type is nnx.graph_utils.PytreeType
+    assert static.nodedef.subgraphs['tree'].type is nnx.graph_utils.PytreeType
 
     m2 = static.merge(state)
 
@@ -327,7 +328,7 @@ class TestGraphUtils:
       ref_out_idx_out, idx_out_idx_in
     )
     m2, _ = nnx.graph_utils.graph_unflatten(
-      static, state, ref_cache=idx_in_ref_out
+      static, state, idxmap=idx_in_ref_out
     )
     assert m2 is m
     assert m2.a is b
@@ -368,7 +369,7 @@ class TestGraphUtils:
       ref_out_idx_out, idx_out_idx_in
     )
     m2, _ = nnx.graph_utils.graph_unflatten(
-      static, state, ref_cache=idx_in_ref_out
+      static, state, idxmap=idx_in_ref_out
     )
     assert m2 is m
     assert m2.a is b
@@ -406,7 +407,7 @@ class TestGraphUtils:
       ref_out_idx_out, idx_out_idx_in
     )
     m2, _ = nnx.graph_utils.graph_unflatten(
-      static, state, ref_cache=idx_in_ref_out
+      static, state, idxmap=idx_in_ref_out
     )
     assert m2 is m
     assert m2.ref is m2

--- a/flax/experimental/nnx/tests/test_module.py
+++ b/flax/experimental/nnx/tests/test_module.py
@@ -51,14 +51,14 @@ class TestModule:
   def test_tree_map(self):
     m = nnx.Dict(a=nnx.Param(1))
 
-    static, state = m.split()
+    static, state = nnx.split(m)
 
     state = jax.tree_util.tree_map(lambda x: x + 1, state)
 
   def test_split_2(self):
     m = nnx.Dict(a=nnx.Param(1))
 
-    empty, some, static = m.split(None, ...)
+    static, empty, some = nnx.split(m, None, ...)
 
     some = jax.tree_util.tree_map(lambda x: x + 1, some)
 
@@ -69,9 +69,9 @@ class TestModule:
     def g(graphdef: nnx.GraphDef[nnx.Dict[int]], state: nnx.State):
       m = graphdef.merge(state)
       m.a = 2
-      return m.split()
+      return nnx.split(m)
 
-    graphdef, state = g(*m.split())
+    graphdef, state = g(*nnx.split(m))
     m2 = graphdef.merge(state)
 
     assert m2.a == 2
@@ -109,7 +109,7 @@ class TestModule:
     m1 = nnx.Dict(a=nnx.Param(1), b=nnx.Param(2))
     m2 = nnx.Dict(x=m1, y=m1, z=nnx.Param(3))
 
-    m3 = nnx.merge(*m2.split())
+    m3 = nnx.merge(*nnx.split(m2))
 
     assert m3['x'] is m3['y']
     assert m3['x']['a'] is m3['y']['a']
@@ -123,7 +123,7 @@ class TestModule:
 
     m = Foo()
 
-    graphdef, state = m.split()
+    graphdef, state = nnx.split(m)
     assert len(state) == 1
 
     m2 = graphdef.merge(state)
@@ -142,9 +142,9 @@ class TestModule:
       assert m['a'][0] is m['b']
       assert m['a'][1] is not m['b']
 
-      return m.split()
+      return nnx.split(m)
 
-    graphdef, state = f(*m.split())
+    graphdef, state = f(*nnx.split(m))
     m = graphdef.merge(state)
 
     assert m['a'][0] is m['b']
@@ -162,9 +162,9 @@ class TestModule:
     def g(graphdef: nnx.GraphDef[nnx.Dict[nnx.Param[int]]], state: nnx.State):
       m = graphdef.merge(state)
       m.a.value += 1
-      return m.split()
+      return nnx.split(m)
 
-    graphdef, state = g(*m.split())
+    graphdef, state = g(*nnx.split(m))
     m2 = graphdef.merge(state)
     assert m2 is not m
     assert m.a.value == 1
@@ -180,23 +180,23 @@ class TestModule:
       n += 1
       m = nnx.merge(*state_and_def)
       m.a.value += 1
-      return m.split()
+      return nnx.split(m)
 
-    m2 = nnx.merge(*g(m.split()))
+    m2 = nnx.merge(*g(nnx.split(m)))
 
     assert n == 1
     assert m2 is not m
     assert m.a.value == 1
     assert m2.a.value == 2
 
-    g(m.split())
+    g(nnx.split(m))
     assert n == 1
 
-    g(m2.split())
+    g(nnx.split(m2))
     assert n == 1
 
     m2.b = nnx.Param(10)
-    g(m2.split())
+    g(nnx.split(m2))
 
     assert n == 2
 
@@ -211,7 +211,7 @@ class TestModule:
       }
     )
 
-    graphdef, p = m.split()
+    graphdef, p = nnx.split(m)
     assert len(p.flat_state()) == 2
     assert len(jax.tree_util.tree_leaves(p)) == 2
 
@@ -221,7 +221,7 @@ class TestModule:
       b=nnx.Dict(c=nnx.Param(1), d=nnx.Param(2)),
     )
 
-    m2 = m.clone()
+    m2 = nnx.clone(m)
 
     assert m is not m2
     assert m2.a[0] == m2.b.c
@@ -247,7 +247,7 @@ class TestModule:
     assert y2 == 11
     assert m.y.value == (3, 11)
 
-    intermediates = m.pop(nnx.Intermediate)
+    intermediates = nnx.pop(m, nnx.Intermediate)
 
     assert isinstance(intermediates.y, nnx.Intermediate)
     assert intermediates['y'].raw_value == (3, 11)
@@ -284,32 +284,6 @@ class TestModule:
     with pytest.raises(ValueError, match='to be of type'):
       m(2)
 
-  def test_update_static_state(self):
-    class Foo(nnx.Module):
-      def add_field(self):
-        self.a = 1
-
-    m1 = Foo()
-    m2 = Foo()
-    m2.add_field()
-
-    m1.update(m2)
-
-    assert m1.a == 1
-
-  def test_update_moduledef(self):
-    class Foo(nnx.Module):
-      def add_field(self):
-        self.a = 1
-
-    m1 = Foo()
-    m2 = Foo()
-    m2.add_field()
-
-    m1.update(m2.get_graphdef())
-
-    assert m1.a == 1
-
   def test_update_static_state_submodules(self):
     class Bar(nnx.Module):
       def __init__(self) -> None:
@@ -324,10 +298,13 @@ class TestModule:
         self.b = self.a
 
     m1 = Foo()
-    m2 = Foo()
-    m2.a.add_field()
+    with nnx.UpdateContext() as ctx:
+      graphdef, state = ctx.split(m1)
+      m2 = ctx.merge(graphdef, state)
+      m2.a.add_field()
+      new_graphdef, state = ctx.split(m2)
 
-    m1.update(m2)
+      ctx.update(new_graphdef, state)
 
     assert m1.a.x == 1
     assert m1.a.y == 2
@@ -347,10 +324,13 @@ class TestModule:
         self.b = Bar()
 
     m1 = Foo()
-    m2 = Foo()
+    ctx = nnx.UpdateContext()
+    graphdef, state = ctx.split(m1)
+    m2 = ctx.merge(graphdef, state)
     m2.add_module()
+    new_graphdef, state = ctx.split(m2)
 
-    m1.update(m2)
+    ctx.update(new_graphdef, state)
 
     assert m1.a.x == 1
     assert m1.b.x == 1
@@ -366,15 +346,17 @@ class TestModule:
         self.b = self.a
 
     m1 = Foo()
-    m2 = Foo()
+    ctx = nnx.UpdateContext()
+    graphdef, state = ctx.split(m1)
+    m2 = ctx.merge(graphdef, state)
     m2.a.x = 2
-
-    m1.update(m2)
+    new_graphdef, state = ctx.split(m2)
+    ctx.update(new_graphdef, state)
 
     assert m1.a.x == 2
     assert m1.b.x == 2
 
-  def test_update_add_shared_error(self):
+  def test_update_add_shared(self):
     class Bar(nnx.Module):
       def __init__(self) -> None:
         self.x = 1
@@ -388,37 +370,14 @@ class TestModule:
         self.c = self.a
 
     m1 = Foo()
-    m2 = Foo()
+    ctx = nnx.UpdateContext()
+    graphdef, state = ctx.split(m1)
+    m2 = ctx.merge(graphdef, state)
     m2.add_submodule()
+    new_graphdef, state = ctx.split(m2)
+    ctx.update(new_graphdef, state)
 
-    assert hasattr(m2, 'c')
-
-    with pytest.raises(ValueError, match='Trying to add a new node at path'):
-      m1.update(m2)
-
-  def test_update_add_shared_error_new_first(self):
-    class Bar(nnx.Module):
-      def __init__(self) -> None:
-        self.x = 1
-
-    class Foo(nnx.Module):
-      def __init__(self) -> None:
-        self.b = Bar()
-        self.c = self.b
-
-      def add_submodule(self):
-        self.a = self.b
-
-    m1 = Foo()
-    m2 = Foo()
-    m2.add_submodule()
-
-    assert hasattr(m2, 'a')
-
-    m2 = m2.clone()  # clone to sort the fields
-
-    with pytest.raises(ValueError, match='Trying to update a node at path'):
-      m1.update(m2)
+    assert hasattr(m1, 'c')
 
   def test_create_abstract(self):
     linear = nnx.Linear.create_abstract(2, 3, rngs=nnx.Rngs(0))
@@ -542,7 +501,7 @@ class TestModuleDataclass:
       f=6,  # static int
     )
 
-    graphdef, state = m.split()
+    graphdef, state = nnx.split(m)
 
     assert len(state) == 4
     assert state.b == nnx.Variable(2)


### PR DESCRIPTION
# What does this PR do?

Adds the `UpdateContex` API that contains special versions of `split`, `merge`, and `update` which are able to perform full graph updates.

```python
with nnx.UpdateContext() as ctx:
  m = Foo()
  graphdef, state = ctx.split(m)

  @jax.jit
  def f_pure(graphdef, state):
    m = ctx.merge(graphdef, state)
    f(m)
    graphdef, state = ctx.split(m)
    return graphdef, state

  graphdef, state = f(graphdef, state)
  
  ctx.update(graphdef, state)
```

To make this possible `GraphDef` is renamed to `NodeDef` and a new `GraphDef` dataclass is defined which contains both the `NodeDef` and a `index_mapping` which is populated by the second `ctx.split` and used by `ctx.update`.

```python
@dataclasses.dataclass(frozen=True)
class GraphDef(tp.Generic[Node], reprlib.Representable):
  nodedef: NodeDef[Node]
  index_mapping: dict[Index, Index] | None
```
