### PR TITLE
add promote_dtype as a config option for multiple layers

### DIFF
--- a/flax/linen/dtypes.py
+++ b/flax/linen/dtypes.py
@@ -13,10 +13,11 @@
 # limitations under the License.
 """APIs for handling dtypes in Linen Modules."""
 
-from typing import Any
+from typing import Any, TypeVar
 from flax.typing import Dtype
 from jax import numpy as jnp
 
+T = TypeVar('T', bound=tuple)
 
 def canonicalize_dtype(
   *args, dtype: Dtype | None = None, inexact: bool = True

--- a/flax/linen/linear.py
+++ b/flax/linen/linear.py
@@ -16,6 +16,7 @@
 
 from typing import (
   Any,
+  Protocol,
 )
 from collections.abc import Iterable, Sequence
 
@@ -29,7 +30,7 @@ import opt_einsum
 
 from flax.core import meta
 from flax.linen import initializers
-from flax.linen.dtypes import promote_dtype
+from flax.linen import dtypes
 from flax.linen import module
 from flax.linen.module import Module, compact
 from flax.typing import (
@@ -45,6 +46,10 @@ from flax.typing import (
   LaxPadding,
 )
 
+class PromoteDtypeFn(Protocol):
+  def __call__(
+    self, *args: jax.Array | None, dtype: Any = None, inexact: bool = True
+  ) -> list[jax.Array | None]: ...
 
 default_kernel_init = initializers.lecun_normal()
 
@@ -94,6 +99,10 @@ class DenseGeneral(Module):
     bias_init: initializer function for the bias.
     precision: numerical precision of the computation see ``jax.lax.Precision``
       for details.
+    promote_dtype: function to promote the dtype of the arrays to the desired
+      dtype. The function should accept a tuple of ``(inputs, kernel, bias)``
+      and a ``dtype`` keyword argument, and return a tuple of arrays with the
+      promoted dtype.
   """
 
   features: int | Sequence[int]
@@ -105,6 +114,7 @@ class DenseGeneral(Module):
   kernel_init: Initializer = default_kernel_init
   bias_init: Initializer = initializers.zeros_init()
   precision: PrecisionLike = None
+  promote_dtype: PromoteDtypeFn = dtypes.promote_dtype
   # Deprecated. Will be removed.
   dot_general: DotGeneralT | None = None
   dot_general_cls: Any = None
@@ -181,7 +191,9 @@ class DenseGeneral(Module):
     else:
       bias = None
 
-    inputs, kernel, bias = promote_dtype(inputs, kernel, bias, dtype=self.dtype)
+    inputs, kernel, bias = self.promote_dtype(
+      inputs, kernel, bias, dtype=self.dtype
+    )
 
     if self.dot_general_cls is not None:
       dot_general = self.dot_general_cls()
@@ -225,6 +237,10 @@ class Dense(Module):
       for details.
     kernel_init: initializer function for the weight matrix.
     bias_init: initializer function for the bias.
+    promote_dtype: function to promote the dtype of the arrays to the desired
+      dtype. The function should accept a tuple of ``(inputs, kernel, bias)``
+      and a ``dtype`` keyword argument, and return a tuple of arrays with the
+      promoted dtype.
   """
 
   features: int
@@ -234,6 +250,7 @@ class Dense(Module):
   precision: PrecisionLike = None
   kernel_init: Initializer = default_kernel_init
   bias_init: Initializer = initializers.zeros_init()
+  promote_dtype: PromoteDtypeFn = dtypes.promote_dtype
   # Deprecated. Will be removed.
   dot_general: DotGeneralT | None = None
   dot_general_cls: Any = None
@@ -260,7 +277,11 @@ class Dense(Module):
       )
     else:
       bias = None
-    inputs, kernel, bias = promote_dtype(inputs, kernel, bias, dtype=self.dtype)
+    inputs, kernel, bias = self.promote_dtype(
+      inputs, kernel, bias, dtype=self.dtype
+    )
+    assert inputs is not None
+    assert kernel is not None
 
     if self.dot_general_cls is not None:
       dot_general = self.dot_general_cls()
@@ -306,6 +327,10 @@ class Einsum(Module):
       for details.
     kernel_init: initializer function for the weight matrix.
     bias_init: initializer function for the bias.
+    promote_dtype: function to promote the dtype of the arrays to the desired
+      dtype. The function should accept a tuple of ``(inputs, kernel, bias)``
+      and a ``dtype`` keyword argument, and return a tuple of arrays with the
+      promoted dtype.
   """
 
   shape: Shape
@@ -316,6 +341,7 @@ class Einsum(Module):
   precision: PrecisionLike = None
   kernel_init: Initializer = default_kernel_init
   bias_init: Initializer = initializers.zeros_init()
+  promote_dtype: PromoteDtypeFn = dtypes.promote_dtype
 
   @compact
   def __call__(self, inputs: Array, einsum_str: str | None = None) -> Array:
@@ -361,7 +387,9 @@ class Einsum(Module):
     else:
       bias = None
 
-    inputs, kernel, bias = promote_dtype(inputs, kernel, bias, dtype=self.dtype)
+    inputs, kernel, bias = self.promote_dtype(
+      inputs, kernel, bias, dtype=self.dtype
+    )
 
     y = jnp.einsum(einsum_str, inputs, kernel, precision=self.precision)
 
@@ -469,6 +497,10 @@ class _Conv(Module):
       for details.
     kernel_init: initializer for the convolutional kernel.
     bias_init: initializer for the bias.
+    promote_dtype: function to promote the dtype of the arrays to the desired
+      dtype. The function should accept a tuple of ``(inputs, kernel, bias)``
+      and a ``dtype`` keyword argument, and return a tuple of arrays with the
+      promoted dtype.
   """
 
   features: int
@@ -485,6 +517,7 @@ class _Conv(Module):
   precision: PrecisionLike = None
   kernel_init: Initializer = default_kernel_init
   bias_init: Initializer = initializers.zeros_init()
+  promote_dtype: PromoteDtypeFn = dtypes.promote_dtype
   # Deprecated. Will be removed.
   conv_general_dilated: ConvGeneralDilatedT | None = None
   conv_general_dilated_cls: Any = None
@@ -647,7 +680,12 @@ class _Conv(Module):
     else:
       bias = None
 
-    inputs, kernel, bias = promote_dtype(inputs, kernel, bias, dtype=self.dtype)
+    inputs, kernel, bias = self.promote_dtype(
+      inputs, kernel, bias, dtype=self.dtype
+    )
+    assert inputs is not None
+    assert kernel is not None
+
     if self.shared_weights:
       if self.conv_general_dilated_cls is not None:
         conv_general_dilated = self.conv_general_dilated_cls()
@@ -749,6 +787,10 @@ class Conv(_Conv):
       for details.
     kernel_init: initializer for the convolutional kernel.
     bias_init: initializer for the bias.
+    promote_dtype: function to promote the dtype of the arrays to the desired
+      dtype. The function should accept a tuple of ``(inputs, kernel, bias)``
+      and a ``dtype`` keyword argument, and return a tuple of arrays with the
+      promoted dtype.
   """
 
   @property
@@ -816,6 +858,10 @@ class ConvLocal(_Conv):
       for details.
     kernel_init: initializer for the convolutional kernel.
     bias_init: initializer for the bias.
+    promote_dtype: function to promote the dtype of the arrays to the desired
+      dtype. The function should accept a tuple of ``(inputs, kernel, bias)``
+      and a ``dtype`` keyword argument, and return a tuple of arrays with the
+      promoted dtype.
   """
 
   @property
@@ -879,6 +925,10 @@ class ConvTranspose(Module):
     bias_init: initializer for the bias.
     transpose_kernel: if ``True`` flips spatial axes and swaps the input/output
       channel axes of the kernel.
+    promote_dtype: function to promote the dtype of the arrays to the desired
+      dtype. The function should accept a tuple of ``(inputs, kernel, bias)``
+      and a ``dtype`` keyword argument, and return a tuple of arrays with the
+      promoted dtype.
   """
 
   features: int
@@ -894,6 +944,7 @@ class ConvTranspose(Module):
   kernel_init: Initializer = default_kernel_init
   bias_init: Initializer = initializers.zeros_init()
   transpose_kernel: bool = False
+  promote_dtype: PromoteDtypeFn = dtypes.promote_dtype
 
   @compact
   def __call__(self, inputs: Array) -> Array:
@@ -976,7 +1027,11 @@ class ConvTranspose(Module):
     else:
       bias = None
 
-    inputs, kernel, bias = promote_dtype(inputs, kernel, bias, dtype=self.dtype)
+    inputs, kernel, bias = self.promote_dtype(
+      inputs, kernel, bias, dtype=self.dtype
+    )
+    assert inputs is not None
+    assert kernel is not None
 
     y = lax.conv_transpose(
       inputs,
@@ -1089,6 +1144,10 @@ class Embed(Module):
     dtype: the dtype of the embedding vectors (default: same as embedding).
     param_dtype: the dtype passed to parameter initializers (default: float32).
     embedding_init: embedding initializer.
+    promote_dtype: function to promote the dtype of the arrays to the desired
+      dtype. The function should accept a tuple of ``(embedding,)`` during ``__call__``
+      or ``(query, embedding)`` during ``attend``, and a ``dtype`` keyword argument,
+      and return a tuple of arrays with the promoted dtype.
   """
 
   num_embeddings: int
@@ -1096,6 +1155,7 @@ class Embed(Module):
   dtype: Dtype | None = None
   param_dtype: Dtype = jnp.float32
   embedding_init: Initializer = default_embed_init
+  promote_dtype: PromoteDtypeFn = dtypes.promote_dtype
 
   def setup(self):
     self.embedding = self.param(
@@ -1120,9 +1180,10 @@ class Embed(Module):
       raise ValueError('Input type must be an integer or unsigned integer.')
     # Use take because fancy indexing numpy arrays with JAX indices does not
     # work correctly.
-    (embedding,) = promote_dtype(
+    (embedding,) = self.promote_dtype(
       self.embedding, dtype=self.dtype, inexact=False
     )
+    assert embedding is not None
     if self.num_embeddings == 1:
       return jnp.broadcast_to(embedding, inputs.shape + (self.features,))
     return jnp.take(embedding, inputs, axis=0)
@@ -1140,5 +1201,10 @@ class Embed(Module):
       Commonly used for weight-sharing between embeddings and logit transform
       in NLP models.
     """
-    query, embedding = promote_dtype(query, self.embedding, dtype=self.dtype)
+    embedding: Array
+    query, embedding = self.promote_dtype(
+      query, self.embedding, dtype=self.dtype
+    )
+    assert query is not None
+    assert embedding is not None
     return jnp.dot(query, embedding.T)

--- a/flax/nnx/nn/attention.py
+++ b/flax/nnx/nn/attention.py
@@ -28,7 +28,7 @@ from flax import nnx
 from flax.nnx import rnglib
 from flax.nnx.module import Module, first_from
 from flax.nnx.nn import initializers
-from flax.nnx.nn.dtypes import promote_dtype
+from flax.nnx.nn import dtypes
 from flax.nnx.nn.linear import (
   LinearGeneral,
   default_kernel_init,
@@ -36,6 +36,7 @@ from flax.nnx.nn.linear import (
 from flax.nnx.nn.normalization import LayerNorm
 from flax.typing import (
   Dtype,
+  PromoteDtypeFn,
   Shape,
   Initializer,
   PrecisionLike,
@@ -57,6 +58,7 @@ def dot_product_attention_weights(
   dtype: Dtype | None = None,
   precision: PrecisionLike = None,
   module: Module | None = None,
+  promote_dtype: PromoteDtypeFn = dtypes.promote_dtype,
 ):
   """Computes dot-product attention weights given query and key.
 
@@ -86,6 +88,9 @@ def dot_product_attention_weights(
     module: the Module that will sow the attention weights into the
       ``nnx.Intermediate`` collection. If ``module`` is None, the attention
       weights will not be sowed.
+    promote_dtype: function to promote the dtype of the arrays to the desired
+      dtype. The function should accept a tuple of ``(query, key)`` and a ``dtype``
+      keyword argument, and return a tuple of arrays with the promoted dtype.
 
   Returns:
     Output of shape `[batch..., num_heads, q_length, kv_length]`.
@@ -148,6 +153,7 @@ def dot_product_attention(
   dtype: Dtype | None = None,
   precision: PrecisionLike = None,
   module: Module | None = None,
+  promote_dtype: PromoteDtypeFn = dtypes.promote_dtype,
 ):
   """Computes dot-product attention given query, key, and value.
 
@@ -182,6 +188,10 @@ def dot_product_attention(
     module: the Module that will sow the attention weights into the
       ``nnx.Intermediate`` collection. If ``module`` is None, the attention
       weights will not be sowed.
+    promote_dtype: function to promote the dtype of the arrays to the desired
+      dtype. The function should accept a tuple of ``(query, key, value)`` and a
+      ``dtype`` keyword argument, and return a tuple of arrays with the promoted
+      dtype.
 
   Returns:
     Output of shape `[batch..., q_length, num_heads, v_depth_per_head]`.

--- a/flax/nnx/nn/linear.py
+++ b/flax/nnx/nn/linear.py
@@ -35,6 +35,7 @@ from flax.typing import (
   ConvGeneralDilatedT,
   PaddingLike,
   LaxPadding,
+  PromoteDtypeFn,
 )
 
 Array = jax.Array
@@ -132,6 +133,10 @@ class LinearGeneral(Module):
     bias_init: initializer function for the bias.
     precision: numerical precision of the computation see ``jax.lax.Precision``
       for details.
+    promote_dtype: function to promote the dtype of the arrays to the desired
+      dtype. The function should accept a tuple of ``(inputs, kernel, bias)``
+      and a ``dtype`` keyword argument, and return a tuple of arrays with the
+      promoted dtype.
     rngs: rng key.
   """
 
@@ -148,6 +153,7 @@ class LinearGeneral(Module):
     kernel_init: Initializer = default_kernel_init,
     bias_init: Initializer = default_bias_init,
     precision: PrecisionLike = None,
+    promote_dtype: PromoteDtypeFn = dtypes.promote_dtype,
     # Deprecated. Will be removed.
     dot_general: DotGeneralT | None = None,
     dot_general_cls: tp.Any = None,
@@ -165,6 +171,7 @@ class LinearGeneral(Module):
     self.precision = precision
     self.dot_general = dot_general
     self.dot_general_cls = dot_general_cls
+    self.promote_dtype = promote_dtype
 
     if len(self.in_features) != len(self.axis):
       raise ValueError(
@@ -257,7 +264,7 @@ class LinearGeneral(Module):
     batch_ind = tuple(range(n_batch_dims))
     contract_ind = tuple(range(n_batch_dims, n_axis + n_batch_dims))
 
-    inputs, kernel, bias = dtypes.promote_dtype(
+    inputs, kernel, bias = self.promote_dtype(
       (inputs, kernel, bias), dtype=self.dtype
     )
 
@@ -313,6 +320,10 @@ class Linear(Module):
     kernel_init: initializer function for the weight matrix.
     bias_init: initializer function for the bias.
     dot_general: dot product function.
+    promote_dtype: function to promote the dtype of the arrays to the desired
+      dtype. The function should accept a tuple of ``(inputs, kernel, bias)``
+      and a ``dtype`` keyword argument, and return a tuple of arrays with the
+      promoted dtype.
     rngs: rng key.
   """
 
@@ -328,6 +339,7 @@ class Linear(Module):
     kernel_init: Initializer = default_kernel_init,
     bias_init: Initializer = default_bias_init,
     dot_general: DotGeneralT = lax.dot_general,
+    promote_dtype: PromoteDtypeFn = dtypes.promote_dtype,
     rngs: rnglib.Rngs,
   ):
     kernel_key = rngs.params()
@@ -350,6 +362,7 @@ class Linear(Module):
     self.kernel_init = kernel_init
     self.bias_init = bias_init
     self.dot_general = dot_general
+    self.promote_dtype = promote_dtype
 
   def __call__(self, inputs: Array) -> Array:
     """Applies a linear transformation to the inputs along the last dimension.
@@ -363,7 +376,7 @@ class Linear(Module):
     kernel = self.kernel.value
     bias = self.bias.value if self.bias is not None else None
 
-    inputs, kernel, bias = dtypes.promote_dtype(
+    inputs, kernel, bias = self.promote_dtype(
       (inputs, kernel, bias), dtype=self.dtype
     )
     y = self.dot_general(
@@ -409,6 +422,10 @@ class Einsum(Module):
       for details.
     kernel_init: initializer function for the weight matrix.
     bias_init: initializer function for the bias.
+    promote_dtype: function to promote the dtype of the arrays to the desired
+      dtype. The function should accept a tuple of ``(inputs, kernel, bias)``
+      and a ``dtype`` keyword argument, and return a tuple of arrays with the
+      promoted dtype.
     rngs: rng key.
   """
 
@@ -423,6 +440,7 @@ class Einsum(Module):
     precision: PrecisionLike = None,
     kernel_init: Initializer = default_kernel_init,
     bias_init: Initializer = default_bias_init,
+    promote_dtype: PromoteDtypeFn = dtypes.promote_dtype,
     rngs: rnglib.Rngs,
   ):
     einsum_str = einsum_str.replace(' ', '')
@@ -446,6 +464,7 @@ class Einsum(Module):
     self.precision = precision
     self.kernel_init = kernel_init
     self.bias_init = bias_init
+    self.promote_dtype = promote_dtype
 
   def __call__(
     self, inputs: Array, einsum_str: tp.Optional[str] = None
@@ -472,7 +491,7 @@ class Einsum(Module):
     einsum_str = einsum_str.replace(' ', '')
     self._einsum_str_check(einsum_str)
 
-    inputs, kernel, bias = dtypes.promote_dtype(
+    inputs, kernel, bias = self.promote_dtype(
       (
         inputs,
         self.kernel.value,
@@ -609,6 +628,10 @@ class Conv(Module):
       for details.
     kernel_init: initializer for the convolutional kernel.
     bias_init: initializer for the bias.
+    promote_dtype: function to promote the dtype of the arrays to the desired
+      dtype. The function should accept a tuple of ``(inputs, kernel, bias)``
+      and a ``dtype`` keyword argument, and return a tuple of arrays with the
+      promoted dtype.
     rngs: rng key.
   """
 
@@ -631,6 +654,7 @@ class Conv(Module):
     kernel_init: Initializer = default_kernel_init,
     bias_init: Initializer = default_bias_init,
     conv_general_dilated: ConvGeneralDilatedT = lax.conv_general_dilated,
+    promote_dtype: PromoteDtypeFn = dtypes.promote_dtype,
     rngs: rnglib.Rngs,
   ):
     if isinstance(kernel_size, int):
@@ -670,6 +694,7 @@ class Conv(Module):
     self.kernel_init = kernel_init
     self.bias_init = bias_init
     self.conv_general_dilated = conv_general_dilated
+    self.promote_dtype = promote_dtype
 
   def __call__(self, inputs: Array) -> Array:
     """Applies a (potentially unshared) convolution to the inputs.
@@ -760,7 +785,7 @@ class Conv(Module):
 
     bias = self.bias.value if self.bias is not None else None
 
-    inputs, kernel, bias = dtypes.promote_dtype(
+    inputs, kernel, bias = self.promote_dtype(
       (inputs, kernel, bias), dtype=self.dtype
     )
 
@@ -857,6 +882,10 @@ class ConvTranspose(Module):
     bias_init: initializer for the bias.
     transpose_kernel: if ``True`` flips spatial axes and swaps the input/output
       channel axes of the kernel.
+    promote_dtype: function to promote the dtype of the arrays to the desired
+      dtype. The function should accept a tuple of ``(inputs, kernel, bias)``
+      and a ``dtype`` keyword argument, and return a tuple of arrays with the
+      promoted dtype.
     rngs: rng key.
   """
 
@@ -877,6 +906,7 @@ class ConvTranspose(Module):
     kernel_init: Initializer = default_kernel_init,
     bias_init: Initializer = default_bias_init,
     transpose_kernel: bool = False,
+    promote_dtype: PromoteDtypeFn = dtypes.promote_dtype,
     rngs: rnglib.Rngs,
   ):
     if isinstance(kernel_size, int):
@@ -898,6 +928,7 @@ class ConvTranspose(Module):
     self.kernel_init = kernel_init
     self.bias_init = bias_init
     self.transpose_kernel = transpose_kernel
+    self.promote_dtype = promote_dtype
 
     if self.transpose_kernel:
       kernel_shape = kernel_size + (self.out_features, in_features)
@@ -982,7 +1013,7 @@ class ConvTranspose(Module):
 
     bias = self.bias.value if self.bias is not None else None
 
-    inputs, kernel, bias = dtypes.promote_dtype(
+    inputs, kernel, bias = self.promote_dtype(
       (inputs, kernel, bias), dtype=self.dtype
     )
 
@@ -1101,6 +1132,10 @@ class Embed(Module):
     dtype: the dtype of the embedding vectors (default: same as embedding).
     param_dtype: the dtype passed to parameter initializers (default: float32).
     embedding_init: embedding initializer.
+    promote_dtype: function to promote the dtype of the arrays to the desired
+      dtype. The function should accept a tuple of ``(embedding,)`` during ``__call__``
+      or ``(query, embedding)`` during ``attend``, and a ``dtype`` keyword argument,
+      and return a tuple of arrays with the promoted dtype.
     rngs: rng key.
   """
 
@@ -1112,6 +1147,7 @@ class Embed(Module):
     dtype: tp.Optional[Dtype] = None,
     param_dtype: Dtype = jnp.float32,
     embedding_init: Initializer = default_embed_init,
+    promote_dtype: PromoteDtypeFn = dtypes.promote_dtype,
     rngs: rnglib.Rngs,
   ):
     self.embedding = nnx.Param(
@@ -1123,6 +1159,7 @@ class Embed(Module):
     self.dtype = dtype or self.embedding.value.dtype
     self.param_dtype = param_dtype
     self.embedding_init = embedding_init
+    self.promote_dtype = promote_dtype
 
   def __call__(self, inputs: Array) -> Array:
     """Embeds the inputs along the last dimension.
@@ -1139,7 +1176,7 @@ class Embed(Module):
       raise ValueError('Input type must be an integer or unsigned integer.')
     # Use take because fancy indexing numpy arrays with JAX indices does not
     # work correctly.
-    (embedding,) = dtypes.promote_dtype(
+    (embedding,) = self.promote_dtype(
       (self.embedding.value,), dtype=self.dtype, inexact=False
     )
     if self.num_embeddings == 1:
@@ -1159,7 +1196,7 @@ class Embed(Module):
       Commonly used for weight-sharing between embeddings and logit transform
       in NLP models.
     """
-    query, embedding = dtypes.promote_dtype(
+    query, embedding = self.promote_dtype(
       (query, self.embedding.value), dtype=self.dtype
     )
     return jnp.dot(query, embedding.T)

--- a/flax/typing.py
+++ b/flax/typing.py
@@ -224,3 +224,12 @@ class SizeBytes:  # type: ignore[misc]
         size_bytes += cls.from_array(leaf)
 
     return size_bytes
+
+
+TupleArg = TypeVar('TupleArg', bound=tuple)
+
+
+class PromoteDtypeFn(Protocol):
+  def __call__(
+    self, args: TupleArg, /, *, dtype: Any = None, inexact: bool = True
+  ) -> TupleArg: ...

--- a/tests/linen/linen_module_test.py
+++ b/tests/linen/linen_module_test.py
@@ -800,6 +800,7 @@ class ModuleTest(absltest.TestCase):
         precision = None
         kernel_init = init
         bias_init = zeros
+        promote_dtype = promote_dtype
         dot_general = None
         dot_general_cls = None
     )
@@ -812,6 +813,7 @@ class ModuleTest(absltest.TestCase):
         precision = None
         kernel_init = init
         bias_init = zeros
+        promote_dtype = promote_dtype
         dot_general = None
         dot_general_cls = None
     )


### PR DESCRIPTION
# What does this PR do?

Adds a `promote_dtype` config option to various layers, defaults to `dtypes.promote_dtype`.