### PR TITLE
[nnx] fix bugs

### DIFF
--- a/flax/experimental/nnx/nnx/graph.py
+++ b/flax/experimental/nnx/nnx/graph.py
@@ -1027,7 +1027,7 @@ def state(
   elif len(filters) == 1:
     states = state.filter(filters[0])
   else:
-    states = state.filter(filters[0], filters[1], *filters[1:])
+    states = state.filter(filters[0], filters[1], *filters[2:])
 
   return states
 

--- a/flax/experimental/nnx/nnx/transforms.py
+++ b/flax/experimental/nnx/nnx/transforms.py
@@ -1023,7 +1023,7 @@ def scan_apply(
 
   # infer length
   lengths: set[int] = set(
-    x.shape[axis]  # type: ignore
+    x.shape[0]  # type: ignore
     for x, axis in zip(flat_scan, flatdef.flat_axes)
     if axis is not None
   )


### PR DESCRIPTION
# What does this PR do?

* Fixes a bug in `nnx.state` that returned an additional argument when using 2 or more filters.
* Correctly estimates the `length` when using `scan`'s in_axis` argument.