### PR TITLE
[nnx] flaxlib types

### DIFF
--- a/benchmarks/nnx_simple_training.py
+++ b/benchmarks/nnx_simple_training.py
@@ -116,14 +116,11 @@ def main(argv):
       loss = jnp.mean((y - y_pred) ** 2)
       return {'loss': loss}
 
-    cached_train_step_nnx = nnx.cached_partial(train_step_nnx, model, optimizer)
-    cached_test_step_nnx = nnx.cached_partial(test_step_nnx, model)
-
     for step, batch in enumerate(dataset(X, Y, batch_size)):
-      cached_train_step_nnx(batch)
+      train_step_nnx(model, optimizer, batch)
 
       if step % 1000 == 0:
-        logs = cached_test_step_nnx((X, Y))
+        logs = test_step_nnx(model, (X, Y))
 
       if step >= total_steps - 1:
         break

--- a/flax/nnx/traversals.py
+++ b/flax/nnx/traversals.py
@@ -220,7 +220,7 @@ def unflatten_mapping(xs: Any,
   result: dict[Any, Any] = {}
   for path, value in xs:
     if sep is not None:
-      path = path.split(sep)
+      path = path.split(sep)  # type: ignore
     if value is empty_node:
       value = {}
     cursor = result

--- a/flaxlib_src/src/flaxlib/__init__.py
+++ b/flaxlib_src/src/flaxlib/__init__.py
@@ -13,4 +13,7 @@
 # limitations under the License.
 
 from .flaxlib_cpp import RefMap as RefMap
-from .flaxlib_cpp import _graph_fingerprint as _graph_fingerprint
+from .flaxlib_cpp import IndexMap as IndexMap
+from .flaxlib_cpp import NodeDef as NodeDef
+from .flaxlib_cpp import VariableDef as VariableDef
+from .flaxlib_cpp import NodeRef as NodeRef

--- a/flaxlib_src/src/flaxlib/flaxlib_cpp.pyi
+++ b/flaxlib_src/src/flaxlib/flaxlib_cpp.pyi
@@ -15,11 +15,51 @@
 import typing as tp
 
 RefMap = tp.MutableMapping[tp.Any, int]
+IndexMap = dict[int, tp.Any]
 
-def _graph_fingerprint(
-  node,
-  node_impl,
-  ref_index: RefMap,
-  new_ref_index: RefMap,
-  next_index: int,
-) -> tuple[tuple[tp.Any, ...], int]: ...
+class NodeDef:
+  type: type
+  index: int | None
+  outer_index: int | None
+  num_attributes: int
+  metadata: tp.Any
+
+  def with_no_outer_index(self) -> NodeDef: ...
+  def with_same_outer_index(self) -> NodeDef: ...
+  def __eq__(self, other: tp.Any) -> bool: ...
+  def __hash__(self) -> int: ...
+  def __getstate__(
+    self,
+  ) -> tuple[tp.Any, tp.Any, tp.Any, tp.Any, tp.Any]: ...
+  @staticmethod
+  def __setstate__(
+    nodedef: NodeDef, state: tuple[tp.Any, tp.Any, tp.Any, tp.Any, tp.Any]
+  ) -> None: ...
+
+class VariableDef:
+  type: type
+  index: int
+  outer_index: int | None
+  metadata: tp.Any
+
+  def with_no_outer_index(self) -> VariableDef: ...
+  def with_same_outer_index(self) -> VariableDef: ...
+  def __eq__(self, other: tp.Any) -> bool: ...
+  def __hash__(self) -> int: ...
+  def __getstate__(
+    self,
+  ) -> tuple[tp.Any, int, tp.Any, tp.Any]: ...
+  @staticmethod
+  def __setstate__(
+    variabledef: 'VariableDef', state: tuple[tp.Any, int, tp.Any, tp.Any]
+  ) -> None: ...
+
+class NodeRef:
+  index: int
+
+  def __eq__(self, other: tp.Any) -> bool: ...
+  def __hash__(self) -> int: ...
+  def __getstate__(self) -> tuple[int]: ...
+  @staticmethod
+  def __setstate__(noderef: NodeRef, state: tuple[int]) -> None: ...
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,7 +92,9 @@ docs = [
     "ipywidgets>=8.1.5",
 ]
 dev = [
+    "nanobind>=2.5.0",
     "pre-commit>=3.8.0",
+    "scikit-build-core[pyproject]>=0.11.0",
 ]
 
 [project.urls]
@@ -230,9 +232,3 @@ quote-style = "single"
 [tool.uv]
 # Ignore uv.lock and always upgrade the package to the latest
 upgrade-package = ["jax", "jaxlib", "orbax-checkpoint"]
-
-[dependency-groups]
-dev = [
-    "nanobind>=2.4.0",
-    "scikit-build-core[pyproject]>=0.10.7",
-]

--- a/tests/nnx/graph_utils_test.py
+++ b/tests/nnx/graph_utils_test.py
@@ -378,11 +378,9 @@ class TestGraphUtils(absltest.TestCase):
 
     @partial(jax.jit, static_argnums=(0,))
     def f_pure(graphdef: nnx.graph.GraphDef[Foo], state):
-      idx_out_ref_in: dict[int, Any] = {}
+      idx_out_ref_in = nnx.graph.IndexMap()
       m = nnx.graph.unflatten(graphdef, state, index_ref=idx_out_ref_in)
-      ref_in_idx_out = nnx.graph.RefMap(
-        {v: k for k, v in idx_out_ref_in.items()}
-      )
+      ref_in_idx_out = nnx.graph.RefMap.from_indexmap(idx_out_ref_in)
       f(m)
       ref_in_idx_in = nnx.graph.RefMap()
       graphdef, state = nnx.graph.flatten(
@@ -392,7 +390,7 @@ class TestGraphUtils(absltest.TestCase):
       return state, graphdef
 
     state, graphdef_out = f_pure(graphdef, state)
-    idx_out_ref_out = {v: k for k, v in ref_out_idx_out.items()}
+    idx_out_ref_out = nnx.graph.IndexMap.from_refmap(ref_out_idx_out)
     m2 = nnx.graph.unflatten(
       graphdef_out, state, outer_index_outer_ref=idx_out_ref_out
     )
@@ -421,11 +419,9 @@ class TestGraphUtils(absltest.TestCase):
 
     @partial(jax.jit, static_argnums=(0,))
     def f_pure(graphdef: nnx.graph.GraphDef[Foo], state):
-      idx_out_ref_in: dict[int, Any] = {}
+      idx_out_ref_in = nnx.graph.IndexMap()
       m = nnx.graph.unflatten(graphdef, state, index_ref=idx_out_ref_in)
-      ref_in_idx_out = nnx.graph.RefMap(
-        {v: k for k, v in idx_out_ref_in.items()}
-      )
+      ref_in_idx_out = nnx.graph.RefMap.from_indexmap(idx_out_ref_in)
       f(m)
       ref_in_idx_in = nnx.graph.RefMap()
       graphdef, state = nnx.graph.flatten(
@@ -455,16 +451,14 @@ class TestGraphUtils(absltest.TestCase):
     ref_out_idx_out = nnx.graph.RefMap()
     graphdef: nnx.graph.GraphDef[Foo]
     graphdef, state = nnx.graph.flatten(m, ref_index=ref_out_idx_out)
-    idx_out_ref_out = {v: k for k, v in ref_out_idx_out.items()}
+    idx_out_ref_out = nnx.graph.IndexMap.from_refmap(ref_out_idx_out)
     state = state.to_nested_state()
 
     @partial(jax.jit, static_argnums=(0,))
     def f_pure(graphdef: nnx.graph.GraphDef[Foo], state):
-      idx_out_ref_in: dict[int, Any] = {}
+      idx_out_ref_in = nnx.graph.IndexMap()
       m = nnx.graph.unflatten(graphdef, state, index_ref=idx_out_ref_in)
-      ref_in_idx_out = nnx.graph.RefMap(
-        {v: k for k, v in idx_out_ref_in.items()}
-      )
+      ref_in_idx_out = nnx.graph.RefMap.from_indexmap(idx_out_ref_in)
       f(m)
       ref_in_idx_in = nnx.graph.RefMap()
       graphdef, state = nnx.graph.flatten(

--- a/uv.lock
+++ b/uv.lock
@@ -753,7 +753,9 @@ all = [
     { name = "matplotlib" },
 ]
 dev = [
+    { name = "nanobind" },
     { name = "pre-commit" },
+    { name = "scikit-build-core" },
 ]
 docs = [
     { name = "dm-haiku" },
@@ -800,12 +802,6 @@ testing = [
     { name = "treescope" },
 ]
 
-[package.dev-dependencies]
-dev = [
-    { name = "nanobind" },
-    { name = "scikit-build-core" },
-]
-
 [package.metadata]
 requires-dist = [
     { name = "ale-py", marker = "extra == 'testing'", specifier = ">=0.10.2" },
@@ -833,6 +829,7 @@ requires-dist = [
     { name = "msgpack" },
     { name = "mypy", marker = "extra == 'testing'" },
     { name = "myst-nb", marker = "extra == 'docs'" },
+    { name = "nanobind", marker = "extra == 'dev'", specifier = ">=2.5.0" },
     { name = "nbstripout", marker = "extra == 'docs'" },
     { name = "numpy", marker = "python_full_version >= '3.11'", specifier = ">=1.23.2" },
     { name = "numpy", marker = "python_full_version >= '3.12'", specifier = ">=1.26.0" },
@@ -849,6 +846,7 @@ requires-dist = [
     { name = "pyyaml", specifier = ">=5.4.1" },
     { name = "recommonmark", marker = "extra == 'docs'" },
     { name = "rich", specifier = ">=11.1" },
+    { name = "scikit-build-core", extras = ["pyproject"], marker = "extra == 'dev'", specifier = ">=0.11.0" },
     { name = "scikit-learn", marker = "extra == 'docs'" },
     { name = "sentencepiece", marker = "extra == 'testing'" },
     { name = "sphinx", marker = "extra == 'docs'", specifier = ">=3.3.1" },
@@ -864,12 +862,6 @@ requires-dist = [
     { name = "typing-extensions", specifier = ">=4.2" },
 ]
 provides-extras = ["all", "testing", "docs", "dev"]
-
-[package.metadata.requires-dev]
-dev = [
-    { name = "nanobind", specifier = ">=2.4.0" },
-    { name = "scikit-build-core", extras = ["pyproject"], specifier = ">=0.10.7" },
-]
 
 [[package]]
 name = "fonttools"


### PR DESCRIPTION
# What does this PR do?

* Implement more types with `nanobind` and patch them if `flax_use_flaxlib` is set.
* Slight refactor to `RefMap` and the new `IndexMap`.

Note that `flaxlib` is currently not being use internally and has not been published to pypi, can only be used by building it for testing purposes.
