### PR TITLE
Fix head pytest breakage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "jax>=0.4.19",
     "msgpack",
     "optax",
-    "orbax-checkpoint",
+    "orbax-checkpoint==0.5.15",  # remove this when they release > 0.5.17
     "tensorstore",
     "rich>=11.1",
     "typing_extensions>=4.2",
@@ -146,8 +146,8 @@ filterwarnings = [
     "ignore:.*pkg_resources is deprecated as an API.*:DeprecationWarning",
     # DeprecationWarning: Deprecated call to `pkg_resources.declare_namespace('google')`.
     "ignore:.*Deprecated call to.*pkg_resources.declare_namespace.*:DeprecationWarning",
-    # DeprecationWarning: jax.tree_map is deprecated: use jax.tree.map (jax v0.4.25 or newer) or jax.tree_util.tree_map (any JAX version).
-    "ignore:.*jax.tree_map is deprecated.*:DeprecationWarning",
+    # jax.xla_computation is deprecated but TF still uses it.
+    "ignore:.*jax.xla_computation is deprecated.*:DeprecationWarning",
 ]
 
 [tool.coverage.report]

--- a/tests/jax_utils_test.py
+++ b/tests/jax_utils_test.py
@@ -16,10 +16,10 @@
 
 from functools import partial
 
+from absl.testing import absltest
 import chex
 import jax
 import numpy as np
-import tensorflow as tf
 from absl.testing import parameterized
 
 from flax import jax_utils
@@ -31,7 +31,7 @@ def setUpModule():
   chex.set_n_cpu_devices(NDEV)
 
 
-class PadShardUnpadTest(chex.TestCase, tf.test.TestCase):
+class PadShardUnpadTest(chex.TestCase):
   BATCH_SIZES = [NDEV, NDEV + 1, NDEV - 1, 5 * NDEV, 5 * NDEV + 1, 5 * NDEV - 1]
   DTYPES = [np.float32, np.uint8, jax.numpy.bfloat16, np.int32]
 
@@ -105,4 +105,4 @@ class PadShardUnpadTest(chex.TestCase, tf.test.TestCase):
 
 
 if __name__ == '__main__':
-  tf.test.main()
+  absltest.main()


### PR DESCRIPTION
* Removed trivial dependency of `tensorflow` on `jax_utils_test.py`
* Ignored JAX-side deprecation warning introduced by Tensorflow
* No longer skipping `jax.tree_.*` deprecation warnings because we are free of them!
* Pinned `orbax-checkpoint` to `0.5.15` because 16 and 17 introduces new bugs