### PR TITLE
[nnx] make State generic

### DIFF
--- a/flax/nnx/__init__.py
+++ b/flax/nnx/__init__.py
@@ -27,6 +27,7 @@ from .nnx import traversals as traversals
 from .nnx.filterlib import All as All
 from .nnx.filterlib import Not as Not
 from .nnx.graph import GraphDef as GraphDef
+from .nnx.graph import GraphState as GraphState
 from .nnx.object import Object as Object
 from .nnx.helpers import Dict as Dict
 from .nnx.helpers import List as List

--- a/flax/nnx/nnx/module.py
+++ b/flax/nnx/nnx/module.py
@@ -26,13 +26,14 @@ from flax.nnx.nnx import (
 from flax.nnx.nnx import variables as variableslib
 from flax.nnx.nnx.graph import GraphDef
 from flax.nnx.nnx.object import Object, ObjectMeta
-from flax.nnx.nnx.state import State, StateLeaf
+from flax.nnx.nnx.graph import GraphState, StateLeaf
+from flax.nnx.nnx.state import State
 from flax.typing import Path, PathParts
 
 A = tp.TypeVar('A')
 B = tp.TypeVar('B')
 M = tp.TypeVar('M', bound='Module')
-S = tp.TypeVar('S', bound=tp.Union[State, tuple[State, ...]])
+S = tp.TypeVar('S', bound=tp.Union[GraphState, tuple[GraphState, ...]])
 V = tp.TypeVar('V', bound=variableslib.Variable[tp.Any])
 F = tp.TypeVar('F', bound=tp.Callable[..., tp.Any])
 


### PR DESCRIPTION
# What does this PR do?

Fixes #3955.

* Makes State generic as `State[K, V]`.
* `State` annotations in `graph` are redifined as `GraphState = State[Key, StateLeaf]`.
