### PR TITLE
Perform shape checks for self.param AFTER unboxing

### DIFF
--- a/flax/core/scope.py
+++ b/flax/core/scope.py
@@ -958,6 +958,8 @@ class Scope:
     self.reserve(name, 'params')
     if self.has_variable('params', name):
       value = self.get_variable('params', name)
+      if unbox:
+        value = meta.unbox(value)
       # Validate that the shape of the init_fn output is the same as the shape
       # of the existing parameter. This is to make sure that the hparams set up
       # in a Flax Module match the shapes coming in during apply, and if not,
@@ -983,8 +985,8 @@ class Scope:
         raise errors.ScopeParamNotFoundError(name, self.path_text)
       value = init_fn(self.make_rng('params'), *init_args, **init_kwargs)
       self.put_variable('params', name, value)
-    if unbox:
-      value = meta.unbox(value)
+      if unbox:
+        value = meta.unbox(value)
     return value
 
   def _populate_collections(self):


### PR DESCRIPTION
This pull request will unbox params before performing shape checks in flax/core/scope.py, rather than after.

This should not affect pjit / jax.jit users as unboxing generally doesn't touch traced array data (and wasn't designed for it). However, users that prefer per-device code and manual collectives will run into trouble when implementing certain patterns like FSDP through their own boxes (i.e., subclassing `nn.meta.AxisMetadata` to achieve a "delayed all-gather") because the shape check fixed here happens at the wrong time.

Fixes # (issue) N/A

## Checklist
- [x] This PR fixes a minor issue (e.g.: typo or small bug) or improves the docs (you can dismiss the other
      checks if that's the case).
- [ ] This change is discussed in a Github issue/
      [discussion](https://github.com/google/flax/discussions) (please add a
      link).
- [ ] The documentation and docstrings adhere to the
      [documentation guidelines](https://github.com/google/flax/blob/main/docs/README.md#how-to-write-code-documentation).
- [ ] This change includes necessary high-coverage tests.
      (No quality testing = no merge!)

All existing tests pass.