### PR TITLE
added `tree_map` deprecation warning filter

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -144,6 +144,8 @@ filterwarnings = [
     "ignore:.*pkg_resources is deprecated as an API.*:DeprecationWarning",
     # DeprecationWarning: Deprecated call to `pkg_resources.declare_namespace('google')`.
     "ignore:.*Deprecated call to.*pkg_resources.declare_namespace.*:DeprecationWarning",
+    # DeprecationWarning: jax.tree_map is deprecated: use jax.tree.map (jax v0.4.25 or newer) or jax.tree_util.tree_map (any JAX version).
+    "ignore:.*jax.tree_map is deprecated.*:DeprecationWarning",
 ]
 
 [tool.coverage.report]


### PR DESCRIPTION
Added `tree_map` deprecation warning filter. This is to unblock HEAD, since Flax is getting an [error](https://github.com/google/flax/actions/runs/8562140920/job/23464811629?pr=3797#step:9:467) because CLU has a deprecation warning. The deprecation warning is fixed [here](https://github.com/google/CommonLoopUtils/pull/342) but we have to wait for CLU to do a new release.