### PR TITLE
[nnx] transforms refactor

### DIFF
--- a/flax/experimental/nnx/__init__.py
+++ b/flax/experimental/nnx/__init__.py
@@ -86,6 +86,7 @@ from .nnx.rnglib import RngStream as RngStream
 from .nnx.rnglib import RngState as RngState
 from .nnx.rnglib import RngKey as RngKey
 from .nnx.rnglib import RngCount as RngCount
+from .nnx.rnglib import ForkStates as ForkStates
 from .nnx.rnglib import fork as fork
 from .nnx.spmd import PARTITION_NAME as PARTITION_NAME
 from .nnx.spmd import get_partition_spec as get_partition_spec
@@ -109,6 +110,7 @@ from .nnx.transforms import scan as scan
 from .nnx.transforms import value_and_grad as value_and_grad
 from .nnx.transforms import vmap as vmap
 from .nnx.transforms import eval_shape as eval_shape
+from .nnx.transforms import cond as cond
 from .nnx.variables import EMPTY as EMPTY
 from .nnx.variables import A as A
 from .nnx.variables import BatchStat as BatchStat

--- a/flax/experimental/nnx/nnx/object.py
+++ b/flax/experimental/nnx/nnx/object.py
@@ -191,7 +191,7 @@ class Object(reprlib.Representable, metaclass=ObjectMeta):
     vars(node).update(_object__state=ObjectState())
     return node
 
-  def _graph_node_clear(self, cls: tp.Type[G]):
+  def _graph_node_clear(self):
     module_state = self._object__state
     module_vars = vars(self)
     module_vars.clear()


### PR DESCRIPTION
# What does this PR do?

* Adds `cond`
* Fixes issue with `scan` not caching properly
* Fixes issue with `scan` having different keys for the every step for non-`split_rngs` keys
* Refactored code for `jit` and `scan` (TODO: port the other transforms to the new simplified style).
* Refactors the implementation of `fork` to make it easier to use.
* `RngCount` now has a `tag` attribute (same as `RngKey`), this enable filtering counts as well (needed for `scan`).
* Fix tracer leakage issues on transforms.