### PR TITLE
Update runners to ubuntu-24.04 from deprecated ubuntu-20.04 label

### DIFF
--- a/.github/workflows/flax_test.yml
+++ b/.github/workflows/flax_test.yml
@@ -82,7 +82,7 @@ jobs:
   tests:
     name: Run Tests
     needs: [pre-commit, commit-count, test-import]
-    runs-on: ubuntu-20.04-16core
+    runs-on: 'ubuntu-24.04'-16core
     strategy:
       matrix:
         python-version: ['3.10', '3.11']


### PR DESCRIPTION
This is a LSC run by http://go/ghss to upgrade all depreacated ubuntu-20.04 runners to ubuntu-24.04.

On April 1, 2025, GitHub will stop supporting ubuntu-20.04 runners and workflows configured with this label will cease to run.  This PR is an attempt to save you work by doing the upgrade for you.

WARNING: We do not know if the updated label is compatiable with your workflow or not.

If you do not want to merge this PR, feel free to close it and deal with the problem yourselves.

More context and feedback: http://b/406537467
