### PR TITLE
Add Unit Tests for `zeros_init` and `ones_init` Initializers

### DIFF
--- a/flax/nnx/tests/initializers_test.py
+++ b/flax/nnx/tests/initializers_test.py
@@ -1,0 +1,34 @@
+from absl.testing import absltest
+import jax
+import jax.numpy as jnp
+from flax.nnx import initializers
+
+class InitializersTest(absltest.TestCase):
+    def test_zeros_init_shape(self):
+        shape = (2, 3)
+        initializer = initializers.zeros_init()
+        result = initializer(jax.random.PRNGKey(0), shape)
+        self.assertEqual(result.shape, shape, "zeros_init did not produce the expected shape")
+
+    def test_zeros_init_values(self):
+        shape = (2, 3)
+        initializer = initializers.zeros_init()
+        result = initializer(jax.random.PRNGKey(0), shape)
+        expected = jnp.zeros(shape)
+        self.assertTrue(jnp.array_equal(result, expected), "zeros_init did not produce the expected values")
+
+    def test_ones_init_shape(self):
+        shape = (2, 3)
+        initializer = initializers.ones_init()
+        result = initializer(jax.random.PRNGKey(0), shape)
+        self.assertEqual(result.shape, shape, "ones_init did not produce the expected shape")
+
+    def test_ones_init_values(self):
+        shape = (2, 3)
+        initializer = initializers.ones_init()
+        result = initializer(jax.random.PRNGKey(0), shape)
+        expected = jnp.ones(shape)
+        self.assertTrue(jnp.array_equal(result, expected), "ones_init did not produce the expected values")
+
+if __name__ == '__main__':
+    absltest.main()


### PR DESCRIPTION
### Add Unit Tests for `zeros_init` and `ones_init` Initializers

#### Description:
This PR adds unit tests for the `zeros_init` and `ones_init` initializers in the `flax.nnx` module. The tests ensure that the initializers produce the expected shapes and values.

#### Changes:
1. **Added Tests for `zeros_init`:**
   - `test_zeros_init_shape`: Verifies that the `zeros_init` initializer produces arrays of the correct shape.
   - `test_zeros_init_values`: Verifies that the `zeros_init` initializer produces arrays filled with zeros.

2. **Added Tests for `ones_init`:**
   - `test_ones_init_shape`: Verifies that the `ones_init` initializer produces arrays of the correct shape.
   - `test_ones_init_values`: Verifies that the `ones_init` initializer produces arrays filled with ones.

#### Testing:
- All tests have been run and passed successfully, confirming that the initializers work as expected.
