### PR TITLE
Linesearch (and lbfgs) support

### DIFF
--- a/flax/nnx/training/optimizer.py
+++ b/flax/nnx/training/optimizer.py
@@ -245,9 +245,8 @@ class Optimizer(Object):
       ...   state.update(grads=grads)
 
     Note that internally this function calls ``.tx.update()`` followed by a call
-    to ``optax.apply_updates()`` to update ``params`` and ``opt_state``.
-
-    For  ``optax.GradientTransformationExtraArgs`` such as ``optax.scale_by_zoom_linesearch``,
+    to ``optax.apply_updates()`` to update ``params`` and ``opt_state``.  For
+    ``optax.GradientTransformationExtraArgs`` such as ``optax.scale_by_zoom_linesearch``,
     the optional ``value, value_fn`` and ``**kwargs`` are passed to ``.tx.update()``.
 
     The ``value_fn`` is assumed to be a univariate function of ``state.model`` if
@@ -257,10 +256,10 @@ class Optimizer(Object):
 
     Args:
       grads: the gradients derived from ``nnx.grad``.
-      value_fn (optional): function to evaluate the objective given the model, used by linesearch optimizers
-      value (optional): value of the objective associated with the current grads update
-      model_static (optional): graph of static elements from ``nnx.split(state.model, self.wrt)``
-      **kwargs: additional keyword arguments passed to the tx.update
+      value_fn (optional): function to evaluate the objective given the model, used by linesearch optimizers.
+      value (optional): value of the objective associated with the current grads update.
+      model_static (optional): graph of static elements from ``nnx.split(state.model, self.wrt)``.
+      **kwargs: additional keyword arguments passed to the tx.update.
     """
     params = nnx.state(self.model, self.wrt)
     opt_state = _opt_state_variables_to_state(self.opt_state)

--- a/flax/nnx/training/optimizer.py
+++ b/flax/nnx/training/optimizer.py
@@ -193,7 +193,7 @@ class Optimizer(Object):
     self.opt_state = _wrap_optimizer_state(tx.init(nnx.state(model, wrt)))
     self.wrt = wrt
 
-  def update(self, grads, value=None, value_fn=None, model_static=None, **kwargs):
+  def update(self, grads, **kwargs):
     """Updates ``step``, ``params``, ``opt_state`` and ``**kwargs`` in return value.
     The ``grads`` must be derived from ``nnx.grad(..., wrt=self.wrt)``, where the
     gradients are with respect to the same :class:`Variable` types as defined in
@@ -245,46 +245,17 @@ class Optimizer(Object):
       ...   state.update(grads=grads)
 
     Note that internally this function calls ``.tx.update()`` followed by a call
-    to ``optax.apply_updates()`` to update ``params`` and ``opt_state``.  For
-    ``optax.GradientTransformationExtraArgs`` such as ``optax.scale_by_zoom_linesearch``,
-    the optional ``value, value_fn`` and ``**kwargs`` are passed to ``.tx.update()``.
-
-    The ``value_fn`` is assumed to be a univariate function of ``state.model`` if
-    ``model_static`` is not provided.  Otherwise, ``model_static`` is assumed to be the result of
-    ``model_static, model_state = nnx.split(state.model, self.wrt)``, and ``value_fn`` is a
-    univariate function of ``model_state``.
+    to ``optax.apply_updates()`` to update ``params`` and ``opt_state``.
 
     Args:
       grads: the gradients derived from ``nnx.grad``.
-      value_fn (optional): function to evaluate the objective given the model, used by linesearch optimizers.
-      value (optional): value of the objective associated with the current grads update.
-      model_static (optional): graph of static elements from ``nnx.split(state.model, self.wrt)``.
-      **kwargs: additional keyword arguments passed to the tx.update.
+      **kwargs: additional keyword arguments passed to the tx.update, to support
+      ``GradientTransformationExtraArgs``, such as ``optax.scale_by_backtracking_linesearch``.
     """
     params = nnx.state(self.model, self.wrt)
     opt_state = _opt_state_variables_to_state(self.opt_state)
 
-    if value is None or value_fn is None:
-        updates, new_opt_state = self.tx.update(grads, opt_state, params)
-    else:
-        if model_static is None:
-          graphdef, _ = nnx.split(self.model, self.wrt)
-          def value_fn_wrapped(state):
-              model = nnx.merge(graphdef, state)
-              return value_fn(model)
-        else:
-          value_fn_wrapped = value_fn
-
-        updates, new_opt_state = self.tx.update(
-            grads,
-            opt_state,
-            params,
-            grad=grads,
-            value=value,
-            value_fn=value_fn_wrapped,
-            **kwargs,
-        )
-
+    updates, new_opt_state = self.tx.update(grads, opt_state, params, **kwargs)
     new_params = optax.apply_updates(params, updates)
     assert isinstance(new_params, nnx.State)
 

--- a/tests/nnx/optimizer_test.py
+++ b/tests/nnx/optimizer_test.py
@@ -128,6 +128,54 @@ class TestOptimizer(parameterized.TestCase):
 
     self.assertTrue(new_loss < initial_loss)
 
+
+  @parameterized.product(
+    module_cls=[nnx.Linear, Model],
+    jit_decorator=[lambda f: f, nnx.jit, jax.jit],
+    optimizer=[optax.lbfgs],
+  )
+  def test_jit_lbfgs(self, module_cls, jit_decorator, optimizer):
+    x = jax.random.normal(jax.random.key(0), (1, 2))
+    y = jnp.ones((1, 4))
+    model = module_cls(2, 4, rngs=nnx.Rngs(0))
+    tx = optimizer(
+      1e-3
+    )
+    state = nnx.Optimizer(model, tx)
+
+    if jit_decorator == jax.jit:
+      model_static, model_state = nnx.split(state.model)
+      loss_fn = lambda graphdef, state, x, y: (
+        (nnx.merge(graphdef, state)(x) - y) ** 2
+      ).mean()
+      initial_loss = loss_fn(model_static, model_state, x, y)
+
+      def jax_jit_train_step(graphdef, state, x, y):
+        state = nnx.merge(graphdef, state)
+        model_static, model_state = nnx.split(state.model)
+        grads = jax.grad(loss_fn, argnums=1)(model_static, model_state, x, y)
+        state.update(grads, value = initial_loss, model_static = model_static, value_fn = lambda state: loss_fn(model_static, state, x, y))
+        return nnx.split(state)
+
+      graphdef, state = jit_decorator(jax_jit_train_step)(
+        *nnx.split(state), x, y
+      )
+      state = nnx.merge(graphdef, state)
+      new_loss = loss_fn(*nnx.split(state.model), x, y)
+
+    else:
+      loss_fn = lambda model, x, y: ((model(x) - y) ** 2).mean()
+      initial_loss = loss_fn(state.model, x, y)
+
+      def nnx_jit_train_step(optimizer: nnx.Optimizer, x, y):
+        grads = nnx.grad(loss_fn)(optimizer.model, x, y)
+        optimizer.update(grads, value = initial_loss,value_fn = lambda model: loss_fn(model, x, y))
+
+      jit_decorator(nnx_jit_train_step)(state, x, y)
+      new_loss = loss_fn(state.model, x, y)
+
+    self.assertTrue(new_loss < initial_loss)
+
   @parameterized.product(
     module_cls=[nnx.Linear, Model],
     optimizer=[optax.sgd, optax.adam],
@@ -203,6 +251,52 @@ class TestOptimizer(parameterized.TestCase):
         )
       )
 
+  @parameterized.parameters(
+    {'variable': nnx.Param},
+    #{'variable': nnx.LoRAParam},
+    {'variable': (nnx.Param, nnx.LoRAParam)},
+  )
+  def test_wrt_update_lbfgs(self, variable):
+    in_features = 4
+    out_features = 10
+    model = nnx.LoRA(
+      in_features=in_features,
+      lora_rank=2,
+      out_features=out_features,
+      base_module=Model(
+        in_features=in_features, out_features=out_features, rngs=nnx.Rngs(0)
+      ),
+      rngs=nnx.Rngs(1),
+    )
+    state = nnx.Optimizer(model, optax.lbfgs(), wrt=variable)
+    prev_variables, prev_other_variables = nnx.state(model, variable, ...)
+
+    x = jnp.ones((1, 4))
+    y = jnp.ones((1, 10))
+    loss_fn = lambda model, x, y: ((model(x) - y) ** 2).mean()
+
+    grads = nnx.grad(loss_fn, argnums=nnx.DiffState(0, variable))(
+      state.model, x, y
+    )
+    initial_loss = loss_fn(model, x, y)
+    state.update(grads=grads, value_fn = lambda model: loss_fn(model, x, y), value = initial_loss)
+    self.assertTrue(loss_fn(model, x, y) < initial_loss)
+
+    # make sure only the Variable's filtered in `wrt` are changed, and the others are unchanged
+    variables, other_variables = nnx.state(model, variable, ...)
+    self.assertTrue(
+      jax.tree.all(
+        jax.tree.map(lambda x, y: (x != y).all(), prev_variables, variables)
+      )
+    )
+    if other_variables:
+      self.assertTrue(
+        jax.tree.all(
+          jax.tree.map(
+            lambda x, y: (x == y).all(), prev_other_variables, other_variables
+          )
+        )
+      )
 
 if __name__ == '__main__':
   absltest.main()

--- a/tests/nnx/optimizer_test.py
+++ b/tests/nnx/optimizer_test.py
@@ -134,7 +134,7 @@ class TestOptimizer(parameterized.TestCase):
     jit_decorator=[lambda f: f, nnx.jit, jax.jit],
     optimizer=[optax.lbfgs],
   )
-  def test_jit_lbfgs(self, module_cls, jit_decorator, optimizer):
+  def test_jit_linesearch(self, module_cls, jit_decorator, optimizer):
     x = jax.random.normal(jax.random.key(0), (1, 2))
     y = jnp.ones((1, 4))
     model = module_cls(2, 4, rngs=nnx.Rngs(0))
@@ -256,7 +256,7 @@ class TestOptimizer(parameterized.TestCase):
     #{'variable': nnx.LoRAParam},
     {'variable': (nnx.Param, nnx.LoRAParam)},
   )
-  def test_wrt_update_lbfgs(self, variable):
+  def test_wrt_update_linesearch(self, variable):
     in_features = 4
     out_features = 10
     model = nnx.LoRA(


### PR DESCRIPTION
# What does this PR do?
This PR modifies the `.update()` to support additional arguments required for the Optax `lbfgs` and related algorithms which rely on linesearch methods.

Fixes #4144 

- Additional tests were added to check the `lbfgs()` (where I believe the additional arguments are required for the `linesearch` more generally)
- The key feature needed is a callback to evaluate the objective function at different "state" values.  This needs to use a `split` and `merge` in the optimization.
  -  In cases where the `model_static, model_state = nnx.split(state.model, self.wrt)` has already been done, the `model_static` can be passed into the `.update` to avoid doing the `nnx.split` step with each iteration.  See the `test_jit_linesearch` for more there.

A feature missing here is support for `value_and_grad_from_state ` as described in https://optax.readthedocs.io/en/stable/_collections/examples/lbfgs.html#linesearches-in-practice.  Implementing this would provide some performance advantages as it would allow the optimizer to reuse the gradients/value.
