### PR TITLE
fix trace-level detection

### DIFF
--- a/flax/core/tracers.py
+++ b/flax/core/tracers.py
@@ -15,6 +15,7 @@
 """Functionality for inspecting jax tracers."""
 
 import jax
+import jax.core
 
 
 def current_trace():
@@ -29,5 +30,9 @@ def current_trace():
   return jax.core.get_opaque_trace_state(convention="flax")
 
 def check_trace_level(base_level):
+  # TODO(cgarciae): skipping for now as it breaks
+  # too many internal tests.
+  # level = current_trace()
+  # if level != base_level:
+  #   raise errors.JaxTransformError()
   pass
-  # TODO: re-enable when we update flax to use stackless trace context

--- a/flax/nnx/tracers.py
+++ b/flax/nnx/tracers.py
@@ -40,8 +40,7 @@ class TraceState(reprlib.Representable):
     return self._jax_trace
 
   def is_valid(self) -> bool:
-    # TODO: re-enable when we update nnx to use stackless trace context
-    return True
+    return self._jax_trace == current_jax_trace()
 
   def __nnx_repr__(self):
     yield reprlib.Object(f'{type(self).__name__}')

--- a/tests/nnx/transforms_test.py
+++ b/tests/nnx/transforms_test.py
@@ -24,6 +24,7 @@ import jax
 from jax.experimental import checkify, mesh_utils
 import jax.numpy as jnp
 import numpy as np
+from flax import errors
 
 
 class List(nnx.Module):
@@ -2662,7 +2663,6 @@ class TestVmap(absltest.TestCase):
 
     f(m, m, m)
 
-  @absltest.skip('Enable once jax#19586 resolved')
   def test_captured_module_in_return_error(self):
     class Foo(nnx.Module):
 
@@ -2676,8 +2676,8 @@ class TestVmap(absltest.TestCase):
       return x, m
 
     with self.assertRaisesRegex(
-        ValueError,
-        r'Trying to extract graph node from different trace level.*Foo',
+      errors.TraceContextError,
+      r'Trying to extract graph node from different trace level.*Foo',
     ):
       x = jnp.zeros((5,))
       f(x)


### PR DESCRIPTION
# What does this PR do?

Adds back trace-level detection to NNX. Linen is still deactivated for now because if breaks too many internal tests.