### PR TITLE
[nnx] update bridge

### DIFF
--- a/flax/nnx/bridge/__init__.py
+++ b/flax/nnx/bridge/__init__.py
@@ -13,8 +13,6 @@
 # limitations under the License.
 
 
-from .wrappers import functional as functional
-from .wrappers import Functional as Functional
 from .wrappers import ToNNX as ToNNX
 from .wrappers import lazy_init as lazy_init
 from .wrappers import ToLinen as ToLinen

--- a/flax/nnx/bridge/module.py
+++ b/flax/nnx/bridge/module.py
@@ -33,7 +33,7 @@ from flax.nnx import variablelib
 import flax.nnx.module as nnx_module
 from flax.nnx.object import Object
 from flax.nnx import variablelib
-from flax.nnx.bridge import variables as bridge_variables
+from flax.nnx import bridge
 import numpy as np
 
 A = tp.TypeVar('A')
@@ -394,7 +394,7 @@ class Module(nnx_module.Module, ModuleBase, metaclass=ModuleMeta):
       ):
         leaf = variable.value
       else:
-        leaf = bridge_variables.to_linen_var(variable)
+        leaf = bridge.wrappers.to_linen_var(variable)
 
       _variables[collection][path] = leaf
 
@@ -429,7 +429,7 @@ class Module(nnx_module.Module, ModuleBase, metaclass=ModuleMeta):
     for col_name, linen_collection in variables.items():
 
       def to_variable(value):
-        return bridge_variables.to_nnx_var(col_name, value)
+        return bridge.wrappers.to_nnx_var(col_name, value)
 
       linen_collection = jax.tree.map(
         to_variable,

--- a/flax/nnx/bridge/wrappers.py
+++ b/flax/nnx/bridge/wrappers.py
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import dataclasses
+"""NNX <> Linen interoperability."""
+
 from functools import partial
 import typing as tp
 from typing import Any
@@ -23,50 +24,118 @@ from flax.core import FrozenDict
 from flax.core import meta
 from flax.nnx import graph
 from flax.nnx import variablelib
-from flax.nnx.bridge import variables as bv
 from flax.nnx.bridge import module as bdg_module
 from flax.nnx.module import Module
 from flax.nnx.object import Object
 from flax.nnx.rnglib import Rngs
-from flax.nnx.statelib import State
 import jax
 from jax import tree_util as jtu
 
-M = tp.TypeVar('M', bound=Module)
-
-# Flax-like style is NNX
-@dataclasses.dataclass
-class Functional(tp.Generic[M]):
-  module_type: tp.Type[M]
-  graphdef: tp.Optional[graph.GraphDef[M]]
-  args: tuple[tp.Any, ...]
-  kwargs: dict[str, tp.Any]
-
-  def init(self, *, rngs: tp.Optional[Rngs] = None) -> State:
-    kwargs = {}
-    if rngs is not None:
-      kwargs['rngs'] = rngs
-    module = self.module_type(*self.args, **self.kwargs, **kwargs)
-    graphdef, state = nnx.split(module)
-    self.graphdef = graphdef
-    return state  # type: ignore
-
-  def apply(self, *states: tp.Any):
-    assert self.graphdef is not None
-    return self.graphdef.apply(*states)
+M = tp.TypeVar("M", bound=Module)
 
 
-def functional(cls: tp.Type[M]) -> tp.Callable[..., Functional[M]]:
-  def _functional_constructor(*args: tp.Any, **kwargs: tp.Any) -> Functional[M]:
-    return Functional(cls, None, args, kwargs)
+def is_vanilla_variable(vs: variablelib.VariableState) -> bool:
+  """A variables state is vanilla if its metadata is essentially blank.
 
-  return _functional_constructor
+  Returns False only if it has non-empty hooks or any non-built-in attribute.
+  """
+  for key, value in vs.get_metadata().items():
+    if key.endswith("_hooks"):
+      if value != ():
+        return False
+    else:
+      return False
+  return True
+
+
+def to_linen_var(vs: variablelib.VariableState) -> meta.AxisMetadata:
+  metadata = vs.get_metadata()
+  if "linen_meta_type" in metadata:
+    linen_type = metadata["linen_meta_type"]
+    if hasattr(linen_type, "from_nnx_metadata"):
+      return linen_type.from_nnx_metadata({"value": vs.value, **metadata})
+    return linen_type(vs.value, **metadata)
+  if is_vanilla_variable(vs):
+    return vs.value
+  return nnx.bridge.NNXMeta(vs.type, vs.value, metadata)
+
+
+def get_col_name(keypath: tp.Sequence[Any]) -> str:
+  """Given the keypath of a Flax variable type, return its Linen collection name."""
+  # Infer variable type from the leaf's path, which contains its Linen collection name
+  assert isinstance(keypath[0], jax.tree_util.DictKey)
+  return str(keypath[0].key)
+
+
+def to_nnx_var(col: str, x: meta.AxisMetadata | Any) -> variablelib.Variable:
+  """Convert a Linen variable to an NNX variable."""
+  vtype = variablelib.variable_type_from_name(col, allow_register=True)
+  if isinstance(x, nnx.bridge.NNXMeta):
+    assert vtype == x.var_type, (
+      f"Type stored in NNXMeta {x.var_type} != type inferred from collection name {vtype}"
+    )
+    return x.to_nnx_variable()
+  if isinstance(x, meta.AxisMetadata):
+    x_metadata = vars(x)
+    if hasattr(x, "to_nnx_metadata"):
+      x_metadata = x.to_nnx_metadata()
+    assert hasattr(x, "value")
+    return vtype(**x_metadata, linen_meta_type=type(x))
+  return vtype(x)
+
+
+def _recursive_merge(dict1, dict2):
+  """Recursively merge two dicts."""
+  flat_map = nnx.traversals.flatten_mapping(dict1)
+  flat_map |= nnx.traversals.flatten_mapping(dict2)
+  return nnx.traversals.unflatten_mapping(flat_map)
+
+
+def linen_vars_to_nnx_attrs(variables: tp.Mapping[str, Any]) -> dict[str, Any]:
+  """Convert a dict of Linen-style variables to NNX variables."""
+  nnx_vars = jax.tree_util.tree_map_with_path(
+    lambda kp, x: to_nnx_var(get_col_name(kp), x),
+    variables,
+    is_leaf=lambda x: not isinstance(x, dict),
+  )
+
+  flat_paths: dict[tuple, tp.Any] = {}
+
+  for col_name, col_variables in nnx_vars.items(): # pylint: disable=unused-variable
+    for path, variable in nnx.traversals.flatten_mapping(col_variables).items():
+      if path in flat_paths:
+        raise ValueError(
+          f"Found duplicate variable path {path} with variables "
+          f"{flat_paths[path]} and {variable}. "
+          "This is not allowed in NNX."
+        )
+      flat_paths[path] = variable
+
+  nnx_vars = nnx.traversals.unflatten_mapping(flat_paths)
+  return nnx_vars
+
+
+def nnx_attrs_to_linen_vars(nnx_attrs: dict) -> dict:
+  """Convert a dict of NNX variables (or variable states) to Linen-style variables."""
+  linen_structured = {}
+  for kp, v in nnx.traversals.flatten_mapping(nnx_attrs).items():
+    if isinstance(v, variablelib.Variable):
+      col_name = variablelib.variable_name_from_type(type(v))
+      v = to_linen_var(v.to_state())
+    elif isinstance(v, variablelib.VariableState):
+      col_name = variablelib.variable_name_from_type(v.type)
+      v = to_linen_var(v)
+    else:
+      raise ValueError(f"Cannot infer collection name from value: {v}")
+    linen_structured[(col_name, *kp)] = v
+  variables = nnx.traversals.unflatten_mapping(linen_structured)
+  return variables
 
 
 def _set_initializing(module: Module, initializing: bool):
-  for k, value in graph.iter_graph(module):
+  for _, value in graph.iter_graph(module):
     if isinstance(value, Object):
-      value._object__state._initializing = initializing
+      value._object__state._initializing = initializing # pylint: disable=protected-access
 
 
 def lazy_init(fn: Module | tp.Callable[..., tp.Any], *args, **kwargs):
@@ -77,8 +146,8 @@ def lazy_init(fn: Module | tp.Callable[..., tp.Any], *args, **kwargs):
     module = fn
     assert callable(fn)
   else:
-    if not (hasattr(fn, '__self__') and isinstance(fn.__self__, Module)):
-      raise ValueError(f'{fn = } needs to be a method of an NNX Module.')
+    if not (hasattr(fn, "__self__") and isinstance(fn.__self__, Module)):
+      raise ValueError(f"{fn = } needs to be a method of an NNX Module.")
     module = fn.__self__
   _set_initializing(module, True)
   try:
@@ -87,7 +156,8 @@ def lazy_init(fn: Module | tp.Callable[..., tp.Any], *args, **kwargs):
     _set_initializing(module, False)
   return fn
 
-class ToNNX(Module, pytree=False):
+
+class ToNNX(Module):
   """A wrapper to turn any Linen module into an NNX module.
 
   The result NNX module can be used standalone with all NNX APIs, or as a submodule of
@@ -120,10 +190,16 @@ class ToNNX(Module, pytree=False):
   def __init__(
     self,
     module: linen.Module,
-    rngs: tp.Optional[Rngs] = None,
+    rngs: Rngs | jax.Array | None = None,
   ):
-    self.module = module
-    self.rngs = rngs
+    self.to_nnx__module = module
+
+    if isinstance(rngs, jax.Array):
+      self.to_nnx__rngs = Rngs(params=rngs)
+    elif isinstance(rngs, nnx.Rngs):
+      self.to_nnx__rngs = rngs.fork() if hasattr(rngs, "fork") else nnx.clone(rngs)
+    else:
+      self.to_nnx__rngs = rngs
 
   def lazy_init(self, *args, **kwargs):
     """A shortcut of calling `nnx.bridge.lazy_init()` upon this module."""
@@ -132,7 +208,7 @@ class ToNNX(Module, pytree=False):
   def __getattr__(self, name: str):
     if hasattr(super(), name):
       return super().__getattribute__(name)
-    maybe_method = getattr(self.module.__class__, name, None)
+    maybe_method = getattr(self.to_nnx__module.__class__, name, None)
     if callable(maybe_method):
       method = partial(self.__call__, method=maybe_method)
       method.__self__ = self
@@ -140,58 +216,65 @@ class ToNNX(Module, pytree=False):
     return super().__getattribute__(name)
 
   def __call__(
-    self, *args: Any, rngs: tp.Optional[Rngs] = None,
-    method: tp.Callable[..., Any] | str | None = None, **kwargs: Any
+    self,
+    *args: Any,
+    rngs: Rngs | jax.Array | None = None,
+    method: tp.Callable[..., Any] | str | None = None,
+    **kwargs: Any,
   ) -> Any:
-
     # Shape-based lazy init of the flax variables
-    if not rngs:
-      rngs = self.rngs
+    if rngs is None:
+      rngs = self.to_nnx__rngs
+    if isinstance(rngs, nnx.Rngs):
+      _rngs = {name: stream() for name, stream in rngs.items()}
+    elif isinstance(rngs, jax.Array):
+      _rngs = {"params": rngs}
+    else:
+      _rngs = {}
+    # rename default to params
+    if "params" not in _rngs and "default" in _rngs:
+      _rngs["params"] = _rngs.pop("default")
     if self._object__state.initializing:
-      _rngs = (
-        {name: stream() for name, stream in rngs.items()} if rngs else {}
+      out, updates = self.to_nnx__module.init_with_output(
+        _rngs, *args, method=method, **kwargs
       )
-      # rename default to params
-      if 'params' not in _rngs and 'default' in _rngs:
-        _rngs['params'] = _rngs.pop('default')
-      out, variables = self.module.init_with_output(_rngs, *args, method=method, **kwargs)
-
-      nnx_attrs = bv.linen_vars_to_nnx_attrs(variables)
-      for attr_name, value in nnx_attrs.items():
-        setattr(self, attr_name, value)
-
     else:
       nnx_attrs = {
         k: v
         for k, v in vars(self).items()
-        if k not in ['module', 'rngs'] and not k.startswith('_object__')
+        if not k.startswith("to_nnx__") and not k.startswith("_object__")
       }
-      variables = bv.nnx_attrs_to_linen_vars(nnx_attrs)
-
-      _rngs = (
-        {name: stream() for name, stream in rngs.items()} if rngs else {}
-      )
+      variables = nnx_attrs_to_linen_vars(nnx_attrs)
 
       # Get `mutable` from top level bridge.Module context if any
       if (m := bdg_module.current_module()) is not None:
         assert m.scope is not None
         mutable = m.scope.mutable
-        if 'mutable' in kwargs and kwargs['mutable'] != mutable:
+        if "mutable" in kwargs and kwargs["mutable"] != mutable:
           raise ValueError(
             f"Multiple `mutable` arguments detected: {mutable} at top level vs "
-            f"{kwargs['mutable']} in ToNNX() call")
-        kwargs['mutable'] = mutable
+            f"{kwargs['mutable']} in ToNNX() call"
+          )
+        kwargs["mutable"] = mutable
 
-      out = self.module.apply(variables, *args, rngs=_rngs, method=method, **kwargs)
+      out = self.to_nnx__module.apply(
+        variables, *args, rngs=_rngs, method=method, **kwargs
+      )
+
+      # Split out the updates if `mutable` is passed into the Flax module
+      if kwargs.get("mutable", False) is not False:
+        out, updates = out
+      else:
+        updates = None
 
     # Split out the updates if `mutable` is passed into the Flax module
-    if kwargs.get('mutable', False) != False:
-      out, updates = out
-      nnx_attrs = bv.linen_vars_to_nnx_attrs(updates)
+    if updates:
+      nnx_attrs = linen_vars_to_nnx_attrs(updates)
       for attr_name, value in nnx_attrs.items():
         if hasattr(self, attr_name) and isinstance(value, dict):
-          original_tree = getattr(self, attr_name)
-          setattr(self, attr_name, original_tree | value)
+          original_value = getattr(self, attr_name)
+          new_values = _recursive_merge(original_value, value)
+          setattr(self, attr_name, new_values)
         else:
           setattr(self, attr_name, value)
 
@@ -200,18 +283,21 @@ class ToNNX(Module, pytree=False):
 
 def linen_rngs_dict(linen_module: linen.Module, add_default: bool = False):
   """Given a module, split out one of its every active RNG key collections."""
-  assert linen_module.scope is not None, 'linen_rngs_dict() must be called inside a Linen module.'
+  assert linen_module.scope is not None, (
+    "linen_rngs_dict() must be called inside a Linen module."
+  )
   rngs: dict[str, tp.Any] = {
-      name: linen_module.make_rng(name)
-      for name in linen_module.scope.rngs.keys()
+    name: linen_module.make_rng(name) for name in linen_module.scope.rngs.keys()
   }
-  if add_default and 'default' not in rngs:
-    rngs['default'] = 0
+  if add_default and "default" not in rngs:
+    rngs["default"] = 0
   return rngs
 
+
 def _get_module_method(module, method: tp.Callable[..., Any] | str | None):
+  """Get a callable method from the module, or raise TypeError."""
   if method is None:
-    method = '__call__'
+    method = "__call__"
 
   if isinstance(method, str):
     attribute_name = method
@@ -219,16 +305,14 @@ def _get_module_method(module, method: tp.Callable[..., Any] | str | None):
     if not callable(method):
       class_name = type(module).__name__
       raise TypeError(
-        f"'{class_name}.{attribute_name}' must be a callable, got"
-        f' {type(method)}.'
+        f"'{class_name}.{attribute_name}' must be a callable, got {type(method)}."
       )
   if not callable(method):
     class_name = type(module).__name__
-    raise TypeError(
-      f"'{method}' must be a callable, got {type(method)}."
-    )
+    raise TypeError(f"'{method}' must be a callable, got {type(method)}.")
 
   return method
+
 
 class ToLinen(linen.Module):
   """A wrapper to turn any NNX module into a Linen module.
@@ -264,30 +348,28 @@ class ToLinen(linen.Module):
       NNX module.
     skip_rng: True if this NNX module doesn't need `rngs` arg during
       initialization (not common).
-    abstract_init: if True (default) the NNX module will be initialized under
-      `nnx.eval_shape`, useful to minimize memory consumption, else it will be
-      initialized normally.
 
   Returns:
     A stateful NNX module that behaves the same as the wrapped Linen module.
   """
+
   nnx_class: tp.Callable[..., Module]
   args: tp.Sequence = ()
   kwargs: tp.Mapping[str, tp.Any] = FrozenDict({})
   skip_rng: bool = False
-  abstract_init: bool = True
-  metadata_fn: tp.Callable[[variablelib.Variable], tp.Any] | None = (
-      bv.to_linen_var
-  )
+  metadata_fn: tp.Callable[[variablelib.VariableState], tp.Any] | None = to_linen_var
 
   @linen.compact
-  def __call__(self, *args, nnx_method: tp.Callable[..., Any] | str | None = None, **kwargs):
+  def __call__(
+    self, *args, nnx_method: tp.Callable[..., Any] | str | None = None, **kwargs
+  ):
     module_kwargs = dict(self.kwargs)
     maybe_add_default = not self.is_initializing()
+
     def _module_kwargs():
       if not self.skip_rng:
-        module_kwargs['rngs'] = nnx.Rngs(
-            **linen_rngs_dict(self, add_default=maybe_add_default)
+        module_kwargs["rngs"] = nnx.Rngs(
+          **linen_rngs_dict(self, add_default=maybe_add_default)
         )
       return module_kwargs
 
@@ -301,30 +383,21 @@ class ToLinen(linen.Module):
       out = method_fn(module, *args, **kwargs)
       return out
 
-    # create state
+    # create the nnx module
+    module = self.nnx_class(*self.args, **_module_kwargs())
+    # update nnx module from linen variables
     def maybe_unbox(x):
       if isinstance(x, meta.AxisMetadata):
         return x.unbox()
       return x
     states = jtu.tree_map(
-        maybe_unbox,
-        list(self.variables.values()),
-        is_leaf=lambda x: isinstance(x, meta.AxisMetadata),
+      maybe_unbox,
+      list(self.variables.values()),
+      is_leaf=lambda x: isinstance(x, meta.AxisMetadata),
     )
     if not states:
       states = ({},)
-
-    # update module state
-    if self.abstract_init:
-      module = nnx.eval_shape(
-          lambda: self.nnx_class(*self.args, **_module_kwargs())
-      )
-    else:
-      module = self.nnx_class(*self.args, **_module_kwargs())
     nnx.update(module, *states)
-    nnx.reseed(
-        module, **linen_rngs_dict(self, add_default=maybe_add_default)
-    )  # reseed with keys from linen apply call.
 
     method_fn = _get_module_method(module, nnx_method)
     out = method_fn(module, *args, **kwargs)
@@ -349,10 +422,8 @@ class ToLinen(linen.Module):
 
     # group state by collection
     for path, leaf in nnx.to_flat_state(state):
-      type_ = type(leaf)
-      collection = variablelib.variable_name_from_type(
-          type_, allow_register=True
-      )
+      type_ = leaf.type if isinstance(leaf, nnx.VariableState) else type(leaf)
+      collection = variablelib.variable_name_from_type(type_, allow_register=True)
       if collection not in collection_flat_state:
         collection_flat_state[collection] = []
       collection_flat_state[collection].append((path, leaf))
@@ -362,41 +433,39 @@ class ToLinen(linen.Module):
       if self.is_mutable_collection(collection):
 
         def _to_linen_var(x):
-          if isinstance(x, nnx.Variable):
-            if self.metadata_fn:
-              return self.metadata_fn(x)
+          if isinstance(x, nnx.VariableState):
+            if self.metadata_fn is not None:
+              return self.metadata_fn(x) # pylint: disable=too-many-function-args
             else:
               return x.value
           return x
 
         collection_state = nnx.traversals.unflatten_mapping(flat_state)
         collection_state = jax.tree.map(
-            _to_linen_var,
-            collection_state,
-            is_leaf=lambda x: isinstance(x, nnx.Variable),
+          _to_linen_var,
+          collection_state,
+          is_leaf=lambda x: isinstance(x, nnx.VariableState),
         )
         for k, v in collection_state.items():
           self.put_variable(collection, k, v)
 
 
 def to_linen(
-    nnx_class: tp.Callable[..., Module],
-    *args,
-    metadata_fn: (
-        tp.Callable[[variablelib.Variable], tp.Any] | None
-    ) = bv.to_linen_var,
-    name: str | None = None,
-    skip_rng: bool = False,
-    abstract_init: bool = True,
-    **kwargs,
+  nnx_class: tp.Callable[..., Module],
+  *args,
+  metadata_fn: (
+    tp.Callable[[variablelib.VariableState], tp.Any] | None
+  ) = to_linen_var,
+  name: str | None = None,
+  skip_rng: bool = False,
+  **kwargs,
 ):
   """Shortcut of `nnx.bridge.ToLinen` if user is not changing any of its default fields."""
   return ToLinen(
-      nnx_class,
-      args=args,
-      kwargs=FrozenDict(kwargs),
-      metadata_fn=metadata_fn,
-      skip_rng=skip_rng,
-      abstract_init=abstract_init,
-      name=name,
+    nnx_class,
+    args=args,
+    kwargs=FrozenDict(kwargs),
+    metadata_fn=metadata_fn,
+    skip_rng=skip_rng,
+    name=name,
   )


### PR DESCRIPTION
# What does this PR do?

* `ToNNX`'s checkpoint structure is now compatible with `ToLinen`.
* `ToLinen` now fully supports partitial initialization, however it must now always be ran under `jit` to maintain the same performance.
* Recent `abstract_init` flag is removed again.