### PR TITLE
bridge module with linen submodule

### DIFF
--- a/flax/nnx/bridge/__init__.py
+++ b/flax/nnx/bridge/__init__.py
@@ -26,5 +26,6 @@ from .module import Scope as Scope
 from .module import compact as compact
 from .module import current_context as current_context
 from .module import current_module as current_module
-from .interop import wrap_nnx_mdl as wrap_nnx_mdl
+from .interop import nnx_in_bridge_mdl as nnx_in_bridge_mdl
+from .interop import linen_in_bridge_mdl as linen_in_bridge_mdl
 from flax.nnx.nn import initializers as initializers


### PR DESCRIPTION
# What does this PR do?

* Allow Linen modules to become submodules of `bridge.Module`, supporting the `mutable` arg and allow custom method call.

* Cleaned up `ToNNX()`: 
  * removed unneeded `linen_attributes`
  * prevent RNG reuse during init
  * auto-recognize `mutable` arg if top level `bridge.Module` context exists.

