### PR TITLE
Allow metadata pass-through in flax.struct.field

### DIFF
--- a/flax/struct.py
+++ b/flax/struct.py
@@ -27,8 +27,9 @@ from . import serialization
 _T = TypeVar('_T')
 
 
-def field(pytree_node=True, **kwargs):
-  return dataclasses.field(metadata={'pytree_node': pytree_node}, **kwargs)
+def field(pytree_node=True, *, metadata=None, **kwargs):
+  return dataclasses.field(metadata=(metadata or {}) | {'pytree_node': pytree_node},
+                           **kwargs)
 
 
 @dataclass_transform(field_specifiers=(field,))  # type: ignore[literal-required]

--- a/tests/struct_test.py
+++ b/tests/struct_test.py
@@ -123,6 +123,12 @@ class StructTest(parameterized.TestCase):
         class B(A, struct.PyTreeNode):
           b: int
 
+  def test_metadata_pass_through(self):
+    @struct.dataclass
+    class A:
+      foo: int = struct.field(default=9, metadata={'baz': 9})
+    assert A.__dataclass_fields__['foo'].metadata == {'baz': 9, 'pytree_node': True}
+
   @parameterized.parameters(
       {'mode': 'dataclass'},
       {'mode': 'pytreenode'},


### PR DESCRIPTION
# What does this PR do?

Allows passing through `metadata` when creating a `flax.struct.field`. This is useful when you want to add some metadata to your field to be read later.

## Checklist
- [ ] This PR fixes a minor issue (e.g.: typo or small bug) or improves the docs (you can dismiss the other
      checks if that's the case).
- [ ] This change is discussed in a Github issue/
      [discussion](https://github.com/google/flax/discussions) (please add a
      link).
- [ ] The documentation and docstrings adhere to the
      [documentation guidelines](https://github.com/google/flax/blob/main/docs/README.md#how-to-write-code-documentation).
- [ ] This change includes necessary high-coverage tests.
      (No quality testing = no merge!)
