### PR TITLE
Add GroupNorm to NNX normalization layers

### DIFF
--- a/docs/api_reference/flax.nnx/nn/normalization.rst
+++ b/docs/api_reference/flax.nnx/nn/normalization.rst
@@ -15,3 +15,7 @@ Normalization
 .. flax_module::
   :module: flax.nnx
   :class: RMSNorm
+
+.. flax_module::
+  :module: flax.nnx
+  :class: GroupNorm

--- a/flax/nnx/__init__.py
+++ b/flax/nnx/__init__.py
@@ -97,6 +97,7 @@ from .nnx.nn.lora import LoRAParam as LoRAParam
 from .nnx.nn.normalization import BatchNorm as BatchNorm
 from .nnx.nn.normalization import LayerNorm as LayerNorm
 from .nnx.nn.normalization import RMSNorm as RMSNorm
+from .nnx.nn.normalization import GroupNorm as GroupNorm
 from .nnx.nn.stochastic import Dropout as Dropout
 from .nnx.rnglib import Rngs as Rngs
 from .nnx.rnglib import RngStream as RngStream

--- a/flax/nnx/nnx/nn/normalization.py
+++ b/flax/nnx/nnx/nn/normalization.py
@@ -163,10 +163,8 @@ def _normalize(
   mean = mean.reshape(stats_shape)
   var = var.reshape(stats_shape)
   feature_shape = [1] * x.ndim
-  reduced_feature_shape = []
   for ax in feature_axes:
     feature_shape[ax] = x.shape[ax]
-    reduced_feature_shape.append(x.shape[ax])
   y = x - mean
   mul = lax.rsqrt(var + epsilon)
   args = [x]
@@ -630,6 +628,204 @@ class RMSNorm(Module):
       None,
       self.reduction_axes,
       self.feature_axes,
+      self.dtype,
+      self.epsilon,
+    )
+
+class GroupNorm(Module):
+  """Group normalization (arxiv.org/abs/1803.08494).
+
+  This op is similar to batch normalization, but statistics are shared across
+  equally-sized groups of channels and not shared across batch dimension.
+  Thus, group normalization does not depend on the batch composition and does
+  not require maintaining internal state for storing statistics.
+  The user should either specify the total number of channel groups or the
+  number of channels per group.
+
+  .. note::
+    LayerNorm is a special case of GroupNorm where ``num_groups=1``.
+
+  Example usage::
+
+    >>> from flax import nnx
+    >>> import jax
+    >>> import numpy as np
+    ...
+    >>> x = jax.random.normal(jax.random.key(0), (3, 4, 5, 6))
+    >>> layer = nnx.GroupNorm(num_features=6, num_groups=3, rngs=nnx.Rngs(0))
+    >>> nnx.state(layer)
+    State({
+      'bias': VariableState(
+        type=Param,
+        value=Array([0., 0., 0., 0., 0., 0.], dtype=float32)
+      ),
+      'scale': VariableState(
+        type=Param,
+        value=Array([1., 1., 1., 1., 1., 1.], dtype=float32)
+      )
+    })
+    >>> y = layer(x)
+    ...
+    >>> y = nnx.GroupNorm(num_features=6, num_groups=1, rngs=nnx.Rngs(0))(x)
+    >>> y2 = nnx.LayerNorm(num_features=6, reduction_axes=(1, 2, 3), rngs=nnx.Rngs(0))(x)
+    >>> np.testing.assert_allclose(y, y2)
+
+  Attributes:
+    num_features: the number of input features/channels.
+    num_groups: the total number of channel groups. The default value of 32 is
+      proposed by the original group normalization paper.
+    group_size: the number of channels in a group.
+    epsilon: A small float added to variance to avoid dividing by zero.
+    dtype: the dtype of the result (default: infer from input and params).
+    param_dtype: the dtype passed to parameter initializers (default: float32).
+    use_bias:  If True, bias (beta) is added.
+    use_scale: If True, multiply by scale (gamma). When the next layer is linear
+      (also e.g. nn.relu), this can be disabled since the scaling will be done
+      by the next layer.
+    bias_init: Initializer for bias, by default, zero.
+    scale_init: Initializer for scale, by default, one.
+    reduction_axes: List of axes used for computing normalization statistics.
+      This list must include the final dimension, which is assumed to be the
+      feature axis. Furthermore, if the input used at call time has additional
+      leading axes compared to the data used for initialisation, for example due
+      to batching, then the reduction axes need to be defined explicitly.
+    axis_name: the axis name used to combine batch statistics from multiple
+      devices. See ``jax.pmap`` for a description of axis names (default: None).
+      This is only needed if the model is subdivided across devices, i.e. the
+      array being normalized is sharded across devices within a pmap or shard
+      map. For SPMD jit, you do not need to manually synchronize. Just make sure
+      that the axes are correctly annotated and XLA:SPMD will insert the
+      necessary collectives.
+    axis_index_groups: groups of axis indices within that named axis
+      representing subsets of devices to reduce over (default: None). For
+      example, ``[[0, 1], [2, 3]]`` would independently batch-normalize over the
+      examples on the first two and last two devices. See ``jax.lax.psum`` for
+      more details.
+    use_fast_variance: If true, use a faster, but less numerically stable,
+      calculation for the variance.
+    rngs: rng key.
+  """
+
+  def __init__(
+    self,
+    num_features: int,
+    num_groups: tp.Optional[int] = 32,
+    group_size: tp.Optional[int] = None,
+    *,
+    epsilon: float = 1e-6,
+    dtype: tp.Optional[Dtype] = None,
+    param_dtype: Dtype = jnp.float32,
+    use_bias: bool = True,
+    use_scale: bool = True,
+    bias_init: Initializer = initializers.zeros_init(),
+    scale_init: Initializer = initializers.ones_init(),
+    reduction_axes: tp.Optional[Axes] = None,
+    axis_name: tp.Optional[str] = None,
+    axis_index_groups: tp.Any = None,
+    use_fast_variance: bool = True,
+    rngs: rnglib.Rngs,
+  ):
+    self.feature_axis = -1
+
+    if (num_groups is None and group_size is None) or (
+      num_groups is not None and group_size is not None
+    ):
+      raise ValueError(
+        'Either `num_groups` or `group_size` should be '
+        'specified. If `group_size` is to be specified, '
+        'pass `num_groups=None` as argument to override '
+        'the default `num_groups` value of 32.'
+      )
+
+    if group_size is not None:
+      if num_features % group_size != 0:
+        raise ValueError(
+          'Number of features ({}) is not multiple of the '
+          'group size ({}).'.format(num_features, group_size)
+        )
+      self.num_groups = num_features // group_size
+      self.group_size = group_size
+    else:
+      if not isinstance(num_groups, int) or num_groups <= 0 or (
+        num_features % num_groups != 0
+      ):
+        raise ValueError(
+          'Number of groups ({}) does not divide the number'
+          ' of channels ({}).'.format(num_groups, num_features)
+        )
+      self.num_groups = num_groups
+      self.group_size = num_features // num_groups
+
+    feature_shape = (num_features,)
+    if use_scale:
+      key = rngs.params()
+      self.scale = nnx.Param(scale_init(key, feature_shape, param_dtype))
+    else:
+      self.scale = nnx.Param(None)
+
+    if use_bias:
+      key = rngs.params()
+      self.bias = nnx.Param(bias_init(key, feature_shape, param_dtype))
+    else:
+      self.bias = nnx.Param(None)
+
+    self.epsilon = epsilon
+    self.dtype = dtype
+    self.param_dtype = param_dtype
+    self.use_bias = use_bias
+    self.use_scale = use_scale
+    self.bias_init = bias_init
+    self.scale_init = scale_init
+    self.reduction_axes = reduction_axes
+    self.axis_name = axis_name
+    self.axis_index_groups = axis_index_groups
+    self.use_fast_variance = use_fast_variance
+
+  def __call__(self, x, *, mask: tp.Optional[jax.Array] = None):
+    """Applies group normalization to the input (arxiv.org/abs/1803.08494).
+
+    Args:
+      x: the input of shape ``...self.num_features`` where ``self.num_features``
+        is a channels dimension and ``...`` represents an arbitrary number of
+        extra dimensions that can be used to accumulate statistics over. If no
+        reduction axes have been specified then all additional dimensions ``...``
+        will be used to accumulate statistics apart from the leading dimension
+        which is assumed to represent the batch.
+      mask: Binary array of shape broadcastable to ``inputs`` tensor, indicating
+        the positions for which the mean and variance should be computed.
+
+    Returns:
+      Normalized inputs (the same shape as inputs).
+    """
+    if self.reduction_axes is not None:
+      reduction_axes = self.reduction_axes
+    else:
+      reduction_axes = list(range(1, x.ndim - 1)) + [-1]
+    reduction_axes = _canonicalize_axes(x.ndim, reduction_axes)
+
+    group_shape = x.shape[:-1] + (self.num_groups, self.group_size)
+    if mask is not None:
+      mask = mask.reshape(mask.shape[:-1] + (self.num_groups, self.group_size))
+
+    mean, var = _compute_stats(
+      x.reshape(group_shape),
+      list(reduction_axes[:-1]) + [-1],
+      self.dtype,
+      self.axis_name,
+      self.axis_index_groups,
+      use_fast_variance=self.use_fast_variance,
+      mask=mask,
+    )
+    mean = jnp.repeat(mean, self.group_size, axis=1)
+    var = jnp.repeat(var, self.group_size, axis=1)
+    return _normalize(
+      x,
+      mean,
+      var,
+      self.scale.value,
+      self.bias.value,
+      reduction_axes[:-1],
+      (self.feature_axis,),
       self.dtype,
       self.epsilon,
     )

--- a/flax/nnx/tests/nn/normalization_test.py
+++ b/flax/nnx/tests/nn/normalization_test.py
@@ -248,6 +248,81 @@ class TestLinenConsistency(parameterized.TestCase):
     assert isinstance(linen_out, jax.Array)
     np.testing.assert_array_equal(linen_out, nnx_out)
 
+  @parameterized.product(
+    dtype=[jnp.float32, jnp.float16],
+    param_dtype=[jnp.float32, jnp.float16],
+    use_fast_variance=[True, False],
+    mask=[None, np.array([True, False, True, False, True, False])],
+  )
+  def test_nnx_linen_groupnorm_equivalence(
+    self,
+    dtype: tp.Optional[Dtype],
+    param_dtype: Dtype,
+    use_fast_variance: bool,
+    mask: tp.Optional[np.ndarray],
+  ):
+    class NNXModel(nnx.Module):
+      def __init__(self, dtype, param_dtype, use_fast_variance, rngs):
+        self.norm_layer = nnx.GroupNorm(
+          6,
+          num_groups=3,
+          dtype=dtype,
+          param_dtype=param_dtype,
+          use_fast_variance=use_fast_variance,
+          rngs=rngs,
+        )
+        self.linear = nnx.Linear(
+          6, 4, dtype=dtype, param_dtype=param_dtype, rngs=rngs
+        )
+
+      def __call__(self, x, *, mask=None):
+        x = self.norm_layer(x, mask=mask)
+        x = self.linear(x)
+        return x
+
+    class LinenModel(linen.Module):
+      dtype: tp.Optional[Dtype] = None
+      param_dtype: Dtype = jnp.float32
+      use_fast_variance: bool = True
+
+      def setup(self):
+        self.norm_layer = linen.GroupNorm(
+          num_groups=3,
+          dtype=self.dtype,
+          param_dtype=self.param_dtype,
+          use_fast_variance=self.use_fast_variance,
+        )
+        self.linear = linen.Dense(
+          4, dtype=self.dtype, param_dtype=self.param_dtype
+        )
+
+      def __call__(self, x, *, mask=None):
+        x = self.norm_layer(x, mask=mask)
+        x = self.linear(x)
+        return x
+
+    rngs = nnx.Rngs(42)
+    x = jax.random.normal(jax.random.key(0), (10, 6))
+
+    linen_model = LinenModel(
+      dtype=dtype, param_dtype=param_dtype, use_fast_variance=use_fast_variance
+    )
+    variables = linen_model.init(jax.random.key(1), x)
+    linen_out = linen_model.apply(variables, x, mask=mask)
+
+    nnx_model = NNXModel(
+      dtype=dtype,
+      param_dtype=param_dtype,
+      use_fast_variance=use_fast_variance,
+      rngs=rngs,
+    )
+    nnx_model.linear.kernel.value = variables['params']['linear']['kernel']
+    nnx_model.linear.bias.value = variables['params']['linear']['bias']
+
+    nnx_out = nnx_model(x, mask=mask)
+    assert isinstance(linen_out, jax.Array)
+    np.testing.assert_array_equal(linen_out, nnx_out)
+
 
 if __name__ == '__main__':
   absltest.main()


### PR DESCRIPTION
# What does this PR do?

Addresses #4086 and adds a GroupNorm layer to NNX. I tried to follow the Linen implementation and how the other layers have been ported. I also tested equivalence checks between Linen's GroupNorm implementation and the NNX implementation.

Some notes:
- I used `num_features` instead of `num_channels` as an input argument to stay consistent with the LayerNorm implementation.
- I deleted the `reduced_feature_shape` list in the `_normalize` function as it is unused. If there is a reason why the list was created without being used I can reverse the deletion.

## Checklist
- [ ] This PR fixes a minor issue (e.g.: typo or small bug) or improves the docs (you can dismiss the other
      checks if that's the case).
- [x] This change is discussed in #4086.
- [x] The documentation and docstrings adhere to the
      [documentation guidelines](https://github.com/google/flax/blob/main/docs/README.md#how-to-write-code-documentation).
- [x] This change includes necessary high-coverage tests.
      (No quality testing = no merge!)