### PR TITLE
Add redirects for Linen guide links in the NNX site scope.

### DIFF
--- a/docs_nnx/developer_notes/lift.rst
+++ b/docs_nnx/developer_notes/lift.rst
@@ -1,0 +1,17 @@
+.. raw:: html
+
+  <!-- This is a dummy page for re-directing existing Linen guides' old links to the Linen site. -->
+  <!DOCTYPE HTML>
+  <html lang="en-US">
+      <head>
+          <meta charset="UTF-8">
+          <meta http-equiv="refresh" content="0; url=https://flax-linen.readthedocs.io/en/latest/developer_notes/lift.html">
+          <script type="text/javascript">
+              window.location.href = "https://flax-linen.readthedocs.io/en/latest/developer_notes/lift.html"
+          </script>
+          <title>Page Redirection</title>
+      </head>
+      <body>
+          The old Flax Linen API and guides has been moved to another domain. Follow this <a href='https://flax-linen.readthedocs.io/en/latest/developer_notes/lift.html'>link to the page.</a>.
+      </body>
+  </html>

--- a/docs_nnx/developer_notes/module_lifecycle.rst
+++ b/docs_nnx/developer_notes/module_lifecycle.rst
@@ -1,0 +1,17 @@
+.. raw:: html
+
+  <!-- This is a dummy page for re-directing existing Linen guides' old links to the Linen site. -->
+  <!DOCTYPE HTML>
+  <html lang="en-US">
+      <head>
+          <meta charset="UTF-8">
+          <meta http-equiv="refresh" content="0; url=https://flax-linen.readthedocs.io/en/latest/developer_notes/module_lifecycle.html">
+          <script type="text/javascript">
+              window.location.href = "https://flax-linen.readthedocs.io/en/latest/developer_notes/module_lifecycle.html"
+          </script>
+          <title>Page Redirection</title>
+      </head>
+      <body>
+          The old Flax Linen API and guides has been moved to another domain. Follow this <a href='https://flax-linen.readthedocs.io/en/latest/developer_notes/module_lifecycle.html'>link to the page.</a>.
+      </body>
+  </html>

--- a/docs_nnx/guides/converting_and_upgrading/convert_pytorch_to_flax.rst
+++ b/docs_nnx/guides/converting_and_upgrading/convert_pytorch_to_flax.rst
@@ -1,0 +1,17 @@
+.. raw:: html
+
+  <!-- This is a dummy page for re-directing existing Linen guides' old links to the Linen site. -->
+  <!DOCTYPE HTML>
+  <html lang="en-US">
+      <head>
+          <meta charset="UTF-8">
+          <meta http-equiv="refresh" content="0; url=https://flax-linen.readthedocs.io/en/latest/guides/converting_and_upgrading/convert_pytorch_to_flax.html">
+          <script type="text/javascript">
+              window.location.href = "https://flax-linen.readthedocs.io/en/latest/guides/converting_and_upgrading/convert_pytorch_to_flax.html"
+          </script>
+          <title>Page Redirection</title>
+      </head>
+      <body>
+          The old Flax Linen API and guides has been moved to another domain. Follow this <a href='https://flax-linen.readthedocs.io/en/latest/guides/converting_and_upgrading/convert_pytorch_to_flax.html'>link to the page.</a>.
+      </body>
+  </html>

--- a/docs_nnx/guides/converting_and_upgrading/haiku_migration_guide.rst
+++ b/docs_nnx/guides/converting_and_upgrading/haiku_migration_guide.rst
@@ -1,0 +1,17 @@
+.. raw:: html
+
+  <!-- This is a dummy page for re-directing existing Linen guides' old links to the Linen site. -->
+  <!DOCTYPE HTML>
+  <html lang="en-US">
+      <head>
+          <meta charset="UTF-8">
+          <meta http-equiv="refresh" content="0; url=https://flax-linen.readthedocs.io/en/latest/guides/converting_and_upgrading/haiku_migration_guide.html">
+          <script type="text/javascript">
+              window.location.href = "https://flax-linen.readthedocs.io/en/latest/guides/converting_and_upgrading/haiku_migration_guide.html"
+          </script>
+          <title>Page Redirection</title>
+      </head>
+      <body>
+          The old Flax Linen API and guides has been moved to another domain. Follow this <a href='https://flax-linen.readthedocs.io/en/latest/guides/converting_and_upgrading/haiku_migration_guide.html'>link to the page.</a>.
+      </body>
+  </html>

--- a/docs_nnx/guides/converting_and_upgrading/linen_upgrade_guide.rst
+++ b/docs_nnx/guides/converting_and_upgrading/linen_upgrade_guide.rst
@@ -1,0 +1,17 @@
+.. raw:: html
+
+  <!-- This is a dummy page for re-directing existing Linen guides' old links to the Linen site. -->
+  <!DOCTYPE HTML>
+  <html lang="en-US">
+      <head>
+          <meta charset="UTF-8">
+          <meta http-equiv="refresh" content="0; url=https://flax-linen.readthedocs.io/en/latest/guides/converting_and_upgrading/linen_upgrade_guide.html">
+          <script type="text/javascript">
+              window.location.href = "https://flax-linen.readthedocs.io/en/latest/guides/converting_and_upgrading/linen_upgrade_guide.html"
+          </script>
+          <title>Page Redirection</title>
+      </head>
+      <body>
+          The old Flax Linen API and guides has been moved to another domain. Follow this <a href='https://flax-linen.readthedocs.io/en/latest/guides/converting_and_upgrading/linen_upgrade_guide.html'>link to the page.</a>.
+      </body>
+  </html>

--- a/docs_nnx/guides/converting_and_upgrading/optax_update_guide.rst
+++ b/docs_nnx/guides/converting_and_upgrading/optax_update_guide.rst
@@ -1,0 +1,17 @@
+.. raw:: html
+
+  <!-- This is a dummy page for re-directing existing Linen guides' old links to the Linen site. -->
+  <!DOCTYPE HTML>
+  <html lang="en-US">
+      <head>
+          <meta charset="UTF-8">
+          <meta http-equiv="refresh" content="0; url=https://flax-linen.readthedocs.io/en/latest/guides/converting_and_upgrading/optax_update_guide.html">
+          <script type="text/javascript">
+              window.location.href = "https://flax-linen.readthedocs.io/en/latest/guides/converting_and_upgrading/optax_update_guide.html"
+          </script>
+          <title>Page Redirection</title>
+      </head>
+      <body>
+          The old Flax Linen API and guides has been moved to another domain. Follow this <a href='https://flax-linen.readthedocs.io/en/latest/guides/converting_and_upgrading/optax_update_guide.html'>link to the page.</a>.
+      </body>
+  </html>

--- a/docs_nnx/guides/converting_and_upgrading/orbax_upgrade_guide.rst
+++ b/docs_nnx/guides/converting_and_upgrading/orbax_upgrade_guide.rst
@@ -1,0 +1,17 @@
+.. raw:: html
+
+  <!-- This is a dummy page for re-directing existing Linen guides' old links to the Linen site. -->
+  <!DOCTYPE HTML>
+  <html lang="en-US">
+      <head>
+          <meta charset="UTF-8">
+          <meta http-equiv="refresh" content="0; url=https://flax-linen.readthedocs.io/en/latest/guides/converting_and_upgrading/orbax_upgrade_guide.html">
+          <script type="text/javascript">
+              window.location.href = "https://flax-linen.readthedocs.io/en/latest/guides/converting_and_upgrading/orbax_upgrade_guide.html"
+          </script>
+          <title>Page Redirection</title>
+      </head>
+      <body>
+          The old Flax Linen API and guides has been moved to another domain. Follow this <a href='https://flax-linen.readthedocs.io/en/latest/guides/converting_and_upgrading/orbax_upgrade_guide.html'>link to the page.</a>.
+      </body>
+  </html>

--- a/docs_nnx/guides/converting_and_upgrading/regular_dict_upgrade_guide.rst
+++ b/docs_nnx/guides/converting_and_upgrading/regular_dict_upgrade_guide.rst
@@ -1,0 +1,17 @@
+.. raw:: html
+
+  <!-- This is a dummy page for re-directing existing Linen guides' old links to the Linen site. -->
+  <!DOCTYPE HTML>
+  <html lang="en-US">
+      <head>
+          <meta charset="UTF-8">
+          <meta http-equiv="refresh" content="0; url=https://flax-linen.readthedocs.io/en/latest/guides/converting_and_upgrading/regular_dict_upgrade_guide.html">
+          <script type="text/javascript">
+              window.location.href = "https://flax-linen.readthedocs.io/en/latest/guides/converting_and_upgrading/regular_dict_upgrade_guide.html"
+          </script>
+          <title>Page Redirection</title>
+      </head>
+      <body>
+          The old Flax Linen API and guides has been moved to another domain. Follow this <a href='https://flax-linen.readthedocs.io/en/latest/guides/converting_and_upgrading/regular_dict_upgrade_guide.html'>link to the page.</a>.
+      </body>
+  </html>

--- a/docs_nnx/guides/converting_and_upgrading/rnncell_upgrade_guide.rst
+++ b/docs_nnx/guides/converting_and_upgrading/rnncell_upgrade_guide.rst
@@ -1,0 +1,17 @@
+.. raw:: html
+
+  <!-- This is a dummy page for re-directing existing Linen guides' old links to the Linen site. -->
+  <!DOCTYPE HTML>
+  <html lang="en-US">
+      <head>
+          <meta charset="UTF-8">
+          <meta http-equiv="refresh" content="0; url=https://flax-linen.readthedocs.io/en/latest/guides/converting_and_upgrading/rnncell_upgrade_guide.html">
+          <script type="text/javascript">
+              window.location.href = "https://flax-linen.readthedocs.io/en/latest/guides/converting_and_upgrading/rnncell_upgrade_guide.html"
+          </script>
+          <title>Page Redirection</title>
+      </head>
+      <body>
+          The old Flax Linen API and guides has been moved to another domain. Follow this <a href='https://flax-linen.readthedocs.io/en/latest/guides/converting_and_upgrading/rnncell_upgrade_guide.html'>link to the page.</a>.
+      </body>
+  </html>

--- a/docs_nnx/guides/data_preprocessing/full_eval.rst
+++ b/docs_nnx/guides/data_preprocessing/full_eval.rst
@@ -1,0 +1,17 @@
+.. raw:: html
+
+  <!-- This is a dummy page for re-directing existing Linen guides' old links to the Linen site. -->
+  <!DOCTYPE HTML>
+  <html lang="en-US">
+      <head>
+          <meta charset="UTF-8">
+          <meta http-equiv="refresh" content="0; url=https://flax-linen.readthedocs.io/en/latest/guides/data_preprocessing/full_eval.html">
+          <script type="text/javascript">
+              window.location.href = "https://flax-linen.readthedocs.io/en/latest/guides/data_preprocessing/full_eval.html"
+          </script>
+          <title>Page Redirection</title>
+      </head>
+      <body>
+          The old Flax Linen API and guides has been moved to another domain. Follow this <a href='https://flax-linen.readthedocs.io/en/latest/guides/data_preprocessing/full_eval.html'>link to the page.</a>.
+      </body>
+  </html>

--- a/docs_nnx/guides/data_preprocessing/loading_datasets.rst
+++ b/docs_nnx/guides/data_preprocessing/loading_datasets.rst
@@ -1,0 +1,17 @@
+.. raw:: html
+
+  <!-- This is a dummy page for re-directing existing Linen guides' old links to the Linen site. -->
+  <!DOCTYPE HTML>
+  <html lang="en-US">
+      <head>
+          <meta charset="UTF-8">
+          <meta http-equiv="refresh" content="0; url=https://flax-linen.readthedocs.io/en/latest/guides/data_preprocessing/loading_datasets.html">
+          <script type="text/javascript">
+              window.location.href = "https://flax-linen.readthedocs.io/en/latest/guides/data_preprocessing/loading_datasets.html"
+          </script>
+          <title>Page Redirection</title>
+      </head>
+      <body>
+          The old Flax Linen API and guides has been moved to another domain. Follow this <a href='https://flax-linen.readthedocs.io/en/latest/guides/data_preprocessing/loading_datasets.html'>link to the page.</a>.
+      </body>
+  </html>

--- a/docs_nnx/guides/flax_fundamentals/arguments.rst
+++ b/docs_nnx/guides/flax_fundamentals/arguments.rst
@@ -1,0 +1,17 @@
+.. raw:: html
+
+  <!-- This is a dummy page for re-directing existing Linen guides' old links to the Linen site. -->
+  <!DOCTYPE HTML>
+  <html lang="en-US">
+      <head>
+          <meta charset="UTF-8">
+          <meta http-equiv="refresh" content="0; url=https://flax-linen.readthedocs.io/en/latest/guides/flax_fundamentals/arguments.html">
+          <script type="text/javascript">
+              window.location.href = "https://flax-linen.readthedocs.io/en/latest/guides/flax_fundamentals/arguments.html"
+          </script>
+          <title>Page Redirection</title>
+      </head>
+      <body>
+          The old Flax Linen API and guides has been moved to another domain. Follow this <a href='https://flax-linen.readthedocs.io/en/latest/guides/flax_fundamentals/arguments.html'>link to the page.</a>.
+      </body>
+  </html>

--- a/docs_nnx/guides/flax_fundamentals/flax_basics.rst
+++ b/docs_nnx/guides/flax_fundamentals/flax_basics.rst
@@ -1,0 +1,17 @@
+.. raw:: html
+
+  <!-- This is a dummy page for re-directing existing Linen guides' old links to the Linen site. -->
+  <!DOCTYPE HTML>
+  <html lang="en-US">
+      <head>
+          <meta charset="UTF-8">
+          <meta http-equiv="refresh" content="0; url=https://flax-linen.readthedocs.io/en/latest/guides/flax_fundamentals/flax_basics.html">
+          <script type="text/javascript">
+              window.location.href = "https://flax-linen.readthedocs.io/en/latest/guides/flax_fundamentals/flax_basics.html"
+          </script>
+          <title>Page Redirection</title>
+      </head>
+      <body>
+          The old Flax Linen API and guides has been moved to another domain. Follow this <a href='https://flax-linen.readthedocs.io/en/latest/guides/flax_fundamentals/flax_basics.html'>link to the page.</a>.
+      </body>
+  </html>

--- a/docs_nnx/guides/flax_fundamentals/rng_guide.rst
+++ b/docs_nnx/guides/flax_fundamentals/rng_guide.rst
@@ -1,0 +1,17 @@
+.. raw:: html
+
+  <!-- This is a dummy page for re-directing existing Linen guides' old links to the Linen site. -->
+  <!DOCTYPE HTML>
+  <html lang="en-US">
+      <head>
+          <meta charset="UTF-8">
+          <meta http-equiv="refresh" content="0; url=https://flax-linen.readthedocs.io/en/latest/guides/flax_fundamentals/rng_guide.html">
+          <script type="text/javascript">
+              window.location.href = "https://flax-linen.readthedocs.io/en/latest/guides/flax_fundamentals/rng_guide.html"
+          </script>
+          <title>Page Redirection</title>
+      </head>
+      <body>
+          The old Flax Linen API and guides has been moved to another domain. Follow this <a href='https://flax-linen.readthedocs.io/en/latest/guides/flax_fundamentals/rng_guide.html'>link to the page.</a>.
+      </body>
+  </html>

--- a/docs_nnx/guides/flax_fundamentals/setup_or_nncompact.rst
+++ b/docs_nnx/guides/flax_fundamentals/setup_or_nncompact.rst
@@ -1,0 +1,17 @@
+.. raw:: html
+
+  <!-- This is a dummy page for re-directing existing Linen guides' old links to the Linen site. -->
+  <!DOCTYPE HTML>
+  <html lang="en-US">
+      <head>
+          <meta charset="UTF-8">
+          <meta http-equiv="refresh" content="0; url=https://flax-linen.readthedocs.io/en/latest/guides/flax_fundamentals/setup_or_nncompact.html">
+          <script type="text/javascript">
+              window.location.href = "https://flax-linen.readthedocs.io/en/latest/guides/flax_fundamentals/setup_or_nncompact.html"
+          </script>
+          <title>Page Redirection</title>
+      </head>
+      <body>
+          The old Flax Linen API and guides has been moved to another domain. Follow this <a href='https://flax-linen.readthedocs.io/en/latest/guides/flax_fundamentals/setup_or_nncompact.html'>link to the page.</a>.
+      </body>
+  </html>

--- a/docs_nnx/guides/flax_fundamentals/state_params.rst
+++ b/docs_nnx/guides/flax_fundamentals/state_params.rst
@@ -1,0 +1,17 @@
+.. raw:: html
+
+  <!-- This is a dummy page for re-directing existing Linen guides' old links to the Linen site. -->
+  <!DOCTYPE HTML>
+  <html lang="en-US">
+      <head>
+          <meta charset="UTF-8">
+          <meta http-equiv="refresh" content="0; url=https://flax-linen.readthedocs.io/en/latest/guides/flax_fundamentals/state_params.html">
+          <script type="text/javascript">
+              window.location.href = "https://flax-linen.readthedocs.io/en/latest/guides/flax_fundamentals/state_params.html"
+          </script>
+          <title>Page Redirection</title>
+      </head>
+      <body>
+          The old Flax Linen API and guides has been moved to another domain. Follow this <a href='https://flax-linen.readthedocs.io/en/latest/guides/flax_fundamentals/state_params.html'>link to the page.</a>.
+      </body>
+  </html>

--- a/docs_nnx/guides/flax_sharp_bits.rst
+++ b/docs_nnx/guides/flax_sharp_bits.rst
@@ -1,0 +1,17 @@
+.. raw:: html
+
+  <!-- This is a dummy page for re-directing existing Linen guides' old links to the Linen site. -->
+  <!DOCTYPE HTML>
+  <html lang="en-US">
+      <head>
+          <meta charset="UTF-8">
+          <meta http-equiv="refresh" content="0; url=https://flax-linen.readthedocs.io/en/latest/guides/flax_sharp_bits.html">
+          <script type="text/javascript">
+              window.location.href = "https://flax-linen.readthedocs.io/en/latest/guides/flax_sharp_bits.html"
+          </script>
+          <title>Page Redirection</title>
+      </head>
+      <body>
+          The old Flax Linen API and guides has been moved to another domain. Follow this <a href='https://flax-linen.readthedocs.io/en/latest/guides/flax_sharp_bits.html'>link to the page.</a>.
+      </body>
+  </html>

--- a/docs_nnx/guides/model_inspection/extracting_intermediates.rst
+++ b/docs_nnx/guides/model_inspection/extracting_intermediates.rst
@@ -1,0 +1,17 @@
+.. raw:: html
+
+  <!-- This is a dummy page for re-directing existing Linen guides' old links to the Linen site. -->
+  <!DOCTYPE HTML>
+  <html lang="en-US">
+      <head>
+          <meta charset="UTF-8">
+          <meta http-equiv="refresh" content="0; url=https://flax-linen.readthedocs.io/en/latest/guides/model_inspection/extracting_intermediates.html">
+          <script type="text/javascript">
+              window.location.href = "https://flax-linen.readthedocs.io/en/latest/guides/model_inspection/extracting_intermediates.html"
+          </script>
+          <title>Page Redirection</title>
+      </head>
+      <body>
+          The old Flax Linen API and guides has been moved to another domain. Follow this <a href='https://flax-linen.readthedocs.io/en/latest/guides/model_inspection/extracting_intermediates.html'>link to the page.</a>.
+      </body>
+  </html>

--- a/docs_nnx/guides/model_inspection/model_surgery.rst
+++ b/docs_nnx/guides/model_inspection/model_surgery.rst
@@ -1,0 +1,17 @@
+.. raw:: html
+
+  <!-- This is a dummy page for re-directing existing Linen guides' old links to the Linen site. -->
+  <!DOCTYPE HTML>
+  <html lang="en-US">
+      <head>
+          <meta charset="UTF-8">
+          <meta http-equiv="refresh" content="0; url=https://flax-linen.readthedocs.io/en/latest/guides/model_inspection/model_surgery.html">
+          <script type="text/javascript">
+              window.location.href = "https://flax-linen.readthedocs.io/en/latest/guides/model_inspection/model_surgery.html"
+          </script>
+          <title>Page Redirection</title>
+      </head>
+      <body>
+          The old Flax Linen API and guides has been moved to another domain. Follow this <a href='https://flax-linen.readthedocs.io/en/latest/guides/model_inspection/model_surgery.html'>link to the page.</a>.
+      </body>
+  </html>

--- a/docs_nnx/guides/parallel_training/ensembling.rst
+++ b/docs_nnx/guides/parallel_training/ensembling.rst
@@ -1,0 +1,17 @@
+.. raw:: html
+
+  <!-- This is a dummy page for re-directing existing Linen guides' old links to the Linen site. -->
+  <!DOCTYPE HTML>
+  <html lang="en-US">
+      <head>
+          <meta charset="UTF-8">
+          <meta http-equiv="refresh" content="0; url=https://flax-linen.readthedocs.io/en/latest/guides/parallel_training/ensembling.html">
+          <script type="text/javascript">
+              window.location.href = "https://flax-linen.readthedocs.io/en/latest/guides/parallel_training/ensembling.html"
+          </script>
+          <title>Page Redirection</title>
+      </head>
+      <body>
+          The old Flax Linen API and guides has been moved to another domain. Follow this <a href='https://flax-linen.readthedocs.io/en/latest/guides/parallel_training/ensembling.html'>link to the page.</a>.
+      </body>
+  </html>

--- a/docs_nnx/guides/parallel_training/flax_on_pjit.rst
+++ b/docs_nnx/guides/parallel_training/flax_on_pjit.rst
@@ -1,0 +1,17 @@
+.. raw:: html
+
+  <!-- This is a dummy page for re-directing existing Linen guides' old links to the Linen site. -->
+  <!DOCTYPE HTML>
+  <html lang="en-US">
+      <head>
+          <meta charset="UTF-8">
+          <meta http-equiv="refresh" content="0; url=https://flax-linen.readthedocs.io/en/latest/guides/parallel_training/flax_on_pjit.html">
+          <script type="text/javascript">
+              window.location.href = "https://flax-linen.readthedocs.io/en/latest/guides/parallel_training/flax_on_pjit.html"
+          </script>
+          <title>Page Redirection</title>
+      </head>
+      <body>
+          The old Flax Linen API and guides has been moved to another domain. Follow this <a href='https://flax-linen.readthedocs.io/en/latest/guides/parallel_training/flax_on_pjit.html'>link to the page.</a>.
+      </body>
+  </html>

--- a/docs_nnx/guides/quantization/fp8_basics.rst
+++ b/docs_nnx/guides/quantization/fp8_basics.rst
@@ -1,0 +1,17 @@
+.. raw:: html
+
+  <!-- This is a dummy page for re-directing existing Linen guides' old links to the Linen site. -->
+  <!DOCTYPE HTML>
+  <html lang="en-US">
+      <head>
+          <meta charset="UTF-8">
+          <meta http-equiv="refresh" content="0; url=https://flax-linen.readthedocs.io/en/latest/guides/quantization/fp8_basics.html">
+          <script type="text/javascript">
+              window.location.href = "https://flax-linen.readthedocs.io/en/latest/guides/quantization/fp8_basics.html"
+          </script>
+          <title>Page Redirection</title>
+      </head>
+      <body>
+          The old Flax Linen API and guides has been moved to another domain. Follow this <a href='https://flax-linen.readthedocs.io/en/latest/guides/quantization/fp8_basics.html'>link to the page.</a>.
+      </body>
+  </html>

--- a/docs_nnx/guides/training_techniques/batch_norm.rst
+++ b/docs_nnx/guides/training_techniques/batch_norm.rst
@@ -1,0 +1,17 @@
+.. raw:: html
+
+  <!-- This is a dummy page for re-directing existing Linen guides' old links to the Linen site. -->
+  <!DOCTYPE HTML>
+  <html lang="en-US">
+      <head>
+          <meta charset="UTF-8">
+          <meta http-equiv="refresh" content="0; url=https://flax-linen.readthedocs.io/en/latest/guides/training_techniques/batch_norm.html">
+          <script type="text/javascript">
+              window.location.href = "https://flax-linen.readthedocs.io/en/latest/guides/training_techniques/batch_norm.html"
+          </script>
+          <title>Page Redirection</title>
+      </head>
+      <body>
+          The old Flax Linen API and guides has been moved to another domain. Follow this <a href='https://flax-linen.readthedocs.io/en/latest/guides/training_techniques/batch_norm.html'>link to the page.</a>.
+      </body>
+  </html>

--- a/docs_nnx/guides/training_techniques/dropout.rst
+++ b/docs_nnx/guides/training_techniques/dropout.rst
@@ -1,0 +1,17 @@
+.. raw:: html
+
+  <!-- This is a dummy page for re-directing existing Linen guides' old links to the Linen site. -->
+  <!DOCTYPE HTML>
+  <html lang="en-US">
+      <head>
+          <meta charset="UTF-8">
+          <meta http-equiv="refresh" content="0; url=https://flax-linen.readthedocs.io/en/latest/guides/training_techniques/dropout.html">
+          <script type="text/javascript">
+              window.location.href = "https://flax-linen.readthedocs.io/en/latest/guides/training_techniques/dropout.html"
+          </script>
+          <title>Page Redirection</title>
+      </head>
+      <body>
+          The old Flax Linen API and guides has been moved to another domain. Follow this <a href='https://flax-linen.readthedocs.io/en/latest/guides/training_techniques/dropout.html'>link to the page.</a>.
+      </body>
+  </html>

--- a/docs_nnx/guides/training_techniques/lr_schedule.rst
+++ b/docs_nnx/guides/training_techniques/lr_schedule.rst
@@ -1,0 +1,17 @@
+.. raw:: html
+
+  <!-- This is a dummy page for re-directing existing Linen guides' old links to the Linen site. -->
+  <!DOCTYPE HTML>
+  <html lang="en-US">
+      <head>
+          <meta charset="UTF-8">
+          <meta http-equiv="refresh" content="0; url=https://flax-linen.readthedocs.io/en/latest/guides/training_techniques/lr_schedule.html">
+          <script type="text/javascript">
+              window.location.href = "https://flax-linen.readthedocs.io/en/latest/guides/training_techniques/lr_schedule.html"
+          </script>
+          <title>Page Redirection</title>
+      </head>
+      <body>
+          The old Flax Linen API and guides has been moved to another domain. Follow this <a href='https://flax-linen.readthedocs.io/en/latest/guides/training_techniques/lr_schedule.html'>link to the page.</a>.
+      </body>
+  </html>

--- a/docs_nnx/guides/training_techniques/transfer_learning.rst
+++ b/docs_nnx/guides/training_techniques/transfer_learning.rst
@@ -1,0 +1,17 @@
+.. raw:: html
+
+  <!-- This is a dummy page for re-directing existing Linen guides' old links to the Linen site. -->
+  <!DOCTYPE HTML>
+  <html lang="en-US">
+      <head>
+          <meta charset="UTF-8">
+          <meta http-equiv="refresh" content="0; url=https://flax-linen.readthedocs.io/en/latest/guides/training_techniques/transfer_learning.html">
+          <script type="text/javascript">
+              window.location.href = "https://flax-linen.readthedocs.io/en/latest/guides/training_techniques/transfer_learning.html"
+          </script>
+          <title>Page Redirection</title>
+      </head>
+      <body>
+          The old Flax Linen API and guides has been moved to another domain. Follow this <a href='https://flax-linen.readthedocs.io/en/latest/guides/training_techniques/transfer_learning.html'>link to the page.</a>.
+      </body>
+  </html>

--- a/docs_nnx/guides/training_techniques/use_checkpointing.rst
+++ b/docs_nnx/guides/training_techniques/use_checkpointing.rst
@@ -1,0 +1,17 @@
+.. raw:: html
+
+  <!-- This is a dummy page for re-directing existing Linen guides' old links to the Linen site. -->
+  <!DOCTYPE HTML>
+  <html lang="en-US">
+      <head>
+          <meta charset="UTF-8">
+          <meta http-equiv="refresh" content="0; url=https://flax-linen.readthedocs.io/en/latest/guides/training_techniques/use_checkpointing.html">
+          <script type="text/javascript">
+              window.location.href = "https://flax-linen.readthedocs.io/en/latest/guides/training_techniques/use_checkpointing.html"
+          </script>
+          <title>Page Redirection</title>
+      </head>
+      <body>
+          The old Flax Linen API and guides has been moved to another domain. Follow this <a href='https://flax-linen.readthedocs.io/en/latest/guides/training_techniques/use_checkpointing.html'>link to the page.</a>.
+      </body>
+  </html>


### PR DESCRIPTION
This prepares for the site flip of `flax-nnx` scope becoming `flax` scope.