### PR TITLE
[NNX] Add `LoRA` and `LoRALinear` to NNX

### DIFF
--- a/flax/experimental/nnx/__init__.py
+++ b/flax/experimental/nnx/__init__.py
@@ -77,6 +77,9 @@ from .nnx.nn.linear import Embed as Embed
 from .nnx.nn.linear import Linear as Linear
 from .nnx.nn.linear import LinearGeneral as LinearGeneral
 from .nnx.nn.linear import Einsum as Einsum
+from .nnx.nn.lora import LoRA as LoRA
+from .nnx.nn.lora import LoRALinear as LoRALinear
+from .nnx.nn.lora import LoRAParam as LoRAParam
 from .nnx.nn.normalization import BatchNorm as BatchNorm
 from .nnx.nn.normalization import LayerNorm as LayerNorm
 from .nnx.nn.normalization import RMSNorm as RMSNorm

--- a/flax/experimental/nnx/nnx/nn/linear.py
+++ b/flax/experimental/nnx/nnx/nn/linear.py
@@ -297,7 +297,8 @@ class Linear(Module):
   """A linear transformation applied over the last dimension of the input.
 
   Attributes:
-    features: the number of output features.
+    in_features: the number of input features.
+    out_features: the number of output features.
     use_bias: whether to add a bias to the output (default: True).
     dtype: the dtype of the computation (default: infer from input and params).
     param_dtype: the dtype passed to parameter initializers (default: float32).

--- a/flax/experimental/nnx/nnx/nn/lora.py
+++ b/flax/experimental/nnx/nnx/nn/lora.py
@@ -1,0 +1,190 @@
+# Copyright 2024 The Flax Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Copyright 2023 The Flax Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import annotations
+
+import typing as tp
+
+import jax
+import jax.numpy as jnp
+
+from flax.experimental import nnx
+from flax.experimental.nnx.nnx import rnglib, variables
+from flax.experimental.nnx.nnx.module import Module
+from flax.experimental.nnx.nnx.nn import initializers
+from flax.typing import (
+  Dtype,
+  Initializer,
+)
+
+Array = jax.Array
+Axis = int
+Size = int
+A = tp.TypeVar('A')
+
+default_kernel_init = initializers.lecun_normal()
+
+
+class LoRAParam(variables.Variable[A]): pass
+
+
+class LoRA(Module):
+  """A standalone LoRA layer.
+
+  Example usage::
+
+    >>> from flax.experimental import nnx
+    >>> import jax, jax.numpy as jnp
+    >>> layer = nnx.LoRA(3, 2, 4, rngs=nnx.Rngs(0))
+    >>> layer.lora_a.value.shape
+    (3, 2)
+    >>> layer.lora_b.value.shape
+    (2, 4)
+    >>> # Wrap around existing layer
+    >>> linear = nnx.Linear(3, 4, rngs=nnx.Rngs(0))
+    >>> wrapper = nnx.LoRA(3, 2, 4, base_module=linear, rngs=nnx.Rngs(1))
+    >>> assert wrapper.base_module == linear
+    >>> wrapper.lora_a.value.shape
+    (3, 2)
+    >>> layer.lora_b.value.shape
+    (2, 4)
+    >>> y = layer(jnp.ones((16, 3)))
+    >>> y.shape
+    (16, 4)
+
+  Attributes:
+    in_features: the number of input features.
+    lora_rank: the rank of the LoRA dimension.
+    out_features: the number of output features.
+    base_module: a base module to call and substitute, if possible.
+    dtype: the dtype of the computation (default: infer from input and params).
+    param_dtype: the dtype passed to parameter initializers (default: float32).
+    precision: numerical precision of the computation see `jax.lax.Precision`
+      for details.
+    kernel_init: initializer function for the weight matrices.
+    lora_param_type: the type of the LoRA params.
+  """
+  def __init__(
+    self,
+    in_features: int,
+    lora_rank: int,
+    out_features: int,
+    *,
+    base_module: tp.Optional[nnx.Module] = None,
+    dtype: tp.Optional[Dtype] = None,
+    param_dtype: Dtype = jnp.float32,
+    kernel_init: Initializer = default_kernel_init,
+    lora_param_type: tp.Type[variables.Variable] = LoRAParam,
+    rngs: rnglib.Rngs,
+  ):
+    self.in_features = in_features
+    self.out_features = out_features
+    self.dtype = dtype
+    self.param_dtype = param_dtype
+    self.lora_param_type = lora_param_type
+    self.base_module = base_module
+
+    self.lora_a = lora_param_type(
+      kernel_init(rngs.params(), (in_features, lora_rank), param_dtype)
+    )
+    self.lora_b = lora_param_type(
+      kernel_init(rngs.params(), (lora_rank, out_features), param_dtype)
+    )
+
+  def __call__(self, x: jax.Array):
+    out = x @ self.lora_a @ self.lora_b
+    if self.base_module is not None:
+      if not callable(self.base_module):
+        raise ValueError('`self.base_module` must be callable.')
+      out += self.base_module(x)
+    return out
+
+
+class LoRALinear(nnx.Linear):
+  """An `nnx.Linear` layer in which the output will be LoRAified.
+
+  The model state structure will be compatible with that of Linear.
+
+  Example usage::
+
+    >>> from flax.experimental import nnx
+    >>> import jax, jax.numpy as jnp
+    >>> linear = nnx.Linear(3, 4, rngs=nnx.Rngs(0))
+    >>> lora_linear = nnx.LoRALinear(3, 4, lora_rank=2, rngs=nnx.Rngs(0))
+    >>> linear.kernel.value.shape
+    (3, 4)
+    >>> lora_linear.kernel.value.shape
+    (3, 4)
+    >>> lora_linear.lora.lora_a.value.shape
+    (3, 2)
+    >>> jnp.allclose(linear.kernel.value, lora_linear.kernel.value)
+    Array(True, dtype=bool)
+    >>> y = lora_linear(jnp.ones((16, 3)))
+    >>> y.shape
+    (16, 4)
+
+  Attributes:
+    in_features: the number of input features.
+    out_features: the number of output features.
+    lora_rank: the rank of the LoRA dimension.
+    base_module: a base module to call and substitute, if possible.
+    dtype: the dtype of the computation (default: infer from input and params).
+    param_dtype: the dtype passed to parameter initializers (default: float32).
+    precision: numerical precision of the computation see `jax.lax.Precision`
+      for details.
+    kernel_init: initializer function for the weight matrices.
+    lora_param_type: the type of the LoRA params.
+  """
+  def __init__(
+    self,
+    in_features: int,
+    out_features: int,
+    *,
+    lora_rank: int,
+    lora_dtype: tp.Optional[Dtype] = None,
+    lora_param_dtype: Dtype = jnp.float32,
+    lora_kernel_init: Initializer = default_kernel_init,
+    lora_param_type: tp.Type[variables.Variable] = LoRAParam,
+    rngs: rnglib.Rngs,
+    **kwargs,
+  ):
+    super().__init__(in_features, out_features, rngs=rngs, **kwargs)
+    self.lora = LoRA(in_features, lora_rank, out_features,
+                     dtype=lora_dtype, param_dtype=lora_param_dtype,
+                     kernel_init=lora_kernel_init, lora_param_type=lora_param_type,
+                     rngs=rngs)
+
+  def __call__(self, x: jax.Array):
+    y = super().__call__(x)
+    y += self.lora(x)
+    return y
+
+
+
+
+
+

--- a/flax/experimental/nnx/tests/nn/test_lora.py
+++ b/flax/experimental/nnx/tests/nn/test_lora.py
@@ -1,0 +1,120 @@
+# Copyright 2024 The Flax Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import jax
+import jax.numpy as jnp
+from absl.testing import absltest
+import numpy as np
+
+from flax.experimental import nnx
+
+
+class TestLora(absltest.TestCase):
+  def test_basic(self):
+    module = nnx.LoRA(3, 2, 4, rngs=nnx.Rngs(0))
+    x = jax.random.normal(jax.random.key(0), (1, 3))
+    y = module(x)
+
+    assert y.shape == (1, 4)
+    assert module.lora_a.value.shape == (3, 2)
+    assert module.lora_b.value.shape == (2, 4)
+    np.testing.assert_allclose(y, x @ module.lora_a.value @ module.lora_b.value)
+
+
+  def test_lora_base_module(self):
+    rngs = nnx.Rngs(0)
+    linear = nnx.Linear(3, 4, use_bias=False, rngs=rngs)
+    module = nnx.LoRA(3, 2, 4, base_module=linear, rngs=rngs)
+    x = jax.random.normal(jax.random.key(0), (1, 3))
+    y = module(x)
+
+    assert y.shape == (1, 4)
+    assert module.base_module == linear
+    assert module.base_module.kernel.value.shape == (3, 4)
+    assert module.base_module.bias.value == None
+    assert module.lora_a.value.shape == (3, 2)
+    assert module.lora_b.value.shape == (2, 4)
+    np.testing.assert_allclose(y, x @ linear.kernel.value + x @ module.lora_a.value @ module.lora_b.value)
+
+
+  def test_layer_swap_lora(self):
+    class MLP(nnx.Module):
+      def __init__(self, dim, rngs: nnx.Rngs):
+        self.linear1 = nnx.Linear(dim, dim, rngs=rngs)
+        self.linear2 = nnx.Linear(dim, dim, rngs=rngs)
+      def __call__(self, x):
+        x = self.linear1(x)
+        return self.linear2(x)
+
+    rngs = nnx.Rngs(0)
+    model = MLP(3, rngs=rngs)
+    x = jax.random.normal(jax.random.key(0), (1, 3))
+    y = model(x)
+
+    # Replace one of the linear layers as LoRA linear layer.
+    model.linear2 = nnx.LoRA(3, 4, 3, base_module=model.linear2, rngs=rngs)
+    lora_y = model(x)
+
+    assert y.shape == (1, 3)
+    assert lora_y.shape == (1, 3)
+    assert not jnp.allclose(y, lora_y)
+    a, b = model.linear2.lora_a.value, model.linear2.lora_b.value
+    np.testing.assert_allclose(y + model.linear1(x) @ a @ b, lora_y)
+
+
+  def test_layer_swap_loralinear(self):
+    class MLP(nnx.Module):
+      def __init__(self, dim, rngs: nnx.Rngs):
+        self.linear1 = nnx.Linear(dim, dim, rngs=rngs)
+        self.linear2 = nnx.Linear(dim, dim, rngs=rngs)
+      def __call__(self, x):
+        x = self.linear1(x)
+        return self.linear2(x)
+
+    rngs = nnx.Rngs(0)
+    model = MLP(3, rngs=rngs)
+    x = jax.random.normal(jax.random.key(0), (1, 3))
+    y = model(x)
+
+    # Replace one of the linear layers as LoRA linear layer.
+    _, state = nnx.split(model.linear2)  # To keep the kernel and bias of linear2
+    model.linear2 = nnx.LoRALinear(3, 3, lora_rank=4, rngs=rngs)
+    nnx.update(model.linear2, state)
+    lora_y = model(x)
+
+    assert y.shape == (1, 3)
+    assert lora_y.shape == (1, 3)
+    assert not jnp.allclose(y, lora_y)
+    a, b = model.linear2.lora.lora_a.value, model.linear2.lora.lora_b.value
+    np.testing.assert_allclose(y + model.linear1(x) @ a @ b, lora_y)
+
+
+  def test_lora_param_type(self):
+    rngs = nnx.Rngs(0)
+    model = nnx.LoRA(3, 4, 2, lora_param_type=nnx.LoRAParam, rngs=rngs)
+    _, params, lora_params = nnx.split(model, nnx.Param, nnx.LoRAParam)
+    assert params == {}
+    assert ('lora_a' in lora_params) and ('lora_b' in lora_params)
+    np.testing.assert_allclose(lora_params.lora_a.value, model.lora_a.value)
+
+    model = nnx.LoRA(3, 4, 2, lora_param_type=nnx.Param, rngs=rngs)
+    _, params, lora_params = nnx.split(model, nnx.Param, nnx.LoRAParam)
+    assert ('lora_a' in params) and ('lora_b' in params)
+    np.testing.assert_allclose(params.lora_a.value, model.lora_a.value)
+    assert lora_params == {}
+
+
+if __name__ == '__main__':
+  absltest.main()
+


### PR DESCRIPTION
Provided here are two ways to add LoRA on any layer:

* `nnx.LoRA` with `base_module` arg that can take any layer instance. Easy for model surgery on modules, but will render mismatching `state`s.
* `nnx.LoRALinear` which subclasses `nnx.Linear` and attach a simple `nnx.LoRA` module along the way. Param structure matches with `nnx.Linear`, but need a bit more surgery on runtime. This technique can be applied for any other NNX modules.

Not yet sure which approach is the best, so providing both at this moment.