### PR TITLE
[nnx] fix nnx_basics dependencies

### DIFF
--- a/docs/nnx/index.rst
+++ b/docs/nnx/index.rst
@@ -64,7 +64,7 @@ Features
          .. div:: sd-font-normal
 
             NNX makes it very easy integrate objects with regular JAX code
-            via the `Functional API <nnx_basics#the-functional-api>`__.
+            via the `Functional API <nnx_basics.html#the-functional-api>`__.
 
 Basic usage
 ^^^^^^^^^^^^

--- a/docs/nnx/nnx_basics.ipynb
+++ b/docs/nnx/nnx_basics.ipynb
@@ -19,6 +19,19 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "skip-execution"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "! pip install -U flax penzai"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": 1,
    "metadata": {},
    "outputs": [],

--- a/docs/nnx/nnx_basics.md
+++ b/docs/nnx/nnx_basics.md
@@ -21,6 +21,12 @@ Despite its simplified implementation, NNX supports the same powerful design pat
 that have allowed Linen to scale effectively to large codebases.
 
 ```{code-cell} ipython3
+:tags: [skip-execution]
+
+! pip install -U flax penzai
+```
+
+```{code-cell} ipython3
 from flax import nnx
 import jax
 import jax.numpy as jnp


### PR DESCRIPTION
# What does this PR do?

* Updates flax on the first cell of NNX Basics.
* Fixes Functional API link in `nnx/index.rst`. 