### PR TITLE
[linen] enable separate initializers for out layer in MultiHeadDotProductAttention

### DIFF
--- a/flax/experimental/nnx/nnx/nn/attention.py
+++ b/flax/experimental/nnx/nnx/nn/attention.py
@@ -281,7 +281,11 @@ class MultiHeadAttention(Module):
     precision: numerical precision of the computation see `jax.lax.Precision`
       for details.
     kernel_init: initializer for the kernel of the Dense layers.
+    out_kernel_init: optional initializer for the kernel of the output Dense layer,
+      if None, the kernel_init is used.
     bias_init: initializer for the bias of the Dense layers.
+    out_bias_init: optional initializer for the bias of the output Dense layer,
+      if None, the bias_init is used.
     use_bias: bool: whether pointwise QKVO dense transforms use bias.
     attention_fn: dot_product_attention or compatible function. Accepts query,
       key, value, and returns output of shape `[bs, dim1, dim2, ..., dimN,,
@@ -304,7 +308,9 @@ class MultiHeadAttention(Module):
     deterministic: bool | None = None,
     precision: PrecisionLike = None,
     kernel_init: Initializer = default_kernel_init,
+    out_kernel_init: Initializer | None = None,
     bias_init: Initializer = initializers.zeros_init(),
+    out_bias_init: Initializer | None = None,
     use_bias: bool = True,
     attention_fn: Callable[..., Array] = dot_product_attention,
     decode: bool | None = None,
@@ -331,7 +337,9 @@ class MultiHeadAttention(Module):
     self.deterministic = deterministic
     self.precision = precision
     self.kernel_init = kernel_init
+    self.out_kernel_init = out_kernel_init
     self.bias_init = bias_init
+    self.out_bias_init = out_bias_init
     self.use_bias = use_bias
     self.attention_fn = attention_fn
     self.decode = decode
@@ -393,8 +401,8 @@ class MultiHeadAttention(Module):
       in_features=(self.num_heads, self.head_dim),
       out_features=self.out_features,
       axis=(-2, -1),
-      kernel_init=self.kernel_init,
-      bias_init=self.bias_init,
+      kernel_init=self.out_kernel_init or self.kernel_init,
+      bias_init=self.out_bias_init or self.bias_init,
       use_bias=self.use_bias,
       dtype=self.dtype,
       param_dtype=self.param_dtype,

--- a/flax/linen/attention.py
+++ b/flax/linen/attention.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 """Attention core modules for Flax."""
+from __future__ import annotations
 
 import functools
 import warnings
@@ -281,7 +282,11 @@ class MultiHeadDotProductAttention(Module):
     precision: Numerical precision of the computation see ``jax.lax.Precision``
       for details.
     kernel_init: Initializer for the kernel of the Dense layers.
+    out_kernel_init: Optional Initializer for the kernel of the output Dense layer,
+      if None, ``kernel_init`` will be used.
     bias_init: Initializer for the bias of the Dense layers.
+    out_bias_init: Optional Initializer for the bias of the output Dense layer,
+      if None, ``bias_init`` will be used.
     use_bias: Whether pointwise QKVO dense transforms use bias.
     attention_fn: dot_product_attention or compatible function. Accepts query,
       key, value, and returns output of shape ``[bs, dim1, dim2, ..., dimN,,
@@ -300,7 +305,9 @@ class MultiHeadDotProductAttention(Module):
   deterministic: Optional[bool] = None
   precision: PrecisionLike = None
   kernel_init: Initializer = default_kernel_init
+  out_kernel_init: Initializer | None = None
   bias_init: Initializer = initializers.zeros_init()
+  out_bias_init: Initializer | None = None
   use_bias: bool = True
   attention_fn: Callable[..., Array] = dot_product_attention
   decode: bool = False
@@ -572,8 +579,8 @@ class MultiHeadDotProductAttention(Module):
     out = DenseGeneral(
       features=features,
       axis=(-2, -1),
-      kernel_init=self.kernel_init,
-      bias_init=self.bias_init,
+      kernel_init=self.out_kernel_init or self.kernel_init,
+      bias_init=self.out_bias_init or self.bias_init,
       use_bias=self.use_bias,
       dtype=self.dtype,
       param_dtype=self.param_dtype,


### PR DESCRIPTION
# What does this PR do?

Adds `out_kernel_init` and `out_bias_init` Initializer arguments so users can specify the initializers for the `out` layer independently. This is useful main to be able to define a different sharding scheme for that layer.