### PR TITLE
[nnx] fix grad

### DIFF
--- a/flax/nnx/nnx/object.py
+++ b/flax/nnx/nnx/object.py
@@ -160,7 +160,10 @@ class Object(reprlib.Representable, metaclass=ObjectMeta):
             return value.replace(
               raw_value=jax.tree.map(to_shape_dtype, value.raw_value)
             )
-          elif isinstance(value, (np.ndarray, jax.Array)):
+          elif (
+            isinstance(value, (np.ndarray, jax.Array))
+            and np.prod(value.shape) > 1
+          ):
             return Array(value.shape, value.dtype)
           return value
 

--- a/flax/nnx/nnx/training/metrics.py
+++ b/flax/nnx/nnx/training/metrics.py
@@ -288,19 +288,19 @@ class MultiMetric(Metric):
       accuracy=Accuracy(
         argname='values',
         total=MetricState(
-          value=Array(shape=(), dtype=float32)
+          value=Array(0., dtype=float32)
         ),
         count=MetricState(
-          value=Array(shape=(), dtype=int32)
+          value=Array(0, dtype=int32)
         )
       ),
       loss=Average(
         argname='values',
         total=MetricState(
-          value=Array(shape=(), dtype=float32)
+          value=Array(0., dtype=float32)
         ),
         count=MetricState(
-          value=Array(shape=(), dtype=int32)
+          value=Array(0, dtype=int32)
         )
       )
     )
@@ -309,10 +309,10 @@ class MultiMetric(Metric):
     Accuracy(
       argname='values',
       total=MetricState(
-        value=Array(shape=(), dtype=float32)
+        value=Array(0., dtype=float32)
       ),
       count=MetricState(
-        value=Array(shape=(), dtype=int32)
+        value=Array(0, dtype=int32)
       )
     )
 
@@ -320,10 +320,10 @@ class MultiMetric(Metric):
     Average(
       argname='values',
       total=MetricState(
-        value=Array(shape=(), dtype=float32)
+        value=Array(0., dtype=float32)
       ),
       count=MetricState(
-        value=Array(shape=(), dtype=int32)
+        value=Array(0, dtype=int32)
       )
     )
 

--- a/flax/nnx/nnx/transforms/parallelization.py
+++ b/flax/nnx/nnx/transforms/parallelization.py
@@ -242,7 +242,7 @@ def vmap(
   spmd_axis_name: AxisName | tuple[AxisName, ...] | None = None,
   # nnx specific
   in_axes_kwargs: tp.Any = 0,
-  state_axes: tp.Mapping[filterlib.Filter, int] = FrozenDict({...: 0}),
+  state_axes: tp.Mapping[filterlib.Filter, int | None] = FrozenDict({...: 0}),
   split_rngs: filterlib.Filter = ...,
   transform_metadata: tp.Mapping[str, tp.Any] = FrozenDict({}),
 ) -> F:


### PR DESCRIPTION
# What does this PR do?

* Fixes a bug in `nnx.grad` where `grad` was not creating new references for non differentiable NNX objects found in `*args`.
* Allows `vmap`'s `state_axes` mapping to accept `None` axes.