### PR TITLE
Fix ToLinen docstring return description

### DIFF
--- a/flax/nnx/bridge/wrappers.py
+++ b/flax/nnx/bridge/wrappers.py
@@ -269,7 +269,7 @@ class ToLinen(linen.Module):
       initialized normally.
 
   Returns:
-    A stateful NNX module that behaves the same as the wrapped Linen module.
+    A Linen module that behaves the same as the wrapped NNX module.
   """
   nnx_class: tp.Callable[..., Module]
   args: tp.Sequence = ()


### PR DESCRIPTION
  # What does this PR do?

  ## Summary
  Fixes the incorrect docstring in the `ToLinen` class.

  ## Changes
  - Fixed the "Returns" section in `ToLinen` docstring
  - Changed from "A stateful NNX module that behaves the same as the wrapped Linen module"
  - To "A Linen module that behaves the same as the wrapped NNX module"

  ## Issue
  - `ToLinen`: Wraps NNX module → returns Linen module
  - `ToNNX`: Wraps Linen module → returns NNX module

  The docstring was incorrectly copied from `ToNNX` and not updated properly.

  Fixes #4803

  ## Checklist
  - [x] This PR fixes a minor issue (e.g.: typo or small bug) or improves the docs (you can dismiss the other
        checks if that's the case).
  - [ ] This change is discussed in a Github issue/
        [discussion](https://github.com/google/flax/discussions) (please add a
        link).
  - [ ] The documentation and docstrings adhere to the
        [documentation guidelines](https://github.com/google/flax/blob/main/docs/README.md#how-to-write-code-documentation).
  - [ ] This change includes necessary high-coverage tests.
        (No quality testing = no merge!)