### PR TITLE
Make FlatState a Mapping instead of a dict

### DIFF
--- a/flax/experimental/nnx/nnx/state.py
+++ b/flax/experimental/nnx/nnx/state.py
@@ -27,6 +27,7 @@
 # limitations under the License.
 from __future__ import annotations
 
+from collections.abc import Mapping
 import typing as tp
 import typing_extensions as tpe
 
@@ -42,7 +43,7 @@ from flax.typing import Key, PathParts
 A = tp.TypeVar('A')
 
 StateLeaf = tp.Union[VariableState[tp.Any], np.ndarray, jax.Array]
-FlatState = dict[PathParts, StateLeaf]
+FlatState = Mapping[PathParts, StateLeaf]
 
 
 def is_state_leaf(x: tp.Any) -> tpe.TypeGuard[StateLeaf]:
@@ -66,8 +67,8 @@ class State(tp.MutableMapping[Key, tp.Any], reprlib.Representable):
   def __init__(
     self,
     mapping: tp.Union[
-      tp.Mapping[Key, tp.Mapping | StateLeaf],
-      tp.Iterator[tuple[Key, tp.Mapping | StateLeaf]],
+      Mapping[Key, Mapping | StateLeaf],
+      tp.Iterator[tuple[Key, Mapping | StateLeaf]],
     ],
     /,
   ):


### PR DESCRIPTION
Other changes:
* Since `nnx.State` calls `flatten_dict`, make the `traverse_util.flatten_dict` accept mappings.
* Add a type annotation to `flatten_dict` so that any future changes to the function (e.g., changing it back to work with dicts only) triggers a type error.
* Add the appropriate type overloads to the signature to satisfy MyPy errors.
* Minor tweaks to imports:
  * import from `collections.abc` instead of `typing` since the latter imports are deprecated.
  * Import from `flax.typing` instead of `flax.core.scope` since the latter has been moved.
* Add `from __future__ import annotations` so that the annotations work on Python 3.9.
* Add `pytype: skip-file` to work around google/pytype#1619.
* Annotate some private functions to make them easier to understand.
* When printing a type, print its `__qualname__` since that's a bit easier to read (`str` instead of `<class 'str'>`).

Fixes https://github.com/google/flax/issues/3879