### PR TITLE
Add optional error handlers to frozen dict

### DIFF
--- a/flax/error_handlers.py
+++ b/flax/error_handlers.py
@@ -1,0 +1,26 @@
+# Copyright 2024 The Flax Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Error Handlers."""
+
+from dataclasses import dataclass
+
+import typing as tp
+
+@dataclass(frozen=True)
+class ErrorHandlers:
+  """Simple dataclass to hold error handlers."""
+
+  missing_key: tp.Optional[tp.Callable[[str], Exception]] = None
+  set_item: tp.Optional[tp.Callable[[str, tp.Any], Exception]] = None

--- a/tests/core/core_frozen_dict_test.py
+++ b/tests/core/core_frozen_dict_test.py
@@ -173,6 +173,20 @@ class FrozenDictTest(parameterized.TestCase):
       frozen,
     )
 
+  def test_error_handlers(self):
+    xs = FrozenDict()
+    xs = xs.set_error_handlers(
+      missing_key=lambda key: KeyError(f'Missing key: {key}'),
+      set_item=lambda key, value: ValueError(
+        f'Cannot set key/value pair: {key}/{value}. '
+        'FrozenDict is immutable.'
+      )
+    )
+    with self.assertRaisesRegex(KeyError, 'Missing key: a'):
+      xs['a']
+    with self.assertRaisesRegex(ValueError, 'Cannot set key/value pair: a/1.'):
+      xs['a'] = 1
+
 
 if __name__ == '__main__':
   absltest.main()


### PR DESCRIPTION
# What does this PR do?

Fixes #513 - implementation based on @cgarciae's [comment](https://github.com/google/flax/issues/513#issuecomment-1237336408)

## Checklist
- [ ] This PR fixes a minor issue (e.g.: typo or small bug) or improves the docs (you can dismiss the other
      checks if that's the case).
- [x] This change is discussed in Github issue #513 
- [x] The documentation and docstrings adhere to the
      [documentation guidelines](https://github.com/google/flax/blob/main/docs/README.md#how-to-write-code-documentation).
- [x] This change includes necessary high-coverage tests.
      (No quality testing = no merge!)
