### PR TITLE
FEAT: add LoRALinearGeneral

### DIFF
--- a/flax/nnx/__init__.py
+++ b/flax/nnx/__init__.py
@@ -99,6 +99,7 @@ from .nn.linear import LinearGeneral as LinearGeneral
 from .nn.linear import Einsum as Einsum
 from .nn.lora import LoRA as LoRA
 from .nn.lora import LoRALinear as LoRALinear
+from .nn.lora import LoRALinearGeneral as LoRALinearGeneral
 from .nn.lora import LoRAParam as LoRAParam
 from .nn.normalization import BatchNorm as BatchNorm
 from .nn.normalization import LayerNorm as LayerNorm

--- a/flax/nnx/nn/linear.py
+++ b/flax/nnx/nn/linear.py
@@ -146,7 +146,7 @@ class LinearGeneral(Module):
     in_features: Size | tp.Sequence[Size],
     out_features: Size | tp.Sequence[Size],
     *,
-    axis: Axis | tp.Sequence[Axis] = -1,
+    axis: Axis | tp.Sequence[Axis] = None,
     batch_axis: tp.Mapping[Axis, Size] = FrozenDict({}),
     use_bias: bool = True,
     dtype: Dtype | None = None,
@@ -162,6 +162,8 @@ class LinearGeneral(Module):
   ):
     self.in_features = _canonicalize_tuple(in_features)
     self.out_features = _canonicalize_tuple(out_features)
+    if axis is None:
+      axis = tuple(range(-len(self.in_features), 0))
     self.axis = _canonicalize_tuple(axis)
     self.batch_axis = FrozenDict[Axis, Size](batch_axis)
     self.use_bias = use_bias


### PR DESCRIPTION
1. add `LoRALinearGeneral` since `MultiHeadAttention` uses `LinearGeneral`.
2. modify default value of `axis` in `LinearGeneral.__init__()` so that it is compatible to in_features that is a suquence of ints
3. add `lora_base_module` param to `LoRALinear` so that it's consistent with `LoRA`
4. update docs in lora.py

Since `LoRA` currently doesn't support dot_general, I reshape the input before and after calling lora. I also add a check on the value of `axis` param in `LinearGeneral`, so that it's only valid to apply linear transformation on the last axes of the input. 

I got trouble running the tests, so I couldn't add one.