### PR TITLE
fixed codecov

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -142,7 +142,9 @@ jobs:
         fi
     - name: Upload coverage to Codecov
       if: matrix.test-type == 'pytest'
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v4
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       with:
         file: ./coverage.xml
     # The below step just reports the success or failure of tests as a "commit status".


### PR DESCRIPTION
Fixed [codecov error](https://github.com/google/flax/actions/runs/8892851127/job/24417876497?pr=3891#step:10:53) breaking HEAD: `{'detail': ErrorDetail(string='Rate limit reached. Please upload with the Codecov repository upload token to resolve issue. Expected available in 800 seconds.', code='throttled')}`

For context, other people are also having [issues](https://github.com/codecov/codecov-action/issues/1373#issuecomment-2082850573) with this error. 

To resolve this error, I followed the steps outlined [here](https://docs.codecov.com/docs/adding-the-codecov-token):
* go to https://app.codecov.io/ and sign in to your github account
* go to the 'Repos' tab and find Flax and click the "Configure" button
* copy the `CODECOV_TOKEN` and add it to Github actions (Settings --> Secrets and variables --> Actions --> Repository secrets --> New repository secret)
* copy the following into the `.github/workflows/build.yml` file:
```
- name: Upload coverage reports to Codecov
    uses: codecov/codecov-action@v4.0.1
    with:
      token: ${{ secrets.CODECOV_TOKEN }}
```
