### PR TITLE
added support to the accuracy metric for binary classification

### DIFF
--- a/tests/nnx/metrics_test.py
+++ b/tests/nnx/metrics_test.py
@@ -124,6 +124,36 @@ class TestMetrics(parameterized.TestCase):
     self.assertTrue(jnp.isnan(values['accuracy']))
     self.assertTrue(jnp.isnan(values['loss']))
 
+  def test_binary_classification_accuracy(self):
+    logits = jnp.array([0.4, 0.7, 0.2, 0.6])
+    labels = jnp.array([0, 1, 1, 1])
+    logits2 = jnp.array([0.1, 0.9, 0.8, 0.3])
+    labels2 = jnp.array([0, 1, 1, 0])
+    accuracy = nnx.metrics.Accuracy(threshold=0.5)
+    accuracy.update(logits=logits, labels=labels)
+    self.assertEqual(accuracy.compute(), 0.75)
+    accuracy.update(logits=logits2, labels=labels2)
+    self.assertEqual(accuracy.compute(), 0.875)
+
+  @parameterized.parameters(
+    {
+      'logits': jnp.array([[[0.0, 0.0], [0.0, 0.0]], [[0.0, 0.0], [0.0, 0.0]]]),
+      'labels': jnp.array([0, 0, 0, 0]),
+      'threshold': None,
+      'error_msg': 'For multi-class classification'
+    },
+    {
+      'logits': jnp.array([0.0, 0.0, 0.0, 0.0]),
+      'labels': jnp.array([[0, 0], [0, 0]]),
+      'threshold': 0.5,
+      'error_msg': 'For binary classification'
+    }
+  )
+  def test_accuracy_dims(self, logits, labels, threshold, error_msg):
+    accuracy = nnx.metrics.Accuracy(threshold=threshold)
+    with self.assertRaisesRegex(ValueError, error_msg):
+      accuracy.update(logits=logits, labels=labels)
+
 
 if __name__ == '__main__':
   absltest.main()


### PR DESCRIPTION
Fixes #4456 

Adds support for binary classification to the accuracy metric.

## Checklist
- [x] This PR fixes a minor issue (e.g.: typo or small bug) or improves the docs (you can dismiss the other
      checks if that's the case).
- [x] This change is discussed in a Github issue/
      [discussion](https://github.com/google/flax/discussions) (please add a
      link).
- [x] The documentation and docstrings adhere to the
      [documentation guidelines](https://github.com/google/flax/blob/main/docs/README.md#how-to-write-code-documentation).
- [x] This change includes necessary high-coverage tests.
      (No quality testing = no merge!)
