### PR TITLE
point nnx banner to flax-linen

### DIFF
--- a/docs_nnx/conf.py
+++ b/docs_nnx/conf.py
@@ -113,7 +113,7 @@ html_extra_path = ['robots.txt']
 # href with no underline and white bold text color
 announcement = """
 <a
-  href="https://flax.readthedocs.io/en/latest"
+  href="https://flax-linen.readthedocs.io/en/latest"
   style="text-decoration: none; color: white;"
 >
   This Flax NNX. Click here for <b>Flax Linen</b>.


### PR DESCRIPTION
# What does this PR do?

* Points the `docs_nnx` banner to https://flax-linen.readthedocs.io/en/latest.