### PR TITLE
Fix hardcoded link to filter guide in docs

### DIFF
--- a/flax/nnx/filterlib.py
+++ b/flax/nnx/filterlib.py
@@ -31,7 +31,7 @@ Filter = tp.Union[FilterLiteral, tuple['Filter', ...], list['Filter']]
 
 def to_predicate(filter: Filter) -> Predicate:
   """Converts a Filter to a predicate function.
-  See `Using Filters <https://flax.readthedocs.io/en/latest/nnx/filters_guide.html>`__.
+  See `Using Filters <https://flax.readthedocs.io/en/latest/guides/filters_guide.html>`__.
   """
 
   if isinstance(filter, str):


### PR DESCRIPTION
# What does this PR do?

Fix hardcoded link in `filterlib.py` that points to the filtering guide in the docs. That guide is not on the `nnx/` path, but in the general guides path.

## Checklist
- [x] This PR fixes a minor issue (e.g.: typo or small bug) or improves the docs (you can dismiss the other
      checks if that's the case).

