### PR TITLE
Add `nnx.Module.perturb`

### DIFF
--- a/flax/nnx/__init__.py
+++ b/flax/nnx/__init__.py
@@ -156,6 +156,7 @@ from .variablelib import A as A
 from .variablelib import BatchStat as BatchStat
 from .variablelib import Cache as Cache
 from .variablelib import Intermediate as Intermediate
+from .variablelib import Perturbation as Perturbation
 from .variablelib import Variable as Variable
 from .variablelib import VariableState as VariableState
 from .variablelib import VariableMetadata as VariableMetadata

--- a/flax/nnx/bridge/variables.py
+++ b/flax/nnx/bridge/variables.py
@@ -140,7 +140,7 @@ def linen_vars_to_nnx_attrs(variables: tp.Mapping[str, Any]) -> dict[str, Any]:
         nnx_attrs[attr_name] = _recursive_merge(nnx_attrs[attr_name], value)
       else:
         nnx_attrs[attr_name] = value     # it's a variable on this layer
-  return nnx_attrs
+  return dict(nnx_attrs)
 
 
 def nnx_attrs_to_linen_vars(nnx_attrs: dict) -> dict:

--- a/flax/nnx/variablelib.py
+++ b/flax/nnx/variablelib.py
@@ -747,6 +747,38 @@ class Intermediate(Variable[A]):
   pass
 
 
+class Perturbation(Intermediate[A]):
+  """:class:`Variable` type that is typically used for
+  :func:`Module.perturb`::
+
+    >>> from flax import nnx
+    >>> import jax, jax.numpy as jnp
+
+    >>> class Model(nnx.Module):
+    ...   def __init__(self, rngs):
+    ...     self.linear1 = nnx.Linear(2, 3, rngs=rngs)
+    ...     self.linear2 = nnx.Linear(3, 4, rngs=rngs)
+    ...   def __call__(self, x):
+    ...     x = self.linear1(x)
+    ...     x = self.perturb('i', x)
+    ...     x = self.linear2(x)
+    ...     return x
+    >>> model = Model(rngs=nnx.Rngs(0))
+
+    >>> x = jnp.ones((1, 2))
+    >>> y = model(x)
+    >>> jax.tree.map(jnp.shape, nnx.state(model, nnx.Perturbation))
+    State({
+      'i': VariableState(
+        type=Perturbation,
+        value=(1, 3)
+      )
+    })
+  """
+
+  pass
+
+
 class VariableState(tp.Generic[A], reprlib.Representable):
   __slots__ = ('type', 'value', '_var_metadata')
   type: type[Variable[A]]
@@ -1012,3 +1044,4 @@ register_variable_name_type_pair('params', Param)
 register_variable_name_type_pair('batch_stats', BatchStat)
 register_variable_name_type_pair('cache', Cache)
 register_variable_name_type_pair('intermediates', Intermediate)
+register_variable_name_type_pair('perturbations', Perturbation)


### PR DESCRIPTION
Add perturb to the `nnx.Module`, same as Linen. Also added a `nnx.Perturbations` variable class.
Covered with tests.

Note: 
* **Diff from Linen behavior**: Since we no longer have mutable collection check, this will create new perturbation variables even if none is passed into the Module. 
* Perturbation variables requires a sample input to be created, as its shape depends on the input shape.
