### PR TITLE
Make FlatState a Mapping instead of a dict

### DIFF
--- a/flax/nnx/__init__.py
+++ b/flax/nnx/__init__.py
@@ -23,6 +23,7 @@ from .nnx import graph as graph
 from .nnx import errors as errors
 from .nnx import helpers as helpers
 from .nnx import compat as compat
+from .nnx import traversals as traversals
 from .nnx.filterlib import All as All
 from .nnx.filterlib import Not as Not
 from .nnx.graph import GraphDef as GraphDef

--- a/flax/nnx/examples/lm1b/models_test.py
+++ b/flax/nnx/examples/lm1b/models_test.py
@@ -26,7 +26,6 @@ import jax.numpy as jnp
 from absl.testing import absltest
 from jax import random
 
-from flax import traverse_util
 from flax import nnx
 from configs import default
 from models import TransformerConfig, TransformerLM
@@ -81,7 +80,7 @@ class ModelTest(absltest.TestCase):
   ):
     rules = dataclasses.asdict(config.axis_rules)
     flat_params_nnx = params_nnx.flat_state()
-    flat_params_linen = traverse_util.flatten_dict(params_linen, sep='/')
+    flat_params_linen = nnx.traversals.flatten_mapping(params_linen, sep='/')
 
     def apply_rules(names: tuple[str, ...]):
       return tuple(rules[name] for name in names)
@@ -165,7 +164,7 @@ class ModelTest(absltest.TestCase):
     cache_linen: dict[str, Any],
   ):
     flat_cache_nnx = cache_nnx.flat_state()
-    flat_cache_linen = traverse_util.flatten_dict(cache_linen, sep='/')
+    flat_cache_linen = nnx.traversals.flatten_mapping(cache_linen, sep='/')
 
     def copy_var(nnx_name: str, linen_name: str):
       nnx_path = tuple(nnx_name.split('/'))

--- a/flax/nnx/nnx/state.py
+++ b/flax/nnx/nnx/state.py
@@ -27,6 +27,7 @@
 # limitations under the License.
 from __future__ import annotations
 
+from collections.abc import Mapping
 import typing as tp
 import typing_extensions as tpe
 
@@ -34,7 +35,7 @@ import jax
 import jax.tree_util as jtu
 import numpy as np
 
-from flax import traverse_util
+from flax.nnx.nnx import traversals
 from flax.nnx.nnx import filterlib, reprlib
 from flax.nnx.nnx.variables import VariableState
 from flax.typing import Key, PathParts
@@ -42,7 +43,7 @@ from flax.typing import Key, PathParts
 A = tp.TypeVar('A')
 
 StateLeaf = tp.Union[VariableState[tp.Any], np.ndarray, jax.Array]
-FlatState = dict[PathParts, StateLeaf]
+FlatState = Mapping[PathParts, StateLeaf]
 
 
 def is_state_leaf(x: tp.Any) -> tpe.TypeGuard[StateLeaf]:
@@ -66,8 +67,8 @@ class State(tp.MutableMapping[Key, tp.Any], reprlib.Representable):
   def __init__(
     self,
     mapping: tp.Union[
-      tp.Mapping[Key, tp.Mapping | StateLeaf],
-      tp.Iterator[tuple[Key, tp.Mapping | StateLeaf]],
+      Mapping[Key, Mapping | StateLeaf],
+      tp.Iterator[tuple[Key, Mapping | StateLeaf]],
     ],
     /,
     *,
@@ -132,13 +133,13 @@ class State(tp.MutableMapping[Key, tp.Any], reprlib.Representable):
       yield reprlib.Attr(repr(k), v)
 
   def flat_state(self) -> FlatState:
-    return traverse_util.flatten_dict(self._mapping)  # type: ignore
+    return traversals.flatten_mapping(self._mapping)  # type: ignore
 
   @classmethod
   def from_flat_path(
     cls, flat_state: tp.Mapping[PathParts, StateLeaf], /
   ) -> State:
-    nested_state = traverse_util.unflatten_dict(flat_state)
+    nested_state = traversals.unflatten_mapping(flat_state)
     return cls(nested_state)
 
   @tp.overload

--- a/flax/nnx/nnx/traversals.py
+++ b/flax/nnx/nnx/traversals.py
@@ -1,0 +1,179 @@
+# Copyright 2024 The Flax Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Utilities for flattening and unflattening mappings.
+"""
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from typing import Any, Union, overload
+
+from flax import struct
+
+
+# the empty node is a struct.dataclass to be compatible with JAX.
+@struct.dataclass
+class _EmptyNode:
+  pass
+
+
+empty_node = _EmptyNode()
+
+
+# TODO: In Python 3.10, use TypeAlias.
+IsLeafCallable = Callable[[tuple[Any, ...], Mapping[Any, Any]], bool]
+
+
+@overload
+def flatten_mapping(xs: Mapping[Any, Any],
+                    /,
+                    *,
+                    keep_empty_nodes: bool = False,
+                    is_leaf: Union[None, IsLeafCallable] = None,
+                    sep: None = None
+                    ) -> dict[tuple[Any, ...], Any]:
+  ...
+
+@overload
+def flatten_mapping(xs: Mapping[Any, Any],
+                    /,
+                    *,
+                    keep_empty_nodes: bool = False,
+                    is_leaf: Union[None, IsLeafCallable] = None,
+                    sep: str,
+                    ) -> dict[str, Any]:
+  ...
+
+def flatten_mapping(xs: Mapping[Any, Any],
+                    /,
+                    *,
+                    keep_empty_nodes: bool = False,
+                    is_leaf: Union[None, IsLeafCallable] = None,
+                    sep: Union[None, str] = None
+                    ) -> dict[Any, Any]:
+  """Flatten a nested mapping.
+
+  The nested keys are flattened to a tuple. See ``unflatten_mapping`` on how to
+  restore the nested mapping.
+
+  Example::
+
+    >>> from flax.experimental import nnx
+    >>> xs = {'foo': 1, 'bar': {'a': 2, 'b': {}}}
+    >>> flat_xs = nnx.traversals.flatten_mapping(xs)
+    >>> flat_xs
+    {('foo',): 1, ('bar', 'a'): 2}
+
+  Note that empty mappings are ignored and will not be restored by
+  ``unflatten_mapping``.
+
+  Args:
+    xs: a nested mapping
+    keep_empty_nodes: replaces empty mappings with
+      ``traverse_util.empty_node``.
+    is_leaf: an optional function that takes the next nested mapping and nested
+      keys and returns True if the nested mapping is a leaf (i.e., should not be
+      flattened further).
+    sep: if specified, then the keys of the returned mapping will be
+      ``sep``-joined strings (if ``None``, then keys will be tuples).
+  Returns:
+    The flattened mapping.
+  """
+  assert isinstance(
+    xs, Mapping
+  ), f'expected Mapping; got {type(xs).__qualname__}'
+
+  def _key(path: tuple[Any, ...]) -> Union[tuple[Any, ...], str]:
+    if sep is None:
+      return path
+    return sep.join(path)
+
+  def _flatten(xs: Any, prefix: tuple[Any, ...]) -> dict[Any, Any]:
+    if not isinstance(xs, Mapping) or (
+      is_leaf and is_leaf(prefix, xs)
+    ):
+      return {_key(prefix): xs}
+    result = {}
+    is_empty = True
+    for key, value in xs.items():
+      is_empty = False
+      path = prefix + (key,)
+      result.update(_flatten(value, path))
+    if keep_empty_nodes and is_empty:
+      if prefix == ():  # when the whole input is empty
+        return {}
+      return {_key(prefix): empty_node}
+    return result
+
+  return _flatten(xs, ())
+
+
+@overload
+def unflatten_mapping(xs: Mapping[tuple[Any, ...], Any],
+                      /,
+                      *,
+                      sep: None = None
+                      ) -> dict[Any, Any]:
+  ...
+
+
+@overload
+def unflatten_mapping(xs: Mapping[str, Any],
+                      /,
+                      *,
+                      sep: str
+                      ) -> dict[Any, Any]:
+  ...
+
+
+def unflatten_mapping(xs: Any,
+                      /,
+                      *,
+                      sep: Union[str, None] = None
+                      ) -> dict[Any, Any]:
+  """Unflatten a mapping.
+
+  See ``flatten_mapping``
+
+  Example::
+
+    >>> from flax.experimental import nnx
+    >>> flat_xs = {
+    ...   ('foo',): 1,
+    ...   ('bar', 'a'): 2,
+    ... }
+    >>> xs = nnx.traversals.unflatten_mapping(flat_xs)
+    >>> xs
+    {'foo': 1, 'bar': {'a': 2}}
+
+  Args:
+    xs: a flattened mapping.
+    sep: separator (same as used with ``flatten_mapping()``).
+  Returns:
+    The nested mapping.
+  """
+  assert isinstance(xs, Mapping), f'expected Mapping; got {type(xs).__qualname__}'
+  result: dict[Any, Any] = {}
+  for path, value in xs.items():
+    if sep is not None:
+      path = path.split(sep)
+    if value is empty_node:
+      value = {}
+    cursor = result
+    for key in path[:-1]:
+      if key not in cursor:
+        cursor[key] = {}
+      cursor = cursor[key]
+    cursor[path[-1]] = value
+  return result

--- a/flax/nnx/tests/test_traversals.py
+++ b/flax/nnx/tests/test_traversals.py
@@ -1,0 +1,106 @@
+# Copyright 2024 The Flax Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for flax.experimental.nnx.traversal."""
+import jax
+from absl.testing import absltest
+
+from flax.core import freeze
+from flax.experimental.nnx import traversals
+
+# Parse absl flags test_srcdir and test_tmpdir.
+jax.config.parse_flags_with_absl()
+
+
+class TraversalTest(absltest.TestCase):
+  def test_flatten_mapping(self):
+    xs = {'foo': 1, 'bar': {'a': 2, 'b': {}}}
+    flat_xs = traversals.flatten_mapping(xs)
+    self.assertEqual(
+      flat_xs,
+      {
+        ('foo',): 1,
+        ('bar', 'a'): 2,
+      },
+    )
+    flat_xs = traversals.flatten_mapping(freeze(xs))
+    self.assertEqual(
+      flat_xs,
+      {
+        ('foo',): 1,
+        ('bar', 'a'): 2,
+      },
+    )
+    flat_xs = traversals.flatten_mapping(xs, sep='/')
+    self.assertEqual(
+      flat_xs,
+      {
+        'foo': 1,
+        'bar/a': 2,
+      },
+    )
+
+  def test_unflatten_mapping(self):
+    expected_xs = {'foo': 1, 'bar': {'a': 2}}
+    xs = traversals.unflatten_mapping(
+      {
+        ('foo',): 1,
+        ('bar', 'a'): 2,
+      }
+    )
+    self.assertEqual(xs, expected_xs)
+    xs = traversals.unflatten_mapping(
+      {
+        'foo': 1,
+        'bar/a': 2,
+      },
+      sep='/',
+    )
+    self.assertEqual(xs, expected_xs)
+
+  def test_flatten_mapping_keep_empty(self):
+    ys = {'a': {}}
+    xs = {'foo': 1, 'bar': {'a': 2, 'b': {}}}
+    flat_ys = traversals.flatten_mapping(ys, keep_empty_nodes=True)
+    flat_xs = traversals.flatten_mapping(xs, keep_empty_nodes=True)
+    empty_node = flat_ys[('a',)]
+    self.assertEqual(
+      flat_xs,
+      {
+        ('foo',): 1,
+        ('bar', 'a'): 2,
+        ('bar', 'b'): empty_node,
+      },
+    )
+    xs_restore = traversals.unflatten_mapping(flat_xs)
+    self.assertEqual(xs, xs_restore)
+
+  def test_flatten_mapping_is_leaf(self):
+    xs = {'foo': {'c': 4}, 'bar': {'a': 2, 'b': {}}}
+    flat_xs = traversals.flatten_mapping(
+      xs, is_leaf=lambda k, x: len(k) == 1 and len(x) == 2
+    )
+    self.assertEqual(
+      flat_xs,
+      {
+        ('foo', 'c'): 4,
+        ('bar',): {'a': 2, 'b': {}},
+      },
+    )
+    xs_restore = traversals.unflatten_mapping(flat_xs)
+    self.assertEqual(xs, xs_restore)
+
+
+if __name__ == '__main__':
+  absltest.main()


### PR DESCRIPTION
* Add nnx.traversals.{flatten_mapping, unflatten_dict}
    * These are modified from traverse_util.{flatten_dict, unflatten_dict}
    * They are annotated so that any future changes to the function (e.g., changing it back to work with dicts only) triggers a type error.

* Minor tweaks to imports:
    * import from collections.abc instead of typing since the latter imports are deprecated.
    * Import from flax.typing instead of flax.core.scope since the latter has been moved.
    * Add from `__future__` import annotations so that the annotations work on Python 3.9.

* Minor tweaks to code:
    * Annotate some private functions to make them easier to understand.
    * When printing a type, print its __qualname__ since that's a bit easier to read (str instead of <class 'str'>).

Fixes #3879 