### PR TITLE
Minor improvements of lm1b_nnx example

### DIFF
--- a/examples/lm1b_nnx/README.md
+++ b/examples/lm1b_nnx/README.md
@@ -52,7 +52,7 @@ Then install Flax + the example dependencies:
 git clone --depth=1 --branch=main https://github.com/google/flax
 cd flax
 pip install -e .
-cd examples/lm1b
+cd examples/lm1b_nnx
 pip install -r requirements.txt
 ```
 
@@ -75,9 +75,9 @@ tensorboard --logdir=$HOME/logs
 You should expect to get numbers similar to these:
 
 
-Hardware | config  | Training time |      Loss      |                             TensorBoard.dev                              |                                                          Workdir
--------- | ------- | ------------- | -------------- | ------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------
-TPU v3-8 | default | 13h18m | 3.127 | [2021-08-08](https://tensorboard.dev/experiment/n30WkNOZTJq3RHWD7wNslg/) | [gs://flax_public/examples/lm1b/default](https://console.cloud.google.com/storage/browser/flax_public/examples/lm1b/default)
+Hardware | config  | Training time |      Loss      |                                                          Workdir
+-------- | ------- | ------------- | -------------- | --------------------------------------------------------------------------------------------------------------------------
+TPU v3-8 | default | 13h18m | 3.127 | [gs://flax_public/examples/lm1b/default](https://console.cloud.google.com/storage/browser/flax_public/examples/lm1b/default)
 
 ### Downloading the LM1B Datasets
 
@@ -87,6 +87,5 @@ data on a storage bucket, from where it can be loaded directly. Set the
 `TFDS_DATA_DIR` to your storage bucket path (`gs://<bucket name>`).
 
 You can download and prepare LM1B datasets using TFDS directly:
-`python -m tensorflow_datasets.scripts.download_and_prepare
---datasets=lm1b`
+`python -m tensorflow_datasets.scripts.download_and_prepare --datasets=lm1b`
 

--- a/examples/lm1b_nnx/input_pipeline_test.py
+++ b/examples/lm1b_nnx/input_pipeline_test.py
@@ -48,9 +48,9 @@ class InputPipelineTest(absltest.TestCase):
     vocab_path = os.path.join(tempfile.mkdtemp(), 'sentencepiece_model')
 
     # Go two directories up to the root of the flax directory.
-    flax_root_dir = pathlib.Path(__file__).parents[4]
+    # "/path/to/flax/examples/lm1b_nnx/models_test.py" -> "/path/to/flax"
+    flax_root_dir = pathlib.Path(__file__).absolute().parents[2]
     data_dir = str(flax_root_dir) + '/.tfds/metadata'  # pylint: disable=unused-variable
-
     with tfds.testing.mock_data(num_examples=128, data_dir=data_dir):
       train_ds, eval_ds, predict_ds, _ = input_pipeline.get_datasets(
         n_devices=2, config=config, vocab_path=vocab_path

--- a/examples/lm1b_nnx/main.py
+++ b/examples/lm1b_nnx/main.py
@@ -34,7 +34,7 @@ config_flags.DEFINE_config_file(
   'File path to the training hyperparameter configuration.',
   lock_config=True,
 )
-flags.mark_flags_as_required(['config', 'workdir'])
+flags.mark_flags_as_required(['workdir'])
 
 
 def main(argv):

--- a/examples/lm1b_nnx/models.py
+++ b/examples/lm1b_nnx/models.py
@@ -292,6 +292,7 @@ class EncoderDecoder1DBlock(nnx.Module):
       broadcast_dropout=False,
       dropout_rate=config.attention_dropout_rate,
       rngs=rngs,
+      keep_rngs=False,
     )
     self.mlp = MlpBlock(config=config, rngs=rngs)
     self.dropout = nnx.Dropout(rate=config.dropout_rate)

--- a/examples/lm1b_nnx/models_test.py
+++ b/examples/lm1b_nnx/models_test.py
@@ -34,7 +34,8 @@ from utils import HasCache
 jax.config.update('jax_disable_most_optimizations', True)
 
 # add project_root to import lm1b Linen model
-project_root = str(Path(__file__).absolute().parents[4])
+# "/path/to/flax/examples/lm1b_nnx/models_test.py" -> "/path/to/flax"
+project_root = str(Path(__file__).absolute().parents[2])
 sys.path.append(project_root)
 from examples.lm1b.models import TransformerLM as TransformerLinen  # type: ignore[import-error]
 

--- a/examples/lm1b_nnx/utils.py
+++ b/examples/lm1b_nnx/utils.py
@@ -159,7 +159,10 @@ def setup_initial_state(
     model = constructor(config, rng)
     graphdef, params = nnx.split(model, nnx.Param)
     state = TrainState.create(
-      apply_fn=graphdef.apply, params=params, tx=tx, graphdef=graphdef
+      apply_fn=graphdef.apply,
+      params=params,
+      tx=tx,
+      graphdef=graphdef,
     )
     state = jax.tree.map(_to_array, state)
     state_spec = nnx.get_partition_spec(state)

--- a/tests/download_dataset_metadata.sh
+++ b/tests/download_dataset_metadata.sh
@@ -8,7 +8,7 @@
 
 set -e
 
-# Download TFDS metadata to flax/.tdfs/metadata directory.
+# Download TFDS metadata to flax/.tfds/metadata directory.
 # This allows the tests to specify the `data_dir` when using tfds.testing.mock_data().
 cd "$( dirname "$0" )"
 


### PR DESCRIPTION
# Description

- Minor changes:
  - removed `from flax import linen as nn` and usage of linen
  - make workdir absolute path otherwise orbax can't save the checkpoint

Training logs on 2 GPUs: https://gist.github.com/vfdev-5/f75a2e32d231d892a6eee6cb1a451aa5
