### PR TITLE
Fix typo on 'Scale up on multiple devices' guide

### DIFF
--- a/docs_nnx/guides/flax_gspmd.ipynb
+++ b/docs_nnx/guides/flax_gspmd.ipynb
@@ -26,7 +26,7 @@
     "\n",
     "> **Note to Flax Linen users**: The [`flax.nnx.spmd`](https://flax.readthedocs.io/en/latest/api_reference/flax.nnx/spmd.html) API is similar to what is described in [the Linen Flax on `(p)jit` guide](https://flax.readthedocs.io/en/latest/guides/parallel_training/flax_on_pjit.html) on the model definition level. However, the top-level code in Flax NNX is simpler due to the benefits brought by Flax NNX, and some text explanations will be more updated and clearer.\n",
     "\n",
-    "If you are new parallelization in JAX, you can learn more about its APIs for scaling up in the following tutorials:\n",
+    "If you are new to parallelization in JAX, you can learn more about its APIs for scaling up in the following tutorials:\n",
     "\n",
     "- [Introduction to parallel programming](https://jax.readthedocs.io/en/latest/sharded-computation.html): A 101 level tutorial covering the basics of automatic parallelization with [`jax.jit`](https://jax.readthedocs.io/en/latest/_autosummary/jax.jit.html#jax.jit), semi-automatic parallelization with [`jax.jit`](https://jax.readthedocs.io/en/latest/_autosummary/jax.jit.html) and [`jax.lax.with_sharding_constraint`](https://jax.readthedocs.io/en/latest/_autosummary/jax.lax.with_sharding_constraint.html), and manual sharding with [`shard_map`](https://jax.readthedocs.io/en/latest/_autosummary/jax.experimental.shard_map.shard_map.html#jax.experimental.shard_map.shard_map).\n",
     "- [JAX in multi-process environments](https://jax.readthedocs.io/en/latest/multi_process.html).\n",

--- a/docs_nnx/guides/flax_gspmd.md
+++ b/docs_nnx/guides/flax_gspmd.md
@@ -26,7 +26,7 @@ To ensure the compilation performance, you often need to instruct JAX how your m
 
 > **Note to Flax Linen users**: The [`flax.nnx.spmd`](https://flax.readthedocs.io/en/latest/api_reference/flax.nnx/spmd.html) API is similar to what is described in [the Linen Flax on `(p)jit` guide](https://flax.readthedocs.io/en/latest/guides/parallel_training/flax_on_pjit.html) on the model definition level. However, the top-level code in Flax NNX is simpler due to the benefits brought by Flax NNX, and some text explanations will be more updated and clearer.
 
-If you are new parallelization in JAX, you can learn more about its APIs for scaling up in the following tutorials:
+If you are new to parallelization in JAX, you can learn more about its APIs for scaling up in the following tutorials:
 
 - [Introduction to parallel programming](https://jax.readthedocs.io/en/latest/sharded-computation.html): A 101 level tutorial covering the basics of automatic parallelization with [`jax.jit`](https://jax.readthedocs.io/en/latest/_autosummary/jax.jit.html#jax.jit), semi-automatic parallelization with [`jax.jit`](https://jax.readthedocs.io/en/latest/_autosummary/jax.jit.html) and [`jax.lax.with_sharding_constraint`](https://jax.readthedocs.io/en/latest/_autosummary/jax.lax.with_sharding_constraint.html), and manual sharding with [`shard_map`](https://jax.readthedocs.io/en/latest/_autosummary/jax.experimental.shard_map.shard_map.html#jax.experimental.shard_map.shard_map).
 - [JAX in multi-process environments](https://jax.readthedocs.io/en/latest/multi_process.html).


### PR DESCRIPTION
# What does this PR do?

This PR fixes a small typo found in the "Scale up on multiple devices" guide, where previously "If you are new parallelization in JAX" is written, but is replaced by "If you are new to parallelization in JAX". For an exact link to the issue found within the documentation, see the link here: [https://flax.readthedocs.io/en/latest/guides/flax_gspmd.html#:~:text=If%20you%20are%20new%20parallelization%20in%20JAX](https://flax.readthedocs.io/en/latest/guides/flax_gspmd.html#:~:text=If%20you%20are%20new%20parallelization%20in%20JAX).
