### PR TITLE
proxy more methods for `nnx.Variable`

### DIFF
--- a/flax/nnx/variables.py
+++ b/flax/nnx/variables.py
@@ -654,6 +654,17 @@ class Variable(tp.Generic[A], reprlib.Representable):
   def __ceil__(self) -> A:
     return self.value.__ceil__()  # type: ignore
 
+  def __array__(self, *args, **kwargs):
+    return self.value.__array__(*args, **kwargs)  # type: ignore
+
+  def __array_namespace__(self, *args, **kwargs):
+    return self.value.__array_namespace__(*args, **kwargs)  # type: ignore
+
+  def __dlpack__(self, *args, **kwargs):
+    return self.value.__dlpack__(*args, **kwargs)  # type: ignore
+
+  def __dlpack_device__(self) -> tuple[enum.Enum, int]:
+    return self.value.__dlpack_device__()  # type: ignore
 
 class Param(Variable[A]):
   """The canonical learnable parameter. All learnable parameters

--- a/tests/nnx/variable_test.py
+++ b/tests/nnx/variable_test.py
@@ -14,6 +14,7 @@
 
 import typing as tp
 
+import numpy as np
 import jax
 import jax.numpy as jnp
 
@@ -81,6 +82,20 @@ class TestVariableState(absltest.TestCase):
 
     self.assertEqual(result, 6)
 
+  def test_proxy_dlpack(self):
+    v = nnx.Param(jnp.ones((2, 3)))
+
+    self.assertEqual(np.from_dlpack(v).shape, (2, 3))
+
+  def test_proxy_array(self):
+    v = nnx.Param(jnp.ones((2, 3)))
+
+    self.assertEqual(np.asarray(v).shape, (2, 3))
+
+  def test_proxy_array_namespace(self):
+    v = nnx.Param(jnp.ones((2, 3)))
+
+    self.assertEqual(v.__array_namespace__(), jnp)
 
 if __name__ == '__main__':
   absltest.main()


### PR DESCRIPTION
# What does this PR do?

<!--

Great, you are contributing to Flax!

But... please read the following carefully so we can make sure your PR is merged
easily.

Replace this text block with a description of the change and which issue it
fixes (if applicable). Please also include relevant motivation/context.

Once you're done, someone in the Flax team will review your PR shortly. They may
suggest changes to make the code even better. If no one reviewed your PR after a
week has passed, don't hesitate to post a new comment @-mentioning the same
persons (sometimes notifications get lost).
-->

Proxy `__array__`, `__array_namespace__`, `__dlpack__`, and `__dlpack_device__` for `flax.nnx.Variable`.

`__array_namespace__`, `__dlpack__`, and `__dlpack_device__` are specified in the [Array API](https://data-apis.org/array-api/latest/API_specification/array_object.html#methods). `__array__` is specified in [NumPy](https://numpy.org/doc/stable/user/basics.interoperability.html#the-array-method). These methods have been supported by `jax.numpy.Array`.

<!-- Fixes # (issue) -->

## Checklist
- [ ] This PR fixes a minor issue (e.g.: typo or small bug) or improves the docs (you can dismiss the other
      checks if that's the case).
- [ ] This change is discussed in a Github issue/
      [discussion](https://github.com/google/flax/discussions) (please add a
      link).
- [ ] The documentation and docstrings adhere to the
      [documentation guidelines](https://github.com/google/flax/blob/main/docs/README.md#how-to-write-code-documentation).
- [x] This change includes necessary high-coverage tests.
      (No quality testing = no merge!)
