### PR TITLE
Add shape-based lazy init to `LinenToNNX` (prev `LinenWrapper`)

### DIFF
--- a/flax/nnx/nnx/bridge/__init__.py
+++ b/flax/nnx/nnx/bridge/__init__.py
@@ -18,6 +18,7 @@ from .module import Module as Module
 from .module import Scope as Scope
 from .module import compact as compact
 from .wrappers import functional as functional
-from .wrappers import LinenWrapper as LinenWrapper
+from .wrappers import LinenToNNX as LinenToNNX
 from .wrappers import Functional as Functional
-from .wrappers import NNXWrapper as NNXWrapper
+from .wrappers import NNXToLinen as NNXToLinen
+from .wrappers import lazy_init as lazy_init

--- a/flax/nnx/tests/bridge/wrappers_test.py
+++ b/flax/nnx/tests/bridge/wrappers_test.py
@@ -12,14 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import jax
+from absl.testing import absltest
 
-from flax import linen
+import flax
+from flax import linen as nn
 from flax import nnx
 from flax.nnx import bridge
+import jax
+import jax.numpy as jnp
+import numpy as np
 
 
-class TestCompatibility:
+class TestCompatibility(absltest.TestCase):
   def test_functional(self):
     # Functional API for NNX Modules
     functional = bridge.functional(nnx.Linear)(32, 64)
@@ -27,9 +31,76 @@ class TestCompatibility:
     x = jax.numpy.ones((1, 32))
     y, updates = functional.apply(state)(x)
 
-  def test_linen_wrapper(self):
+  def test_linen_to_nnx(self):
     ## Wrapper API for Linen Modules
-    linen_module = linen.Dense(features=64)
+    linen_module = nn.Dense(features=64)
     x = jax.numpy.ones((1, 32))
-    module = bridge.LinenWrapper(linen_module, x, rngs=nnx.Rngs(0))  # init
-    y = module(x)  # apply
+    model = bridge.LinenToNNX(linen_module, rngs=nnx.Rngs(0)).lazy_init(x)  # like linen init
+    y = model(x)  # like linen apply
+    assert y.shape == (1, 64)
+
+  def test_linen_to_nnx_submodule(self):
+    class NNXOuter(nnx.Module):
+      def __init__(self, dout: int, *, rngs: nnx.Rngs):
+        self.nn_dense1 = bridge.LinenToNNX(nn.Dense(dout, use_bias=False), rngs=rngs)
+        self.b = nnx.Param(jax.random.uniform(rngs.params(), (1, dout,)))
+        self.batchnorm = bridge.LinenToNNX(nn.BatchNorm(use_running_average=True), rngs=rngs)
+        self.rngs = rngs
+
+      def __call__(self, x):
+        x = self.nn_dense1(x) + self.b
+        return self.batchnorm(x)
+
+    x = jax.random.normal(jax.random.key(0), (2, 4))
+    model = NNXOuter(3, rngs=nnx.Rngs(0))
+    gdef_before_lazy_init, _ = nnx.split(model)
+    bridge.lazy_init(model, x)
+    gdef_full, state = nnx.split(model)
+    assert gdef_before_lazy_init != gdef_full
+    assert 'params' in state.nn_dense1
+    assert 'batch_stats' in state.batchnorm
+    y = model(x)
+    k, b = state.nn_dense1.params.kernel.value, state.b.value
+    np.testing.assert_allclose(y, x @ k + b, rtol=1e-5)
+    assert gdef_full == nnx.graphdef(model)  # static data is stable now
+
+  def test_linen_to_nnx_noncall_method(self):
+    class Foo(nn.Module):
+      @nn.compact
+      def __call__(self, x):
+        b = self.param('b', nn.zeros_init(), (1, 3,))
+        return self.dot(x) + b
+
+      @nn.compact
+      def dot(self, x):
+        w = self.param('w', nn.initializers.lecun_normal(), (4, 3))
+        return x @ w
+
+    x = jax.random.normal(jax.random.key(0), (2, 4))
+    model = bridge.LinenToNNX(Foo(), rngs=nnx.Rngs(0))
+    bridge.lazy_init(model, x, method=model.module.dot)
+    y = model(x, method=model.module.dot)
+    np.testing.assert_allclose(y, x @ nnx.state(model).params.w.value)
+    # lazy_init only initialized param w inside dot(), so calling __call__ should fail
+    with self.assertRaises(flax.errors.ScopeParamNotFoundError):
+      y = model(x)
+
+  def test_linen_to_nnx_mutable(self):
+    class Foo(nn.Module):
+      def setup(self):
+        self.count = self.variable('counter', 'count', lambda: jnp.zeros((), jnp.int32))
+
+      def __call__(self, x):
+        if not self.is_initializing():
+          self.count.value += 1
+        return x
+
+    x = lambda: jnp.zeros((), jnp.int32)
+    model = bridge.LinenToNNX(Foo(), rngs=nnx.Rngs(0)).lazy_init(x)
+    assert nnx.state(model).counter.count.value == 0
+    y = model(x, mutable=True)
+    assert nnx.state(model).counter.count.value == 1
+
+
+if __name__ == '__main__':
+  absltest.main()


### PR DESCRIPTION
* Renamed wrappers to `LinenToNNX` and `NNXToLinen` to minimize confusion.
* Moved state initialization of `LinenToNNX` to `__call__` to realize lazy init. This allows it to be a submodule of an NNX module, which doesn't have input args during initialization.
  * User can use `nnx.shaped_init` to do a dry run of `__call__` and initialize the whole state & full graphdef.
* Made state initialization of `LinenToNNX` nested & closer to NNX, aka. each `VariableState` is created for every jax Array, not every collection.