### PR TITLE
[nnx] LoRAParam inherits from Param

### DIFF
--- a/flax/nnx/nnx/nn/lora.py
+++ b/flax/nnx/nnx/nn/lora.py
@@ -46,8 +46,9 @@ A = tp.TypeVar('A')
 default_kernel_init = initializers.lecun_normal()
 
 
-class LoRAParam(variables.Variable[A]):
+class LoRAParam(variables.Param[A]):
   pass
+
 
 
 class LoRA(Module):

--- a/flax/nnx/tests/nn/lora_test.py
+++ b/flax/nnx/tests/nn/lora_test.py
@@ -105,7 +105,7 @@ class TestLora(absltest.TestCase):
   def test_lora_param_type(self):
     rngs = nnx.Rngs(0)
     model = nnx.LoRA(3, 4, 2, lora_param_type=nnx.LoRAParam, rngs=rngs)
-    _, params, lora_params = nnx.split(model, nnx.Param, nnx.LoRAParam)
+    _, lora_params, params = nnx.split(model, nnx.LoRAParam, nnx.Param)
     assert params == {}
     assert ('lora_a' in lora_params) and ('lora_b' in lora_params)
     np.testing.assert_allclose(lora_params.lora_a.value, model.lora_a.value)


### PR DESCRIPTION
# What does this PR do?

Makes `LoRAParam` inherit from `Param`. With this change `LoRAParam`s are trained by default along with any other `Param` types on `grad`, `value_and_grad` and `Optimizer`.