### PR TITLE
Rename variable string mapping utils and move them to variableslib

### DIFF
--- a/flax/nnx/__init__.py
+++ b/flax/nnx/__init__.py
@@ -19,9 +19,6 @@ from flax.linen.pooling import pool as pool
 from flax.typing import Initializer as Initializer
 
 from .bridge import wrappers as wrappers
-from .bridge.variables import (
-  register_variable_name_type_pair as register_variable_name_type_pair,
-)
 from .filterlib import WithTag as WithTag
 from .filterlib import PathContains as PathContains
 from .filterlib import OfType as OfType
@@ -163,6 +160,9 @@ from .variablelib import Variable as Variable
 from .variablelib import VariableState as VariableState
 from .variablelib import VariableMetadata as VariableMetadata
 from .variablelib import with_metadata as with_metadata
+from .variablelib import variable_type_from_name as variable_type_from_name
+from .variablelib import variable_name_from_type as variable_name_from_type
+from .variablelib import register_variable_name_type_pair as register_variable_name_type_pair
 from .visualization import display as display
 from .extract import to_tree as to_tree
 from .extract import from_tree as from_tree

--- a/flax/nnx/bridge/__init__.py
+++ b/flax/nnx/bridge/__init__.py
@@ -20,4 +20,3 @@ from .wrappers import lazy_init as lazy_init
 from .wrappers import ToLinen as ToLinen
 from .wrappers import to_linen as to_linen
 from .variables import NNXMeta as NNXMeta
-from .variables import register_variable_name_type_pair as register_variable_name_type_pair

--- a/flax/nnx/bridge/wrappers.py
+++ b/flax/nnx/bridge/wrappers.py
@@ -21,6 +21,7 @@ from flax import nnx
 from flax.core import FrozenDict
 from flax.core import meta
 from flax.nnx import graph
+from flax.nnx import variablelib
 from flax.nnx.bridge import variables as bv
 from flax.nnx.module import GraphDef, Module
 from flax.nnx.object import Object
@@ -271,7 +272,7 @@ class ToLinen(linen.Module):
     # Each variable type goes to its own linen collection, and
     # each attribute goes to its own linen variable
     for typ, state in zip(types, state_by_types):
-      collection = bv.variable_type_name(typ)
+      collection = variablelib.variable_name_from_type(typ)
       if self.is_mutable_collection(collection):
         for k, v in state.raw_mapping.items():
           v = jax.tree.map(bv.to_linen_var, v,


### PR DESCRIPTION
* Renamed `variable_type` and `variable_type_name` to more concise `named_variable` and `variable_name`

* Move the registry that maps `nnx.Variable` types to strings from `nnx.bridge.variables` to `nnx.variablelib`, so that it can be used in core NNX methods like `nnx.Module.sow` and perturb.