### PR TITLE
Improve docs related with dataclasses

### DIFF
--- a/docs_nnx/key_concepts.ipynb
+++ b/docs_nnx/key_concepts.ipynb
@@ -126,7 +126,7 @@
     "\n",
     "Many things are pytrees: Python dicts, lists, tuples, dataclasses, and more. The key is that a pytree can be \"flattened\" into multiple children, which are either pytrees or individual leaves - a `jax.Array` counts as a leaf. Other metadata of a pytree are stored in the `PyTreeDef` object, allowing \"unflattening\" to restore the old pytree.\n",
     "\n",
-    "Pytree is the primary data holder in JAX. When JAX transforms see a pytree argument, they automatically trace its internal `jax.Array`s when compiling. Therefore, it's crucial to organize your data as pytrees. You can register your own classes as pytree nodes. [JAX pytree documentation](https://docs.jax.dev/en/latest/working-with-pytrees.html) has a thorough overview on pytrees and JAX APIs to manipulate them. \n",
+    "Pytree is the primary data holder in JAX. When JAX transforms see a pytree argument, they automatically trace its internal `jax.Array`s when compiling. Therefore, it's crucial to organize your data as pytrees. You can use [`flax.struct.dataclass`](https://flax.readthedocs.io/en/latest/api_reference/flax.struct.html#flax.struct.dataclass) to quickly construct a pytree node dataclass, or register your own classes via JAX API. [JAX pytree documentation](https://docs.jax.dev/en/latest/working-with-pytrees.html) has a thorough overview on pytrees and JAX APIs to manipulate them. \n",
     "\n",
     "In Flax, a `Module` is a pytree, and variables are its flattenable data. This means you can directly run JAX transforms upon a Flax model."
    ]

--- a/docs_nnx/key_concepts.md
+++ b/docs_nnx/key_concepts.md
@@ -81,7 +81,7 @@ Your code likely needs more than one `jax.Array`. A **pytree** is a container st
 
 Many things are pytrees: Python dicts, lists, tuples, dataclasses, and more. The key is that a pytree can be "flattened" into multiple children, which are either pytrees or individual leaves - a `jax.Array` counts as a leaf. Other metadata of a pytree are stored in the `PyTreeDef` object, allowing "unflattening" to restore the old pytree.
 
-Pytree is the primary data holder in JAX. When JAX transforms see a pytree argument, they automatically trace its internal `jax.Array`s when compiling. Therefore, it's crucial to organize your data as pytrees. You can register your own classes as pytree nodes. [JAX pytree documentation](https://docs.jax.dev/en/latest/working-with-pytrees.html) has a thorough overview on pytrees and JAX APIs to manipulate them. 
+Pytree is the primary data holder in JAX. When JAX transforms see a pytree argument, they automatically trace its internal `jax.Array`s when compiling. Therefore, it's crucial to organize your data as pytrees. You can use [`flax.struct.dataclass`](https://flax.readthedocs.io/en/latest/api_reference/flax.struct.html#flax.struct.dataclass) to quickly construct a pytree node dataclass, or register your own classes via JAX API. [JAX pytree documentation](https://docs.jax.dev/en/latest/working-with-pytrees.html) has a thorough overview on pytrees and JAX APIs to manipulate them. 
 
 In Flax, a `Module` is a pytree, and variables are its flattenable data. This means you can directly run JAX transforms upon a Flax model.
 
@@ -103,7 +103,7 @@ linear = jax.tree.unflatten(treedef, [value for _, value in arrays])
      [ 0.6772455   0.2807398 ]
      [ 0.16276604  0.16813846]
      [ 0.310975   -0.43336964]]
-    treedef = PyTreeDef(CustomNode(Linear[(('_pytree__state', 'bias', 'kernel'), (('_pytree__nodes', frozenset({'kernel', '_pytree__state', 'bias'})), ('bias_init', <function zeros at 0x117826700>), ('dot_general', <function dot_general at 0x1172aa480>), ('dtype', None), ('in_features', 4), ('kernel_init', <function variance_scaling.<locals>.init at 0x120f45260>), ('out_features', 2), ('param_dtype', <class 'jax.numpy.float32'>), ('precision', None), ('promote_dtype', <function promote_dtype at 0x120f45440>), ('use_bias', True)))], [CustomNode(PytreeState[(False, False)], []), CustomNode(Param[()], [*]), CustomNode(Param[()], [*])]))
+    treedef = PyTreeDef(CustomNode(Linear[(('_pytree__state', 'bias', 'kernel'), (('_object__nodes', frozenset({'kernel', '_pytree__state', 'bias'})), ('bias_init', <function zeros at 0x117826700>), ('dot_general', <function dot_general at 0x1172aa480>), ('dtype', None), ('in_features', 4), ('kernel_init', <function variance_scaling.<locals>.init at 0x120f45260>), ('out_features', 2), ('param_dtype', <class 'jax.numpy.float32'>), ('precision', None), ('promote_dtype', <function promote_dtype at 0x120f45440>), ('use_bias', True)))], [CustomNode(ObjectState[(False, False)], []), CustomNode(Param[()], [*]), CustomNode(Param[()], [*])]))
 
 
 

--- a/flax/struct.py
+++ b/flax/struct.py
@@ -60,7 +60,10 @@ def dataclass(
   Jax transformations such as ``jax.jit`` and ``jax.grad`` require objects that are
   immutable and can be mapped over using the ``jax.tree_util`` methods.
   The ``dataclass`` decorator makes it easy to define custom classes that can be
-  passed safely to Jax. For example::
+  passed safely to Jax. Define JAX data as normal attribute fields, and use
+  ``pytree_node=False`` to define static metadata.
+
+  See example::
 
     >>> from flax import struct
     >>> import jax
@@ -92,16 +95,9 @@ def dataclass(
 
   Note that dataclasses have an auto-generated ``__init__`` where
   the arguments of the constructor and the attributes of the created
-  instance match 1:1. This correspondence is what makes these objects
-  valid containers that work with JAX transformations and
-  more generally the ``jax.tree_util`` library.
-
-  Sometimes a "smart constructor" is desired, for example because
-  some of the attributes can be (optionally) derived from others.
-  The way to do this with Flax dataclasses is to make a static or
-  class method that provides the smart constructor.
-  This way the simple constructor used by ``jax.tree_util`` is
-  preserved. Consider the following example::
+  instance match 1:1. If you desire a "smart constructor", for example to
+  optionally derive some of the attributes from others,
+  make an additional static or class method. Consider the following example::
 
     >>> @struct.dataclass
     ... class DirectionAndScaleKernel:


### PR DESCRIPTION
Fixes https://github.com/google/flax/issues/4870

Made `dataclasses` docstring much more concise. Also made a reference from the pytree key concept doc.