### PR TITLE
[nnx] Add specific model typing for nnx.Optimizer

### DIFF
--- a/flax/nnx/training/optimizer.py
+++ b/flax/nnx/training/optimizer.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 from __future__ import annotations
 
+import typing as tp
+
 import jax
 import jax.numpy as jnp
 import optax
@@ -22,6 +24,8 @@ from flax.nnx import filterlib
 from flax.nnx import variablelib
 from flax.nnx.object import Object
 from flax.nnx.variablelib import Variable, VariableState
+
+M = tp.TypeVar('M', bound=nnx.Module)
 
 # TODO: add tests and docstrings
 
@@ -101,7 +105,7 @@ def _update_opt_state(opt_state, updates):
   return jax.tree.map(optimizer_update_variables, opt_state, updates)
 
 
-class Optimizer(Object):
+class Optimizer(Object, tp.Generic[M]):
   """Simple train state for the common case with a single Optax optimizer.
 
   Example usage::
@@ -168,7 +172,7 @@ class Optimizer(Object):
 
   def __init__(
     self,
-    model: nnx.Module,
+    model: M,
     tx: optax.GradientTransformation,
     wrt: filterlib.Filter = nnx.Param,
   ):


### PR DESCRIPTION
# What does this PR do?

<!--

Great, you are contributing to Flax!

But... please read the following carefully so we can make sure your PR is merged
easily.

Replace this text block with a description of the change and which issue it
fixes (if applicable). Please also include relevant motivation/context.

Once you're done, someone in the Flax team will review your PR shortly. They may
suggest changes to make the code even better. If no one reviewed your PR after a
week has passed, don't hesitate to post a new comment @-mentioning the same
persons (sometimes notifications get lost).
-->

This PR adds a type variable for `nnx.Optimizer.model` to make type inference and IDE autocomplete better.

Before:
```python
class MyModel(nnx.Module):
    ...

optimizer = nnx.Optimizer(MyModel(), tx=...)

optimizer.model  # inferred type: nnx.Module

def use_optimizer(optimizer:​ nnx.Optimizer):
    optimizer.model  # inferred type: nnx.Module
```

After PR:
```python
class MyModel(nnx.Module):
    ...

optimizer = nnx.Optimizer(MyModel(), tx=...)

optimizer.model  # inferred type: MyModel

def use_optimizer(optimizer:​ nnx.Optimizer[MyModel]):
    optimizer.model  # inferred type: MyModel

# Can also be used as before with generic type hints
def use_optimizer(optimizer: nnx.Optimizer):
    optimizer.model  # inferred type: nnx.Module
```

## Checklist
- [x] This PR fixes a minor issue.
