### PR TITLE
[nnx] bridge Module

### DIFF
--- a/flax/nnx/bridge/__init__.py
+++ b/flax/nnx/bridge/__init__.py
@@ -20,3 +20,6 @@ from .wrappers import lazy_init as lazy_init
 from .wrappers import ToLinen as ToLinen
 from .wrappers import to_linen as to_linen
 from .variables import NNXMeta as NNXMeta
+from .module import Module as Module
+from .module import Scope as Scope
+from .module import compact as compact

--- a/flax/nnx/bridge/module.py
+++ b/flax/nnx/bridge/module.py
@@ -1,0 +1,508 @@
+# Copyright 2025 The Flax Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from collections import defaultdict
+import dataclasses
+import functools
+import inspect
+import threading
+import typing as tp
+import jax
+import typing_extensions as tpe
+
+from flax import errors
+from flax.core.frozen_dict import FrozenDict
+from flax.nnx import graph, rnglib, statelib, traversals
+from flax.nnx import variablelib
+import flax.nnx.module as nnx_module
+from flax.nnx.object import Object
+from flax.nnx import variablelib
+from flax import errors
+import jax.numpy as jnp
+
+A = tp.TypeVar('A')
+M = tp.TypeVar('M', bound='Module')
+F = tp.TypeVar('F', bound=tp.Callable[..., tp.Any])
+
+
+@dataclasses.dataclass
+class CompactContext:
+  module: Module
+  type_counter: defaultdict[type, int] = dataclasses.field(
+    default_factory=lambda: defaultdict(int)
+  )
+
+
+@dataclasses.dataclass
+class ModuleContext(threading.local):
+  parent_stack: list[tp.Optional[CompactContext]] = dataclasses.field(
+    default_factory=lambda: [None]
+  )
+
+
+MODULE_CONTEXT = ModuleContext()
+
+class ModuleState(statelib.State):
+  pass
+
+
+class Scope(Object):
+  def __init__(self, rngs: rnglib.Rngs):
+    self.rngs = rngs
+
+  def copy(self):
+    return Scope(self.rngs)
+
+
+class _HasSetup(tp.Protocol):
+  def setup(self) -> None: ...
+
+
+def has_setup(x: tp.Any) -> tp.TypeGuard[_HasSetup]:
+  return hasattr(x, 'setup')
+
+
+class _HasUnbox(tp.Protocol):
+  unbox: bool
+
+
+def has_unbox(x: tp.Any) -> tp.TypeGuard[_HasUnbox]:
+  return hasattr(x, 'unbox')
+
+
+def _maybe_call_setup(module: Module):
+  if (
+    has_setup(module)
+    and isinstance(module, Object)
+    and not module._object__state.is_setup
+  ):
+    # void parent context
+    MODULE_CONTEXT.parent_stack.append(None)
+    try:
+      module.setup()  # type: ignore[attribute-error]
+      module._object__state._is_setup = True
+    finally:
+      MODULE_CONTEXT.parent_stack.pop()
+
+
+def _bind_module(parent: Module, module: Module) -> Module:
+  assert parent.scope is not None
+
+  for _, value in reversed(list(graph.iter_graph(module))):
+    if isinstance(value, Module):
+      if module.scope is None:
+        value.scope = parent.scope.copy()  # type: ignore[attribute-error]
+      _maybe_call_setup(value)
+  return module
+
+
+class ModuleMeta(nnx_module.ModuleMeta):
+  if not tp.TYPE_CHECKING:
+
+    def __call__(cls, *args, **kwargs):
+      return _module_meta_call(cls, *args, **kwargs)
+
+  def _object_meta_construct(cls, self, *args, **kwargs):
+    vars(self)['scope'] = None
+    super()._object_meta_construct(self, *args, **kwargs)
+
+
+def _module_meta_call(cls: type[M], *args, **kwargs) -> M:
+  # compact behavior
+  parent_ctx = MODULE_CONTEXT.parent_stack[-1]
+  parent = None
+  module: M
+
+  if parent_ctx is not None:
+    if 'parent' in kwargs:
+      parent = kwargs.pop('parent')
+      if parent is not None:
+        raise ValueError(
+          f"'parent' can only be set to None, got {type(parent).__name__}"
+        )
+      name = None
+    else:
+      type_index = parent_ctx.type_counter[cls]
+      parent_ctx.type_counter[cls] += 1
+
+      if 'name' in kwargs:
+        name = kwargs.pop('name')
+        if not isinstance(name, str):
+          raise ValueError(f"'name' must be a 'str', got {type(name).__name__}")
+      else:
+        name = f'{cls.__name__}_{type_index}'
+
+      parent = parent_ctx.module
+  else:
+    name = None
+
+  module = nnx_module.ModuleMeta.__call__(cls, *args, **kwargs)
+  module.scope = None
+
+  if parent is not None:
+    assert parent.scope is not None
+    assert name is not None
+    setattr(parent, name, module)
+
+  return module  # type: ignore
+
+
+class ModuleBase:
+  if tp.TYPE_CHECKING:
+    scope: Scope | None
+
+
+@tpe.dataclass_transform(field_specifiers=(dataclasses.field,))  # type: ignore[not-supported-yet]
+class Module(nnx_module.Module, ModuleBase, metaclass=ModuleMeta):
+  def __init_subclass__(cls, experimental_pytree: bool = False) -> None:
+    super().__init_subclass__(experimental_pytree)
+
+    cls = dataclasses.dataclass(repr=False)(cls)
+    cls.__hash__ = object.__hash__  # type: ignore[method-assign]
+
+  if not tp.TYPE_CHECKING:
+
+    def __getattribute__(self, name: str):
+      return type(self)._getattr(self, name)
+
+  def _getattr(self, name: str) -> tp.Any:
+    value = super().__getattribute__(name)
+    if isinstance(value, ModuleState):
+      raise AttributeError
+    return value
+
+  def _setattr(self, name: str, value: tp.Any) -> None:
+    if self.scope is not None:
+      if name in vars(self) and isinstance(
+        state := vars(self)[name], ModuleState
+      ):
+        graph.update(value, state)
+      for leaf in jax.tree.leaves(value):
+        if isinstance(leaf, Module):
+          _bind_module(self, leaf)
+    super()._setattr(name, value)
+
+  def make_rng(self, name: str = 'default') -> jax.Array:
+    if self.scope is None:
+      raise ValueError("Can't use RNGs on unbound modules")
+    return self.scope.rngs[name]()  # type: ignore[attribute-error]
+
+  def param(  # type: ignore[invalid-annotation]
+    self,
+    name: str,
+    init_fn: tp.Callable[..., A],
+    *init_args,
+    unbox: bool = True,
+    **init_kwargs,
+  ) -> variablelib.Param[A]:
+    # TODO(cgarciae): implement same condition as linen
+    if self.scope is None:
+      raise ValueError(
+        'Parameters must be initialized in `setup()` or in a method '
+        'wrapped in `@compact`'
+      )
+    if hasattr(self, name):
+      value = getattr(self, name)
+      # TODO(cgarciae): implement reservations
+      # if self._name_taken(name):
+      #   raise errors.NameInUseError('param', name, self.__class__.__name__)
+
+      if isinstance(value, variablelib.Variable):
+        if not isinstance(value, variablelib.Param):
+          raise ValueError(
+            f"Expected '{name}' to be a Param, got {type(value).__name__}"
+          )
+        return value
+
+      abs_value = jax.eval_shape(
+        lambda: init_fn(jax.random.key(0), *init_args, **init_kwargs)
+      )
+      abs_value_flat = jax.tree_util.tree_leaves(abs_value)
+      value_flat = jax.tree_util.tree_leaves(value)
+      for val, abs_val in zip(value_flat, abs_value_flat):
+        if jnp.shape(val) != jnp.shape(abs_val):
+          raise errors.ScopeParamShapeError(
+            name, '', jnp.shape(abs_val), jnp.shape(val)
+          )
+
+      if isinstance(abs_value, variablelib.VariableMetadata):
+        abs_value.raw_value = value
+        value = abs_value
+
+      variable = variablelib.Param(
+        value,
+        unbox=unbox,
+      )
+    else:
+      value = init_fn(self.make_rng('params'), *init_args, **init_kwargs)
+      variable = variablelib.Param(
+        value,
+        unbox=unbox,
+      )
+
+    setattr(self, name, variable)
+    return variable
+
+  def variable(  # type: ignore[invalid-annotation]
+    self,
+    col: str,
+    name: str,
+    init_fn: tp.Callable[..., A] | None = None,
+    *init_args,
+    unbox: bool = True,
+    **init_kwargs,
+  ) -> variablelib.Variable[A]:
+    variable_type = variablelib.variable_type_from_name(
+      col, allow_register=True
+    )
+    if self.scope is None:
+      raise ValueError(
+        'Variables must be initialized in `setup()` or in a method '
+        'wrapped in `@compact`'
+      )
+
+    if hasattr(self, name):
+      value = getattr(self, name)
+      # TODO(cgarciae): implement reservations
+      # if self._name_taken(name):
+      #   raise errors.NameInUseError('param', name, self.__class__.__name__)
+
+      if isinstance(value, variablelib.Variable):
+        return value
+
+      if init_fn is None:
+        raise ValueError(f"Expected 'init_fn' to be a callable, got None")
+
+      abs_value = jax.eval_shape(lambda: init_fn(*init_args, **init_kwargs))
+      abs_value_flat = jax.tree_util.tree_leaves(abs_value)
+      value_flat = jax.tree_util.tree_leaves(value)
+      for val, abs_val in zip(value_flat, abs_value_flat):
+        if jnp.shape(val) != jnp.shape(abs_val):
+          raise errors.ScopeParamShapeError(
+            name, '', jnp.shape(abs_val), jnp.shape(val)
+          )
+
+      if isinstance(abs_value, variablelib.VariableMetadata):
+        abs_value.raw_value = value
+        value = abs_value
+
+      variable = variable_type(value, unbox=unbox)
+    else:
+      if init_fn is None:
+        raise ValueError(f"Expected 'init_fn' to be a callable, got None")
+
+      value = init_fn(*init_args, **init_kwargs)
+      variable = variable_type(value, unbox=unbox)
+
+    setattr(self, name, variable)
+    return variable
+
+  def _get_variables(self) -> tp.Mapping:
+    state = graph.state(self)
+    _variables: dict = {}
+
+    variable_state: variablelib.VariableState
+    for path, variable_state in state.flat_state():
+      try:
+        collection = variablelib.variable_name_from_type(variable_state.type)
+      except ValueError:
+        collection = variable_state.type.__name__
+
+      if collection not in _variables:
+        _variables[collection] = {}
+
+      if has_unbox(variable_state):
+        assert isinstance(variable_state, variablelib.VariableState)
+        if variable_state.unbox:
+          leaf = variable_state.value
+        else:
+          # TODO: convert to linen box
+          leaf = variable_state
+      else:
+        leaf = variable_state.value
+
+      _variables[collection][path] = leaf
+
+    _variables = {
+      collection: traversals.unflatten_mapping(flat_state)
+      for collection, flat_state in _variables.items()
+    }
+
+    return _variables
+
+  @property
+  def variables(self):
+    _variables = FrozenDict(self._get_variables())
+    return _variables
+
+  def apply(
+    self,
+    variables: dict[str, tp.Mapping],
+    *args,
+    rngs: int | jax.Array | dict[str, jax.Array] | rnglib.Rngs | None = None,
+    method: tp.Callable[..., tp.Any] | str = '__call__',
+    mutable: tp.Any = False,
+    _initialize: bool = False,
+    **kwargs,
+  ) -> tp.Any:
+    module = graph.clone(self)
+
+    # create variables
+    real_variables = dict(variables)
+    for collection, state in variables.items():
+      variable_type = variablelib.variable_type_from_name(
+        collection, allow_register=True
+      )
+
+      def to_variable(value):
+        if isinstance(value, variablelib.VariableState):
+          variable = value.to_variable()
+          if not isinstance(variable, variable_type):
+            raise ValueError(
+              f'Expected variable to be of type {variable_type}, got {type(variable).__name__}'
+            )
+          return variable
+        return variable_type(value)
+
+      state = jax.tree.map(to_variable, state)
+      real_variables[collection] = state
+
+    states = ({},) if not real_variables else real_variables.values()
+    state = ModuleState.merge(*states)
+    graph.update(module, state)
+
+    if rngs is None:
+      rngs = rnglib.Rngs()
+    elif isinstance(rngs, jax.Array | int):
+      rngs = rnglib.Rngs(rngs)
+    elif isinstance(rngs, dict):
+      rngs = rnglib.Rngs(**rngs)
+
+    # get method
+    _method: tp.Callable[..., tp.Any]
+    if isinstance(method, str):
+      attribute_name = method
+      _method = getattr(module, attribute_name)
+      if not callable(_method):
+        class_name = type(module).__name__
+        raise TypeError(
+          f"'{class_name}.{attribute_name}' must be a callable, got"
+          f' {type(_method)}.'
+        )
+      # if the `method` string is a submodule, we create a lambda function
+      # that calls the submodule, forwarding all arguments.
+      if isinstance(_method, Module):
+        _method = lambda module, *args, **kwargs: getattr(
+          module, attribute_name
+        )(*args, **kwargs)
+    else:
+      _method = method
+    _method = _get_unbound_fn(_method)
+
+    # set temporary state
+    for _, value in graph.iter_graph(module):
+      if isinstance(value, Object):
+        value._object__state._initializing = _initialize
+      if isinstance(value, Module):
+        value.scope = Scope(rngs)
+        if has_setup(value):
+          value.setup()
+
+    try:
+      out = _method(module, *args, **kwargs)
+    finally:
+      # reset temporary state
+      for _, value in graph.iter_graph(module):
+        if isinstance(value, Object):
+          value._object__state._initializing = False
+        if isinstance(value, Module):
+          value.scope = None
+
+    _variables: tp.Mapping = module._get_variables()
+
+    if mutable is False:
+      return out
+    else:
+      return out, _variables
+
+  def init(
+    self,
+    rngs: int | jax.Array | dict[str, jax.Array] | rnglib.Rngs | None = None,
+    *args,
+    method: tp.Callable[..., tp.Any] | str = '__call__',
+    **kwargs,
+  ):
+    out, variables = self.apply(
+      {},
+      *args,
+      _initialize=True,
+      mutable=True,
+      rngs=rngs,
+      method=method,
+      **kwargs,
+    )
+    return variables
+
+  def init_with_output(
+    self,
+    rngs: int | jax.Array | dict[str, jax.Array] | rnglib.Rngs | None = None,
+    *args,
+    method: tp.Callable[..., tp.Any] | str = '__call__',
+    mutable: tp.Any = False,
+    # capture_intermediates: bool | Callable[['Module', str], bool] = False,
+    **kwargs,
+  ) -> tuple[tp.Any, dict[str, tp.Mapping]]:
+    return self.apply(
+      {},
+      *args,
+      rngs=rngs,
+      method=method,
+      mutable=True,
+      _initialize=True,
+      **kwargs,
+    )
+
+
+def compact(f: F) -> F:
+  @functools.wraps(f)
+  def compact_wrapper(self, *args, **kwargs):
+    if not isinstance(self, Module):
+      raise ValueError(
+        f"Expected 'self' to be a nnx.compat.Module, got {type(self).__name__}"
+      )
+
+    MODULE_CONTEXT.parent_stack.append(CompactContext(self))
+
+    try:
+      return f(self, *args, **kwargs)
+    finally:
+      MODULE_CONTEXT.parent_stack.pop()
+
+  return compact_wrapper  # type: ignore
+
+
+def _get_unbound_fn(method_or_fn: tp.Callable) -> tp.Callable:
+  if inspect.ismethod(method_or_fn) and isinstance(
+    method_or_fn.__self__, Module
+  ):  # pytype: disable=attribute-error
+    method_or_fn = method_or_fn.__func__  # pytype: disable=attribute-error
+  if (
+    not callable(method_or_fn)
+    or len(inspect.signature(method_or_fn).parameters) < 1
+  ):
+    raise errors.ApplyModuleInvalidMethodError(method_or_fn)
+
+  return method_or_fn

--- a/flax/nnx/bridge/variables.py
+++ b/flax/nnx/bridge/variables.py
@@ -105,7 +105,7 @@ def get_col_name(keypath: tp.Sequence[Any]) -> str:
 
 def to_nnx_var(col: str, x: meta.AxisMetadata | Any) -> variablelib.Variable:
   """Convert a Linen variable to an NNX variable."""
-  vtype = variablelib.variable_type_from_name(col)
+  vtype = variablelib.variable_type_from_name(col, allow_register=True)
   if isinstance(x, NNXMeta):
     assert vtype == x.var_type, f'Type stored in NNXMeta {x.var_type} != type inferred from collection name {vtype}'
     return x.to_nnx_variable()

--- a/flax/nnx/bridge/wrappers.py
+++ b/flax/nnx/bridge/wrappers.py
@@ -273,7 +273,7 @@ class ToLinen(linen.Module):
     # Each variable type goes to its own linen collection, and
     # each attribute goes to its own linen variable
     for typ, state in zip(types, state_by_types):
-      collection = variablelib.variable_name_from_type(typ)
+      collection = variablelib.variable_name_from_type(typ, allow_register=True)
       if self.is_mutable_collection(collection):
         for k, v in state.raw_mapping.items():
           v = jax.tree.map(bv.to_linen_var, v,

--- a/flax/nnx/graph.py
+++ b/flax/nnx/graph.py
@@ -2127,9 +2127,10 @@ def update(
     *states: Additional :class:`State` objects.
   """
   if states:
-    state = State.merge(state, *states)
-  if isinstance(state, State):
-    state = state.raw_mapping
+    if isinstance(state, State):
+      state = type(state).merge(state, *states)
+    else:
+      state = State.merge(state, *states)
   _graph_update_dynamic(node, state)
 
 
@@ -2484,6 +2485,7 @@ def iter_graph(node: tp.Any, /) -> tp.Iterator[tuple[PathParts, tp.Any]]:
     >>> for path, value in nnx.iter_graph(graph):
     ...   print(path, type(value).__name__)
     ...
+    (0, '_object__state') ObjectState
     (0, 'b') Param
     (0, 'din') int
     (0, 'dout') int

--- a/flax/nnx/tracers.py
+++ b/flax/nnx/tracers.py
@@ -67,3 +67,17 @@ class TraceState(reprlib.Representable):
 
   def __setstate__(self, state):
     self._jax_trace = current_jax_trace()
+
+def _flatten_trace_state(trace_state: TraceState):
+  return (), None
+
+
+def _unflatten_trace_state(_1, _2):
+  return TraceState()
+
+
+jax.tree_util.register_pytree_node(
+  TraceState,
+  _flatten_trace_state,
+  _unflatten_trace_state,
+)

--- a/flax/nnx/variablelib.py
+++ b/flax/nnx/variablelib.py
@@ -1010,23 +1010,40 @@ VariableTypeCache: dict[str, tp.Type[Variable[tp.Any]]] = {}
 
 
 def variable_type_from_name(
-    name: str,
-    *,
-    base: type[Variable[tp.Any]] = Variable,
+  name: str,
+  /,
+  *,
+  base: type[Variable[tp.Any]] = Variable,
+  allow_register: bool = False,
 ) -> tp.Type[Variable[tp.Any]]:
   """Given a Linen-style collection name, get or create its NNX Variable class."""
   if name not in VariableTypeCache:
+    if not allow_register:
+      raise ValueError(
+        f'Name {name} is not registered in the registry. '
+        'To register a new name, use register_variable_name() '
+        'or set allow_register=True.'
+      )
     VariableTypeCache[name] = type(name, (base,), {})
   return VariableTypeCache[name]
 
 
-def variable_name_from_type(typ: tp.Type[Variable[tp.Any]]) -> str:
+def variable_name_from_type(
+  typ: tp.Type[Variable[tp.Any]], /, *, allow_register: bool = False
+) -> str:
   """Given an NNX Variable type, get its Linen-style collection name.
 
   Should output the exact inversed result of `variable_type_from_name()`."""
   for name, t in VariableTypeCache.items():
     if typ == t:
       return name
+
+  if not allow_register:
+    raise ValueError(
+      f'Type {typ} is not registered in the registry. '
+      'To register a new type, use register_variable_name() '
+      'or set allow_register=True.'
+    )
   name = typ.__name__
   if name in VariableTypeCache:
     raise ValueError(

--- a/tests/nnx/bridge/wrappers_test.py
+++ b/tests/nnx/bridge/wrappers_test.py
@@ -13,6 +13,9 @@
 # limitations under the License.
 
 import os
+from typing import Any
+
+from flax.linen.dtypes import promote_dtype
 os.environ["XLA_FLAGS"] = '--xla_force_host_platform_device_count=4'
 
 from absl.testing import absltest
@@ -486,6 +489,214 @@ class TestCompatibility(absltest.TestCase):
     # TODO: add when we can safely `lazy_init` the NNX module inside `ToLinen` without
     # messing up the stateful part of the NNX module.
     pass
+
+class TestCompatModule(absltest.TestCase):
+  def test_update(self):
+    class Foo(bridge.Module):
+      a: int
+
+    foo = Foo(1)
+    state = {'b': {'c': nnx.Param(jnp.array(2))}}
+    nnx.update(foo, state)
+
+  def test_compact_basic(self):
+    class Linear(bridge.Module):
+      dout: int
+
+      @bridge.compact
+      def __call__(self, x):
+        w = self.param(
+          'w', nnx.initializers.uniform(), (x.shape[-1], self.dout)
+        )
+        b = self.param('b', nn.initializers.zeros_init(), (self.dout,))
+        return x @ w + b[None]
+
+    class Foo(bridge.Module):
+      dout: int
+
+      @bridge.compact
+      def __call__(self, x):
+        din = x.shape[-1]
+        self.linear = Linear(self.dout)
+        x = self.linear(x)
+        return x
+
+    foo = Foo(5)
+    x = jnp.ones((3, 2))
+
+    variables = foo.init(0, x)
+    params = variables['params']
+
+    self.assertIn('Linear_0', params)
+    self.assertIn('w', params['Linear_0'])
+    self.assertIn('b', params['Linear_0'])
+    self.assertEqual(params['Linear_0']['w'].shape, (2, 5))
+    self.assertEqual(params['Linear_0']['b'].shape, (5,))
+
+    y: jax.Array = foo.apply(variables, x)
+
+    self.assertEqual(y.shape, (3, 5))
+
+  def test_mutable_state(self):
+    class FooLinen(nn.Module):
+      @nn.compact
+      def __call__(self):
+        count = self.variable(
+          'counts', 'count', lambda: jnp.zeros((), jnp.int32)
+        )
+        count.value += 1
+
+    model_linen = FooLinen()
+    initial_vars_linen = model_linen.init({})
+    _, vars_linen = model_linen.apply(initial_vars_linen, mutable='counts')
+
+    class FooNNX(bridge.Module):
+      @bridge.compact
+      def __call__(self):
+        count = self.variable(
+          'counts', 'count', lambda: jnp.zeros((), jnp.int32)
+        )
+        count.value += 1
+
+    model_nnx = FooNNX()
+
+    initial_vars_nnx = model_nnx.init({})
+    _, vars_nnx = model_nnx.apply(initial_vars_nnx, mutable='counts')
+
+    self.assertEqual(
+      initial_vars_linen['counts']['count'], initial_vars_nnx['counts']['count']
+    )
+    self.assertEqual(vars_linen['counts']['count'], vars_nnx['counts']['count'])
+
+  def test_compact_parent_none(self):
+    class Foo(bridge.Module):
+      pass
+
+    class Bar(bridge.Module):
+      @bridge.compact
+      def __call__(self):
+        return Foo().scope
+
+    bar = Bar()
+    scope = bar.apply({}, rngs=1)
+    self.assertIsNone(bar.scope)
+
+    self.assertEqual(scope.rngs.default.key.value, jax.random.key(1))
+    self.assertEqual(scope.rngs.default.count.value, 0)
+
+    class Baz(bridge.Module):
+      @bridge.compact
+      def __call__(self):
+        return Foo(parent=None).scope
+
+    baz = Baz()
+    scope = baz.apply({}, rngs=1)
+    self.assertIsNone(scope)
+
+  def test_name(self):
+    class Foo(bridge.Module):
+      dout: int
+
+      def __call__(self, x):
+        w = self.param(
+          'w', nnx.initializers.uniform(), (x.shape[-1], self.dout)
+        )
+        return x @ w
+
+    class Bar(bridge.Module):
+      @bridge.compact
+      def __call__(self, x):
+        return Foo(5, name='xyz')(x)
+
+    bar = Bar()
+    x = jnp.ones((1, 2))
+    y, variables = bar.init_with_output(0, x)
+
+    self.assertIn('xyz', variables['params'])
+    self.assertEqual(variables['params']['xyz']['w'].shape, (2, 5))
+    self.assertEqual(y.shape, (1, 5))
+
+    y = bar.apply(variables, x)
+    self.assertEqual(y.shape, (1, 5))
+
+  def test_dense_port(self):
+    class Dense(bridge.Module):
+      features: int
+      use_bias: bool = True
+      dtype: Any = None
+      param_dtype: Any = jnp.float32
+      precision: Any = None
+      kernel_init: Any = nnx.initializers.lecun_normal()
+      bias_init: Any = nnx.initializers.zeros_init()
+      # Deprecated. Will be removed.
+      dot_general: Any | None = None
+      dot_general_cls: Any = None
+
+      @bridge.compact
+      def __call__(self, inputs: jax.Array) -> jax.Array:
+        kernel = self.param(
+          'kernel',
+          self.kernel_init,
+          (jnp.shape(inputs)[-1], self.features),
+          self.param_dtype,
+        )
+        if self.use_bias:
+          bias = self.param(
+            'bias', self.bias_init, (self.features,), self.param_dtype
+          )
+        else:
+          bias = None
+        inputs, kernel, bias = promote_dtype(
+          inputs, kernel, bias, dtype=self.dtype
+        )
+
+        if self.dot_general_cls is not None:
+          dot_general = self.dot_general_cls()
+        elif self.dot_general is not None:
+          dot_general = self.dot_general
+        else:
+          dot_general = jax.lax.dot_general
+        y = dot_general(
+          inputs,
+          kernel,
+          (((inputs.ndim - 1,), (0,)), ((), ())),
+          precision=self.precision,
+        )
+        if bias is not None:
+          y += jnp.reshape(bias, (1,) * (y.ndim - 1) + (-1,))
+        return y
+
+    m = Dense(3)
+    x = jnp.ones((1, 10, 2))
+    y, variables = m.init_with_output(0, x)
+
+    self.assertEqual(y.shape, (1, 10, 3))
+    self.assertEqual(variables['params']['kernel'].shape, (2, 3))
+    self.assertEqual(variables['params']['bias'].shape, (3,))
+
+    y = m.apply(variables, x)
+
+    self.assertEqual(y.shape, (1, 10, 3))
+    self.assertEqual(variables['params']['kernel'].shape, (2, 3))
+    self.assertEqual(variables['params']['bias'].shape, (3,))
+
+    @jax.jit
+    def train_step(params, x, y):
+      def loss_fn(params):
+        y_pred = m.apply({'params': params}, x)
+        return jnp.mean((y - y_pred) ** 2)
+
+      grads = jax.grad(loss_fn)(params)
+
+      params = jax.tree.map(lambda p, g: p - 0.01 * g, params, grads)
+
+      return params
+
+    params = variables['params']
+    x = jnp.ones((1, 10, 2))
+    y = jnp.ones((1, 10, 3))
+
+    params = train_step(params, x, y)
 
 
 if __name__ == '__main__':

--- a/uv.lock
+++ b/uv.lock
@@ -772,7 +772,7 @@ wheels = [
 
 [[package]]
 name = "flax"
-version = "0.10.2"
+version = "0.10.3"
 source = { editable = "." }
 dependencies = [
     { name = "jax" },
@@ -2258,7 +2258,7 @@ wheels = [
 
 [[package]]
 name = "orbax-checkpoint"
-version = "0.11.0"
+version = "0.11.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "absl-py" },
@@ -2276,9 +2276,9 @@ dependencies = [
     { name = "tensorstore" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/de/b3/a9a8a6bc08ded7634a9d85ba440400172f0a11f9341897b8fd3389fad245/orbax_checkpoint-0.11.0.tar.gz", hash = "sha256:d4a0dcc81edd29191cf5a4feb9cf2a4edd31fc5da79d7be616a04f11f2a4d484", size = 253035 }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/b4/262439a3fe00064b53a5182c0149447304f5a2d5a328a92d64390c18d189/orbax_checkpoint-0.11.5.tar.gz", hash = "sha256:8331ff594980a241ba43eb59dd683e5b590b339cff32a7b72d78cb5a350030b4", size = 249258 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/87/32/3779fa524a2272f408ab51d869fde9ff1c0ca731eedd01e40436bcf7ba2c/orbax_checkpoint-0.11.0-py3-none-any.whl", hash = "sha256:892a124fce71f3e7c71451a2b2090c0251db1097803a119a00baa377113bc9ba", size = 360423 },
+    { url = "https://files.pythonhosted.org/packages/66/80/e659696b5b1c2ced427efedd2d9d29c1bc31d841ac8a031215aa38f6b2ae/orbax_checkpoint-0.11.5-py3-none-any.whl", hash = "sha256:b55a7a254ea0ab18237e8234a6ca8bf5522f589fcc2ac698cf6893d5e7ae3500", size = 342800 },
 ]
 
 [[package]]


### PR DESCRIPTION
# What does this PR do?

* Adds `bridge.Module`
* Makes `ObjectState` and `TraceState` static pytrees and simplifies `Object` recreation logic.
* Adds `allow_register: bool` option to `variable_type_from_name` and `variable_name_from_type`. Its now `False` by default.