### PR TITLE
[WIP] Auto mode spmd sharding utilities and docs

### DIFF
--- a/flax/core/meta.py
+++ b/flax/core/meta.py
@@ -179,10 +179,12 @@ def replace_boxed(tree: Any, updates: Any) -> Any:
 PARTITION_NAME = 'partition_name'
 
 
-def _global_mesh_defined() -> bool:
+def global_mesh_defined() -> bool:
   """Checks if global mesh resource environment is defined."""
-  env = pxla.thread_resources.env
-  return env.physical_mesh.devices.shape != ()  # pylint: disable=g-explicit-bool-comparison
+  if not jax.sharding.get_abstract_mesh().empty:
+    return True
+  # TODO(ivyzheng): remove this check when `with mesh` context is deprecated
+  return not pxla.thread_resources.env.physical_mesh.empty
 
 
 class Partitioned(struct.PyTreeNode, AxisMetadata[A]):
@@ -249,7 +251,7 @@ class Partitioned(struct.PyTreeNode, AxisMetadata[A]):
 
   def unbox(self, apply_constraint=True) -> A:
     """Returns the wrapped value with the partitioning applied as a sharding constraint."""
-    if apply_constraint and (_global_mesh_defined() or self.mesh is not None):
+    if apply_constraint and (global_mesh_defined() or self.mesh is not None):
       axis_resource = self.get_partition_spec()
       if self.mesh is not None:
         sharding = jax.sharding.NamedSharding(self.mesh, axis_resource)

--- a/flax/linen/spmd.py
+++ b/flax/linen/spmd.py
@@ -33,7 +33,6 @@ from collections.abc import Callable, Sequence
 
 import jax
 from jax import lax
-from jax.interpreters import pxla
 
 from flax import struct
 from flax.core import meta
@@ -61,17 +60,6 @@ class _UnassignedAxis:
 
 
 _unassigned_axis = _UnassignedAxis()
-
-
-def is_cpu_platform(mesh: jax.sharding.Mesh | None):
-  if mesh is None:
-    if _global_mesh_defined():
-      device = pxla.thread_resources.env.physical_mesh.devices.reshape(-1)[0]
-    else:
-      device = jax.devices()[0]
-  else:
-    device = mesh.devices.reshape(-1)[0]
-  return device.platform == 'cpu'
 
 
 def _mesh_assignment_free(new_assignment, existing_assignments):
@@ -188,12 +176,6 @@ def logical_to_mesh_sharding(
   )
 
 
-def _global_mesh_defined() -> bool:
-  """Checks if global mesh resource environment is defined."""
-  env = pxla.thread_resources.env
-  return env.physical_mesh.devices.shape != ()  # pylint: disable=g-explicit-bool-comparison
-
-
 class RulesFallback(enum.Enum):
   """How a sharding constraint should behave when no matching rule is found."""
 
@@ -208,7 +190,7 @@ def _with_sharding_constraint(
   mesh: jax.sharding.Mesh | None = None,
 ):
   """Wrapper for lax.with_sharding_constraint, no-op on cpu or outside jit."""
-  if is_cpu_platform(mesh) or (not _global_mesh_defined() and mesh is None):
+  if not meta.global_mesh_defined() and mesh is None:
     return x
   else:
     if mesh is not None and axis_resources is not None:
@@ -292,7 +274,7 @@ class LogicallyPartitioned(meta.Partitioned):
 
   def unbox(self, apply_constraint=True) -> Any:
     """Returns the wrapped value with the partitioning constraint applied."""
-    if apply_constraint and (_global_mesh_defined() or self.mesh is not None):
+    if apply_constraint and (meta.global_mesh_defined() or self.mesh is not None):
       return with_logical_constraint(
         self.value,
         self.get_partition_spec(),

--- a/flax/nnx/__init__.py
+++ b/flax/nnx/__init__.py
@@ -125,7 +125,10 @@ from .spmd import PARTITION_NAME as PARTITION_NAME
 from .spmd import get_partition_spec as get_partition_spec
 from .spmd import get_named_sharding as get_named_sharding
 from .spmd import with_partitioning as with_partitioning
-from .spmd import with_sharding_constraint as with_sharding_constraint
+from .spmd import shard_variable as shard_variable
+from .spmd import shard_model as shard_model
+from .spmd import sharded_init as sharded_init
+from .spmd import get_abstract_state as get_abstract_state
 from .statelib import State as State
 from .statelib import to_flat_state as to_flat_state
 from .statelib import from_flat_state as from_flat_state

--- a/flax/nnx/spmd.py
+++ b/flax/nnx/spmd.py
@@ -12,19 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import functools
+from functools import partial
 import typing as tp
 
+from flax.core import meta
 import flax.core.spmd as core_spmd
+from flax.nnx import graph
+from flax.nnx import module
 from flax.nnx import variablelib
 from flax.typing import (
-  Array,
-  ArrayPytree,  # pylint: disable=invalid-name
-  PartitionSpecPytree,  # pylint: disable=invalid-name
   Sharding,
 )
 import jax
-from jax.interpreters import pxla
 from jax.sharding import PartitionSpec
 
 A = tp.TypeVar('A')
@@ -32,12 +31,8 @@ F = tp.TypeVar('F', bound=tp.Callable[..., tp.Any])
 PARTITION_NAME = 'partition_name'
 
 
-class HasSharding(tp.Protocol):
-  sharding: tuple[str | None, ...] | None
-
-
-def _has_sharding(x: tp.Any) -> tp.TypeGuard[HasSharding]:
-  return hasattr(x, 'sharding') and x.sharding is not None
+# Transform axis change helpers
+# ------------------------------------------------------------------------------
 
 
 def add_axis(tree: A, index: int, transform_metadata: tp.Mapping) -> A:
@@ -112,32 +107,50 @@ def _get_partition_name_and_metadata(
   return transform_metadata[PARTITION_NAME], other_meta
 
 
+# Annotation handling
+# ------------------------------------------------------------------------------
+
+
+def with_partitioning(
+  initializer: F,
+  sharding: Sharding,
+  mesh: tp.Optional[jax.sharding.Mesh] = None,
+  **metadata: tp.Any,
+) -> F:
+  """A wrapper over any initializer to add sharding annotation data to a `Variable`."""
+  return variablelib.with_metadata(
+    initializer,
+    sharding=sharding,
+    mesh=mesh,
+    **metadata,
+  )
+
+
+def get_var_pspec(v: variablelib.Variable) -> PartitionSpec:
+  """Given an `nnx.Variable`, return its `PartitionSpec`."""
+  metadata = v.get_metadata()
+  if 'sharding' in metadata and metadata['sharding']:
+    sharding = metadata['sharding']
+    if core_spmd.get_logical_axis_rules() or 'sharding_rules' in metadata:
+      context_rules = core_spmd.get_logical_axis_rules()
+      local_rules = metadata.get('sharding_rules', ())
+      rules = core_spmd.composite_rules(context_rules, local_rules)
+      return PartitionSpec(*core_spmd.from_sharding_rules(sharding, rules))
+    return PartitionSpec(*sharding)
+  elif hasattr(v, 'shape'):
+      return PartitionSpec()
+  return None
+
+
 def get_partition_spec(tree: A) -> A:
   """Extracts a PartitionSpec tree from a PyTree containing ``Variable`` values."""
 
-  def _maybe_replicate(x):
-    if hasattr(x, 'shape'):
-      return PartitionSpec()
-    else:
-      return None
-
   def f(x):
     if isinstance(x, variablelib.Variable):
-      metadata = x.get_metadata()
-      if 'sharding' in metadata and metadata['sharding']:
-        sharding = metadata['sharding']
-        if core_spmd.get_logical_axis_rules() or 'sharding_rules' in metadata:
-          context_rules = core_spmd.get_logical_axis_rules()
-          local_rules = metadata.get('sharding_rules', ())
-          rules = core_spmd.composite_rules(context_rules, local_rules)
-          return x.replace(
-              PartitionSpec(*core_spmd.from_sharding_rules(sharding, rules))
-          )
-        return x.replace(PartitionSpec(*sharding))
-      else:
-        return x.replace(_maybe_replicate(x.raw_value))
-
-    return _maybe_replicate(x)
+      return x.replace(get_var_pspec(x))
+    elif hasattr(x, 'shape'):
+        return PartitionSpec()
+    return None
 
   return jax.tree.map(
     f, tree, is_leaf=lambda x: isinstance(x, variablelib.Variable)
@@ -150,63 +163,53 @@ def get_named_sharding(tree: A, mesh: jax.sharding.Mesh) -> A:
   return sharding
 
 
-# Dynamic Axis Mapping Rngs
+# Sharding constraints
 # ------------------------------------------------------------------------------
 
 
-def _global_mesh_defined() -> bool:
-  """Checks if global mesh resource environment is defined."""
-  env = pxla.thread_resources.env
-  return env.physical_mesh.devices.shape != ()  # pylint: disable=g-explicit-bool-comparison
+def shard_variable(v: variablelib.Variable, mesh=None, require_mesh=False) -> variablelib.Variable:
+  """Apply sharding constraint on a variable according to its annotations.
+
+  Recommend to only use inside a `jax.jit` under a mesh."""
+  if mesh is None and not meta.global_mesh_defined():
+    if require_mesh:
+      raise ValueError(
+        'A mesh or mesh context is required if running `nnx.shard_model()` or'
+        ' `nnx.sharded_init()` to initialize a model distributedly.')
+    return v
+  sharding = get_var_pspec(v)
+  if mesh is not None:
+    sharding = jax.sharding.NamedSharding(mesh, sharding)
+  if sharding is not None:
+    v.value = jax.lax.with_sharding_constraint(v.value, sharding)
+  return v
 
 
-def _with_sharding_constraint(
-  x: Array,
-  axis_resources: tp.Optional[jax.sharding.PartitionSpec],
-  mesh: tp.Optional[jax.sharding.Mesh] = None,
-):
-  # if jax.devices()[0].platform == "cpu" or (
-  if not _global_mesh_defined() and mesh is None:
-    return x
-  else:
-    if mesh is not None and axis_resources is not None:
-      sharding = jax.sharding.NamedSharding(mesh, axis_resources)
-      return jax.lax.with_sharding_constraint(x, sharding)
-    return jax.lax.with_sharding_constraint(x, axis_resources)
+def shard_model(model, mesh=None) -> module.Module:
+  """Recommend to only use inside a `jax.jit`."""
+  gdef, state = graph.split(model)
+  state = jax.tree.map(partial(shard_variable, mesh=mesh, require_mesh=True), state,
+                       is_leaf=lambda x: isinstance(x, variablelib.Variable))
+  return graph.merge(gdef, state)
 
 
-def _is_spec(x):
-  return x is None or isinstance(x, variablelib.Variable) or (
-    isinstance(x, tuple) and all(isinstance(e, str) or e is None for e in x)
+def sharded_init(init_fn, mesh=None) -> module.Module:
+  @jax.jit
+  def f():
+    model = init_fn()
+    return graph.split(shard_model(model, mesh))
+  return graph.merge(*f())
+
+
+
+# Other utilities
+# ------------------------------------------------------------------------------
+
+
+def get_abstract_state(init_fn, mesh):
+  abs_state = jax.eval_shape(lambda: graph.state(init_fn()))
+  abs_state = jax.tree.map(
+    lambda a, s: jax.ShapeDtypeStruct(a.shape, a.dtype, sharding=s),
+    abs_state, get_named_sharding(abs_state, mesh)
   )
-
-
-def with_sharding_constraint(
-  x: ArrayPytree,
-  axis_resources: PartitionSpecPytree,
-  mesh: tp.Optional[jax.sharding.Mesh] = None,
-):
-  # If no axis binding is set, this is a no-op.
-  if axis_resources is None:
-    return x
-  # Translate logical names to mesh assignments.
-  return jax.tree.map(
-    functools.partial(_with_sharding_constraint, mesh=mesh),
-    x,
-    axis_resources,
-    is_leaf=_is_spec,
-  )
-
-
-def with_partitioning(
-  initializer: F,
-  sharding: Sharding,
-  mesh: tp.Optional[jax.sharding.Mesh] = None,
-  **metadata: tp.Any,
-) -> F:
-  return variablelib.with_metadata(
-    initializer,
-    sharding=sharding,
-    mesh=mesh,
-    **metadata,
-  )
+  return abs_state


### PR DESCRIPTION
This PR creates a few helpful utilities for users to do auto mode sharding, and removed a few functions that people are not using actively.

`nnx.sharded_init` allows user to create sharded model with one line, without creating custom `jit` functions and impose sharding constraints. Users can now do:
```python
with jax.sharding.use_mesh(mesh):
  sharded_model = nnx.sharded_init(lambda: nnx.Linear(16, 16, nnx.Rngs(0)))
```

If user want to explicitly create their jitted functions, they can do this instead of explicitly extracting specs and applying contraints:
```python
@jax.jit
def sharded_init_model():
  model = nnx.Linear(16, 16, nnx.Rngs(0))
  model = nnx.shard_model(model)
  return graph.split(model)
```
