### PR TITLE
[nnx] cleanup graph

### DIFF
--- a/flax/experimental/nnx/tests/test_graph_utils.py
+++ b/flax/experimental/nnx/tests/test_graph_utils.py
@@ -60,9 +60,7 @@ class TestGraphUtils:
 
     graphdef, state = nnx.split(g)
 
-    with pytest.raises(
-      ValueError, match='Expected key for Variable but was not found in state'
-    ):
+    with pytest.raises(ValueError, match='Expected key'):
       nnx.graph.unflatten(graphdef, nnx.State({}))
 
   def test_update_dynamic(self):


### PR DESCRIPTION
# What does this PR do?

* Renames `NodeDef.variables` to `leaves`.
* Changes to type of `NodeDef.leaves` to allow passing `None` indexes.
* Adds non-VariableState leaves to `NodeDef.leaves` during flattening with a `None` index.
* Adds more comments to the unflatten code and cleans up the logic a bit.