### PR TITLE
Fix scale dtype and refactor q_dot_dq

### DIFF
--- a/tests/linen/linen_test.py
+++ b/tests/linen/linen_test.py
@@ -1263,7 +1263,7 @@ class Fp8Test(parameterized.TestCase):
     # Used to cast the inputs to be representable in FP8, so that the difference
     # of the results from the original gemm and fp8 gemm is small.
     cast_to_representable = functools.partial(
-      fp8_ops.quantize_dequantize,
+      fp8_ops.qdq,
       scale=jnp.ones((1,)),
       compute_dtype=jnp.float32,
     )


### PR DESCRIPTION
1. Address type mismatches or inconsistencies in scale factors for FP8 operations.
2. Refactor the q-dot-dq (direct quantization pattern) into smaller, more granular components to enable greater flexibility.
@kaixih @levskaya 
https://github.com/google/praxis/pull/69 depends on this PR.
