### PR TITLE
Fixes colab link for nnx docs

### DIFF
--- a/docs_nnx/conf.py
+++ b/docs_nnx/conf.py
@@ -127,7 +127,7 @@ html_theme_options = {
   'use_repository_button': True,  # add a 'link to repository' button
   'use_issues_button': False,  # add an 'Open an Issue' button
   'path_to_docs': (
-    'docs'
+    'docs_nnx'
   ),  # used to compute the path to launch notebooks in colab
   'launch_buttons': {
     'colab_url': 'https://colab.research.google.com/',


### PR DESCRIPTION
# What does this PR do?

Fixes colab link for nnx docs:
- Currently: launch button with colab gives URL: https://colab.research.google.com/github/google/flax/blob/master/docs/guides/transforms.ipynb which leads to "Notebook not found" error on Colab.

<img width="746" alt="image" src="https://github.com/user-attachments/assets/584d4aa6-5330-4524-bfa0-d94fc4b3a78b" />

<img width="972" alt="image" src="https://github.com/user-attachments/assets/f60b789e-b78d-4787-b7fd-336f3ab84390" />


- This PR should fix this URL problem by replacing docs path -> docs_nnx

<img width="926" alt="image" src="https://github.com/user-attachments/assets/3688b0fe-60e9-42eb-bf89-bebd6a8ff267" />
