### PR TITLE
feat: Add overload signatures to module.apply

### DIFF
--- a/flax/linen/module.py
+++ b/flax/linen/module.py
@@ -2085,6 +2085,30 @@ class Module(ModuleBase):
     module = self.clone(_deep_clone=True, _reset_names=True, name=None)
     return module, variables
 
+  @overload
+  def apply(
+    self,
+    variables: VariableDict,
+    *args,
+    rngs: PRNGKey | RNGSequences | None = None,
+    method: Callable[..., Any] | str | None = None,
+    mutable: Literal[False] = False,
+    capture_intermediates: bool | Callable[['Module', str], bool] = False,
+    **kwargs,
+  ) -> Any: ...
+
+  @overload
+  def apply(
+    self,
+    variables: VariableDict,
+    *args,
+    rngs: PRNGKey | RNGSequences | None = None,
+    method: Callable[..., Any] | str | None = None,
+    mutable: CollectionFilter,
+    capture_intermediates: bool | Callable[['Module', str], bool] = False,
+    **kwargs,
+  ) -> tuple[Any, FrozenVariableDict | dict[str, Any]]: ...
+
   @traceback_util.api_boundary
   def apply(
     self,


### PR DESCRIPTION
# What does this PR do?

The `apply` method returns either the output or a `tuple[output, dict]` depending on `mutable` (in `core.apply`).

https://github.com/google/flax/blob/7d4a288491acec7f24e0ae469b41590fb05dd400/flax/core/scope.py#L1080-L1083

The current type hints are were general in the return type `-> Any | tuple[Any, FrozenVariableDict | dict[str, Any]]:` which can be confusing lead to type-checking errors. A related SO [question](https://stackoverflow.com/q/79658104/12439683) how to type `Module.apply` correctly.

**This PR adds two typing.overload signatures to `Module.apply` to differentiate these cases - when to expect a tuple and when not**

See also #2086 as a related discussion.

<!--

Great, you are contributing to Flax!

But... please read the following carefully so we can make sure your PR is merged
easily.

Replace this text block with a description of the change and which issue it
fixes (if applicable). Please also include relevant motivation/context.

Once you're done, someone in the Flax team will review your PR shortly. They may
suggest changes to make the code even better. If no one reviewed your PR after a
week has passed, don't hesitate to post a new comment @-mentioning the same
persons (sometimes notifications get lost).
-->

Resolves:
#4779

## Checklist
- [x] This PR fixes a minor issue (e.g.: typo or small bug) or improves the docs (you can dismiss the other
      checks if that's the case).
- [x] This change is discussed in a Github issue/
      [discussion](https://github.com/google/flax/discussions) (please add a
      link).
