### PR TITLE
Remove the repeated methods in flax.nnx.Module documentation

### DIFF
--- a/docs_nnx/api_reference/flax.nnx/module.rst
+++ b/docs_nnx/api_reference/flax.nnx/module.rst
@@ -6,6 +6,3 @@ module
 
 .. autoclass:: Module
    :members:
-
-   .. automethod:: sow
-   .. automethod:: iter_modules


### PR DESCRIPTION
# What does this PR do?
The methods `sow` and `iter_modules` are repeated in the documentation of `flax.nnx.Module`. This PR removes these repeated methods.

Fixes # (issue)

## Checklist
- [x] This PR fixes a minor issue (e.g.: typo or small bug) or improves the docs (you can dismiss the other
      checks if that's the case).