### PR TITLE
[nnx] add support for standalone Variables

### DIFF
--- a/flax/nnx/bridge/wrappers.py
+++ b/flax/nnx/bridge/wrappers.py
@@ -49,7 +49,7 @@ class Functional(tp.Generic[M]):
     graphdef, state = nnx.split(module)
     assert type(graphdef) is graph.NodeDef
     self.graphdef = graphdef
-    return state
+    return state  # type: ignore
 
   def apply(self, *states: tp.Any):
     assert self.graphdef is not None

--- a/flax/nnx/module.py
+++ b/flax/nnx/module.py
@@ -497,7 +497,9 @@ class Module(Object, metaclass=ModuleMeta):
 # -------------------------
 def _module_flatten(module: Module, *, with_keys: bool):
   graphdef, state = graph.split(module)
-  key_values = sorted(state.raw_mapping.items())
+  key_values = sorted(
+    state.raw_mapping.items()  # type: ignore
+  )
   keys = tuple(key for key, _ in key_values)
 
   children: tuple[tp.Any, ...]

--- a/flax/nnx/statelib.py
+++ b/flax/nnx/statelib.py
@@ -445,6 +445,7 @@ class State(MutableMapping[K, V], reprlib.Representable):
     )
 
 
+
 def _state_flatten_with_keys(x: State):
   items = sorted(x._mapping.items())
   children = tuple((jtu.DictKey(key), value) for key, value in items)
@@ -465,6 +466,9 @@ jax.tree_util.register_pytree_with_keys(
   partial(_state_unflatten, State),  # type: ignore[arg-type]
 )
 
+class EmptyState(State):
+  def __init__(self):
+    super().__init__({})
 
 def map_state(f: tp.Callable[[tuple, tp.Any], tp.Any], state: State) -> State:
   flat_state = to_flat_state(state)


### PR DESCRIPTION
# What does this PR do?

Adds support for using Variables outside of graph nodes, meaning they can now be passed directly to transforms, including inside pytrees without a parent graph node, and the ability to call `split`, `merge`, and `update` on them directly.

```python
rngs = nnx.Rngs(0)
w = nnx.Param(jax.random.normal(rngs(), (2, 3)))
b = nnx.Param(jnp.zeros((3,)))
count = nnx.Variable(jnp.array(0))

@nnx.jit
def linear(w, b, count, x):
  count += 1
  return x @ w + b[None]

x = jax.random.normal(rngs(), (1, 2))
y = linear(w, b, count, x)

assert count.value == 1
assert y.shape == (1, 3)
```