### PR TITLE
fix mypy failures due tu numpy update

### DIFF
--- a/flax/nnx/tests/nn/conv_test.py
+++ b/flax/nnx/tests/nn/conv_test.py
@@ -108,6 +108,7 @@ class TestConvLinenConsistency(parameterized.TestCase):
 
     out_nnx = model_nnx(x)
     out = model.apply(variables, x)
+    assert isinstance(out, jax.Array)
     np.testing.assert_array_equal(out, out_nnx)
 
   @parameterized.product(
@@ -177,6 +178,7 @@ class TestConvLinenConsistency(parameterized.TestCase):
 
     out_nnx = model_nnx(x)
     out = model.apply(variables, x)
+    assert isinstance(out, jax.Array)
     np.testing.assert_array_equal(out, out_nnx)
 
 

--- a/flax/nnx/tests/nn/embed_test.py
+++ b/flax/nnx/tests/nn/embed_test.py
@@ -63,6 +63,7 @@ class TestLinenConsistency(parameterized.TestCase):
 
     out_nnx = model_nnx(x)
     out = model.apply(variables, x)
+    assert isinstance(out, jax.Array)
     np.testing.assert_array_equal(out, out_nnx)
 
     x = jax.numpy.ones((10,), dtype=input_dtype) * 10

--- a/flax/nnx/tests/nn/linear_test.py
+++ b/flax/nnx/tests/nn/linear_test.py
@@ -92,6 +92,7 @@ class TestLinenConsistency(parameterized.TestCase):
 
     out_nnx = model_nnx(x)
     out = model.apply(variables, x)
+    assert isinstance(out, jax.Array)
     np.testing.assert_array_equal(out, out_nnx)
 
   @parameterized.product(
@@ -140,6 +141,7 @@ class TestLinenConsistency(parameterized.TestCase):
       variables['params']['bias'] = model_nnx.bias.value
     out_nnx = model_nnx(x)
     out = model.apply(variables, x)
+    assert isinstance(out, jax.Array)
     np.testing.assert_array_equal(out, out_nnx)
 
     variables = model.init(key, x)
@@ -149,6 +151,7 @@ class TestLinenConsistency(parameterized.TestCase):
       model_nnx.bias.value = variables['params']['bias']
     out_nnx = model_nnx(x)
     out = model.apply(variables, x)
+    assert isinstance(out, jax.Array)
     np.testing.assert_array_equal(out, out_nnx)
 
 

--- a/flax/nnx/tests/nn/normalization_test.py
+++ b/flax/nnx/tests/nn/normalization_test.py
@@ -161,6 +161,7 @@ class TestLinenConsistency(parameterized.TestCase):
     )
     variables = linen_model.init(jax.random.key(1), x)
     linen_out = linen_model.apply(variables, x, mask=mask)
+    assert isinstance(linen_out, jax.Array)
 
     nnx_model = NNXModel(
       dtype=dtype,
@@ -244,6 +245,7 @@ class TestLinenConsistency(parameterized.TestCase):
     nnx_model.linear.bias.value = variables['params']['linear']['bias']
 
     nnx_out = nnx_model(x, mask=mask)
+    assert isinstance(linen_out, jax.Array)
     np.testing.assert_array_equal(linen_out, nnx_out)
 
 


### PR DESCRIPTION
# What does this PR do?

Adds type checks to avoid `mypy` errors in calls to `np.testing.assert_array_equal`.