### PR TITLE
Allow bridge module to have 'name' field

### DIFF
--- a/flax/nnx/bridge/module.py
+++ b/flax/nnx/bridge/module.py
@@ -142,7 +142,8 @@ def _module_meta_call(cls: type[M], *args, **kwargs) -> M:
 
   name = None
   if parent_ctx is not None:
-    if not parent_ctx.in_compact and 'name' in kwargs:
+    want_name = 'name' in kwargs and 'name' in inspect.get_annotations(cls)
+    if not want_name and not parent_ctx.in_compact and 'name' in kwargs:
       raise ValueError(
         f"'name' can only be set in @compact functions. If in setup(), "
           "use parent's `self.<attr_name> to set the submodule name.")
@@ -156,7 +157,7 @@ def _module_meta_call(cls: type[M], *args, **kwargs) -> M:
           )
       else:
         if 'name' in kwargs:
-          name = kwargs.pop('name')
+          name = kwargs['name'] if want_name else kwargs.pop('name')
           if not isinstance(name, str):
             raise ValueError(f"'name' must be a 'str', got {type(name).__name__}")
         else:

--- a/tests/nnx/bridge/module_test.py
+++ b/tests/nnx/bridge/module_test.py
@@ -431,6 +431,19 @@ class TestBridgeModule(absltest.TestCase):
     y2 = model.apply(variables, x, rngs={'params': k1, 'dropout': k3})
     assert not jnp.array_equal(y1, y2)
 
+  def test_name(self):
+    class Foo(bridge.Module):
+      name: str
+
+    class Bar(bridge.Module):
+      @bridge.compact
+      def __call__(self):
+        f = Foo(name='f')
+        assert f.name == 'f'
+        assert self.f == f
+
+    Bar().init()
+
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This could be helpful since Linen modules always have `name` field and people may use it. Also will make type checker happier.