### PR TITLE
remove Embed nan casting

### DIFF
--- a/flax/linen/linear.py
+++ b/flax/linen/linear.py
@@ -1124,12 +1124,7 @@ class Embed(Module):
       self.embedding, dtype=self.dtype, inexact=False
     )
     if self.num_embeddings == 1:
-      return jnp.where(
-        jnp.broadcast_to(inputs[..., None], inputs.shape + (self.features,))
-        == 0,
-        embedding,
-        jnp.nan,
-      )
+      return jnp.broadcast_to(embedding, inputs.shape + (self.features,))
     return jnp.take(embedding, inputs, axis=0)
 
   def attend(self, query: Array) -> Array:

--- a/flax/nnx/nn/linear.py
+++ b/flax/nnx/nn/linear.py
@@ -1143,12 +1143,7 @@ class Embed(Module):
       (self.embedding.value,), dtype=self.dtype, inexact=False
     )
     if self.num_embeddings == 1:
-      return jnp.where(
-        jnp.broadcast_to(inputs[..., None], inputs.shape + (self.features,))
-        == 0,
-        embedding,
-        jnp.nan,
-      )
+      return jnp.broadcast_to(embedding, inputs.shape + (self.features,))
     return jnp.take(embedding, inputs, axis=0)
 
   def attend(self, query: Array) -> Array:

--- a/tests/linen/linen_linear_test.py
+++ b/tests/linen/linen_linear_test.py
@@ -1280,40 +1280,6 @@ class LinearTest(parameterized.TestCase):
     )
     np.testing.assert_allclose(z, 3.0 * jnp.arange(4))
 
-  @parameterized.product(num_embedding=(1, 4))
-  def test_embed_nan(self, num_embedding):
-    rng = dict(params=random.key(0))
-    x = jnp.zeros(4)[None].astype(jnp.int32)
-    dummy_embedding = jnp.arange(3)[None, ...].astype(jnp.float32)
-    dummy_embedding = jnp.broadcast_to(dummy_embedding, (num_embedding, 3))
-    embed_module = nn.Embed(
-      num_embeddings=num_embedding,
-      features=3,
-      embedding_init=lambda rng, shape, dtype: dummy_embedding,
-    )
-    y, initial_params = embed_module.init_with_output(rng, x)
-    np.testing.assert_allclose(
-      y, jnp.broadcast_to(dummy_embedding[0][None], (4, 3))[None]
-    )
-    x = jnp.arange(2)[None] + num_embedding - 1
-    y, initial_params = embed_module.init_with_output(rng, x)
-    expected = jnp.broadcast_to(
-      jnp.array(
-        [
-          [
-            [
-              False,
-            ],
-            [
-              True,
-            ],
-          ]
-        ]
-      ),
-      (1, 2, 3),
-    )
-    np.testing.assert_allclose(jnp.isnan(y), expected)
-
   def test_embed_hash(self):
     self.assertEqual(hash(nn.Embed(2, 3)), hash(nn.Embed(2, 3)))
     self.assertNotEqual(hash(nn.Embed(3, 4)), hash(nn.Embed(2, 3)))

--- a/tests/nnx/nn/embed_test.py
+++ b/tests/nnx/nn/embed_test.py
@@ -71,7 +71,6 @@ class TestLinenConsistency(parameterized.TestCase):
     out = model.apply(variables, x)
     assert isinstance(out, jax.Array)
     np.testing.assert_array_equal(out, out_nnx)
-    np.testing.assert_array_equal(jax.numpy.isnan(out).all(), jax.numpy.array([True]))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
# What does this PR do?

Fixes #4557. Remove code that adds `nan`s in `Embed`.