### PR TITLE
Update typo in nnx.Optimizer

### DIFF
--- a/flax/nnx/training/optimizer.py
+++ b/flax/nnx/training/optimizer.py
@@ -169,7 +169,7 @@ class Optimizer(Pytree, tp.Generic[M]):
     def __getattribute__(self, name: str) -> tp.Any:
       if name == 'model' and name not in vars(self):
         raise AttributeError(
-          f"{type(self).__name__} does have attribute 'model' since Flax 0.11.0. "
+          f"{type(self).__name__} does not have attribute 'model' since Flax 0.11.0. "
           "To keep the previous behavior, use nnx.ModelAndOptimizer instead of nnx.Optimizer."
         )
       return super().__getattribute__(name)


### PR DESCRIPTION
# What does this PR do?

The error message in nnx.Optimizer states "<module> *does* have `model` attribute", but in reality, it wants to say it *does not*.

Fixes # (issue)

## Checklist
- [x] This PR fixes a minor issue (e.g.: typo or small bug) or improves the docs (you can dismiss the other
      checks if that's the case).
- [ ] This change is discussed in a Github issue/
      [discussion](https://github.com/google/flax/discussions) (please add a
      link).
- [ ] The documentation and docstrings adhere to the
      [documentation guidelines](https://github.com/google/flax/blob/main/docs/README.md#how-to-write-code-documentation).
- [ ] This change includes necessary high-coverage tests.
      (No quality testing = no merge!)
