### PR TITLE
Exposed OptState in nnx module

### DIFF
--- a/flax/nnx/__init__.py
+++ b/flax/nnx/__init__.py
@@ -139,6 +139,7 @@ from .training import optimizer as optimizer
 from .training.metrics import Metric as Metric
 from .training.metrics import MultiMetric as MultiMetric
 from .training.optimizer import Optimizer as Optimizer
+from .training.optimizer import OptState as OptState
 from .transforms.autodiff import DiffState as DiffState
 from .transforms.autodiff import grad as grad
 from .transforms.autodiff import value_and_grad as value_and_grad


### PR DESCRIPTION
# What does this PR do?

According to an internal discussion about Optimizer state serialization:
```python
optimizer_state = nnx.state(optimizer, nnx.optimizer.OptState)
```
> we should simplify this to nnx.OptState

In this PR a minor change, exposing `nnx.optimizer.OptState` as `nnx.OptState`:
```python
>>> import flax.nnx as nnx
>>> nnx.OptState
<class 'flax.nnx.training.optimizer.OptState'>
```