### PR TITLE
[NVIDIA] Extend the custom fp8 accumulate dtype in non-jit scenarios

### DIFF
--- a/tests/linen/linen_test.py
+++ b/tests/linen/linen_test.py
@@ -1244,7 +1244,7 @@ class IdsTest(absltest.TestCase):
     self.assertNotEqual(hash(id1), hash(id1dc))
 
 
-class Fp8Test(absltest.TestCase):
+class Fp8Test(parameterized.TestCase):
   def test_fp8_dot_general_injection(self):
     # Used to cast the inputs to be representable in FP8, so that the difference
     # of the results from the original gemm and fp8 gemm is small.
@@ -1389,7 +1389,8 @@ class Fp8Test(absltest.TestCase):
       np.testing.assert_allclose(fp8_vars['kernel_scale'][0], scale_k)
       np.testing.assert_allclose(fp8_vars['output_grad_scale'][0], scale_g)
 
-  def test_fp8_meta_dtype(self):
+  @parameterized.parameters([True, False])
+  def test_fp8_meta_dtype(self, use_jit):
     f32 = jnp.dtype('float32')
     fm32 = fp8_ops.fm32
 
@@ -1406,7 +1407,9 @@ class Fp8Test(absltest.TestCase):
       array_x, _ = jax.lax.scan(body_fun, array_x, None, length=3)
       return array_x[0]
 
-    outer_fn = jax.jit(jax.grad(outer, (0, 1, 2)))
+    outer_fn = jax.grad(outer, (0, 1, 2))
+    if use_jit:
+      outer_fn = jax.jit(outer_fn)
     ah = jnp.array([0., 0., 0.], f32)
     sf = jnp.array([1.], f32)
     # 1st iteration

--- a/tests/linen/linen_test.py
+++ b/tests/linen/linen_test.py
@@ -1391,6 +1391,8 @@ class Fp8Test(parameterized.TestCase):
 
   @parameterized.parameters([True, False])
   def test_fp8_meta_dtype(self, use_jit):
+    if not use_jit and not fp8_ops.CAN_USE_EARRAY:
+      self.skipTest("TODO: requires newer jax that has earray")
     f32 = jnp.dtype('float32')
     fm32 = fp8_ops.fm32
 


### PR DESCRIPTION
This PR extends the custom fp8 dtype in the non-jit scenarios. The custom fp8 dtype is for the grad accumulation where we can do a max op rather than the default add op to accumulate the grads. This is designed for the fp8 parameters whose grads are their new values and we only want to pick the max among the grads of the sub-tensors.

Previously, this custom dtype has to be in the jit scope and this PR relaxes that restriction.

Note, this PR depends on https://github.com/google/jax/pull/20266

cc. @nluehr @mingxu1067 