### PR TITLE
[nnx] add custom_vjp to docs

### DIFF
--- a/docs_nnx/api_reference/flax.nnx/transforms.rst
+++ b/docs_nnx/api_reference/flax.nnx/transforms.rst
@@ -21,3 +21,4 @@ transforms
 .. autofunction:: vmap
 .. autofunction:: eval_shape
 .. autofunction:: cond
+.. autofunction:: custom_vjp


### PR DESCRIPTION
# What does this PR do?

Adds entry for `custom_vjp` to API reference.