### PR TITLE
[nnx] fix transforms guide

### DIFF
--- a/docs_nnx/guides/transforms.ipynb
+++ b/docs_nnx/guides/transforms.ipynb
@@ -90,7 +90,7 @@
     "  def __init__(self, kernel: jax.Array, bias: jax.Array):\n",
     "    self.kernel, self.bias = nnx.Param(kernel), nnx.Param(bias)\n",
     "\n",
-    "self = Weights(\n",
+    "weights = Weights(\n",
     "  kernel=random.uniform(random.key(0), (10, 2, 3)),\n",
     "  bias=jnp.zeros((10, 3)),\n",
     ")\n",
@@ -101,10 +101,10 @@
     "  assert x.ndim == 1, 'Batch dimensions not allowed'\n",
     "  return x @ weights.kernel + weights.bias\n",
     "\n",
-    "y = nnx.vmap(vector_dot, in_axes=0, out_axes=1)(self, x)\n",
+    "y = nnx.vmap(vector_dot, in_axes=0, out_axes=1)(weights, x)\n",
     "\n",
     "print(f'{y.shape = }')\n",
-    "nnx.display(self)"
+    "nnx.display(weights)"
    ]
   },
   {
@@ -158,8 +158,8 @@
     "  )\n",
     "\n",
     "seeds = jnp.arange(10)\n",
-    "self = nnx.vmap(create_weights)(seeds)\n",
-    "nnx.display(self)"
+    "weights = nnx.vmap(create_weights)(seeds)\n",
+    "nnx.display(weights)"
    ]
   },
   {
@@ -276,7 +276,7 @@
     "    self.kernel, self.bias = nnx.Param(kernel), nnx.Param(bias)\n",
     "    self.count = Count(count)\n",
     "\n",
-    "self = Weights(\n",
+    "weights = Weights(\n",
     "  kernel=random.uniform(random.key(0), (10, 2, 3)),\n",
     "  bias=jnp.zeros((10, 3)),\n",
     "  count=jnp.arange(10),\n",
@@ -290,9 +290,9 @@
     "  return x @ weights.kernel + weights.bias\n",
     "\n",
     "\n",
-    "y = nnx.vmap(stateful_vector_dot, in_axes=0, out_axes=1)(self, x)\n",
+    "y = nnx.vmap(stateful_vector_dot, in_axes=0, out_axes=1)(weights, x)\n",
     "\n",
-    "self.count"
+    "weights.count"
    ]
   },
   {
@@ -353,7 +353,7 @@
     "    self.kernel, self.bias = nnx.Param(kernel), nnx.Param(bias)\n",
     "    self.count = Count(count)\n",
     "\n",
-    "self = Weights(\n",
+    "weights = Weights(\n",
     "  kernel=random.uniform(random.key(0), (10, 2, 3)),\n",
     "  bias=jnp.zeros((10, 3)),\n",
     "  count=jnp.arange(10),\n",
@@ -370,9 +370,9 @@
     "  weights.new_param = weights.kernel # share reference\n",
     "  return y\n",
     "\n",
-    "y = nnx.vmap(crazy_vector_dot, in_axes=0, out_axes=1)(self, x)\n",
+    "y = nnx.vmap(crazy_vector_dot, in_axes=0, out_axes=1)(weights, x)\n",
     "\n",
-    "nnx.display(self)"
+    "nnx.display(weights)"
    ]
   },
   {
@@ -433,7 +433,7 @@
     "    self.kernel, self.bias = nnx.Param(kernel), nnx.Param(bias)\n",
     "    self.count = Count(count)\n",
     "\n",
-    "self = Weights(\n",
+    "weights = Weights(\n",
     "  kernel=random.uniform(random.key(0), (10, 2, 3)),\n",
     "  bias=jnp.zeros((10, 3)),\n",
     "  count=jnp.array(0),\n",
@@ -448,9 +448,9 @@
     "  return x @ weights.kernel + weights.bias\n",
     "\n",
     "state_axes = nnx.StateAxes({nnx.Param: 0, Count: None}) # broadcast Count\n",
-    "y = nnx.vmap(stateful_vector_dot, in_axes=(state_axes, 0), out_axes=1)(self, x)\n",
+    "y = nnx.vmap(stateful_vector_dot, in_axes=(state_axes, 0), out_axes=1)(weights, x)\n",
     "\n",
-    "self.count"
+    "weights.count"
    ]
   },
   {
@@ -517,7 +517,7 @@
     "    self.count = Count(count)\n",
     "    self.rngs = nnx.Rngs(noise=seed)\n",
     "\n",
-    "self = Weights(\n",
+    "weights = Weights(\n",
     "  kernel=random.uniform(random.key(0), (2, 3)),\n",
     "  bias=jnp.zeros((3,)),\n",
     "  count=jnp.array(0),\n",
@@ -533,11 +533,11 @@
     "  return y + random.normal(weights.rngs.noise(), y.shape)\n",
     "\n",
     "state_axes = nnx.StateAxes({nnx.RngState: 0, (nnx.Param, Count): None})\n",
-    "y1 = nnx.vmap(noisy_vector_dot, in_axes=(state_axes, 0))(self, x)\n",
-    "y2 = nnx.vmap(noisy_vector_dot, in_axes=(state_axes, 0))(self, x)\n",
+    "y1 = nnx.vmap(noisy_vector_dot, in_axes=(state_axes, 0))(weights, x)\n",
+    "y2 = nnx.vmap(noisy_vector_dot, in_axes=(state_axes, 0))(weights, x)\n",
     "\n",
     "print(jnp.allclose(y1, y2))\n",
-    "nnx.display(self)"
+    "nnx.display(weights)"
    ]
   },
   {
@@ -589,7 +589,7 @@
     }
    ],
    "source": [
-    "self = Weights(\n",
+    "weights = Weights(\n",
     "  kernel=random.uniform(random.key(0), (2, 3)),\n",
     "  bias=jnp.zeros((3,)),\n",
     "  count=jnp.array(0),\n",
@@ -608,11 +608,11 @@
     "  y = x @ weights.kernel + weights.bias\n",
     "  return y + random.normal(weights.rngs.noise(), y.shape)\n",
     "\n",
-    "y1 = noisy_vector_dot(self, x)\n",
-    "y2 = noisy_vector_dot(self, x)\n",
+    "y1 = noisy_vector_dot(weights, x)\n",
+    "y2 = noisy_vector_dot(weights, x)\n",
     "\n",
     "print(jnp.allclose(y1, y2))\n",
-    "nnx.display(self)"
+    "nnx.display(weights)"
    ]
   },
   {


### PR DESCRIPTION
# What does this PR do?

Renames some variables named `self` to `weights` that where wrongly modified by vscode during a refactor operation.