### PR TITLE
added `wrt` option to `nnx.Optimizer`

### DIFF
--- a/flax/nnx/__init__.py
+++ b/flax/nnx/__init__.py
@@ -103,6 +103,9 @@ from .nnx.spmd import with_partitioning as with_partitioning
 from .nnx.spmd import with_sharding_constraint as with_sharding_constraint
 from .nnx.state import State as State
 from .nnx.training import metrics as metrics
+from .nnx.variables import (
+  Param as Param,
+)  # this needs to be imported before optimizer to prevent circular import
 from .nnx.training import optimizer as optimizer
 from .nnx.training.metrics import Metric as Metric
 from .nnx.training.metrics import MultiMetric as MultiMetric
@@ -127,7 +130,6 @@ from .nnx.variables import BatchStat as BatchStat
 from .nnx.variables import Cache as Cache
 from .nnx.variables import Empty as Empty
 from .nnx.variables import Intermediate as Intermediate
-from .nnx.variables import Param as Param
 from .nnx.variables import Variable as Variable
 from .nnx.variables import VariableState as VariableState
 from .nnx.variables import VariableMetadata as VariableMetadata


### PR DESCRIPTION
added `wrt` option to [`nnx.Optimizer`](https://flax--3983.org.readthedocs.build/en/3983/api_reference/flax.nnx/training/optimizer.html#module-flax.nnx.optimizer), to allow the user to specify which variables to keep track off in the optimizer state and which variables update in `nnx.Optimizer.update`.