### PR TITLE
[nnx] mutable array p2

### DIFF
--- a/docs_nnx/api_reference/flax.nnx/transforms.rst
+++ b/docs_nnx/api_reference/flax.nnx/transforms.rst
@@ -3,16 +3,6 @@ transforms
 
 .. automodule:: flax.nnx
 .. currentmodule:: flax.nnx
-
-.. autoclass:: Jit
-   :members:
-.. autoclass:: Remat
-   :members:
-.. autoclass:: Scan
-   :members:
-.. autoclass:: Vmap
-   :members:
-
 .. autofunction:: grad
 .. autofunction:: jit
 .. autofunction:: shard_map

--- a/docs_nnx/api_reference/flax.nnx/variables.rst
+++ b/docs_nnx/api_reference/flax.nnx/variables.rst
@@ -8,8 +8,6 @@ variables
    :members:
 .. autoclass:: Cache
    :members:
-.. autoclass:: Empty
-   :members:
 .. autoclass:: Intermediate
    :members:
 .. autoclass:: Param

--- a/examples/nnx_toy_examples/01_functional_api.py
+++ b/examples/nnx_toy_examples/01_functional_api.py
@@ -20,8 +20,8 @@ import numpy as np
 
 from flax import nnx
 
-X = np.linspace(0, 1, 100)[:, None]
-Y = 0.8 * X**2 + 0.1 + np.random.normal(0, 0.1, size=X.shape)
+X = np.linspace(-jnp.pi, jnp.pi, 100)[:, None]
+Y = 0.8 * jnp.sin(X) + 0.1 + np.random.normal(0, 0.1, size=X.shape)
 
 
 def dataset(batch_size):
@@ -50,11 +50,8 @@ class MLP(nnx.Module):
     self.linear2 = Linear(dhidden, dout, rngs=rngs)
 
   def __call__(self, x):
-    self.count.value += 1
-    x = self.linear1(x)
-    x = jax.nn.relu(x)
-    x = self.linear2(x)
-    return x
+    self.count[...] += 1
+    return self.linear2(jax.nn.relu(self.linear1(x) * 0.5))
 
 
 graphdef, params, counts = nnx.split(

--- a/flax/core/scope.py
+++ b/flax/core/scope.py
@@ -357,7 +357,7 @@ class Variable(Generic[T]):
         value, is_leaf=meta.is_axis_metadata
       )
       has_meta = any(map(meta.is_axis_metadata, cur_struct.flatten_up_to(cur)))
-      if cur_struct == value_struct and has_meta:
+      if cur_struct == value_struct and has_meta: # type: ignore[operator]
         value = meta.replace_boxed(cur, value)
 
     self.scope.put_variable(self.collection, self.name, value)

--- a/flax/nnx/__init__.py
+++ b/flax/nnx/__init__.py
@@ -53,6 +53,9 @@ from .graph import split_context as split_context
 from .graph import MergeContext as MergeContext
 from .graph import merge_context as merge_context
 from .graph import variables as variables
+from .graph import freeze as freeze
+from .graph import mutable as mutable
+from .graph import pure as pure
 from .graph import cached_partial as cached_partial
 from .nn import initializers as initializers
 from .nn.activations import celu as celu
@@ -168,6 +171,7 @@ from .variablelib import variable_type_from_name as variable_type_from_name
 from .variablelib import variable_name_from_type as variable_name_from_type
 from .variablelib import register_variable_name as register_variable_name
 from .variablelib import mutable_array as mutable_array
+from .variablelib import MutableArray as MutableArray
 from .variablelib import is_mutable_array as is_mutable_array
 from .visualization import display as display
 from .extract import to_tree as to_tree
@@ -178,3 +182,4 @@ from . import traversals as traversals
 from .dataclasses import dataclass as dataclass
 from .dataclasses import Static as Static
 from .dataclasses import field as field
+from .dataclasses import static as static

--- a/flax/nnx/bridge/module.py
+++ b/flax/nnx/bridge/module.py
@@ -224,7 +224,8 @@ class ModuleBase:
 @tpe.dataclass_transform(field_specifiers=(dataclasses.field,))  # type: ignore[not-supported-yet]
 class Module(nnx_module.Module, ModuleBase, metaclass=ModuleMeta):
   def __init_subclass__(cls) -> None:
-    super().__init_subclass__(pytree='auto')
+    cls.__data__ = 'auto'
+    super().__init_subclass__()
 
     cls = dataclasses.dataclass(repr=False)(cls)
     cls.__hash__ = object.__hash__  # type: ignore[method-assign]

--- a/flax/nnx/bridge/wrappers.py
+++ b/flax/nnx/bridge/wrappers.py
@@ -30,9 +30,9 @@ from flax.nnx.rnglib import Rngs
 from flax.nnx.statelib import State
 import jax
 from jax import tree_util as jtu
+from flax import config
 
 M = tp.TypeVar('M', bound=Module)
-
 
 # Flax-like style is NNX
 @dataclasses.dataclass
@@ -87,8 +87,9 @@ def lazy_init(fn: Module | tp.Callable[..., tp.Any], *args, **kwargs):
     _set_initializing(module, False)
   return fn
 
+PYTREE_DEFAULT = 'auto' if config.flax_mutable_array else None
 
-class ToNNX(Module, pytree='auto'):
+class ToNNX(Module):
   """A wrapper to turn any Linen module into an NNX module.
 
   The result NNX module can be used standalone with all NNX APIs, or as a submodule of
@@ -117,6 +118,8 @@ class ToNNX(Module, pytree='auto'):
   Returns:
     A stateful NNX module that behaves the same as the wrapped Linen module.
   """
+
+  __data__ = 'auto'
 
   def __init__(
     self,

--- a/flax/nnx/extract.py
+++ b/flax/nnx/extract.py
@@ -114,6 +114,7 @@ def broadcast_prefix(
     prefix_tree,
     full_tree,
     is_leaf=lambda x: isinstance(x, variablelib.Variable)
+    or graph.is_graph_node(x)
     or (prefix_is_leaf is not None and prefix_is_leaf(x)),
   )
   return result
@@ -315,5 +316,6 @@ def clear_non_graph_nodes(tree):
     if graph.is_graph_node(x) or isinstance(x, variablelib.Variable)
     else None,
     tree,
-    is_leaf=lambda x: isinstance(x, variablelib.Variable),
+    is_leaf=lambda x: isinstance(x, variablelib.Variable)
+    or graph.is_graph_node(x),
   )

--- a/flax/nnx/helpers.py
+++ b/flax/nnx/helpers.py
@@ -33,7 +33,9 @@ M = tp.TypeVar('M', bound=Module)
 TS = tp.TypeVar('TS', bound='TrainState')
 
 
-class Dict(Module, tp.Mapping[str, A], pytree='all'):
+class Dict(Module, tp.Mapping[str, A]):
+  __data__ = 'all'
+
   @tp.overload
   def __init__(self, iterable: tp.Iterable[tp.Tuple[str, A]], /): ...
 

--- a/flax/nnx/nn/linear.py
+++ b/flax/nnx/nn/linear.py
@@ -141,6 +141,8 @@ class LinearGeneral(Module):
     rngs: rng key.
   """
 
+  __data__ = ('kernel', 'bias')
+
   def __init__(
     self,
     in_features: Size | tp.Sequence[Size],
@@ -645,7 +647,7 @@ class Conv(Module):
     rngs: rng key.
   """
 
-  __data__ = ('kernel', 'bias')
+  __data__ = ('kernel', 'bias', 'mask')
 
   def __init__(
     self,
@@ -903,7 +905,7 @@ class ConvTranspose(Module):
     rngs: rng key.
   """
 
-  __data__ = ('kernel', 'bias')
+  __data__ = ('kernel', 'bias', 'mask')
 
   def __init__(
     self,

--- a/flax/nnx/nn/lora.py
+++ b/flax/nnx/nn/lora.py
@@ -109,7 +109,7 @@ class LoRA(Module):
 
   def __call__(self, x: jax.Array):
     x, lora_a, lora_b = promote_dtype(
-      (x, self.lora_a.value, self.lora_b.value), dtype=self.dtype
+      (x, self.lora_a[...], self.lora_b[...]), dtype=self.dtype
     )
     out = x @ lora_a @ lora_b
     if self.base_module is not None:

--- a/flax/nnx/nn/normalization.py
+++ b/flax/nnx/nn/normalization.py
@@ -361,12 +361,10 @@ class BatchNorm(Module):
         mask=mask,
       )
 
-      self.mean.value = (
+      self.mean[...] = (
         self.momentum * self.mean.value + (1 - self.momentum) * mean
       )
-      self.var.value = (
-        self.momentum * self.var.value + (1 - self.momentum) * var
-      )
+      self.var[...] = self.momentum * self.var.value + (1 - self.momentum) * var
 
     return _normalize(
       x,

--- a/flax/nnx/nn/stochastic.py
+++ b/flax/nnx/nn/stochastic.py
@@ -75,6 +75,8 @@ class Dropout(Module):
   rng_collection: str = 'dropout'
   rngs: rnglib.Rngs | None = None
 
+  __data__ = ('rngs',)
+
   def __call__(
     self,
     inputs,

--- a/flax/nnx/training/metrics.py
+++ b/flax/nnx/training/metrics.py
@@ -80,6 +80,8 @@ class Average(Metric):
     Array(nan, dtype=float32)
   """
 
+  __data__ = ('total', 'count')
+
   def __init__(self, argname: str = 'values'):
     """Pass in a string denoting the key-word argument that :func:`update` will use to derive the new value.
     For example, constructing the metric as ``avg = Average('test')`` would allow you to make updates with
@@ -152,6 +154,8 @@ class Welford(Metric):
     >>> metrics.compute()
     Statistics(mean=Array(0., dtype=float32), standard_error_of_mean=Array(nan, dtype=float32), standard_deviation=Array(nan, dtype=float32))
   """
+
+  __data__ = ('count', 'mean', 'm2')
 
   def __init__(self, argname: str = 'values'):
     """Pass in a string denoting the key-word argument that :func:`update` will use to derive the new value.

--- a/flax/nnx/transforms/transforms.py
+++ b/flax/nnx/transforms/transforms.py
@@ -138,7 +138,7 @@ def eval_shape(
   def _eval_shape_fn(*args, **kwargs):
     args, kwargs = extract.from_tree((args, kwargs))
     out = f(*args, **kwargs)
-    return extract.to_tree(out)
+    return extract.to_tree(graph.freeze(out))
 
   out = jax.eval_shape(_eval_shape_fn, *args, **kwargs)
   return extract.from_tree(out)

--- a/tests/nnx/nn/attention_test.py
+++ b/tests/nnx/nn/attention_test.py
@@ -14,9 +14,10 @@
 
 import jax, jax.numpy as jnp
 from jax.lax import Precision
+import pytest
 
 from flax import linen
-from flax import nnx
+from flax import nnx, config
 from flax.typing import Dtype, PrecisionLike
 
 import numpy as np
@@ -38,6 +39,10 @@ class TestMultiHeadAttention(absltest.TestCase):
     y = module(jnp.ones((1, 7, 3)), decode=False)
     assert y.shape == (1, 7, 6)
 
+  @pytest.mark.skipif(
+    config.flax_mutable_array,
+    reason='sow is not supported with flax_mutable_array',
+  )
   def test_multihead_sow_attention_weights(self):
     class Model(nnx.Module):
       attention_kwargs: dict

--- a/tests/nnx/nn/lora_test.py
+++ b/tests/nnx/nn/lora_test.py
@@ -50,6 +50,7 @@ class TestLora(absltest.TestCase):
 
   def test_layer_swap_lora(self):
     class MLP(nnx.Module):
+      __data__ = 'auto'
       def __init__(self, dim, rngs: nnx.Rngs):
         self.linear1 = nnx.Linear(dim, dim, rngs=rngs)
         self.linear2 = nnx.Linear(dim, dim, rngs=rngs)
@@ -75,6 +76,7 @@ class TestLora(absltest.TestCase):
 
   def test_layer_swap_loralinear(self):
     class MLP(nnx.Module):
+      __data__ = 'auto'
       def __init__(self, dim, rngs: nnx.Rngs):
         self.linear1 = nnx.Linear(dim, dim, rngs=rngs)
         self.linear2 = nnx.Linear(dim, dim, rngs=rngs)

--- a/tests/nnx/nn/normalization_test.py
+++ b/tests/nnx/nn/normalization_test.py
@@ -40,6 +40,7 @@ class TestLinenConsistency(parameterized.TestCase):
     mask: tp.Optional[np.ndarray],
   ):
     class NNXModel(nnx.Module):
+      __data__ = ('norm_layer', 'linear')
       def __init__(self, dtype, param_dtype, use_fast_variance, rngs):
         self.norm_layer = nnx.BatchNorm(
           5,
@@ -116,6 +117,7 @@ class TestLinenConsistency(parameterized.TestCase):
     mask: tp.Optional[np.ndarray],
   ):
     class NNXModel(nnx.Module):
+      __data__ = ('norm_layer', 'linear')
       def __init__(self, dtype, param_dtype, use_fast_variance, rngs):
         self.norm_layer = nnx.LayerNorm(
           5,
@@ -189,6 +191,7 @@ class TestLinenConsistency(parameterized.TestCase):
     mask: tp.Optional[np.ndarray],
   ):
     class NNXModel(nnx.Module):
+      __data__ = ('norm_layer', 'linear')
       def __init__(self, dtype, param_dtype, use_fast_variance, rngs):
         self.norm_layer = nnx.RMSNorm(
           5,
@@ -262,6 +265,7 @@ class TestLinenConsistency(parameterized.TestCase):
     mask: tp.Optional[np.ndarray],
   ):
     class NNXModel(nnx.Module):
+      __data__ = ('norm_layer', 'linear')
       def __init__(self, dtype, param_dtype, use_fast_variance, rngs):
         self.norm_layer = nnx.GroupNorm(
           6,

--- a/tests/nnx/rngs_test.py
+++ b/tests/nnx/rngs_test.py
@@ -59,8 +59,8 @@ class TestRngs(absltest.TestCase):
     @jax.jit
     def f():
       with self.assertRaisesRegex(
-          errors.TraceContextError,
-          'Cannot call RngStream from a different trace level',
+        errors.TraceContextError,
+        'Cannot mutate RngStream from a different trace level',
       ):
         rngs.params()
 
@@ -78,7 +78,7 @@ class TestRngs(absltest.TestCase):
     self.assertIsInstance(rngs1, nnx.Rngs)
     with self.assertRaisesRegex(
       errors.TraceContextError,
-      'Cannot call RngStream from a different trace level',
+      'Cannot mutate RngStream from a different trace level',
     ):
       rngs1.params()
 


### PR DESCRIPTION
# What does this PR do?

* Adds `nnx.mutable_array` and `nnx.MutableArray`, re-exporting them from `jax.experimental`.
* Uses `[...]` notation in some places instead of `.value`.
* Adds `__data__` to most / all public Object-derived types.
* `__data__`'s type is now `tuple[str, ...] | Literal['all', 'auto']`