### PR TITLE
batch_norm.rst: == should be =

### DIFF
--- a/docs/guides/training_techniques/batch_norm.rst
+++ b/docs/guides/training_techniques/batch_norm.rst
@@ -141,8 +141,8 @@ collection.
 Modifying ``flax.linen.apply``
 ******************************
 
-When using :meth:`flax.linen.apply <flax.linen.apply>` to run your model with the ``train==True``
-argument (that is, you have ``use_running_average==False`` in the call to ``BatchNorm``), you
+When using :meth:`flax.linen.apply <flax.linen.apply>` to run your model with the ``train=True``
+argument (that is, you have ``use_running_average=False`` in the call to ``BatchNorm``), you
 need to consider the following:
 
 * ``batch_stats`` must be passed as an input variable.


### PR DESCRIPTION
Fix small mistake in docs, == should be =.

## Checklist
- [V] This PR fixes a minor issue (e.g.: typo or small bug) or improves the docs (you can dismiss the other
      checks if that's the case).
