### PR TITLE
Fix broken contributing documentation link

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -10,9 +10,9 @@ build:
   tools:
     python: "3.11"
 
-# Build documentation in the docs/ directory with Sphinx
+# Build documentation in the docs_nnx/ directory with Sphinx
 sphinx:
-  configuration: docs/conf.py
+  configuration: docs_nnx/conf.py
 
 # Optionally build your docs in additional formats such as PDF and ePub
 formats:


### PR DESCRIPTION
Fix readthedocs.yml to build from docs_nnx/ instead of docs/ to resolve 404 error on contributing page. The docs_nnx directory contains the contributing.md file while docs/ does not.

Fixes #4853

 # What does this PR do?

This PR fixes a broken link in the Flax documentation, where `https://flax.readthedocs.io/en/latest/contributing.html` was redirecting to `https://flax-linen.readthedocs.io/en/latest/contributing.html` and returning a 404 error.

## Root Cause 
The issue occurred because:
 1. The main documentation site (`flax.readthedocs.io`) was configured to build from `docs/` (Linen documentation)
 2. The `docs/` directory does not contain a `contributing.md` file
 3. The complete contributing documentation exists in `docs_nnx/contributing.md` 
 4. Since the main site already serves NNX content, the ReadTheDocs configuration should build from the NNX source directory

  ## Solution
 Updated `.readthedocs.yml` to build from `docs_nnx/conf.py` instead of `docs/conf.py`. This aligns the build source with the intended NNX content structure and ensures the contributing page is available at the expected URL.

  ## Testing Performed
  - Verified `docs_nnx/contributing.md` exists and contains a complete contributing guide
  - Confirmed `docs/` directory has no contributing file
  - Local Sphinx build test shows `contributing.html` generates correctly 
  - HTTP 200 response when accessing `/contributing.html` locally
  - Tested both with and without contributing.md to confirm the difference

After ReadTheDocs rebuilds, users will be able to access the contributing documentation directly without redirects or 404 errors.

  Fixes #4853

  ## Checklist
  - [x] This PR fixes a minor issue (e.g., typo or small bug) or improves the docs (you can dismiss the other
        checks if that's the case).
  - [x] This change is discussed in a GitHub issue/
        [discussion](https://github.com/google/flax/discussions) (please add a
        link).
  - [] The documentation and docstrings adhere to the
        [documentation guidelines](https://github.com/google/flax/blob/main/docs/README.md#how-to-write-code-documentation).
  - [] This change includes necessary high-coverage tests.
        (No quality testing = no merge!)