### PR TITLE
Remove outdated compatibility code.

### DIFF
--- a/flax/core/scope.py
+++ b/flax/core/scope.py
@@ -1218,12 +1218,8 @@ def _is_valid_rng(rng: Array):
     return False
 
   # Handle new-style typed PRNG keys
-  if hasattr(jax.dtypes, 'prng_key'):  # JAX 0.4.14 or newer
-    if jax.dtypes.issubdtype(rng.dtype, jax.dtypes.prng_key):
-      return rng.shape == ()
-  elif hasattr(jax.random, 'PRNGKeyArray'):  # Previous JAX versions
-    if isinstance(rng, jax.random.PRNGKeyArray):
-      return rng.shape == ()
+  if jax.dtypes.issubdtype(rng.dtype, jax.dtypes.prng_key):
+    return rng.shape == ()
 
   # Handle old-style raw PRNG keys
   expected_rng = jax.eval_shape(

--- a/flax/struct.py
+++ b/flax/struct.py
@@ -124,41 +124,7 @@ def dataclass(clz: _T, **kwargs) -> _T:
 
   data_clz.replace = replace
 
-  # Remove this guard once minimux JAX version is >0.4.26.
-  try:
-    if hasattr(jax.tree_util, 'register_dataclass'):
-      jax.tree_util.register_dataclass(
-          data_clz, data_fields, meta_fields
-      )
-    else:
-      raise NotImplementedError
-  except NotImplementedError:
-
-    def iterate_clz(x):
-      meta = tuple(getattr(x, name) for name in meta_fields)
-      data = tuple(getattr(x, name) for name in data_fields)
-      return data, meta
-
-    def iterate_clz_with_keys(x):
-      meta = tuple(getattr(x, name) for name in meta_fields)
-      data = tuple(
-          (jax.tree_util.GetAttrKey(name), getattr(x, name))
-          for name in data_fields
-      )
-      return data, meta
-
-    def clz_from_iterable(meta, data):
-      meta_args = tuple(zip(meta_fields, meta))
-      data_args = tuple(zip(data_fields, data))
-      kwargs = dict(meta_args + data_args)
-      return data_clz(**kwargs)
-
-    jax.tree_util.register_pytree_with_keys(
-        data_clz,
-        iterate_clz_with_keys,
-        clz_from_iterable,
-        iterate_clz,
-    )
+  jax.tree_util.register_dataclass(data_clz, data_fields, meta_fields)
 
   def to_state_dict(x):
     state_dict = {

--- a/tests/linen/linen_attention_test.py
+++ b/tests/linen/linen_attention_test.py
@@ -113,10 +113,7 @@ class AttentionTest(parameterized.TestCase):
 
   def test_multihead_self_attention_explicit_dropout(self):
     def clone(key):
-      if hasattr(jax.random, "clone"):
-        # JAX v0.4.26+
-        return jax.tree.map(jax.random.clone, key)
-      return key
+      return jax.tree.map(jax.random.clone, key)
 
     class Foo(nn.Module):
       attention_kwargs: dict

--- a/tests/linen/linen_test.py
+++ b/tests/linen/linen_test.py
@@ -1040,17 +1040,12 @@ class StochasticTest(parameterized.TestCase):
         self.assertTrue(slice_fn(out, i).sum() in (0, summed_total))
 
   def test_dropout_manual_rng(self):
-    def clone(key):
-      if hasattr(jax.random, 'clone'):
-        # JAX v0.4.26+
-        return jax.random.clone(key)
-      return key
     class Foo(nn.Module):
       @nn.compact
       def __call__(self, x):
         key = self.make_rng('dropout')
         x1 = nn.Dropout(rate=0.5, deterministic=False)(x, rng=key)
-        x2 = nn.Dropout(rate=0.5, deterministic=False)(x, rng=clone(key))
+        x2 = nn.Dropout(rate=0.5, deterministic=False)(x, rng=jax.random.clone(key))
         return x1, x2
 
     module = Foo()

--- a/tests/linen/linen_transforms_test.py
+++ b/tests/linen/linen_transforms_test.py
@@ -32,10 +32,6 @@ from jax import random
 import jax.numpy as jnp
 import numpy as np
 
-# TODO(jakevdp): use jax.debug_key_reuse directly once min jax version is 0.4.26
-jax_debug_key_reuse = (jax.debug_key_reuse if hasattr(jax, 'debug_key_reuse')
-                       else jax.enable_key_reuse_checks)
-
 # Parse absl flags test_srcdir and test_tmpdir.
 jax.config.parse_flags_with_absl()
 
@@ -2141,7 +2137,7 @@ class TransformTest(parameterized.TestCase):
     self.assertTrue(
       jnp.equal(vars['state']['rng_params'][0], vars['state']['rng_params'][1])
     )
-    with jax_debug_key_reuse(False):
+    with jax.debug_key_reuse(False):
       self.assertFalse(
         jnp.equal(
           vars['state']['rng_loop'][0],


### PR DESCRIPTION
The minimum supported JAX version is now 0.4.27, so these compatibility shims for older versions are no longer necessary.