### PR TITLE
[nnx] allow method calls in ToLinen

### DIFF
--- a/flax/nnx/graph.py
+++ b/flax/nnx/graph.py
@@ -704,7 +704,7 @@ def _graph_flatten(
   ref_outer_index: RefMap | None,
   nodes: list[NodeDefType[tp.Any]],
   attributes: list[tuple[Key, AttrType]],
-  leaves: list[LeafType],
+  leaves: list[tp.Any],
   paths: list[PathParts] | None,
   return_variables: bool,
 ) -> None:


### PR DESCRIPTION
# What does this PR do?

Allow calling methods from `ToLinen` Module by forwarding the call to the underlying NNX Module.