### PR TITLE
[linen] add share_scope

### DIFF
--- a/docs/api_reference/flax.linen/module.rst
+++ b/docs/api_reference/flax.linen/module.rst
@@ -11,3 +11,4 @@ Module
 .. autofunction:: init
 .. autofunction:: init_with_output
 .. autofunction:: intercept_methods
+.. autofunction:: share_scope

--- a/flax/errors.py
+++ b/flax/errors.py
@@ -691,6 +691,24 @@ class CallUnbindOnUnboundModuleError(FlaxError):
   def __init__(self):
     super().__init__("Can't call `unbind()` on unbound modules")
 
+class CallShareScopeOnUnboundModuleError(FlaxError):
+  """This error occurs when you are trying to call ``nn.share_scope`` on an unbound
+  Module. For instance, when you try to use ``nn.share_scope`` at the top-level::
+
+    from flax import linen as nn
+
+    class CustomDense(nn.Dense):
+      def __call__(self, x):
+        return super().__call__(x) + 1
+
+    custom_dense = CustomDense(5)
+    dense = nn.Dense(5)  # has the parameters
+
+    nn.share_scope(custom_dense, dense) # <-- ERROR!
+  """
+
+  def __init__(self):
+    super().__init__("Can't call `share_scope` on unbound modules")
 
 class InvalidInstanceModuleError(FlaxError):
   """This error occurs when you are trying to call ``.init()``, ``.init_with_output()``, ``.apply()`` or ``.bind()``

--- a/flax/linen/__init__.py
+++ b/flax/linen/__init__.py
@@ -117,6 +117,7 @@ from .module import (
     merge_param as merge_param,
     nowrap as nowrap,
     override_named_call as override_named_call,
+    share_scope as share_scope,
 )
 from .normalization import (
     BatchNorm as BatchNorm,


### PR DESCRIPTION
# What does this PR do?

Adds`nn.share_scope` can be used to share a scope between two Modules. This means that any parameters created by any of the Modules will be added to their common scope. This is useful when you want to wrap a Module and extend its functionality without changing the parameter structure.

```python
import flax.linen as nn
import jax
from jax import numpy as jnp, random

class DenseLoRA(nn.Module):
  base: nn.Dense
  rank: int

  def setup(self):
    nn.share_scope(self, self.base)

  @nn.compact
  def __call__(self, x: jax.Array):
    din, dout = x.shape[-1], self.base.features
    A = self.param('A', nn.zeros_init(), (din, self.rank))
    B = self.param('B', nn.zeros_init(), (self.rank, dout))
    return self.base(x) + x @ A @ B

class Model(nn.Module):
  @nn.compact
  def __call__(self, x: jax.Array):
    base = nn.Dense(10)  # base scope
    return DenseLoRA(base, rank=2)(x)  # reuse base scope

model = Model()

params = model.init(random.key(0), jnp.ones((1, 5)))['params']
list(params['Dense_0'].keys())
# ['A', 'B', 'kernel', 'bias']
```