### PR TITLE
Fix typo in `nnx_basics` doc

### DIFF
--- a/docs/nnx/nnx_basics.ipynb
+++ b/docs/nnx/nnx_basics.ipynb
@@ -89,7 +89,7 @@
     "\n",
     "To actually initialize a Module you simply call the constructor, all the parameters \n",
     "of a Module are usually created eagerly. Since Modules hold their own state methods \n",
-    "can be called directly without the no need for a separate `apply` method, this is very \n",
+    "can be called directly without the need for a separate `apply` method, this is very \n",
     "convenient for debugging as entire structure of the model can be inspected directly."
    ]
   },

--- a/docs/nnx/nnx_basics.md
+++ b/docs/nnx/nnx_basics.md
@@ -66,7 +66,7 @@ inner value is a JAX array).
 
 To actually initialize a Module you simply call the constructor, all the parameters 
 of a Module are usually created eagerly. Since Modules hold their own state methods 
-can be called directly without the no need for a separate `apply` method, this is very 
+can be called directly without the need for a separate `apply` method, this is very 
 convenient for debugging as entire structure of the model can be inspected directly.
 
 ```{code-cell} ipython3


### PR DESCRIPTION
Fixed typo from `without the no need for` to `without the need for`.

Fixes #4046