### PR TITLE
Fixing numbering in mnist_tutorial.md

### DIFF
--- a/docs_nnx/mnist_tutorial.md
+++ b/docs_nnx/mnist_tutorial.md
@@ -241,7 +241,7 @@ ax2.legend()
 plt.show()
 ```
 
-## 10. Perform inference on the test set
+## 8. Perform inference on the test set
 
 Create a `jit`-compiled model inference function (with `nnx.jit`) - `pred_step` - to generate predictions on the test set using the learned model parameters. This will enable you to visualize test images alongside their predicted labels for a qualitative assessment of model performance.
 


### PR DESCRIPTION
# What does this PR do?

<!--
Fixing numbering. The numbered list jumps directly from 7 to 10, omitting 8 and 9.
-->

Fixes # (issue)

## Checklist
- [X] This PR fixes a minor issue (e.g.: typo or small bug) or improves the docs (you can dismiss the other
      checks if that's the case).
- [ ] This change is discussed in a Github issue/
      [discussion](https://github.com/google/flax/discussions) (please add a
      link).
- [ ] The documentation and docstrings adhere to the
      [documentation guidelines](https://github.com/google/flax/blob/main/docs/README.md#how-to-write-code-documentation).
- [ ] This change includes necessary high-coverage tests.
      (No quality testing = no merge!)
