### PR TITLE
Fix `_ParentType` annotation

### DIFF
--- a/flax/linen/module.py
+++ b/flax/linen/module.py
@@ -2901,7 +2901,7 @@ class Module(ModuleBase):
     return {'/'.join(row.path): row.module_copy for row in table}
 
 
-_ParentType = Union[type[Module], Scope, type[_Sentinel], None]
+_ParentType = Union[Module, Scope, _Sentinel, None]
 
 
 def merge_param(name: str, a: T | None, b: T | None) -> T:


### PR DESCRIPTION
Fixes definition of `_ParentType` so that runtime type checkers work with nested Flax modules.

# What does this PR do?

Fixes #3756. The parents that `_ParentType` refers to are *instances of classes*, not the classes themselves, so `type[Module]` and `type[_Sentinel]` should become `Module` and `_Sentinel` respectively.

## Checklist
- [x] This PR fixes a minor issue (e.g.: typo or small bug) or improves the docs (you can dismiss the other
      checks if that's the case).
- [x] This change is discussed [here](https://github.com/google/flax/issues/3756)
