### PR TITLE
Fix Gemma test to unbreak head

### DIFF
--- a/flax/nnx/examples/gemma/helpers.py
+++ b/flax/nnx/examples/gemma/helpers.py
@@ -30,7 +30,7 @@
 
 from __future__ import annotations
 
-from typing import Callable, Optional, Tuple, TypeVar
+from typing import Callable, Optional, Tuple, TypeVar, Union
 import flax
 from flax import nnx
 from flax.typing import VariableDict  # pylint: disable=g-importing-member,g-multiple-import
@@ -38,7 +38,7 @@ from flax.typing import VariableDict  # pylint: disable=g-importing-member,g-mul
 M = TypeVar('M', bound='nnx.Module')
 
 
-def _flatten_path(path: Tuple[str | int, ...]) -> str:
+def _flatten_path(path: Tuple[Union[str, int], ...]) -> str:
   def f(item) -> str:
     if isinstance(item, str):
       return f'{item}'
@@ -54,7 +54,7 @@ def module_from_linen_variables(
     module_factory: Callable[[], M],
     variables: VariableDict,
     map_key_fn: Optional[
-        Callable[[Tuple[str, ...]], Tuple[str | int, ...]]
+        Callable[[Tuple[str, ...]], Tuple[Union[str, int], ...]]
     ] = None,
 ) -> M:
   """Returns an `nnx.Module` initialized with the `variables` of a linen module.
@@ -70,7 +70,7 @@ def module_from_linen_variables(
   """
   if map_key_fn is None:
 
-    def map_key_fn(path: Tuple[str, ...]) -> Tuple[str | int, ...]:
+    def map_key_fn(path: Tuple[str, ...]) -> Tuple[Union[str, int], ...]:
       return path[1:] if 'params' in variables else path
 
   mdl: M = nnx.eval_shape(module_factory)

--- a/flax/nnx/examples/gemma/layers.py
+++ b/flax/nnx/examples/gemma/layers.py
@@ -30,7 +30,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Sequence, TypeAlias
+from typing import Any, Sequence, Union
 
 from flax import nnx
 import flax.linen as nn
@@ -38,7 +38,7 @@ import jax.numpy as jnp
 from jaxtyping import Array, ArrayLike  # pylint: disable=g-importing-member,g-multiple-import
 
 
-Shape: TypeAlias = Sequence[int | Any]
+Shape = Sequence[Union[int, Any]]
 
 
 class Einsum(nnx.Module):

--- a/flax/nnx/examples/gemma/modules.py
+++ b/flax/nnx/examples/gemma/modules.py
@@ -31,7 +31,7 @@
 from __future__ import annotations
 
 import enum
-from typing import Any, Sequence, TypeAlias
+from typing import Any, Sequence, Union
 
 from flax import nnx
 import flax.linen as nn
@@ -41,8 +41,8 @@ import jax
 import jax.numpy as jnp
 from jaxtyping import Array, ArrayLike  # pylint: disable=g-importing-member,g-multiple-import
 
-LayerCache: TypeAlias = dict[str, Array]
-Shape: TypeAlias = Sequence[int | Any]
+LayerCache = dict[str, Array]
+Shape = Sequence[Union[int, Any]]
 
 K_MASK = -2.3819763e38  # Set to a large negative number.
 
@@ -95,8 +95,8 @@ class Attention(nnx.Module):
       attn_type: AttentionType,
       *,
       rngs: nnx.Rngs,
-      attn_logits_soft_cap: float | None = None,
-      sliding_window_size: int | None = None,
+      attn_logits_soft_cap: Union[float, None] = None,
+      sliding_window_size: Union[int, None] = None,
   ):
     if attn_type == AttentionType.LOCAL_SLIDING and sliding_window_size is None:
       raise ValueError(
@@ -130,9 +130,9 @@ class Attention(nnx.Module):
       self,
       x: Array,
       segment_pos: Array,
-      cache: LayerCache | None,
+      cache: Union[LayerCache, None],
       attn_mask: Array,
-  ) -> tuple[LayerCache | None, Array]:
+  ) -> tuple[Union[LayerCache, None], Array]:
     seq_len = x.shape[1]
 
     if self.use_qkv_einsum:
@@ -291,8 +291,8 @@ class Block(nnx.Module):
       attn_type: AttentionType,
       *,
       rngs: nnx.Rngs,
-      attn_logits_soft_cap: float | None = None,
-      sliding_window_size: int | None = None,
+      attn_logits_soft_cap: Union[float, None] = None,
+      sliding_window_size: Union[int, None] = None,
   ):
     self.pre_attention_norm = layers.RMSNorm(embed_dim, rngs=rngs)
     self.attn = Attention(
@@ -321,9 +321,9 @@ class Block(nnx.Module):
       self,
       x: jax.Array,
       segment_pos: jax.Array,
-      cache: LayerCache | None,
+      cache: Union[LayerCache, None],
       attn_mask: jax.Array,
-  ) -> tuple[LayerCache | None, jax.Array]:
+  ) -> tuple[Union[LayerCache, None], jax.Array]:
     inputs_normalized = self.pre_attention_norm(x)
     cache, attn_output = self.attn(
         inputs_normalized,

--- a/flax/nnx/examples/gemma/positional_embeddings.py
+++ b/flax/nnx/examples/gemma/positional_embeddings.py
@@ -33,6 +33,10 @@ import jax.numpy as jnp
 
 _MAX_WAVELENGTH = 10_000
 
+# This code uses implicit rank broadcast and needs this config to be 'allow',
+# while the rest of Flax can use jax_numpy_rank_promotion=raise.
+jax.config.update('jax_numpy_rank_promotion', 'allow')
+
 
 def add_positional_embedding(
     input_embedding: jax.Array,


### PR DESCRIPTION
* Loosen the JAX broadcast check
* Modify some typing annotations to be runnable on Python 3.9