### PR TITLE
Fix minor typos in docstring and markdown file

### DIFF
--- a/docs/guides/flax_fundamentals/arguments.md
+++ b/docs/guides/flax_fundamentals/arguments.md
@@ -21,7 +21,7 @@ And some clear call time arguments:
 There is however one property that is ambiguous -- the `deterministic` property in a Dropout module.
 
 If `deterministic` is `True` no dropout mask is sampled. This is typically used during model evaluation.
-However, if we pass `eval=True` or `train=False` to a top-level Module. The `deterministic` argument needs
+However, if we pass `eval=True` or `train=False` to a top-level Module, the `deterministic` argument needs
 to be applied everywhere and the boolean argument needs to be passed down to all the layers that might use `Dropout`.
 If instead `deterministic` is a dataclass attribute, we might do the following:
 

--- a/flax/linen/module.py
+++ b/flax/linen/module.py
@@ -2192,7 +2192,7 @@ class Module(ModuleBase):
 
     Returns:
       If ``mutable`` is False, returns output. If any collections are
-      mutable, returns ``(output, vars)``, where ``vars`` are is a dict
+      mutable, returns ``(output, vars)``, where ``vars`` is a dict
       of the modified collections.
     """
     Module._module_checks(self)


### PR DESCRIPTION
# What does this PR do?

<!--

Great, you are contributing to Flax!

But... please read the following carefully so we can make sure your PR is merged
easily.

Replace this text block with a description of the change and which issue it
fixes (if applicable). Please also include relevant motivation/context.

Once you're done, someone in the Flax team will review your PR shortly. They may
suggest changes to make the code even better. If no one reviewed your PR after a
week has passed, don't hesitate to post a new comment @-mentioning the same
persons (sometimes notifications get lost).
-->

Fix small typo in docstring of `flax.linen.Module.init_with_output` and another one in guide "Dealing with Flax Module arguments".

## Checklist
- [x] This PR fixes a minor issue (e.g.: typo or small bug) or improves the docs (you can dismiss the other
      checks if that's the case).
- [ ] This change is discussed in a Github issue/
      [discussion](https://github.com/google/flax/discussions) (please add a
      link).
- [ ] The documentation and docstrings adhere to the
      [documentation guidelines](https://github.com/google/flax/blob/main/docs/README.md#how-to-write-code-documentation).
- [ ] This change includes necessary high-coverage tests.
      (No quality testing = no merge!)
