### PR TITLE
implements error handling for reserved keywords in the `MultiMetric` class.

### DIFF
--- a/flax/nnx/nnx/training/metrics.py
+++ b/flax/nnx/nnx/training/metrics.py
@@ -362,7 +362,15 @@ class MultiMetric(Metric):
       **metrics: the key-word arguments that will be used to access
         the corresponding ``Metric``.
     """
-    # TODO: raise error if a kwarg is passed that is in ('reset', 'update', 'compute'), since these names are reserved for methods
+    # Raise error if a kwarg is passed that is in ('reset', 'update', 'compute'), since these names are reserved for methods
+    reserved_names = {'reset', 'update', 'compute'}
+    for metric_name in metrics:
+        if metric_name in reserved_names:
+            raise ValueError(
+                f"The keyword argument '{metric_name}' is reserved and cannot be used. "
+                f"Please use names other than {', '.join(reserved_names)}."
+            )
+    
     self._metric_names = []
     for metric_name, metric in metrics.items():
       self._metric_names.append(metric_name)


### PR DESCRIPTION
### Description

This PR implements error handling for reserved keywords in the `MultiMetric` class.

### Test Implementation

 The tests have been implemented using `pytest` and have been verified to pass successfully.

```python
import pytest
from flax.nnx.nnx.training.metrics import MultiMetric

@pytest.mark.parametrize("reserved_name", ['reset', 'update', 'compute'])
def test_reserved_names(reserved_name):
    with pytest.raises(ValueError) as excinfo:
        MultiMetric(**{reserved_name: None})
    assert f"The keyword argument '{reserved_name}' is reserved and cannot be used." in str(excinfo.value)
    
    
    
    
    
   
    $ pytest test_multimetric.py
================================ test session starts ================================
platform linux -- Python 3.12.1, pytest-7.1.2, pluggy-1.0.0
collected 3 items

test_multimetric.py ...                                                      [100%]

================================ 3 passed in 0.01s ================================