### PR TITLE
[nnx] add reseed

### DIFF
--- a/docs/api_reference/flax.nnx/rnglib.rst
+++ b/docs/api_reference/flax.nnx/rnglib.rst
@@ -8,3 +8,4 @@ rnglib
    :members: __init__
 .. autoclass:: RngStream
    :members:
+.. autofunction:: reseed

--- a/flax/nnx/__init__.py
+++ b/flax/nnx/__init__.py
@@ -105,6 +105,7 @@ from .nnx.rnglib import RngKey as RngKey
 from .nnx.rnglib import RngCount as RngCount
 from .nnx.rnglib import ForkStates as ForkStates
 from .nnx.rnglib import fork as fork
+from .nnx.rnglib import reseed as reseed
 from .nnx.spmd import PARTITION_NAME as PARTITION_NAME
 from .nnx.spmd import get_partition_spec as get_partition_spec
 from .nnx.spmd import get_named_sharding as get_named_sharding


### PR DESCRIPTION
# What does this PR do?

Adds `nnx.reseed` to update the nested keys of a graph node.

```python
class Model(nnx.Module):
  def __init__(self, rngs):
    self.linear = nnx.Linear(2, 3, rngs=rngs)
    self.dropout = nnx.Dropout(0.5, rngs=rngs)

  def __call__(self, x):
    return self.dropout(self.linear(x))

model = Model(nnx.Rngs(params=0, dropout=42))
x = jnp.ones((1, 2))

y1 = model(x)

# reset the ``dropout`` stream key to 42
nnx.reseed(model, dropout=42)
y2 = model(x)

assert jnp.allclose(y1, y2)
```