### PR TITLE
Fix philosophy link

### DIFF
--- a/docs_nnx/index.rst
+++ b/docs_nnx/index.rst
@@ -197,6 +197,6 @@ Learn more
    guides/index
    examples/index
    nnx_glossary
-   The Flax philosophy <philosophyhttps://flax.readthedocs.io/en/latest/philosophy.html>
+   The Flax philosophy <https://flax.readthedocs.io/en/latest/philosophy.html>
    How to contribute <https://flax.readthedocs.io/en/latest/contributing.html>
    api_reference/index


### PR DESCRIPTION
# What does this PR do?
This PR fixes a broken link in the nav bar.

The link redirects to the old linen API. If the old philosophy no longer applies, we may want to update the philosophy or delete the link.

## Checklist
- [x] This PR fixes a minor issue (e.g.: typo or small bug) or improves the docs (you can dismiss the other
      checks if that's the case).
