### PR TITLE
fix deprecation warning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ testing = [
     "sentencepiece",  # WMT/LM1B examples
     "tensorflow_text>=2.11.0",  # WMT/LM1B examples
     "tensorflow_datasets",
-    "tensorflow",
+    "tensorflow>=2.12.0", # to fix Numpy np.bool8 deprecation error
     "torch",
     "nbstripout",
     "black[jupyter]==23.7.0",


### PR DESCRIPTION
HEAD is getting the following [deprecation warning](https://github.com/google/flax/actions/runs/9459808719/job/26057558848?pr=3981#step:8:478):
```
ERROR tests/jax_utils_test.py - DeprecationWarning: `np.bool8` is a deprecated alias for `np.bool_`.  (Deprecated NumPy 1.24)
```

This is because tensorflow uses [`np.bool8` in version `2.11.0`](https://github.com/tensorflow/tensorflow/blob/v2.11.0/tensorflow/python/framework/dtypes.py#L246). The solution is to enforce [`tensorflow>=2.12.0`](https://github.com/tensorflow/tensorflow/blob/v2.12.0-rc0/tensorflow/python/framework/dtypes.py#L264).
