### PR TITLE
Fix broken links in docs/nnx/mnist_tutorial.md

### DIFF
--- a/docs/nnx/mnist_tutorial.md
+++ b/docs/nnx/mnist_tutorial.md
@@ -9,8 +9,8 @@ jupytext:
     jupytext_version: 1.13.8
 ---
 
-[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/google/flax/blob/main/docs/mnist_tutorial.ipynb)
-[![Open On GitHub](https://img.shields.io/badge/Open-on%20GitHub-blue?logo=GitHub)](https://github.com/google/flax/blob/main/docs/mnist_tutorial.ipynb)
+[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/google/flax/blob/main/docs/nnx/mnist_tutorial.ipynb)
+[![Open On GitHub](https://img.shields.io/badge/Open-on%20GitHub-blue?logo=GitHub)](https://github.com/google/flax/blob/main/docs/nnx/mnist_tutorial.ipynb)
 
 # MNIST Tutorial
 


### PR DESCRIPTION
pointed to prev location

# What does this PR do?

fixes a couple of broken links to the notebook for the mnist tutorial

Fixes # (issue)

## Checklist
- [x] This PR fixes a minor issue (e.g.: typo or small bug) or improves the docs (you can dismiss the other
      checks if that's the case).
- [ ] This change is discussed in a Github issue/
      [discussion](https://github.com/google/flax/discussions) (please add a
      link).
- [x] The documentation and docstrings adhere to the
      [documentation guidelines](https://github.com/google/flax/blob/main/docs/README.md#how-to-write-code-documentation).
- [ ] This change includes necessary high-coverage tests.
      (No quality testing = no merge!)

I personally checked the fixed links:
https://colab.research.google.com/github/google/flax/blob/main/docs/nnx/mnist_tutorial.ipynb
https://github.com/google/flax/blob/main/docs/nnx/mnist_tutorial.ipynb

both worked after adding /nnx/ between /docs/ and mnist_tutorial.ipynb