### PR TITLE
Test runner ubuntu upgrade 24.04

### DIFF
--- a/.github/workflows/flax_test.yml
+++ b/.github/workflows/flax_test.yml
@@ -82,7 +82,7 @@ jobs:
   tests:
     name: Run Tests
     needs: [pre-commit, commit-count, test-import]
-    runs-on: ubuntu-20.04-16core
+    runs-on: ubuntu-24.04-16core
     strategy:
       matrix:
         python-version: ['3.10', '3.11']


### PR DESCRIPTION
#4658 doesn't seem to actively run the test workflows. Trying this fix instead.