### PR TITLE
Fix Flax Glossary and Philosophy links, update copyright year, make Checkpointing guide non-executable

### DIFF
--- a/docs_nnx/conf.py
+++ b/docs_nnx/conf.py
@@ -40,7 +40,7 @@ sys.path.append(os.path.abspath('./_ext'))
 # -- Project information -----------------------------------------------------
 
 project = 'Flax'
-copyright = '2023, The Flax authors'  # pylint: disable=redefined-builtin
+copyright = '2024, The Flax authors'  # pylint: disable=redefined-builtin
 author = 'The Flax authors'
 
 
@@ -113,7 +113,7 @@ html_extra_path = ['robots.txt']
 # href with no underline and white bold text color
 announcement = """
 <a
-  href="https://flax-linen.readthedocs.io/en/latest"
+  href="https://flax.readthedocs.io/en/latest"
   style="text-decoration: none; color: white;"
 >
   This site covers the new Flax NNX API. <span style="color: lightgray;">[Click here for the old <b>Flax Linen</b> API]</span>
@@ -151,6 +151,7 @@ nb_execution_excludepatterns = [
   'guides/why.ipynb',  # TODO(cgarciae): broken, remove in favor on the new guide
   'guides/flax_gspmd.ipynb',  # TODO(IvyZX): broken, needs to be updated
   'guides/surgery.ipynb',  # TODO(IvyZX): broken, needs to be updated
+  'guides/checkpointing.ipynb',
 ]
 # raise exceptions on execution so CI can catch errors
 nb_execution_allow_errors = False

--- a/docs_nnx/index.rst
+++ b/docs_nnx/index.rst
@@ -62,7 +62,7 @@ Features
 
          .. div:: sd-font-normal
 
-            Flax NNX allows fine-grained control of the model's state via
+            Flax NNX enables fine-grained control of the model's state via
             its `Filter <https://flax.readthedocs.io/en/latest/nnx/filters_guide.html>`__
             system.
 
@@ -197,6 +197,6 @@ Learn more
    guides/index
    examples/index
    glossary
-   The Flax philosophy <philosophyhttps://flax.readthedocs.io/en/latest/philosophy.html>
+   The Flax philosophy <https://flax.readthedocs.io/en/latest/philosophy.html>
    How to contribute <https://flax.readthedocs.io/en/latest/contributing.html>
    api_reference/index


### PR DESCRIPTION
Small fixes to the Flax website.

---

`conf.py`: Fixing the Glossary URL:

```diff
...
- href="https://flax-linen.readthedocs.io/en/latest"
+ href="https://flax.readthedocs.io/en/latest"
...
```

The checkpointing guide is now in `nb_execution_excludepatterns`, fixes local Sphinx builds.

Change the copyright year to 2024.

---


`index.rst`: Fixing the Philosophy URL

```diff
-The Flax philosophy <philosophyhttps://flax.readthedocs.io/en/latest/philosophy.html>
+ The Flax philosophy <https://flax.readthedocs.io/en/latest/philosophy.html>
```