### PR TITLE
[nnx] add call

### DIFF
--- a/docs/api_reference/flax.nnx/graph.rst
+++ b/docs/api_reference/flax.nnx/graph.rst
@@ -13,6 +13,7 @@ graph
 .. autofunction:: graphdef
 .. autofunction:: iter_graph
 .. autofunction:: clone
+.. autofunction:: call
 
 .. autoclass:: GraphDef
   :members:

--- a/flax/nnx/__init__.py
+++ b/flax/nnx/__init__.py
@@ -35,6 +35,7 @@ from .nnx.filterlib import Everything as Everything
 from .nnx.filterlib import Nothing as Nothing
 from .nnx.graph import GraphDef as GraphDef
 from .nnx.graph import GraphState as GraphState
+from .nnx.graph import GraphDefState as GraphDefState
 from .nnx.object import Object as Object
 from .nnx.helpers import Dict as Dict
 from .nnx.helpers import List as List
@@ -53,6 +54,7 @@ from .nnx.graph import pop as pop
 from .nnx.graph import state as state
 from .nnx.graph import graphdef as graphdef
 from .nnx.graph import iter_graph as iter_graph
+from .nnx.graph import call as call
 from .nnx.nn import initializers as initializers
 from .nnx.nn.activations import celu as celu
 from .nnx.nn.activations import elu as elu


### PR DESCRIPTION
# What does this PR do?

Docs: [preview](https://flax--4004.org.readthedocs.build/en/4004/api_reference/flax.nnx/pure.html#flax.nnx.Pure).

Adds `nnx.call` which takes a `(GraphDef, State)` pair and creates a proxy object that can be
  used to call methods on the underlying graph node. When a method is called, the
  output is returned along with a new (GraphDef, State) pair that represents the
  updated state of the graph node. 

```python
from flax import nnx
import jax
import jax.numpy as jnp

class StatefulLinear(nnx.Module):
  def __init__(self, din, dout, rngs):
    self.w = nnx.Param(jax.random.uniform(rngs(), (din, dout)))
    self.b = nnx.Param(jnp.zeros((dout,)))
    self.count = nnx.Variable(jnp.array(0, dtype=jnp.uint32))

  def __call__(self, x):
    self.count.value += 1
    return x @ self.w + self.b

linear = StatefulLinear(3, 2, nnx.Rngs(0))
linear_state = nnx.split(linear)

@jax.jit
def forward(x, linear_state):
  y, linear_state = nnx.call(linear_state)(x)
  return y, linear_state

x = jnp.ones((1, 3))
y, linear_state = forward(x, linear_state)
y, linear_state = forward(x, linear_state)

linear = nnx.merge(*linear_state)
assert linear.count.value == 2
```