### PR TITLE
Minor doc formatting fixes for `flax.linen.Module.init_with_output`

### DIFF
--- a/flax/linen/module.py
+++ b/flax/linen/module.py
@@ -2178,7 +2178,7 @@ class Module(ModuleBase):
         module. If provided, applies this method. If not provided, applies the
         ``__call__`` method of the module. A string can also be provided to
         specify a method by name.
-      mutable: Can be bool, str, or list. Specifies which collections should be
+      mutable: Can be `bool`, `str`, or `list`. Specifies which collections should be
         treated as mutable: ``bool``: all/no collections are mutable. ``str``:
         The name of a single mutable collection. ``list``: A list of names of
         mutable collections.
@@ -2192,7 +2192,7 @@ class Module(ModuleBase):
 
     Returns:
       If ``mutable`` is False, returns output. If any collections are
-      mutable, returns ``(output, vars)``, where ``vars`` are is a dict
+      mutable, returns ``(output, vars)``, where ``vars`` is a dict
       of the modified collections.
     """
     Module._module_checks(self)


### PR DESCRIPTION
Fix small grammatical typos and formatting issues that appear in the `flax.linen.Module.init_with_output` docstring.

## Checklist
- [x] This PR fixes a minor issue (e.g.: typo or small bug) or improves the docs