### PR TITLE
Make ConvLSTMCell.__call__ infer the number of features from its input, like the other recurrent cells.

### DIFF
--- a/flax/linen/recurrent.py
+++ b/flax/linen/recurrent.py
@@ -828,9 +828,10 @@ class ConvLSTMCell(RNNCellBase):
       A tuple with the new carry and the output.
     """
     c, h = carry
+    features = c.shape[-1]
     input_to_hidden = partial(
       Conv,
-      features=4 * self.features,
+      features=4 * features,
       kernel_size=self.kernel_size,
       strides=self.strides,
       padding=self.padding,
@@ -842,7 +843,7 @@ class ConvLSTMCell(RNNCellBase):
 
     hidden_to_hidden = partial(
       Conv,
-      features=4 * self.features,
+      features=4 * features,
       kernel_size=self.kernel_size,
       strides=self.strides,
       padding=self.padding,


### PR DESCRIPTION
Partially addresses #3717 by bringing [`ConvLSTMCell`](https://flax.readthedocs.io/en/latest/api_reference/flax.linen/layers.html#flax.linen.ConvLSTMCell) in line with other recurrent cells, in terms of inferring `features` from the inputs to `__call__`.