### PR TITLE
updated `robots.txt`

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -108,6 +108,8 @@ html_title = ''
 # so a file named 'default.css' will overwrite the builtin 'default.css'.
 html_static_path = ['_static']
 
+html_extra_path = ['robots.txt']
+
 html_theme_options = {
   'repository_url': 'https://github.com/google/flax',
   'use_repository_button': True,  # add a 'link to repository' button

--- a/docs/robots.txt
+++ b/docs/robots.txt
@@ -1,0 +1,5 @@
+User-agent: *
+
+Disallow: /api_reference/flax.linen/_autosummary/ # for SEO, since Google still indexes this deprecated link
+
+Sitemap: https://flax.readthedocs.io/sitemap.xml


### PR DESCRIPTION
Resolves #3854.

Updated `robots.txt` to omit Google search from indexing the deprecated `_autosummary` links (currently they are getting 404 errors).

More details on adding `robots.txt` to RTD:
* [RTD SEO](https://docs.readthedocs.io/en/stable/guides/technical-docs-seo-guide.html#use-a-robots-txt-file)
* [RTD `robots.txt`](https://docs.readthedocs.io/en/stable/reference/robots.html)
* [Sphinx documentation on `html_extra_path`](https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-html_extra_path)
* Example usages:
  * https://test-builds.readthedocs.io/en/robots-txt/
  * https://github.com/SpecFlowOSS/Getting-Started-Step-By-Step/tree/main