### PR TITLE
Fix broken link to NNX Basics in the docs

### DIFF
--- a/docs/nnx/haiku_linen_vs_nnx.rst
+++ b/docs/nnx/haiku_linen_vs_nnx.rst
@@ -199,7 +199,7 @@ simply inspect the ``params`` object returned from ``.init()``.
 To see the parameter structure in NNX, the user can call ``nnx.split`` to
 generate ``Graphdef`` and ``State`` objects. The ``Graphdef`` is a static pytree
 denoting the structure of the model (for example usages, see
-`NNX Basics <https://flax.readthedocs.io/en/latest/experimental/nnx/nnx_basics.html>`__).
+`NNX Basics <https://flax.readthedocs.io/en/latest/nnx/nnx_basics.html>`__).
 ``State`` objects contains all the module variables (i.e. any class that sub-classes
 ``nnx.Variable``). If we filter for ``nnx.Param``, we will generate a ``State`` object
 of all the learnable module parameters.


### PR DESCRIPTION
# What does this PR do?

The [Migrating from Haiku/Linen to NNX](https://flax.readthedocs.io/en/latest/nnx/haiku_linen_vs_nnx.html) page in the docs contains a broken link to the [NNX Basics](https://flax.readthedocs.io/en/latest/nnx/nnx_basics.html) page. This PR updates the link to the correct address.

## Checklist
- [x] This PR fixes a minor issue (e.g.: typo or small bug) or improves the docs (you can dismiss the other
      checks if that's the case).
