### PR TITLE
Sharding API improvements (non breaking)

### DIFF
--- a/docs_nnx/guides/transforms.ipynb
+++ b/docs_nnx/guides/transforms.ipynb
@@ -779,7 +779,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "id": "d85c772c",
    "metadata": {},
    "outputs": [
@@ -796,19 +796,19 @@
    ],
    "source": [
     "class Weights(nnx.Module):\n",
-    "  def __init__(self, array: jax.Array, sharding: tuple[str | None, ...]):\n",
-    "    self.param = nnx.Param(array, sharding=sharding)\n",
+    "  def __init__(self, array: jax.Array, sharding_names: tuple[str | None, ...]):\n",
+    "    self.param = nnx.Param(array, sharding_names=sharding_names)\n",
     "\n",
-    "m = Weights(jnp.ones((3, 4, 5)), sharding=('a', 'b', None))\n",
+    "m = Weights(jnp.ones((3, 4, 5)), sharding_names=('a', 'b', None))\n",
     "\n",
     "@nnx.vmap(in_axes=1, transform_metadata={nnx.PARTITION_NAME: 'b'})\n",
     "def f(m: Weights):\n",
     "  print(f'Inner {m.param.shape = }')\n",
-    "  print(f'Inner {m.param.sharding = }')\n",
+    "  print(f'Inner {m.param.sharding_names = }')\n",
     "\n",
     "f(m)\n",
     "print(f'Outter {m.param.shape = }')\n",
-    "print(f'Outter {m.param.sharding = }')"
+    "print(f'Outter {m.param.sharding_names = }')"
    ]
   },
   {
@@ -823,7 +823,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "id": "358e51f7",
    "metadata": {},
    "outputs": [
@@ -839,11 +839,11 @@
    "source": [
     "@nnx.vmap(out_axes=1, axis_size=4, transform_metadata={nnx.PARTITION_NAME: 'b'})\n",
     "def init_vmap():\n",
-    "  return Weights(jnp.ones((3, 5)), sharding=('a', None))\n",
+    "  return Weights(jnp.ones((3, 5)), sharding_names=('a', None))\n",
     "\n",
     "m = init_vmap()\n",
     "print(f'Outter {m.param.shape = }')\n",
-    "print(f'Outter {m.param.sharding = }')"
+    "print(f'Outter {m.param.sharding_names = }')"
    ]
   }
  ],
@@ -863,7 +863,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.9"
+   "version": "3.12.7"
   }
  },
  "nbformat": 4,

--- a/docs_nnx/guides/transforms.md
+++ b/docs_nnx/guides/transforms.md
@@ -391,19 +391,19 @@ Let's see an example of this in action:
 
 ```{code-cell} ipython3
 class Weights(nnx.Module):
-  def __init__(self, array: jax.Array, sharding: tuple[str | None, ...]):
-    self.param = nnx.Param(array, sharding=sharding)
+  def __init__(self, array: jax.Array, sharding_names: tuple[str | None, ...]):
+    self.param = nnx.Param(array, sharding_names=sharding_names)
 
-m = Weights(jnp.ones((3, 4, 5)), sharding=('a', 'b', None))
+m = Weights(jnp.ones((3, 4, 5)), sharding_names=('a', 'b', None))
 
 @nnx.vmap(in_axes=1, transform_metadata={nnx.PARTITION_NAME: 'b'})
 def f(m: Weights):
   print(f'Inner {m.param.shape = }')
-  print(f'Inner {m.param.sharding = }')
+  print(f'Inner {m.param.sharding_names = }')
 
 f(m)
 print(f'Outter {m.param.shape = }')
-print(f'Outter {m.param.sharding = }')
+print(f'Outter {m.param.sharding_names = }')
 ```
 
 Here, you added a `sharding` metadata to the `nnx.Param` variables, and used `transform_metadata` to update the `sharding` metadata to reflect the axis changes. Specifically, you can see that the first axis `b` was removed from the `sharding` metadata when inside of `nnx.vmap`, and then added back when outside of `nnx.vmap`.
@@ -413,9 +413,9 @@ You can verify that this also works when `nnx.Module`s are created inside the tr
 ```{code-cell} ipython3
 @nnx.vmap(out_axes=1, axis_size=4, transform_metadata={nnx.PARTITION_NAME: 'b'})
 def init_vmap():
-  return Weights(jnp.ones((3, 5)), sharding=('a', None))
+  return Weights(jnp.ones((3, 5)), sharding_names=('a', None))
 
 m = init_vmap()
 print(f'Outter {m.param.shape = }')
-print(f'Outter {m.param.sharding = }')
+print(f'Outter {m.param.sharding_names = }')
 ```

--- a/examples/gemma/utils.py
+++ b/examples/gemma/utils.py
@@ -24,6 +24,7 @@ import numpy as np
 from jax.experimental import mesh_utils
 from transformer import TransformerConfig, Transformer
 
+
 from flax import nnx
 from flax.training import train_state
 
@@ -32,6 +33,12 @@ if TYPE_CHECKING:
 
 Dtype = Any
 Shape = tuple[int, ...]
+
+# JAX version compatibility
+if hasattr(jax.sharding, 'use_mesh'):
+  set_mesh = jax.sharding.use_mesh
+else:
+  set_mesh = jax.set_mesh
 
 
 class TrainState(train_state.TrainState):
@@ -165,7 +172,7 @@ def setup_initial_state(
     return state
 
   # Initialization
-  with jax.set_mesh(mesh):
+  with set_mesh(mesh):
     state = sharded_init()
 
   state_sharding = nnx.get_named_sharding(state, mesh)

--- a/flax/core/meta.py
+++ b/flax/core/meta.py
@@ -179,10 +179,19 @@ def replace_boxed(tree: Any, updates: Any) -> Any:
 PARTITION_NAME = 'partition_name'
 
 
-def _global_mesh_defined() -> bool:
+def get_global_mesh() -> jax.sharding.AbstractMesh | jax.sharding.Mesh | None:
+  mesh = jax.sharding.get_abstract_mesh()
+  if mesh.empty:
+    mesh = pxla.thread_resources.env.physical_mesh
+    if mesh.empty:
+      return None
+  return mesh
+
+
+def global_mesh_defined() -> bool:
   """Checks if global mesh resource environment is defined."""
-  env = pxla.thread_resources.env
-  return env.physical_mesh.devices.shape != ()  # pylint: disable=g-explicit-bool-comparison
+  mesh = get_global_mesh()
+  return mesh is not None
 
 
 class Partitioned(struct.PyTreeNode, AxisMetadata[A]):
@@ -249,7 +258,7 @@ class Partitioned(struct.PyTreeNode, AxisMetadata[A]):
 
   def unbox(self, apply_constraint=True) -> A:
     """Returns the wrapped value with the partitioning applied as a sharding constraint."""
-    if apply_constraint and (_global_mesh_defined() or self.mesh is not None):
+    if apply_constraint and (global_mesh_defined() or self.mesh is not None):
       axis_resource = self.get_partition_spec()
       if self.mesh is not None:
         sharding = jax.sharding.NamedSharding(self.mesh, axis_resource)
@@ -290,15 +299,14 @@ class Partitioned(struct.PyTreeNode, AxisMetadata[A]):
 
   def to_nnx_metadata(self) -> dict[str, Any]:
     """Return a dict of metadata that can translate into an `nnx.Variable`."""
-    metadata = vars(self)
-    if 'names' in metadata:
-      metadata['sharding'] = metadata.pop('names')
+    metadata = dict(vars(self))
+    metadata['sharding_names'] = metadata.pop('names')
     return metadata
 
   @classmethod
   def from_nnx_metadata(cls, metadata: dict[str, Any]):
     """Given a dict of `nnx.Variable` format metadata, create a `nn.Partitioned`."""
-    metadata['names'] = metadata.pop('sharding')
+    metadata['names'] = metadata.pop('sharding_names')
     fields = {x.name for x in dataclasses.fields(cls)}
     return cls(**{k: v for k, v in metadata.items() if k in fields})
 

--- a/flax/linen/linear.py
+++ b/flax/linen/linear.py
@@ -247,7 +247,6 @@ class Dense(Module):
   kernel_init: Initializer = default_kernel_init
   bias_init: Initializer = initializers.zeros_init()
   promote_dtype: PromoteDtypeFn = promote_dtype
-  # Deprecated. Will be removed.
   dot_general: DotGeneralT | None = None
   dot_general_cls: Any = None
 

--- a/flax/linen/spmd.py
+++ b/flax/linen/spmd.py
@@ -33,7 +33,6 @@ from collections.abc import Callable, Sequence
 
 import jax
 from jax import lax
-from jax.interpreters import pxla
 
 from flax import struct
 from flax.core import meta
@@ -61,17 +60,6 @@ class _UnassignedAxis:
 
 
 _unassigned_axis = _UnassignedAxis()
-
-
-def is_cpu_platform(mesh: jax.sharding.Mesh | None):
-  if mesh is None:
-    if _global_mesh_defined():
-      device = pxla.thread_resources.env.physical_mesh.devices.reshape(-1)[0]
-    else:
-      device = jax.devices()[0]
-  else:
-    device = mesh.devices.reshape(-1)[0]
-  return device.platform == 'cpu'
 
 
 def _mesh_assignment_free(new_assignment, existing_assignments):
@@ -188,12 +176,6 @@ def logical_to_mesh_sharding(
   )
 
 
-def _global_mesh_defined() -> bool:
-  """Checks if global mesh resource environment is defined."""
-  env = pxla.thread_resources.env
-  return env.physical_mesh.devices.shape != ()  # pylint: disable=g-explicit-bool-comparison
-
-
 class RulesFallback(enum.Enum):
   """How a sharding constraint should behave when no matching rule is found."""
 
@@ -208,7 +190,7 @@ def _with_sharding_constraint(
   mesh: jax.sharding.Mesh | None = None,
 ):
   """Wrapper for lax.with_sharding_constraint, no-op on cpu or outside jit."""
-  if is_cpu_platform(mesh) or (not _global_mesh_defined() and mesh is None):
+  if not meta.global_mesh_defined() and mesh is None:
     return x
   else:
     if mesh is not None and axis_resources is not None:
@@ -292,7 +274,7 @@ class LogicallyPartitioned(meta.Partitioned):
 
   def unbox(self, apply_constraint=True) -> Any:
     """Returns the wrapped value with the partitioning constraint applied."""
-    if apply_constraint and (_global_mesh_defined() or self.mesh is not None):
+    if apply_constraint and (meta.global_mesh_defined() or self.mesh is not None):
       return with_logical_constraint(
         self.value,
         self.get_partition_spec(),
@@ -306,7 +288,7 @@ class LogicallyPartitioned(meta.Partitioned):
     """Return a dict of metadata that can translate into an `nnx.Variable`."""
     metadata = vars(self)
     if 'names' in metadata:
-      metadata['sharding'] = metadata.pop('names')
+      metadata['sharding_names'] = metadata.pop('names')
     if 'rules' in metadata:
       metadata['sharding_rules'] = metadata.pop('rules')
     return metadata
@@ -314,7 +296,7 @@ class LogicallyPartitioned(meta.Partitioned):
   @classmethod
   def from_nnx_metadata(cls, metadata: dict[str, Any]):
     """Given a dict of `nnx.Variable` format metadata, create a `nn.LogicallyPartitioned`."""
-    metadata['names'] = metadata.pop('sharding')
+    metadata['names'] = metadata.pop('sharding_names')
     metadata['rules'] = metadata.pop('sharding_rules')
     fields = {x.name for x in dataclasses.fields(cls)}
     return cls(**{k: v for k, v in metadata.items() if k in fields})

--- a/flax/nnx/__init__.py
+++ b/flax/nnx/__init__.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from flax.core.spmd import logical_axis_rules as logical_axis_rules
 from flax.linen.pooling import avg_pool as avg_pool
 from flax.linen.pooling import max_pool as max_pool
 from flax.linen.pooling import min_pool as min_pool
@@ -127,7 +128,7 @@ from .spmd import PARTITION_NAME as PARTITION_NAME
 from .spmd import get_partition_spec as get_partition_spec
 from .spmd import get_named_sharding as get_named_sharding
 from .spmd import with_partitioning as with_partitioning
-from .spmd import with_sharding_constraint as with_sharding_constraint
+from .spmd import get_abstract_model as get_abstract_model
 from .statelib import State as State
 from .statelib import to_flat_state as to_flat_state
 from .statelib import from_flat_state as from_flat_state

--- a/flax/nnx/nn/linear.py
+++ b/flax/nnx/nn/linear.py
@@ -156,7 +156,6 @@ class LinearGeneral(Module):
     bias_init: Initializer = default_bias_init,
     precision: PrecisionLike = None,
     promote_dtype: PromoteDtypeFn = dtypes.promote_dtype,
-    # Deprecated. Will be removed.
     dot_general: DotGeneralT | None = None,
     dot_general_cls: tp.Any = None,
     rngs: rnglib.Rngs,

--- a/flax/nnx/spmd.py
+++ b/flax/nnx/spmd.py
@@ -12,32 +12,30 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import functools
 import typing as tp
 
 import flax.core.spmd as core_spmd
-from flax.nnx import variablelib
+from flax.nnx import variablelib, graph
+from flax.nnx.transforms.transforms import eval_shape
 from flax.typing import (
-  Array,
-  ArrayPytree,  # pylint: disable=invalid-name
-  PartitionSpecPytree,  # pylint: disable=invalid-name
   Sharding,
 )
 import jax
-from jax.interpreters import pxla
 from jax.sharding import PartitionSpec
+
+# JAX version compatibility
+if hasattr(jax.sharding, 'use_mesh'):
+  set_mesh = jax.sharding.use_mesh
+else:
+  set_mesh = jax.set_mesh
 
 A = tp.TypeVar('A')
 F = tp.TypeVar('F', bound=tp.Callable[..., tp.Any])
 PARTITION_NAME = 'partition_name'
 
 
-class HasSharding(tp.Protocol):
-  sharding: tuple[str | None, ...] | None
-
-
-def _has_sharding(x: tp.Any) -> tp.TypeGuard[HasSharding]:
-  return hasattr(x, 'sharding') and x.sharding is not None
+# Transform axis change helpers
+# ------------------------------------------------------------------------------
 
 
 def add_axis(tree: A, index: int, transform_metadata: tp.Mapping) -> A:
@@ -53,9 +51,9 @@ def add_axis(tree: A, index: int, transform_metadata: tp.Mapping) -> A:
   def _add_axis(x: tp.Any):
     if isinstance(x, variablelib.Variable):
       metadata = x.get_metadata()
-      if 'sharding' in metadata and metadata['sharding']:
-        sharding = metadata['sharding']
-        x.sharding = insert_field(sharding, index, axis_name)
+      if 'sharding_names' in metadata and metadata['sharding_names']:
+        sharding = metadata['sharding_names']
+        x.sharding_names = insert_field(sharding, index, axis_name)
 
       for k, v in other_meta.items():
         if hasattr(x, k) and (t := getattr(x, k)) and isinstance(t, tuple):
@@ -82,8 +80,8 @@ def remove_axis(
 
   def _remove_axis(x: tp.Any):
     if isinstance(x, variablelib.Variable):
-      if hasattr(x, 'sharding') and x.sharding is not None:
-        x.sharding = remove_field(x.sharding, index, axis_name)
+      if hasattr(x, 'sharding_names') and x.sharding_names is not None:
+        x.sharding_names = remove_field(x.sharding_names, index, axis_name)
 
       for k, v in other_meta.items():
         if hasattr(x, k) and (t := getattr(x, k)) and isinstance(t, tuple):
@@ -112,34 +110,50 @@ def _get_partition_name_and_metadata(
   return transform_metadata[PARTITION_NAME], other_meta
 
 
+# Annotation handling
+# ------------------------------------------------------------------------------
+
+
+def with_partitioning(
+  initializer: F,
+  sharding: Sharding,
+  mesh: tp.Optional[jax.sharding.Mesh] = None,
+  **metadata: tp.Any,
+) -> F:
+  """A wrapper over any initializer to add sharding annotation data to a `Variable`."""
+  return variablelib.with_metadata(
+    initializer,
+    sharding_names=sharding,
+    mesh=mesh,
+    **metadata,
+  )
+
+
+def get_var_pspec(v: variablelib.Variable) -> PartitionSpec | None:
+  """Given an `nnx.Variable`, return its `PartitionSpec`."""
+  metadata = v.get_metadata()
+  if 'sharding_names' in metadata and metadata['sharding_names']:
+    sharding = metadata['sharding_names']
+    if core_spmd.get_logical_axis_rules() or 'sharding_rules' in metadata:
+      context_rules = core_spmd.get_logical_axis_rules()
+      local_rules = metadata.get('sharding_rules', ())
+      rules = core_spmd.composite_rules(context_rules, local_rules)
+      return PartitionSpec(*core_spmd.from_sharding_rules(sharding, rules))
+    return PartitionSpec(*sharding)
+  elif hasattr(v, 'shape'):
+      return PartitionSpec()
+  return None
+
+
 def get_partition_spec(tree: A) -> A:
   """Extracts a PartitionSpec tree from a PyTree containing ``Variable`` values."""
 
-  def _maybe_replicate(x):
-    if hasattr(x, 'shape'):
-      return PartitionSpec()
-    else:
-      return None
-
   def f(x):
     if isinstance(x, variablelib.Variable):
-      metadata = x.get_metadata()
-      if 'sharding' in metadata and metadata['sharding']:
-        sharding = metadata['sharding']
-        if core_spmd.get_logical_axis_rules() or 'sharding_rules' in metadata:
-          context_rules = core_spmd.get_logical_axis_rules()
-          local_rules = metadata.get('sharding_rules', ())
-          if local_rules is None:
-            local_rules = ()
-          rules = core_spmd.composite_rules(context_rules, local_rules)
-          return x.replace(
-              PartitionSpec(*core_spmd.from_sharding_rules(sharding, rules))
-          )
-        return x.replace(PartitionSpec(*sharding))
-      else:
-        return x.replace(_maybe_replicate(x.raw_value))
-
-    return _maybe_replicate(x)
+      return x.replace(get_var_pspec(x))
+    elif hasattr(x, 'shape'):
+        return PartitionSpec()
+    return None
 
   return jax.tree.map(
     f, tree, is_leaf=lambda x: isinstance(x, variablelib.Variable)
@@ -152,63 +166,16 @@ def get_named_sharding(tree: A, mesh: jax.sharding.Mesh) -> A:
   return sharding
 
 
-# Dynamic Axis Mapping Rngs
+# Other utilities
 # ------------------------------------------------------------------------------
 
 
-def _global_mesh_defined() -> bool:
-  """Checks if global mesh resource environment is defined."""
-  env = pxla.thread_resources.env
-  return env.physical_mesh.devices.shape != ()  # pylint: disable=g-explicit-bool-comparison
-
-
-def _with_sharding_constraint(
-  x: Array,
-  axis_resources: tp.Optional[jax.sharding.PartitionSpec],
-  mesh: tp.Optional[jax.sharding.Mesh] = None,
-):
-  # if jax.devices()[0].platform == "cpu" or (
-  if not _global_mesh_defined() and mesh is None:
-    return x
-  else:
-    if mesh is not None and axis_resources is not None:
-      sharding = jax.sharding.NamedSharding(mesh, axis_resources)
-      return jax.lax.with_sharding_constraint(x, sharding)
-    return jax.lax.with_sharding_constraint(x, axis_resources)
-
-
-def _is_spec(x):
-  return x is None or isinstance(x, variablelib.Variable) or (
-    isinstance(x, tuple) and all(isinstance(e, str) or e is None for e in x)
-  )
-
-
-def with_sharding_constraint(
-  x: ArrayPytree,
-  axis_resources: PartitionSpecPytree,
-  mesh: tp.Optional[jax.sharding.Mesh] = None,
-):
-  # If no axis binding is set, this is a no-op.
-  if axis_resources is None:
-    return x
-  # Translate logical names to mesh assignments.
-  return jax.tree.map(
-    functools.partial(_with_sharding_constraint, mesh=mesh),
-    x,
-    axis_resources,
-    is_leaf=_is_spec,
-  )
-
-
-def with_partitioning(
-  initializer: F,
-  sharding: Sharding,
-  mesh: tp.Optional[jax.sharding.Mesh] = None,
-  **metadata: tp.Any,
-) -> F:
-  return variablelib.with_metadata(
-    initializer,
-    sharding=sharding,
-    mesh=mesh,
-    **metadata,
-  )
+def get_abstract_model(init_fn, mesh):
+  with set_mesh(mesh):
+    abs_model = eval_shape(init_fn)
+    gdef, abs_state = graph.split(abs_model)
+    abs_state = jax.tree.map(
+      lambda a, s: jax.ShapeDtypeStruct(a.shape, a.dtype, sharding=s),
+      abs_state, get_named_sharding(abs_state, mesh)
+    )
+  return gdef, abs_state

--- a/flax/nnx/variablelib.py
+++ b/flax/nnx/variablelib.py
@@ -268,6 +268,9 @@ class Variable(tp.Generic[A], reprlib.Representable):
     if hasattr(var_t, 'on_remove_axis') and 'on_remove_axis' not in metadata:
       metadata['on_remove_axis'] = var_t.on_remove_axis
 
+    if 'sharding' in metadata:
+      metadata['sharding_names'] = metadata.pop('sharding')
+
     object.__setattr__(self, '_var_metadata', metadata)
     # run create_value hooks
     object.__setattr__(self, 'raw_value', self.create_value(self.raw_value))

--- a/tests/jax_utils_test.py
+++ b/tests/jax_utils_test.py
@@ -16,7 +16,7 @@
 
 from functools import partial
 import os
-import re
+os.environ['XLA_FLAGS'] = '--xla_force_host_platform_device_count=4'
 
 from absl.testing import absltest
 from absl.testing import parameterized
@@ -27,22 +27,6 @@ import jax.numpy as jnp
 import numpy as np
 
 NDEV = 4
-
-_xla_device_count_flag_regexp = (
-  r'[-]{0,2}xla_force_host_platform_device_count=(\d+)?(\s|$)'
-)
-
-
-def set_n_cpu_devices(n: int):
-  xla_flags = os.getenv('XLA_FLAGS', '')
-  xla_flags = re.sub(_xla_device_count_flag_regexp, '', xla_flags)
-  os.environ['XLA_FLAGS'] = ' '.join(
-    [f'--xla_force_host_platform_device_count={n}'] + xla_flags.split()
-  )
-
-
-def setUpModule():
-  set_n_cpu_devices(NDEV)
 
 
 class PadShardUnpadTest(chex.TestCase):

--- a/tests/run_all_tests.sh
+++ b/tests/run_all_tests.sh
@@ -111,16 +111,9 @@ export FLAX_PROFILE=1
 
 if $RUN_PYTEST; then
   echo "=== RUNNING PYTESTS ==="
-  # Run some test on separate process, avoiding device configs poluting each other
-  PYTEST_IGNORE=
-  for file in "tests/jax_utils_test.py"; do
-      echo "pytest -n auto $file $PYTEST_OPTS"
-      pytest -n auto $file $PYTEST_OPTS
-      PYTEST_IGNORE+=" --ignore=$file"
-  done
   # Run battery of core FLAX API tests.
-  echo "pytest -n auto tests $PYTEST_OPTS $PYTEST_IGNORE"
-  pytest -n auto tests $PYTEST_OPTS $PYTEST_IGNORE
+  echo "XLA_FLAGS='--xla_force_host_platform_device_count=4' pytest -n auto tests $PYTEST_OPTS"
+  XLA_FLAGS='--xla_force_host_platform_device_count=4' pytest -n auto tests $PYTEST_OPTS
   # Run nnx tests
   pytest -n auto docs/_ext/codediff_test.py $PYTEST_OPTS $PYTEST_IGNORE
   pytest -n auto docs_nnx/_ext/codediff_test.py $PYTEST_OPTS $PYTEST_IGNORE


### PR DESCRIPTION
A splitted version of #4844 that contains all the sharding API benefits but is not breaking:

* Allow Flax to recognize the new style JAX mesh context (which based off `AbstractMesh`).

* Renamed annotation from `sharding` to `sharding_names`, so that `variable.sharding` can just point to the JAX sharding of the actual value.

* Changed CI to run everything on 4 fake CPU devices, so that we no longer to distinguish between single device and multi device tests.

* Removed a few redundant functions like `nnx.with_sharding_constraint`.