### PR TITLE
Make `Sequential()` be identity

### DIFF
--- a/flax/nnx/helpers.py
+++ b/flax/nnx/helpers.py
@@ -41,6 +41,16 @@ class Sequential(Module):
     self.layers = nnx.data(list(fns))
 
   def __call__(self, *args, rngs: tp.Optional[Rngs] = None, **kwargs) -> tp.Any:
+    if len(self.layers) == 0:
+      if len(args) == 1:
+        return args[0]
+      elif len(args) > 0:
+        return args
+      elif len(kwargs) > 0:
+        return kwargs
+      else:
+        return None
+
     output: tp.Any = None
 
     for i, f in enumerate(self.layers):

--- a/tests/nnx/helpers_test.py
+++ b/tests/nnx/helpers_test.py
@@ -114,6 +114,14 @@ class TestHelpers(absltest.TestCase):
     out = model.apply(variables, x)
     np.testing.assert_array_equal(out, out_nnx)
 
+  def test_nnx_empty_sequential_is_identity(self):
+    iden = nnx.Sequential()
+    assert iden(12) == 12
+    assert iden(12, 23) == (12, 23)
+    assert iden() is None
+    assert iden(k=2) == {'k': 2}
+
+
 
 if __name__ == '__main__':
   absltest.main()


### PR DESCRIPTION
# What does this PR do?

Fixes #4782 

The behavior here matches `torch.Sequential` for single args, the old behavior with no `args`, and is consistent with more `args` or `kwargs`.

The helpers test pass in the docker container. 

## Checklist
- [x] This change is discussed in a Github issue/
      [discussion](https://github.com/google/flax/issues/4782).
- [x] The documentation and docstrings adhere to the
      [documentation guidelines](https://github.com/google/flax/blob/main/docs/README.md#how-to-write-code-documentation).
- [x] This change includes necessary high-coverage tests.
      (No quality testing = no merge!)

@cgarciae 