### PR TITLE
Minor typo fix in `flax_fundamentals/flax_basics.ipynb`

### DIFF
--- a/docs/guides/flax_fundamentals/flax_basics.ipynb
+++ b/docs/guides/flax_fundamentals/flax_basics.ipynb
@@ -506,7 +506,7 @@
    "source": [
     "### Module basics\n",
     "\n",
-    "The base abstraction for models is the `nn.Module` class, and every type of predefined layers in Flax (like the previous `Dense`) is a subclass of `nn.Module`. Let's take a look and start by defining a simple but custom multi-layer perceptron i.e. a sequence of Dense layers interleaved with calls to a non-linear activation function."
+    "The base abstraction for models is the `nn.Module` class, and every type of predefined layer in Flax (like the previous `Dense`) is a subclass of `nn.Module`. Let's take a look and start by defining a simple but custom multi-layer perceptron i.e. a sequence of Dense layers interleaved with calls to a non-linear activation function."
    ]
   },
   {


### PR DESCRIPTION
Minor grammar typo fix in the introductory ipython notebook called `flax_basics.ipynb`