### PR TITLE
[WIP] Require `transform_metadata` when variables have sharding annotation

### DIFF
--- a/flax/errors.py
+++ b/flax/errors.py
@@ -65,6 +65,25 @@ class FlaxError(Exception):
 
 
 #################################################
+# NNX errors                                    #
+#################################################
+
+
+class TraceContextError(FlaxError):
+  pass
+
+
+class AxisNameMissingError(FlaxError):
+  def __init__(self, x_sharding):
+    super().__init__(
+      'You are trying to modify param dimension via transforms like `nnx.vmap` '
+      f'or `nnx.scan`, while the param is partition-annotated as: {x_sharding} '
+      'You need to provide the axis name of the transform via extra '
+      'argument: transform_metadata={nnx.PARTITION_NAME: "your_axis_name"}'
+    )
+
+
+#################################################
 # lazy_init.py errors                           #
 #################################################
 

--- a/flax/nnx/variables.py
+++ b/flax/nnx/variables.py
@@ -870,17 +870,15 @@ class VariableState(tp.Generic[A], reprlib.Representable):
     del metadata['value']
     return metadata
 
-  def add_axis(self, axis_name: AxisName, axis_index: AxisIndex):
-    if not hasattr(self, 'add_axis_hooks'):
-      raise ValueError(f'No add_axis_hooks found for VariableState: {self}')
-    for hook in self.add_axis_hooks:
-      hook(self, axis_name, axis_index)
+  def add_axis(self, axis_index: AxisIndex, axis_name: AxisName | None = None):
+    if hasattr(self, 'add_axis_hooks'):
+      for hook in self.add_axis_hooks:
+        hook(self, axis_name, axis_index)
 
-  def remove_axis(self, axis_name: AxisName, axis_index: AxisIndex):
-    if not hasattr(self, 'remove_axis_hooks'):
-      raise ValueError(f'No remove_axis_hooks found for VariableState: {self}')
-    for hook in self.remove_axis_hooks:
-      hook(self, axis_name, axis_index)
+  def remove_axis(self, axis_index: AxisIndex, axis_name: AxisName | None = None):
+    if hasattr(self, 'remove_axis_hooks'):
+      for hook in self.remove_axis_hooks:
+        hook(self, axis_name, axis_index)
 
 
 def _variable_state_flatten(x: VariableState[tp.Any], *, with_keys: bool):


### PR DESCRIPTION
Goal: to force user to input a `transform_metadata` if they do transform upon annotated variables. 

Todo: Can we auto-infer the transform axis name from the annotated variables and only throw errors when not? Would that be more clever than requiring it always?