### PR TITLE
static + pytree guide

### DIFF
--- a/.github/workflows/flax_test.yml
+++ b/.github/workflows/flax_test.yml
@@ -82,7 +82,7 @@ jobs:
 
   tests:
     name: Run Tests
-    needs: [pre-commit, commit-count, test-import]
+    needs: [pre-commit, commit-count]
     runs-on: ubuntu-24.04-16core
     strategy:
       # Make sure to change `github_check_runs` in `copy.bara.sky` if you change the tests here.

--- a/docs_nnx/api_reference/flax.nnx/helpers.rst
+++ b/docs_nnx/api_reference/flax.nnx/helpers.rst
@@ -7,5 +7,9 @@ helpers
 
 .. autoclass:: Sequential
    :members:
+.. autoclass:: List
+   :members:
+.. autoclass:: Dict
+   :members:
 .. autoclass:: TrainState
    :members:

--- a/docs_nnx/api_reference/flax.nnx/object.rst
+++ b/docs_nnx/api_reference/flax.nnx/object.rst
@@ -4,10 +4,16 @@ object
 .. automodule:: flax.nnx
 .. currentmodule:: flax.nnx
 
+.. autoclass:: Pytree
+   :members:
 .. autoclass:: Object
    :members:
 .. autofunction:: data
 .. autodata:: Data
    :annotation:
-.. autofunction:: is_data_type
+.. autofunction:: static
+.. autodata:: Static
+   :annotation:
+.. autofunction:: is_data
 .. autofunction:: register_data_type
+.. autofunction:: check_pytree

--- a/docs_nnx/api_reference/flax.nnx/rnglib.rst
+++ b/docs_nnx/api_reference/flax.nnx/rnglib.rst
@@ -9,4 +9,5 @@ rnglib
 .. autoclass:: RngStream
    :members:
 .. autofunction:: split_rngs
+.. autofunction:: fork_rngs
 .. autofunction:: reseed

--- a/docs_nnx/guides/array_ref.ipynb
+++ b/docs_nnx/guides/array_ref.ipynb
@@ -152,6 +152,14 @@
   },
   {
    "cell_type": "markdown",
+   "id": "839332be",
+   "metadata": {},
+   "source": [
+    "Mention `nnx.use_refs` can be used as global flag"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "1b2632f1",
    "metadata": {},
    "source": [

--- a/docs_nnx/guides/array_ref.md
+++ b/docs_nnx/guides/array_ref.md
@@ -58,6 +58,10 @@ with nnx.use_refs(True):
 print(f"{variable.has_ref = }")
 ```
 
+Mention `nnx.use_refs` can be used as global flag
+
++++
+
 ### Changing Status
 
 ```{code-cell} ipython3

--- a/docs_nnx/guides/pytree.ipynb
+++ b/docs_nnx/guides/pytree.ipynb
@@ -1,0 +1,656 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "9b2b929d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from flax import nnx\n",
+    "import jax\n",
+    "import jax.numpy as jnp\n",
+    "import dataclasses\n",
+    "\n",
+    "#----------------------\n",
+    "# helper functions\n",
+    "#----------------------\n",
+    "def pytree_structure(pytree, title='pytree structure'):\n",
+    "  print(f\"{title}:\")\n",
+    "  for path, value in jax.tree.leaves_with_path(pytree):\n",
+    "    print(f\"- pytree{jax.tree_util.keystr(path)} = {value!r}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d603fa09",
+   "metadata": {},
+   "source": [
+    "## Pytree"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "95016a94",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "pytree structure:\n",
+      "- pytree.layers[0].b = Array([0.], dtype=float32)\n",
+      "- pytree.layers[0].w = Array([[1.]], dtype=float32)\n",
+      "- pytree.layers[1].b = Array([0.], dtype=float32)\n",
+      "- pytree.layers[1].w = Array([[1.]], dtype=float32)\n"
+     ]
+    }
+   ],
+   "source": [
+    "class Linear(nnx.Pytree):\n",
+    "  def __init__(self, din: int, dout: int):\n",
+    "    self.din, self.dout = din, dout\n",
+    "    self.w = jnp.ones((din, dout))\n",
+    "    self.b = jnp.zeros((dout,))\n",
+    "\n",
+    "class MLP(nnx.Pytree):\n",
+    "  def __init__(self, num_layers, dim):\n",
+    "    self.num_layers = num_layers\n",
+    "    self.layers = nnx.List([Linear(dim, dim) for _ in range(num_layers)])\n",
+    "\n",
+    "pytree = MLP(num_layers=2, dim=1)\n",
+    "pytree_structure(pytree)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "83032d9f",
+   "metadata": {},
+   "source": [
+    "### Attribute Annotations"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "4ff9789a",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "pytree structure:\n",
+      "- pytree.ls[0].i = 0\n",
+      "- pytree.ls[0].x = Array(0, dtype=int32, weak_type=True)\n",
+      "- pytree.ls[1].i = 1\n",
+      "- pytree.ls[1].x = Array(42, dtype=int32, weak_type=True)\n"
+     ]
+    }
+   ],
+   "source": [
+    "class Foo(nnx.Pytree):\n",
+    "  def __init__(self, i: int):\n",
+    "    self.i = nnx.data(i)  # explicit data\n",
+    "    self.f = nnx.static(i * 0.5)  # explicit static\n",
+    "    self.x = jnp.array(42 * i)  # arrays are data\n",
+    "    self.s = \"Hi\" + \"!\" * i  # strings are static\n",
+    "    self.h = hash(i)  # weak types are static\n",
+    "    self.u = None  # empty pytrees are static\n",
+    "\n",
+    "class Bar(nnx.Pytree):\n",
+    "  def __init__(self):\n",
+    "    self.ls = nnx.List([Foo(i) for i in range(2)])  # nnx.Pytrees are data\n",
+    "    self.shapes = (8, 16, 32)  # common pytrees are static\n",
+    "\n",
+    "pytree = Bar()\n",
+    "pytree_structure(pytree)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "27682936",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "# ------ DATA ------------\n",
+      "nnx.is_data( jnp.array(0) ) = True                   # Arrays are data\n",
+      "nnx.is_data( nnx.Param(1) ) = True                   # Variables are data\n",
+      "nnx.is_data( nnx.Rngs(2) ) = True                    # nnx.Pytrees are data\n",
+      "\n",
+      "# ------ STATIC ------------\n",
+      "nnx.is_data( 'hello' ) = False                       # strings, arbitrary objects\n",
+      "nnx.is_data( 42 ) = False                            # int, float, bool, complex, etc.\n",
+      "nnx.is_data( [1, 2.0, 3j, jnp.array(1)] ) = False    # list, dict, tuple, pytrees\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(f\"\"\"\n",
+    "# ------ DATA ------------\n",
+    "{nnx.is_data( jnp.array(0) ) = }                   # Arrays are data\n",
+    "{nnx.is_data( nnx.Param(1) ) = }                   # Variables are data\n",
+    "{nnx.is_data( nnx.Rngs(2) ) = }                    # nnx.Pytrees are data\n",
+    "\n",
+    "# ------ STATIC ------------\n",
+    "{nnx.is_data( 'hello' ) = }                       # strings, arbitrary objects\n",
+    "{nnx.is_data( 42 ) = }                            # int, float, bool, complex, etc.\n",
+    "{nnx.is_data( [1, 2.0, 3j, jnp.array(1)] ) = }    # list, dict, tuple, pytrees\n",
+    "\"\"\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ce86873a",
+   "metadata": {},
+   "source": [
+    "* remove mixed\n",
+    "* error on nnx.data/nnx.static in pytrees"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8055b72c",
+   "metadata": {},
+   "source": [
+    "### Class Annotations"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9ca77d65",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "pytree structure:\n",
+      "- pytree.ls[0].i = 0\n",
+      "- pytree.ls[0].x = Array(0, dtype=int32, weak_type=True)\n",
+      "- pytree.ls[1].i = 1\n",
+      "- pytree.ls[1].x = Array(42, dtype=int32, weak_type=True)\n"
+     ]
+    }
+   ],
+   "source": [
+    "@dataclasses.dataclass\n",
+    "class Foo(nnx.Pytree):\n",
+    "  i: nnx.Data[int]\n",
+    "  s: nnx.Static[str]\n",
+    "  x: jax.Array\n",
+    "  a: int\n",
+    "\n",
+    "@dataclasses.dataclass\n",
+    "class Bar(nnx.Pytree):\n",
+    "  ls: nnx.Data[list[Foo]]\n",
+    "  shapes: list[int]\n",
+    "\n",
+    "pytree = Bar(\n",
+    "  ls=[Foo(i, \"Hi\" + \"!\" * i, jnp.array(42 * i), hash(i)) for i in range(2)],\n",
+    "  shapes=[8, 16, 32]\n",
+    ")\n",
+    "pytree_structure(pytree)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5ab06e79",
+   "metadata": {},
+   "source": [
+    "#### When to use explicit annotations?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9e064461",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "pytree structure:\n",
+      "- pytree.bias.value = Array(0., dtype=float32, weak_type=True)\n",
+      "- pytree.ls[0] = Array(0, dtype=int32, weak_type=True)\n",
+      "- pytree.ls[1] = Array(1, dtype=int32, weak_type=True)\n",
+      "- pytree.ls[2] = Array(2, dtype=int32, weak_type=True)\n",
+      "- pytree.x = 1.0\n",
+      "- pytree.y = 42\n"
+     ]
+    }
+   ],
+   "source": [
+    "class Bar(nnx.Pytree):\n",
+    "  def __init__(self, x, use_bias: bool):\n",
+    "    self.x = nnx.data(x)  # constrain inputs (e.g. user could pass Array or ShapeDtypeStruct)\n",
+    "    self.y = nnx.data(42)  # force undefined types\n",
+    "    self.ls = nnx.data([jnp.array(i) for i in range(3)]) # on pytrees\n",
+    "    if use_bias:\n",
+    "      self.bias = nnx.Param(jnp.array(0.0))\n",
+    "    else:\n",
+    "      self.bias = nnx.data(None)  # on branches that cause mismatch\n",
+    "\n",
+    "pytree = Bar(1.0, True)\n",
+    "pytree_structure(pytree)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d6036a0e",
+   "metadata": {},
+   "source": [
+    "### Attribute Updates"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "509a517e",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "original:\n",
+      "- pytree.a = Array(1., dtype=float32, weak_type=True)\n",
+      "- pytree.c = 3.14\n",
+      "updated:\n",
+      "- pytree.a = '🤔'\n",
+      "- pytree.b = 42\n"
+     ]
+    }
+   ],
+   "source": [
+    "class Foo(nnx.Pytree):\n",
+    "  def __init__(self):\n",
+    "    self.a = jnp.array(1.0)  # data\n",
+    "    self.b = \"Hello, world!\"               # static\n",
+    "    self.c = nnx.data(3.14)         # data\n",
+    "\n",
+    "pytree = Foo()\n",
+    "pytree_structure(pytree, \"original\")\n",
+    "\n",
+    "pytree.a = \"🤔\"  # static values don't change status on data attributes\n",
+    "pytree.b = nnx.data(42)     # annotation to override status\n",
+    "pytree.c = nnx.static(0.5)  # annotation to override status\n",
+    "pytree_structure(pytree, \"updated\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "17fd41f5",
+   "metadata": {},
+   "source": [
+    "### Attribute checks"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "98e04ff9",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "ValueError: Found Arrays in value annotated with nnx.static(...) when setting attribute 'name'.\n"
+     ]
+    }
+   ],
+   "source": [
+    "class Foo(nnx.Pytree):\n",
+    "  def __init__(self, name):\n",
+    "    self.name = nnx.static(name)\n",
+    "\n",
+    "try:\n",
+    "  foo = Foo(name=jnp.array(123))\n",
+    "except ValueError as e:\n",
+    "  print(\"ValueError:\", e)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c864d5b1",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "ValueError: Cannot assign 'data' value to 'static' attribute 'name'. To override the status explicitly annotate the value on assignment:\n",
+      "\n",
+      "  _.name = nnx.data(...)\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "try:\n",
+    "  foo = Foo(name=\"mattjj\")\n",
+    "  foo.name = jnp.array(123)\n",
+    "except ValueError as e:\n",
+    "  print(\"ValueError:\", e)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c3b17f07",
+   "metadata": {},
+   "source": [
+    "* `nnx.check_pytree`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "628698dd",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "ValueError: Found unexpected Arrays on static attribute 'ls' after __init__, this is an error starting from Flax version 0.11.2.\n",
+      "Consider one of the following options:\n",
+      "\n",
+      "1. If the attribute is meant to be static, either remove the Array value or wrap it in a static container.\n",
+      "2. Annotate the value with nnx.data on assignment:\n",
+      "\n",
+      "  _.ls = nnx.data(...)\n",
+      "\n",
+      "3. Annotate the class attribute with nnx.Data:\n",
+      "\n",
+      "  class Foo(Pytree):\n",
+      "    ls: nnx.Data[list]\n",
+      "\n",
+      "4. If the container is a list or dict, try using nnx.List(...) or nnx.Dict(...) instead.\n",
+      "5. Disable pytree for this class:\n",
+      "\n",
+      "  class Foo(Pytree, pytree=False):\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "class Foo(nnx.Pytree):\n",
+    "  def __init__(self):\n",
+    "    self.ls = []  # should be nnx.data([]), treated as static\n",
+    "    for i in range(5):\n",
+    "      self.ls.append(jnp.array(i))  # error: inserting arrays into static attribute\n",
+    "\n",
+    "try:\n",
+    "  foo = Foo()  # nnx.check_pytree ran after __init__\n",
+    "except ValueError as e:\n",
+    "  print(\"ValueError:\", e)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f9d69634",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "ValueError: Found unexpected tags {'data'} on attribute 'a'. Values from nnx.data(...) and\n",
+      "nnx.static(...) should be assigned to nnx.Pytree attributes directly, they should not\n",
+      "be stored inside lists, dicts, tuples, or any pytree type.\n"
+     ]
+    }
+   ],
+   "source": [
+    "class Foo(nnx.Pytree):\n",
+    "  def __init__(self):\n",
+    "    self.a = [nnx.data(1), nnx.data(2)]  # annotations in sub-pytree\n",
+    "\n",
+    "try:\n",
+    "  foo = Foo()\n",
+    "except ValueError as e:\n",
+    "  print(\"ValueError:\", e)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "452915ac",
+   "metadata": {},
+   "source": [
+    "### Trace-level awareness"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "668db479",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Error: Cannot mutate 'Foo' from different trace level (https://flax.readthedocs.io/en/latest/api_reference/flax.errors.html#flax.errors.TraceContextError)\n"
+     ]
+    }
+   ],
+   "source": [
+    "class Foo(nnx.Pytree):\n",
+    "  def __init__(self):\n",
+    "    self.count = nnx.data(0)\n",
+    "\n",
+    "foo = Foo()\n",
+    "\n",
+    "@jax.vmap  # or jit, grad, shard_map, pmap, scan, etc.\n",
+    "def increment(n):\n",
+    "  foo.count += 1\n",
+    "\n",
+    "try:\n",
+    "  increment(jnp.arange(5))\n",
+    "except Exception as e:\n",
+    "  print(f\"Error: {e}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bfaf17de",
+   "metadata": {},
+   "source": [
+    "## Module"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bfba41f9",
+   "metadata": {},
+   "source": [
+    "### set_attributes"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f26e0e69",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "train:\n",
+      "- model.mode = 1\n",
+      "- model.bn.use_running_average = False\n",
+      "- model.dropout.deterministic = False\n",
+      "eval:\n",
+      "- model.mode = 2\n",
+      "- model.bn.use_running_average = True\n",
+      "- model.dropout.deterministic = True\n"
+     ]
+    }
+   ],
+   "source": [
+    "class Block(nnx.Module):\n",
+    "  def __init__(self, din: int, dout: int, rngs: nnx.Rngs):\n",
+    "    self.mode = 1\n",
+    "    self.linear = nnx.Linear(din, dout, rngs=rngs)\n",
+    "    self.bn = nnx.BatchNorm(dout, rngs=rngs)\n",
+    "    self.dropout = nnx.Dropout(0.1, rngs=rngs)\n",
+    "\n",
+    "  def __call__(self, x):\n",
+    "    return nnx.relu(self.dropout(self.bn(self.linear(x))))\n",
+    "  \n",
+    "model = Block(din=1, dout=2, rngs=nnx.Rngs(0))\n",
+    "\n",
+    "print(\"train:\")\n",
+    "print(f\"- {model.mode = }\")\n",
+    "print(f\"- {model.bn.use_running_average = }\")\n",
+    "print(f\"- {model.dropout.deterministic = }\")\n",
+    "\n",
+    "# Set attributes for evaluation\n",
+    "model.set_attributes(deterministic=True, use_running_average=True, mode=2)\n",
+    "\n",
+    "print(\"eval:\")\n",
+    "print(f\"- {model.mode = }\")\n",
+    "print(f\"- {model.bn.use_running_average = }\")\n",
+    "print(f\"- {model.dropout.deterministic = }\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a1a7dfff",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "eval:\n",
+      "- model.mode = 2\n",
+      "- model.bn.use_running_average = True\n",
+      "- model.dropout.deterministic = True\n",
+      "train:\n",
+      "- model.mode = 1\n",
+      "- model.bn.use_running_average = False\n",
+      "- model.dropout.deterministic = False\n"
+     ]
+    }
+   ],
+   "source": [
+    "model = Block(din=1, dout=2, rngs=nnx.Rngs(0))\n",
+    "\n",
+    "model.eval(mode=2)  # .set_attributes(deterministic=True, use_running_average=True, mode=2)\n",
+    "print(\"eval:\")\n",
+    "print(f\"- {model.mode = }\")\n",
+    "print(f\"- {model.bn.use_running_average = }\")\n",
+    "print(f\"- {model.dropout.deterministic = }\")\n",
+    "\n",
+    "model.train(mode=1)  # .set_attributes(deterministic=False, use_running_average=False, mode=1)\n",
+    "print(\"train:\")\n",
+    "print(f\"- {model.mode = }\")\n",
+    "print(f\"- {model.bn.use_running_average = }\")\n",
+    "print(f\"- {model.dropout.deterministic = }\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cc5afc70",
+   "metadata": {},
+   "source": [
+    "### sow"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ca9f58a2",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[38;2;79;201;177mState\u001b[0m\u001b[38;2;255;213;3m({\u001b[0m\u001b[38;2;105;105;105m\u001b[0m\n",
+      "  \u001b[38;2;156;220;254m'blocks'\u001b[0m\u001b[38;2;212;212;212m: \u001b[0m\u001b[38;2;255;213;3m{\u001b[0m\u001b[38;2;105;105;105m\u001b[0m\n",
+      "    \u001b[38;2;156;220;254m0\u001b[0m\u001b[38;2;212;212;212m: \u001b[0m\u001b[38;2;255;213;3m{\u001b[0m\u001b[38;2;105;105;105m\u001b[0m\n",
+      "      \u001b[38;2;156;220;254m'y_mean'\u001b[0m\u001b[38;2;212;212;212m: \u001b[0m\u001b[38;2;79;201;177mIntermediate\u001b[0m\u001b[38;2;255;213;3m(\u001b[0m\u001b[38;2;105;105;105m # 1 (4 B)\u001b[0m\n",
+      "        \u001b[38;2;156;220;254mvalue\u001b[0m\u001b[38;2;212;212;212m=\u001b[0m\u001b[38;2;255;213;3m(\u001b[0mArray(4.659754e-06, dtype=float32),\u001b[38;2;255;213;3m)\u001b[0m\n",
+      "      \u001b[38;2;255;213;3m)\u001b[0m\n",
+      "    \u001b[38;2;255;213;3m}\u001b[0m,\n",
+      "    \u001b[38;2;156;220;254m1\u001b[0m\u001b[38;2;212;212;212m: \u001b[0m\u001b[38;2;255;213;3m{\u001b[0m\u001b[38;2;105;105;105m\u001b[0m\n",
+      "      \u001b[38;2;156;220;254m'y_mean'\u001b[0m\u001b[38;2;212;212;212m: \u001b[0m\u001b[38;2;79;201;177mIntermediate\u001b[0m\u001b[38;2;255;213;3m(\u001b[0m\u001b[38;2;105;105;105m # 1 (4 B)\u001b[0m\n",
+      "        \u001b[38;2;156;220;254mvalue\u001b[0m\u001b[38;2;212;212;212m=\u001b[0m\u001b[38;2;255;213;3m(\u001b[0mArray(0.00025933, dtype=float32),\u001b[38;2;255;213;3m)\u001b[0m\n",
+      "      \u001b[38;2;255;213;3m)\u001b[0m\n",
+      "    \u001b[38;2;255;213;3m}\u001b[0m,\n",
+      "    \u001b[38;2;156;220;254m2\u001b[0m\u001b[38;2;212;212;212m: \u001b[0m\u001b[38;2;255;213;3m{\u001b[0m\u001b[38;2;105;105;105m\u001b[0m\n",
+      "      \u001b[38;2;156;220;254m'y_mean'\u001b[0m\u001b[38;2;212;212;212m: \u001b[0m\u001b[38;2;79;201;177mIntermediate\u001b[0m\u001b[38;2;255;213;3m(\u001b[0m\u001b[38;2;105;105;105m # 1 (4 B)\u001b[0m\n",
+      "        \u001b[38;2;156;220;254mvalue\u001b[0m\u001b[38;2;212;212;212m=\u001b[0m\u001b[38;2;255;213;3m(\u001b[0mArray(0.05561922, dtype=float32),\u001b[38;2;255;213;3m)\u001b[0m\n",
+      "      \u001b[38;2;255;213;3m)\u001b[0m\n",
+      "    \u001b[38;2;255;213;3m}\u001b[0m\n",
+      "  \u001b[38;2;255;213;3m}\u001b[0m\n",
+      "\u001b[38;2;255;213;3m})\u001b[0m\n"
+     ]
+    }
+   ],
+   "source": [
+    "class Block(nnx.Module):\n",
+    "  def __init__(self, din: int, dout: int, rngs: nnx.Rngs):\n",
+    "    self.linear = nnx.Linear(din, dout, rngs=rngs)\n",
+    "    self.bn = nnx.BatchNorm(dout, rngs=rngs)\n",
+    "    self.dropout = nnx.Dropout(0.1, rngs=rngs)\n",
+    "\n",
+    "  def __call__(self, x):\n",
+    "    y = nnx.relu(self.dropout(self.bn(self.linear(x))))\n",
+    "    self.sow(nnx.Intermediate, \"y_mean\", jnp.mean(y))\n",
+    "    return y\n",
+    "\n",
+    "class MLP(nnx.Module):\n",
+    "  def __init__(self, num_layers, dim, rngs: nnx.Rngs):\n",
+    "    self.blocks = nnx.data([Block(dim, dim, rngs) for _ in range(num_layers)])\n",
+    "\n",
+    "  def __call__(self, x):\n",
+    "    for block in self.blocks:\n",
+    "      x = block(x)\n",
+    "    return x\n",
+    "\n",
+    "\n",
+    "model = MLP(num_layers=3, dim=20, rngs=nnx.Rngs(0))\n",
+    "x = jnp.ones((10, 20))\n",
+    "y = model(x)\n",
+    "intermediates = nnx.pop(model, nnx.Intermediate) # extract intermediate values\n",
+    "print(intermediates)"
+   ]
+  }
+ ],
+ "metadata": {
+  "jupytext": {
+   "formats": "ipynb,md:myst"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs_nnx/guides/pytree.md
+++ b/docs_nnx/guides/pytree.md
@@ -1,0 +1,285 @@
+---
+jupytext:
+  formats: ipynb,md:myst
+  text_representation:
+    extension: .md
+    format_name: myst
+    format_version: 0.13
+    jupytext_version: 1.13.8
+---
+
+```{code-cell} ipython3
+from flax import nnx
+import jax
+import jax.numpy as jnp
+import dataclasses
+
+#----------------------
+# helper functions
+#----------------------
+def pytree_structure(pytree, title='pytree structure'):
+  print(f"{title}:")
+  for path, value in jax.tree.leaves_with_path(pytree):
+    print(f"- pytree{jax.tree_util.keystr(path)} = {value!r}")
+```
+
+## Pytree
+
+```{code-cell} ipython3
+class Linear(nnx.Pytree):
+  def __init__(self, din: int, dout: int):
+    self.din, self.dout = din, dout
+    self.w = jnp.ones((din, dout))
+    self.b = jnp.zeros((dout,))
+
+class MLP(nnx.Pytree):
+  def __init__(self, num_layers, dim):
+    self.num_layers = num_layers
+    self.layers = nnx.List([Linear(dim, dim) for _ in range(num_layers)])
+
+pytree = MLP(num_layers=2, dim=1)
+pytree_structure(pytree)
+```
+
+### Attribute Annotations
+
+```{code-cell} ipython3
+class Foo(nnx.Pytree):
+  def __init__(self, i: int):
+    self.i = nnx.data(i)  # explicit data
+    self.f = nnx.static(i * 0.5)  # explicit static
+    self.x = jnp.array(42 * i)  # arrays are data
+    self.s = "Hi" + "!" * i  # strings are static
+    self.h = hash(i)  # weak types are static
+    self.u = None  # empty pytrees are static
+
+class Bar(nnx.Pytree):
+  def __init__(self):
+    self.ls = nnx.List([Foo(i) for i in range(2)])  # nnx.Pytrees are data
+    self.shapes = (8, 16, 32)  # common pytrees are static
+
+pytree = Bar()
+pytree_structure(pytree)
+```
+
+```{code-cell} ipython3
+print(f"""
+# ------ DATA ------------
+{nnx.is_data( jnp.array(0) ) = }                   # Arrays are data
+{nnx.is_data( nnx.Param(1) ) = }                   # Variables are data
+{nnx.is_data( nnx.Rngs(2) ) = }                    # nnx.Pytrees are data
+
+# ------ STATIC ------------
+{nnx.is_data( 'hello' ) = }                       # strings, arbitrary objects
+{nnx.is_data( 42 ) = }                            # int, float, bool, complex, etc.
+{nnx.is_data( [1, 2.0, 3j, jnp.array(1)] ) = }    # list, dict, tuple, pytrees
+""")
+```
+
+* remove mixed
+* error on nnx.data/nnx.static in pytrees
+
++++
+
+### Class Annotations
+
+```{code-cell} ipython3
+@dataclasses.dataclass
+class Foo(nnx.Pytree):
+  i: nnx.Data[int]
+  s: nnx.Static[str]
+  x: jax.Array
+  a: int
+
+@dataclasses.dataclass
+class Bar(nnx.Pytree):
+  ls: nnx.Data[list[Foo]]
+  shapes: list[int]
+
+pytree = Bar(
+  ls=[Foo(i, "Hi" + "!" * i, jnp.array(42 * i), hash(i)) for i in range(2)],
+  shapes=[8, 16, 32]
+)
+pytree_structure(pytree)
+```
+
+#### When to use explicit annotations?
+
+```{code-cell} ipython3
+class Bar(nnx.Pytree):
+  def __init__(self, x, use_bias: bool):
+    self.x = nnx.data(x)  # constrain inputs (e.g. user could pass Array or ShapeDtypeStruct)
+    self.y = nnx.data(42)  # force undefined types
+    self.ls = nnx.data([jnp.array(i) for i in range(3)]) # on pytrees
+    if use_bias:
+      self.bias = nnx.Param(jnp.array(0.0))
+    else:
+      self.bias = nnx.data(None)  # on branches that cause mismatch
+
+pytree = Bar(1.0, True)
+pytree_structure(pytree)
+```
+
+### Attribute Updates
+
+```{code-cell} ipython3
+class Foo(nnx.Pytree):
+  def __init__(self):
+    self.a = jnp.array(1.0)  # data
+    self.b = "Hello, world!"               # static
+    self.c = nnx.data(3.14)         # data
+
+pytree = Foo()
+pytree_structure(pytree, "original")
+
+pytree.a = "🤔"  # static values don't change status on data attributes
+pytree.b = nnx.data(42)     # annotation to override status
+pytree.c = nnx.static(0.5)  # annotation to override status
+pytree_structure(pytree, "updated")
+```
+
+### Attribute checks
+
+```{code-cell} ipython3
+class Foo(nnx.Pytree):
+  def __init__(self, name):
+    self.name = nnx.static(name)
+
+try:
+  foo = Foo(name=jnp.array(123))
+except ValueError as e:
+  print("ValueError:", e)
+```
+
+```{code-cell} ipython3
+try:
+  foo = Foo(name="mattjj")
+  foo.name = jnp.array(123)
+except ValueError as e:
+  print("ValueError:", e)
+```
+
+* `nnx.check_pytree`
+
+```{code-cell} ipython3
+class Foo(nnx.Pytree):
+  def __init__(self):
+    self.ls = []  # should be nnx.data([]), treated as static
+    for i in range(5):
+      self.ls.append(jnp.array(i))  # error: inserting arrays into static attribute
+
+try:
+  foo = Foo()  # nnx.check_pytree ran after __init__
+except ValueError as e:
+  print("ValueError:", e)
+```
+
+```{code-cell} ipython3
+class Foo(nnx.Pytree):
+  def __init__(self):
+    self.a = [nnx.data(1), nnx.data(2)]  # annotations in sub-pytree
+
+try:
+  foo = Foo()
+except ValueError as e:
+  print("ValueError:", e)
+```
+
+### Trace-level awareness
+
+```{code-cell} ipython3
+class Foo(nnx.Pytree):
+  def __init__(self):
+    self.count = nnx.data(0)
+
+foo = Foo()
+
+@jax.vmap  # or jit, grad, shard_map, pmap, scan, etc.
+def increment(n):
+  foo.count += 1
+
+try:
+  increment(jnp.arange(5))
+except Exception as e:
+  print(f"Error: {e}")
+```
+
+## Module
+
++++
+
+### set_attributes
+
+```{code-cell} ipython3
+class Block(nnx.Module):
+  def __init__(self, din: int, dout: int, rngs: nnx.Rngs):
+    self.mode = 1
+    self.linear = nnx.Linear(din, dout, rngs=rngs)
+    self.bn = nnx.BatchNorm(dout, rngs=rngs)
+    self.dropout = nnx.Dropout(0.1, rngs=rngs)
+
+  def __call__(self, x):
+    return nnx.relu(self.dropout(self.bn(self.linear(x))))
+  
+model = Block(din=1, dout=2, rngs=nnx.Rngs(0))
+
+print("train:")
+print(f"- {model.mode = }")
+print(f"- {model.bn.use_running_average = }")
+print(f"- {model.dropout.deterministic = }")
+
+# Set attributes for evaluation
+model.set_attributes(deterministic=True, use_running_average=True, mode=2)
+
+print("eval:")
+print(f"- {model.mode = }")
+print(f"- {model.bn.use_running_average = }")
+print(f"- {model.dropout.deterministic = }")
+```
+
+```{code-cell} ipython3
+model = Block(din=1, dout=2, rngs=nnx.Rngs(0))
+
+model.eval(mode=2)  # .set_attributes(deterministic=True, use_running_average=True, mode=2)
+print("eval:")
+print(f"- {model.mode = }")
+print(f"- {model.bn.use_running_average = }")
+print(f"- {model.dropout.deterministic = }")
+
+model.train(mode=1)  # .set_attributes(deterministic=False, use_running_average=False, mode=1)
+print("train:")
+print(f"- {model.mode = }")
+print(f"- {model.bn.use_running_average = }")
+print(f"- {model.dropout.deterministic = }")
+```
+
+### sow
+
+```{code-cell} ipython3
+class Block(nnx.Module):
+  def __init__(self, din: int, dout: int, rngs: nnx.Rngs):
+    self.linear = nnx.Linear(din, dout, rngs=rngs)
+    self.bn = nnx.BatchNorm(dout, rngs=rngs)
+    self.dropout = nnx.Dropout(0.1, rngs=rngs)
+
+  def __call__(self, x):
+    y = nnx.relu(self.dropout(self.bn(self.linear(x))))
+    self.sow(nnx.Intermediate, "y_mean", jnp.mean(y))
+    return y
+
+class MLP(nnx.Module):
+  def __init__(self, num_layers, dim, rngs: nnx.Rngs):
+    self.blocks = nnx.data([Block(dim, dim, rngs) for _ in range(num_layers)])
+
+  def __call__(self, x):
+    for block in self.blocks:
+      x = block(x)
+    return x
+
+
+model = MLP(num_layers=3, dim=20, rngs=nnx.Rngs(0))
+x = jnp.ones((10, 20))
+y = model(x)
+intermediates = nnx.pop(model, nnx.Intermediate) # extract intermediate values
+print(intermediates)
+```

--- a/docs_nnx/key_concepts.ipynb
+++ b/docs_nnx/key_concepts.ipynb
@@ -315,7 +315,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "id": "f9b1b308",
    "metadata": {},
    "outputs": [
@@ -347,7 +347,7 @@
    "source": [
     "class MLP(nnx.Module):\n",
     "  def __init__(self, dim, nlayers, rngs):\n",
-    "    self.blocks = [nnx.Linear(dim, dim, rngs=rngs) for _ in range(nlayers)]\n",
+    "    self.blocks = nnx.List([nnx.Linear(dim, dim, rngs=rngs) for _ in range(nlayers)])\n",
     "    self.activation = jax.nn.relu\n",
     "    self.nlayers = nlayers\n",
     "  def __call__(self, x):\n",

--- a/examples/gemma/transformer.py
+++ b/examples/gemma/transformer.py
@@ -529,7 +529,7 @@ class Transformer(nnx.Module):
         dtype=config.dtype,
         rngs=rngs,
     )
-    self.layers = [
+    self.layers = nnx.List([
         modules.Block(
           config=config,
           attn_type=attn_type,
@@ -539,7 +539,7 @@ class Transformer(nnx.Module):
         for _, attn_type in zip(
             range(config.num_layers), config.attention_types
         )
-    ]
+    ])
     self.final_norm = layers.RMSNorm(
       config.embed_dim,
       scale_init=modules.maybe_with_partitioning(

--- a/examples/nnx_toy_examples/05_vae.py
+++ b/examples/nnx_toy_examples/05_vae.py
@@ -138,7 +138,7 @@ def train_step(model: VAE, optimizer: nnx.Optimizer, x: jax.Array):
     return loss
 
   loss, grads = nnx.value_and_grad(loss_fn)(model)
-  optimizer.update(grads)
+  optimizer.update(model, grads)
 
   return loss
 

--- a/examples/nnx_toy_examples/10_fsdp_and_optimizer.py
+++ b/examples/nnx_toy_examples/10_fsdp_and_optimizer.py
@@ -83,12 +83,12 @@ class SGD(nnx.Pytree):
       )
 
     self.lr = lr
-    self.params = params
-    self.momentum: nnx.State = jax.tree.map(
+    self.params = nnx.data(params)
+    self.momentum: nnx.State = nnx.data(jax.tree.map(
       init_optimizer_state,
       self.params,
       is_leaf=lambda x: isinstance(x, nnx.Variable),
-    )
+    ))
     self.decay = decay
 
   def update(self, grads: nnx.State):
@@ -120,10 +120,10 @@ def create_model():
 
   def get_named_shardings(path: tuple, value: nnx.Variable):
     if path[0] == 'params':
-      return NamedSharding(mesh, P(*value.sharding))
+      return NamedSharding(mesh, P(*value.sharding_names))
     elif path[0] == 'momentum':
       # currently the same as above but in general it could be different
-      return NamedSharding(mesh, P(*value.sharding))
+      return NamedSharding(mesh, P(*value.sharding_names))
     else:
       raise ValueError(f'Unknown path: {path}')
 

--- a/examples/nnx_toy_examples/mutable_array_demo.py
+++ b/examples/nnx_toy_examples/mutable_array_demo.py
@@ -140,7 +140,7 @@ class Model(nnx.Module):
 
       self.blocks = nnx.to_refs(create_block(rngs.fork(split=num_blocks)))
     else:
-      self.blocks = [Block(dhidden, dhidden, rngs=rngs) for i in range(num_blocks)]
+      self.blocks = nnx.List([Block(dhidden, dhidden, rngs=rngs) for i in range(num_blocks)])
 
   def __call__(self, x: jax.Array, *, rngs: nnx.Rngs | None = None):
     self.count[...] += 1
@@ -150,7 +150,7 @@ class Model(nnx.Module):
     # list or use jax.lax.scan to apply the blocks, if we
     # had shared state we would use split and merge to
     # pass the shared state as a capture
-    if isinstance(self.blocks, list):
+    if isinstance(self.blocks, nnx.List):
       for block in self.blocks:
         x = block(x, rngs=rngs)
     else:
@@ -184,11 +184,11 @@ class SGD(nnx.Pytree):
       else:
         return OptState(jnp.zeros_like(x))
 
-    self.momentum = jax.tree.map(
+    self.momentum = nnx.data(jax.tree.map(
         make_opt_state,
         params,
         is_leaf=lambda x: isinstance(x, nnx.Variable),
-      )
+      ))
 
   # during the update we simply map over (params, momentum, grads),
   # for each triplet we implement the SGD update rule which updates

--- a/flax/nnx/__init__.py
+++ b/flax/nnx/__init__.py
@@ -35,9 +35,14 @@ from . import pytreelib as object
 from .pytreelib import Pytree as Pytree
 from .pytreelib import Object as Object
 from .pytreelib import Data as Data
+from .pytreelib import Static as Static
 from .pytreelib import data as data
+from .pytreelib import static as static
 from .pytreelib import register_data_type as register_data_type
-from .pytreelib import is_data_type as is_data_type
+from .pytreelib import is_data as is_data
+from .pytreelib import check_pytree as check_pytree
+from .helpers import Dict as Dict
+from .helpers import List as List
 from .helpers import Sequential as Sequential
 from .helpers import TrainState as TrainState
 from .module import M as M

--- a/flax/nnx/graph.py
+++ b/flax/nnx/graph.py
@@ -73,7 +73,7 @@ REPEATED = Repeated()
 @jax.tree_util.register_dataclass
 @dataclasses.dataclass(frozen=True, slots=True, repr=False)
 class ArrayRefOutput(reprlib.Representable):
-  value: jax.Array | NoUpdate | Repeated
+  value: jax.Array
 
   def __nnx_repr__(self):
     yield reprlib.Object(type=type(self))
@@ -325,6 +325,12 @@ class HashableMapping(tp.Mapping[HA, HB], tp.Hashable):
 
   def __repr__(self) -> str:
     return repr(self._mapping)
+
+  def update(self, other: tp.Mapping[HA, HB]) -> HashableMapping[HA, HB]:
+    """Updates the mapping with another mapping."""
+    mapping = dict(self._mapping)
+    mapping.update(other)
+    return HashableMapping(mapping, copy=False)
 
 
 @jax.tree_util.register_static
@@ -2887,7 +2893,7 @@ def iter_graph(node: tp.Any, /) -> tp.Iterator[tuple[PathParts, tp.Any]]:
     >>> for path, value in nnx.iter_graph(graph):
     ...   print(path, type(value).__name__)
     ...
-    (0, '_pytree__nodes') frozenset
+    (0, '_pytree__nodes') HashableMapping
     (0, '_pytree__state') PytreeState
     (0, 'b') Param
     (0, 'din') int

--- a/flax/nnx/nn/attention.py
+++ b/flax/nnx/nn/attention.py
@@ -414,8 +414,8 @@ class MultiHeadAttention(Module):
         rngs=rngs,
       )
     else:
-      self.query_ln = None
-      self.key_ln = None
+      self.query_ln = nnx.data(None)
+      self.key_ln = nnx.data(None)
 
     self.out = LinearGeneral(
       in_features=(self.num_heads, self.head_dim),
@@ -433,9 +433,9 @@ class MultiHeadAttention(Module):
     )
     self.rngs = rngs.dropout.fork() if keep_rngs and dropout_rate > 0 else None
 
-    self.cached_key: nnx.Cache[Array] | None = None
-    self.cached_value: nnx.Cache[Array] | None = None
-    self.cache_index: nnx.Cache[Array] | None = None
+    self.cached_key: nnx.Cache[Array] | None = nnx.data(None)
+    self.cached_value: nnx.Cache[Array] | None = nnx.data(None)
+    self.cache_index: nnx.Cache[Array] | None = nnx.data(None)
 
   def __call__(
     self,

--- a/flax/nnx/nn/linear.py
+++ b/flax/nnx/nn/linear.py
@@ -235,7 +235,7 @@ class LinearGeneral(Module):
         bias_init_wrap(rngs.params(), bias_shape, self.param_dtype)
       )
     else:
-      self.bias = None
+      self.bias = nnx.data(None)
 
   def __call__(self, inputs: Array) -> Array:
     """Applies a linear transformation to the inputs along multiple dimensions.
@@ -350,7 +350,7 @@ class Linear(Module):
       bias_key = rngs.params()
       self.bias = nnx.Param(bias_init(bias_key, (out_features,), param_dtype))
     else:
-      self.bias = None
+      self.bias = nnx.data(None)
 
     self.in_features = in_features
     self.out_features = out_features
@@ -456,7 +456,7 @@ class Einsum(Module):
       bias_key = rngs.params()
       self.bias = nnx.Param(bias_init(bias_key, bias_shape, param_dtype))
     else:
-      self.bias = None
+      self.bias = nnx.data(None)
 
     self.einsum_str = einsum_str
     self.kernel_shape = kernel_shape
@@ -680,7 +680,7 @@ class Conv(Module):
       bias_key = rngs.params()
       self.bias = nnx.Param(bias_init(bias_key, bias_shape, param_dtype))
     else:
-      self.bias = None
+      self.bias = nnx.data(None)
 
     self.in_features = in_features
     self.out_features = out_features
@@ -951,7 +951,7 @@ class ConvTranspose(Module):
         self.bias_init(rngs.params(), (self.out_features,), self.param_dtype)
       )
     else:
-      self.bias = None
+      self.bias = nnx.data(None)
 
   def __call__(self, inputs: Array) -> Array:
     """Applies a transposed convolution to the inputs.

--- a/flax/nnx/nn/normalization.py
+++ b/flax/nnx/nn/normalization.py
@@ -288,14 +288,14 @@ class BatchNorm(Module):
       key = rngs.params()
       self.scale = nnx.Param(scale_init(key, feature_shape, param_dtype))
     else:
-      self.scale = None
+      self.scale = nnx.data(None)
 
     self.bias: nnx.Param[jax.Array] | None
     if use_bias:
       key = rngs.params()
       self.bias = nnx.Param(bias_init(key, feature_shape, param_dtype))
     else:
-      self.bias = None
+      self.bias = nnx.data(None)
 
     self.num_features = num_features
     self.use_running_average = use_running_average
@@ -460,14 +460,14 @@ class LayerNorm(Module):
       key = rngs.params()
       self.scale = nnx.Param(scale_init(key, feature_shape, param_dtype))
     else:
-      self.scale = None
+      self.scale = nnx.data(None)
 
     self.bias: nnx.Param[jax.Array] | None
     if use_bias:
       key = rngs.params()
       self.bias = nnx.Param(bias_init(key, feature_shape, param_dtype))
     else:
-      self.bias = None
+      self.bias = nnx.data(None)
 
     self.num_features = num_features
     self.epsilon = epsilon
@@ -589,7 +589,7 @@ class RMSNorm(Module):
       key = rngs.params()
       self.scale = nnx.Param(scale_init(key, feature_shape, param_dtype))
     else:
-      self.scale = None
+      self.scale = nnx.data(None)
 
     self.num_features = num_features
     self.epsilon = epsilon
@@ -764,14 +764,14 @@ class GroupNorm(Module):
       key = rngs.params()
       self.scale = nnx.Param(scale_init(key, feature_shape, param_dtype))
     else:
-      self.scale = None
+      self.scale = nnx.data(None)
 
     self.bias: nnx.Param[jax.Array] | None
     if use_bias:
       key = rngs.params()
       self.bias = nnx.Param(bias_init(key, feature_shape, param_dtype))
     else:
-      self.bias = None
+      self.bias = nnx.data(None)
 
     self.epsilon = epsilon
     self.dtype = dtype

--- a/flax/nnx/nn/recurrent.py
+++ b/flax/nnx/nn/recurrent.py
@@ -141,7 +141,7 @@ class LSTMCell(RNNCellBase):
     if keep_rngs:
       self.rngs = rngs.carry.fork()
     else:
-      self.rngs = None
+      self.rngs = nnx.data(None)
 
     # input and recurrent layers are summed so only one needs a bias.
     dense_i = partial(
@@ -296,7 +296,7 @@ class OptimizedLSTMCell(RNNCellBase):
     if keep_rngs:
       self.rngs = rngs.carry.fork()
     else:
-      self.rngs = None
+      self.rngs = nnx.data(None)
 
     # input and recurrent layers are summed so only one needs a bias.
     self.dense_i = Linear(
@@ -436,7 +436,7 @@ class SimpleCell(RNNCellBase):
     if keep_rngs:
       self.rngs = rngs.carry.fork()
     else:
-      self.rngs = None
+      self.rngs = nnx.data(None)
 
     # self.hidden_features = carry.shape[-1]
     # input and recurrent layers are summed so only one needs a bias.
@@ -558,7 +558,7 @@ class GRUCell(RNNCellBase):
     if keep_rngs:
       self.rngs = rngs.carry.fork()
     else:
-      self.rngs = None
+      self.rngs = nnx.data(None)
 
     # Combine input transformations into a single linear layer
     self.dense_i = Linear(
@@ -679,7 +679,7 @@ class RNN(Module):
     elif isinstance(rngs, rnglib.Rngs):
       self.rngs = rngs.carry.fork()
     elif rngs is False:
-      self.rngs = None
+      self.rngs = nnx.data(None)
     else:
       raise ValueError(
         'Expected rngs to be a jax.Array, int, Rngs, or bool. '

--- a/flax/nnx/nn/stochastic.py
+++ b/flax/nnx/nn/stochastic.py
@@ -21,6 +21,7 @@ from jax import lax, random
 
 from flax.nnx import rnglib
 from flax.nnx.module import Module, first_from
+from flax import nnx
 
 
 class Dropout(Module):
@@ -86,7 +87,7 @@ class Dropout(Module):
     elif isinstance(rngs, rnglib.RngStream):
       self.rngs = rngs.fork()
     elif rngs is None:
-      self.rngs = None
+      self.rngs = nnx.data(None)
     else:
       raise TypeError(
         f'rngs must be a Rngs, RngStream or None, but got {type(rngs)}.'

--- a/flax/nnx/pytreelib.py
+++ b/flax/nnx/pytreelib.py
@@ -44,8 +44,8 @@ BUILDING_DOCS = 'FLAX_DOC_BUILD' in os.environ
 A = tp.TypeVar('A')
 O = tp.TypeVar('O', bound='Object')
 
-DataTag = '__data__'
-Data = tp.Annotated[A, DataTag]
+DataAnnotation = '__data__'
+Data = tp.Annotated[A, DataAnnotation]
 Data.__doc__ = """Data marks attributes of a class as pytree data using type annotations.
 
 Data annotations must be used at the class level and will apply to all instances.
@@ -131,18 +131,17 @@ def register_data_type(type_: type, /) -> None:
 
     foo = Foo(42)
 
-    assert nnx.is_data_type(foo.a)  # True
+    assert nnx.is_data(foo.a)  # True
     assert jax.tree.leaves(foo) == [MyType(value=42)]
 
   """
   DATA_REGISTRY.add(type_)
 
-
-def is_data_type(value: tp.Any, /) -> bool:
+def is_data(value: tp.Any, /) -> bool:
   """Checks if a value is a registered data type.
 
   This function checks a the value is registered data type, which means it is
-  automatically recognized as pytree data when assigned to an Object attribute.
+  automatically recognized as data when assigned a nnx.Pytree attribute.
 
   Data types are:
   - jax.Arrays
@@ -151,40 +150,69 @@ def is_data_type(value: tp.Any, /) -> bool:
   - Variables (Param, BatchStat, RngState, etc.)
   - All graph nodes (Object, Module, Rngs, etc.)
   - Any type registered with `nnx.register_data_type`
+  - Any pytree that contains at least one node or leaf element of the above
 
   Example::
 
-    from flax import nnx
-    import jax.numpy as jnp
-
-    module = nnx.Linear(1, 1, rngs=nnx.Rngs(0))
-    blocks = [module, module, module]
-
-    assert nnx.is_data_type(jnp.array(42))  # Arrays are data
-    assert nnx.is_data_type(nnx.Param(1))   # Variables are data
-    assert nnx.is_data_type(nnx.Rngs(0))    # Objects are data
-    assert nnx.is_data_type(module)         # Objects are data
-
-    assert not nnx.is_data_type(0.)         # float is not data
-    assert not nnx.is_data_type(1)          # int is not data
-    assert not nnx.is_data_type("hello")    # str is not data
-    assert not nnx.is_data_type(blocks)     # list is not data
+    >>> from flax import nnx
+    >>> import jax.numpy as jnp
+    ... # ------ DATA ------------
+    >>> assert nnx.is_data( jnp.array(0) )                      # Arrays
+    >>> assert nnx.is_data( nnx.Param(1) )                      # Variables
+    >>> assert nnx.is_data( nnx.Rngs(2) )                       # nnx.Pytrees
+    >>> assert nnx.is_data( nnx.Linear(1, 1,rngs=nnx.Rngs(0)) ) # Modules
+    ... # ------ STATIC ------------
+    >>> assert not nnx.is_data( 'hello' )                       # strings, arbitrary objects
+    >>> assert not nnx.is_data( 42 )                            # int, float, bool, complex, etc.
+    >>> assert not nnx.is_data( [1, 2.0, 3j, jnp.array(1)] )    # list, dict, tuple, pytrees
 
 
   Args:
     value: The value to check.
 
   Returns:
-    True if the value is a registered data type, False otherwise.
-
-
+    A string representing the attribute status.
   """
-
   return (
     graph.is_node_leaf(value)
     or graph.is_graph_node(value)
     or type(value) in DATA_REGISTRY
   )
+
+StaticAnnotation = '__static__'
+Static = tp.Annotated[A, StaticAnnotation]
+Static.__doc__ = """Static marks attributes of a class as static using type annotations.
+Static annotations must be used at the class level and will apply to all instances.
+The usage of Static is recommended when type annotations are used already present
+or required e.g. for dataclasses.
+"""
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class StaticAttr:
+  value: tp.Any
+
+def static(value: A, /) -> A:
+  """Annotates a an attribute as static.
+
+  The return value from `static` must be directly assigned to an Object attribute
+  which will be registered as static attribute.
+
+  Example::
+
+    from flax import nnx
+
+    class Foo(nnx.Pytree):
+      def __init__(self, a, b):
+        self.a = nnx.static(a)  # pytree metadata
+        self.b = nnx.data(b)    # pytree data
+
+    foo = Foo("one", "two")
+
+    assert jax.tree.leaves(foo) == ["two"]
+
+  By default ``nnx.Pytree`` will ...
+  """
+  return StaticAttr(value)  # type: ignore[return-value]
 
 
 def _collect_stats(
@@ -282,6 +310,15 @@ jax.tree_util.register_pytree_node(
 )
 
 
+def check_pytree(pytree):
+  """Checks if a pytree is valid."""
+  if not isinstance(pytree, Pytree):
+    raise TypeError(f'Expected a Pytree, got {type(pytree)}.')
+
+  for name, value in vars(pytree).items():
+    pytree._check_value(name, value, new_status=None)
+
+
 class PytreeMeta(ABCMeta):
   if not tp.TYPE_CHECKING:
 
@@ -299,14 +336,14 @@ def _graph_node_meta_call(cls: tp.Type[O], *args, **kwargs) -> O:
   vars_obj['_pytree__state'] = PytreeState()
   vars_obj['_pytree__nodes'] = cls._pytree__nodes
   cls._pytree_meta_construct(node, *args, **kwargs)
-  # register possible new data attributes after initialization
-  for name, value in vars_obj.items():
-    if name not in vars_obj['_pytree__nodes']:
-      if any(
-        is_data_type(leaf)
-        for leaf in jax.tree.leaves(value, is_leaf=is_data_type)
-      ):
-        vars_obj['_pytree__nodes'] = vars_obj['_pytree__nodes'].union((name,))
+  if cls._pytree__is_pytree:
+    missing: dict[str, bool] = {}
+    for name, value in vars(node).items():
+      if name not in vars_obj['_pytree__nodes']:
+        missing[name] = is_data(value)
+    if missing:
+      vars_obj['_pytree__nodes'] = vars_obj['_pytree__nodes'].update(missing)
+    check_pytree(node)
 
   return node
 
@@ -341,17 +378,27 @@ class MutableArrayRepr(reprlib.Representable):
     yield reprlib.Attr('dtype', self.dtype)
 
 
+class AttributeStatus(tp.NamedTuple):
+  is_data: bool
+  explicit: bool
+
+
 class Pytree(reprlib.Representable, metaclass=PytreeMeta):
   """Base class for all NNX objects."""
 
   if tp.TYPE_CHECKING:
-    _pytree__nodes: frozenset[str]
+    _pytree__nodes: graph.HashableMapping[tp.Any, bool]
     _pytree__state: PytreeState
+    _pytree__is_pytree: bool
 
   def __init_subclass__(
-    cls, *, pytree: bool = config.flax_pytree_module, **kwargs
+    cls,
+    *,
+    pytree: bool = config.flax_pytree_module,
+    **kwargs,
   ) -> None:
     super().__init_subclass__(**kwargs)
+    cls._pytree__is_pytree = pytree
 
     graph.register_graph_node_type(
       type=cls,
@@ -363,17 +410,19 @@ class Pytree(reprlib.Representable, metaclass=PytreeMeta):
       init=cls._graph_node_init,  # type: ignore
     )
 
-    parent_nodes: tp.Iterable[str] = getattr(cls, '_pytree__nodes', ())
-
-    all_nodes: set[str] = set(parent_nodes)
-
-    all_nodes.add('_pytree__state')
-    # add DataTag attributes
-    type_: type
+    nodes: dict[str, bool] = dict(getattr(cls, '_pytree__nodes', ()))
+    nodes['_pytree__state'] = True
+    # add annotation attributes
     for name, type_ in cls.__annotations__.items():
-      if type_ != tp.ClassVar and DataTag in getattr(type_, '__metadata__', ()):
-        all_nodes.add(name)
-    cls._pytree__nodes = frozenset(all_nodes)
+      type_metadata = getattr(type_, '__metadata__', ())
+      if type_ == tp.ClassVar:
+        continue
+      elif DataAnnotation in type_metadata:
+        nodes[name] = True
+      elif StaticAnnotation in type_metadata:
+        nodes[name] = False
+
+    cls._pytree__nodes = graph.HashableMapping(nodes, copy=False)
 
     if pytree:
       jax.tree_util.register_pytree_with_keys(
@@ -389,10 +438,10 @@ class Pytree(reprlib.Representable, metaclass=PytreeMeta):
 
   # Backward compatibility with PR #4863
   @property
-  def _object__nodes(self) -> frozenset[str]:
+  def _object__nodes(self):
     return self._pytree__nodes
   @property
-  def _object__state(self) -> PytreeState:
+  def _object__state(self):
     return self._pytree__state
 
   if not tp.TYPE_CHECKING:
@@ -400,21 +449,111 @@ class Pytree(reprlib.Representable, metaclass=PytreeMeta):
     def __setattr__(self, name: str, value: Any) -> None:
       self._setattr(name, value)
 
-  def _setattr(self, name: str, value: tp.Any) -> None:
+  def _setattr(self, name, value: tp.Any) -> None:
     self._check_valid_context(
       lambda: f"Cannot mutate '{type(self).__name__}' from different trace level"
     )
+    data: bool = False
+    explicit: bool = False
     if type(value) is DataAttr:
       value = value.value
-      if name not in self._pytree__nodes:
-        self._pytree__nodes = self._pytree__nodes.union((name,))
-    # any attribute that contains known data types will be registered as data
-    elif name not in self._pytree__nodes and any(
-      is_data_type(leaf)
-      for leaf in jax.tree.leaves(value, is_leaf=is_data_type)
+      if self._pytree__is_pytree:
+        data = True
+        explicit = True
+    elif type(value) is StaticAttr:
+      value = value.value
+      if self._pytree__is_pytree:
+        data = False
+        explicit = True
+    elif self._pytree__is_pytree:
+      data = is_data(value)
+    if self._pytree__is_pytree:
+      self._check_value(name, value, AttributeStatus(data, explicit))
+      if name not in self._pytree__nodes or (explicit and self._pytree__nodes[name] != data):
+        vars(self)['_pytree__nodes'] = self._pytree__nodes.update({name: data})
+    vars(self)[name] = value
+
+  def _check_value(self, key, value, new_status: AttributeStatus | None):
+    def _has_arrays(leaves):
+      return any(
+        isinstance(leaf, (np.ndarray, jax.Array))
+        or variablelib.is_array_ref(leaf)
+        for leaf in leaves
+      )
+
+    def _get_annotations(leaves):
+      return {
+        "data" if type(leaf) is DataAttr else "static"
+        for leaf in leaves
+        if type(leaf) is DataAttr or type(leaf) is StaticAttr
+      }
+
+    def _has_visited(x):
+      if id(x) in visited:
+        return True
+      visited.add(id(x))
+      return False
+
+    visited: set[int] = set()
+    leaves = jax.tree.leaves(value, is_leaf=_has_visited)
+    current_is_data = self._pytree__nodes[key] if key in self._pytree__nodes else False
+    existing_attr = key in vars(self)
+    if (
+      new_status is not None
+      and not new_status.explicit
+      and new_status.is_data
+      and existing_attr
+      and not current_is_data
     ):
-      self._pytree__nodes = self._pytree__nodes.union((name,))
-    object.__setattr__(self, name, value)
+        raise ValueError(
+          f"Cannot assign 'data' value to 'static' attribute '{key}'. To override "
+          "the status explicitly annotate the value on assignment:\n\n"
+          f"  _.{key} = nnx.data(...)\n"
+        )
+
+    if _has_arrays(leaves):
+      # check no data in nnx.static assignments
+      if new_status is not None:
+        if not new_status.is_data and new_status.explicit:
+          raise ValueError(
+            f'Found Arrays in value annotated with nnx.static(...) when setting '
+            f"attribute '{key}'."
+          )
+        if (
+          not new_status.explicit
+          and not current_is_data
+          and existing_attr
+        ):
+          raise ValueError(
+            f"Found Arrays in value assigned to static attribute '{key}'."
+          )
+      # check no data in static attributes after __init__
+      elif not current_is_data:
+        base_pytree_type = Pytree
+        for t in type(self).mro()[1:]:
+          if issubclass(t, nnx.Pytree):
+            base_pytree_type = t
+            break
+        raise ValueError(
+          f"Found unexpected Arrays on static attribute '{key}' after __init__, this is an error "
+          'starting from Flax version 0.11.2.\nConsider one of the following options:\n\n'
+          '1. If the attribute is meant to be static, either remove the Array value or wrap it '
+          'in a static container.\n'
+          '2. Annotate the value with nnx.data on assignment:\n\n'
+          f'  _.{key} = nnx.data(...)\n\n'
+          '3. Annotate the class attribute with nnx.Data:\n\n'
+          f'  class {type(self).__name__}({base_pytree_type.__name__}):\n'
+          f'    {key}: nnx.Data[{type(value).__name__}]\n\n'
+          '4. If the container is a list or dict, try using nnx.List(...) or nnx.Dict(...) instead.\n'
+          '5. Disable pytree for this class:\n\n'
+          f'  class {type(self).__name__}({base_pytree_type.__name__}, pytree=False):\n'
+        )
+    if tags := _get_annotations(leaves):
+      raise ValueError(
+        f"Found unexpected tags {tags} on attribute '{key}'. Values from nnx.data(...) and\n"
+        f'nnx.static(...) should be assigned to nnx.Pytree attributes directly, they should not\n'
+        f'be stored inside lists, dicts, tuples, or any pytree type.'
+      )
 
   def _check_valid_context(self, error_msg: tp.Callable[[], str]) -> None:
     if not self._pytree__state.trace_state.is_valid():
@@ -550,16 +689,25 @@ class Pytree(reprlib.Representable, metaclass=PytreeMeta):
   # -------------------------
   # Pytree Definition
   # -------------------------
+  _pytree__key_sort_fn: tp.Callable | None = None
+
   def _pytree__flatten_with_paths(self):
     obj_vars = vars(self)
-    type_nodes = self._pytree__nodes
+    node_attributes = self._pytree__nodes
     node_names: list[str] = []
     node_attrs: list[tuple[tp.Any, tp.Any]] = []
     static_attrs: list[tuple[str, tp.Any]] = []
-    for name, value in sorted(obj_vars.items()):
-      if name in type_nodes:
+    for name, value in sorted(obj_vars.items(), key=self._pytree__key_sort_fn):
+      if name in node_attributes and node_attributes[name]:
         node_names.append(name)
-        node_attrs.append((jax.tree_util.GetAttrKey(name), value))
+        node_attrs.append(
+          (
+            jax.tree_util.GetAttrKey(name)
+            if isinstance(name, str)
+            else jax.tree_util.SequenceKey(name),
+            value,
+          )
+        )
       else:
         static_attrs.append((name, value))
 
@@ -567,12 +715,12 @@ class Pytree(reprlib.Representable, metaclass=PytreeMeta):
 
   def _pytree__flatten(self):
     obj_vars = vars(self)
-    type_nodes = self._pytree__nodes
+    node_attributes = self._pytree__nodes
     node_names: list[str] = []
     node_attrs: list[tp.Any] = []
     static_attrs: list[tuple[str, tp.Any]] = []
-    for name, value in sorted(obj_vars.items()):
-      if name in type_nodes:
+    for name, value in sorted(obj_vars.items(), key=self._pytree__key_sort_fn):
+      if name in node_attributes and node_attributes[name]:
         node_names.append(name)
         node_attrs.append(value)
       else:
@@ -597,8 +745,8 @@ class Pytree(reprlib.Representable, metaclass=PytreeMeta):
   # Graph Definition
   # -------------------------
   def _graph_node_flatten(self):
-    nodes = vars(self).copy()
-    nodes = sorted(nodes.items())
+    nodes = vars(self)
+    nodes = sorted(nodes.items(), key=self._pytree__key_sort_fn)
     return nodes, type(self)
 
   def _graph_node_set_key(self, key: str, value: tp.Any):

--- a/flax/nnx/reprlib.py
+++ b/flax/nnx/reprlib.py
@@ -233,7 +233,7 @@ def get_repr(obj: Representable) -> str:
 
 class MappingReprMixin(Representable):
   def __nnx_repr__(self):
-    yield Object(type='', kv_sep=': ', start='{', end='}')
+    yield Object(type=type(self), kv_sep=': ', start='({', end='})')
 
     for key, value in self.items():  # type: ignore
       yield Attr(colorized(key), value, use_raw_key=True)

--- a/flax/nnx/rnglib.py
+++ b/flax/nnx/rnglib.py
@@ -840,7 +840,7 @@ def split_rngs(
       if squeeze:
         key = key[0]
       if variablelib.is_array_ref(stream.key.raw_value):
-        stream.key.raw_value = variablelib.array_ref(key)
+        stream.key.raw_value = variablelib.array_ref(key)  # type: ignore[assignment]
       else:
         stream.key.value = key
       if squeeze:
@@ -852,7 +852,7 @@ def split_rngs(
 
       count = jnp.zeros(counts_shape, dtype=jnp.uint32)
       if variablelib.is_array_ref(stream.count.raw_value):
-        stream.count.raw_value = variablelib.array_ref(count)
+        stream.count.raw_value = variablelib.array_ref(count)  # type: ignore[assignment]
       else:
         stream.count.value = count
 
@@ -882,17 +882,17 @@ def fork_rngs(
     | int
     | None = None,
 ) -> SplitBackups | tp.Callable[[F], F]:
-  """Splits the (nested) Rng states of the given node.
+  """Forks the (nested) Rng states of the given node.
 
   Args:
-    node: the base node containing the rng states to split.
-    splits: an integer or tuple of integers specifying the
-      shape of the split rng keys.
-    only: a Filter selecting which rng states to split.
+    node: the base node containing the rng states to fork.
+    split: an integer, tuple of integers, or mapping specifying the
+      shape of the forked rng keys. If a mapping, keys are filters selecting
+      which rng states to fork with the corresponding split shape.
 
   Returns:
     A SplitBackups iterable if ``node`` is provided, otherwise a
-    decorator that splits the rng states of the inputs to the
+    decorator that forks the rng states of the inputs to the
     decorated function.
 
   Example::
@@ -900,22 +900,22 @@ def fork_rngs(
     >>> from flax import nnx
     ...
     >>> rngs = nnx.Rngs(params=0, dropout=1)
-    >>> _ = nnx.split_rngs(rngs, splits=5)
+    >>> _ = nnx.fork_rngs(rngs, split=5)
     >>> rngs.params.key.shape, rngs.dropout.key.shape
     ((5,), (5,))
 
     >>> rngs = nnx.Rngs(params=0, dropout=1)
-    >>> _ = nnx.split_rngs(rngs, splits=(2, 5))
+    >>> _ = nnx.fork_rngs(rngs, split=(2, 5))
     >>> rngs.params.key.shape, rngs.dropout.key.shape
     ((2, 5), (2, 5))
 
 
     >>> rngs = nnx.Rngs(params=0, dropout=1)
-    >>> _ = nnx.split_rngs(rngs, splits=5, only='params')
+    >>> _ = nnx.fork_rngs(rngs, split={'params': 5})
     >>> rngs.params.key.shape, rngs.dropout.key.shape
     ((5,), ())
 
-  Once split, random state can be used with transforms like :func:`nnx.vmap`::
+  Once forked, random state can be used with transforms like :func:`nnx.vmap`::
 
     >>> class Model(nnx.Module):
     ...   def __init__(self, rngs):
@@ -923,7 +923,7 @@ def fork_rngs(
     ...     self.dropout = nnx.Dropout(0.5, rngs=rngs)
     ...
     >>> rngs = nnx.Rngs(params=0, dropout=1)
-    >>> _ = nnx.split_rngs(rngs, splits=5, only='params')
+    >>> _ = nnx.fork_rngs(rngs, split={'params': 5})
     ...
     >>> state_axes = nnx.StateAxes({(nnx.Param, 'params'): 0, ...: None})
     ...
@@ -935,13 +935,13 @@ def fork_rngs(
     >>> model.dropout.rngs.key.shape
     ()
 
-  ``split_rngs`` returns a SplitBackups object that can be used to restore the
-  original unsplit rng states using :func:`nnx.restore_rngs`, this is useful
-  when you only want to split the rng states temporarily::
+  ``fork_rngs`` returns a SplitBackups object that can be used to restore the
+  original unforked rng states using :func:`nnx.restore_rngs`, this is useful
+  when you only want to fork the rng states temporarily::
 
     >>> rngs = nnx.Rngs(params=0, dropout=1)
     ...
-    >>> backups = nnx.split_rngs(rngs, splits=5, only='params')
+    >>> backups = nnx.fork_rngs(rngs, split={'params': 5})
     >>> model = create_model(rngs)
     >>> nnx.restore_rngs(backups)
     ...
@@ -953,7 +953,7 @@ def fork_rngs(
 
     >>> rngs = nnx.Rngs(params=0, dropout=1)
     ...
-    >>> with nnx.split_rngs(rngs, splits=5, only='params'):
+    >>> with nnx.fork_rngs(rngs, split={'params': 5}):
     ...   model = create_model(rngs)
     ...
     >>> model.dropout.rngs.key.shape
@@ -961,7 +961,7 @@ def fork_rngs(
 
     >>> state_axes = nnx.StateAxes({(nnx.Param, 'params'): 0, ...: None})
     ...
-    >>> @nnx.split_rngs(splits=5, only='params')
+    >>> @nnx.fork_rngs(split={'params': 5})
     ... @nnx.vmap(in_axes=(state_axes,), out_axes=state_axes)
     ... def create_model(rngs):
     ...   return Model(rngs)
@@ -970,8 +970,6 @@ def fork_rngs(
     >>> model = create_model(rngs)
     >>> model.dropout.rngs.key.shape
     ()
-
-
   """
   if isinstance(node, Missing):
 

--- a/flax/nnx/statelib.py
+++ b/flax/nnx/statelib.py
@@ -496,6 +496,19 @@ def to_pure_dict(
   return traversals.unflatten_mapping(flat_values)
 
 
+def restore_int_paths(pure_dict: dict[str, tp.Any]):
+  def try_convert_int(x):
+    try:
+      return int(x)
+    except ValueError:
+      return x
+
+  fixed = {
+      tuple(map(try_convert_int, path)): value
+      for path, value in traversals.flatten_mapping(pure_dict).items()
+  }
+  return traversals.unflatten_mapping(fixed)
+
 def replace_by_pure_dict(
   state, pure_dict: dict[str, tp.Any], replace_fn: SetValueFn | None = None
 ):

--- a/flax/nnx/training/metrics.py
+++ b/flax/nnx/training/metrics.py
@@ -392,7 +392,7 @@ class MultiMetric(Metric):
     self._metric_names = []
     for metric_name, metric in metrics.items():
       self._metric_names.append(metric_name)
-      vars(self)[metric_name] = metric
+      setattr(self, metric_name, metric)
 
   def reset(self) -> None:
     """Reset all underlying ``Metric``'s."""

--- a/flax/nnx/variablelib.py
+++ b/flax/nnx/variablelib.py
@@ -247,7 +247,7 @@ class Variable(tp.Generic[A], reprlib.Representable):
       if is_array_ref(value):
         _value = tp.cast(A, value)
       else:
-        _value = array_ref(jnp.asarray(value))
+        _value = array_ref(jnp.asarray(value)) # type: ignore[assignment]
     else:
       _value = value
 

--- a/tests/nnx/mutable_array_test.py
+++ b/tests/nnx/mutable_array_test.py
@@ -119,7 +119,7 @@ class TestObject(absltest.TestCase):
 
     foo = Foo(42)
 
-    self.assertTrue(nnx.is_data_type(foo.a))
+    self.assertTrue(nnx.is_data(foo.a))
     self.assertEqual(jax.tree.leaves(foo), [MyType(value=42)])
 
 

--- a/tests/nnx/nn/attention_test.py
+++ b/tests/nnx/nn/attention_test.py
@@ -44,9 +44,9 @@ class TestMultiHeadAttention(parameterized.TestCase):
       attention_kwargs: dict
 
       def __init__(self, attention_kwargs, rng):
-        self.attention_layers = [
+        self.attention_layers = nnx.data([
           nnx.MultiHeadAttention(**attention_kwargs, rngs=rng) for i in range(3)
-        ]
+        ])
 
       def __call__(self, x, sow_weights=False):
         x = self.attention_layers[0](x, sow_weights=sow_weights)

--- a/tests/nnx/partitioning_test.py
+++ b/tests/nnx/partitioning_test.py
@@ -12,43 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import TYPE_CHECKING
 from absl.testing import absltest
 from flax import nnx
 import jax
 
 
-class List(nnx.Module):
-  def __init__(self, items):
-    vars(self).update({str(i): item for i, item in enumerate(items)})
-
-  def __getitem__(self, idx):
-    return getattr(self, str(idx))
-
-  def __setitem__(self, idx, value):
-    setattr(self, str(idx), value)
-
-
-class Dict(nnx.Module):
-  def __init__(self, *args, **kwargs):
-    vars(self).update(dict(*args, **kwargs))
-
-  def __getitem__(self, key):
-    return vars(self)[key]
-
-  def __setitem__(self, key, value):
-    vars(self)[key] = value
-
-  if TYPE_CHECKING:
-
-    def __getattr__(self, key): ...
-
 
 class TestPartitioning(absltest.TestCase):
 
   def test_partition(self):
-    m = Dict(
-      a=List([nnx.Param(1), nnx.BatchStat(2)]),
+    m = nnx.Dict(
+      a=nnx.List([nnx.Param(1), nnx.BatchStat(2)]),
       b=nnx.Param(2),
       c=100,
     )
@@ -59,41 +33,41 @@ class TestPartitioning(absltest.TestCase):
     self.assertLen(rest, 1)
 
     # check params
-    self.assertEqual(params['a']['0'].value, m.a['0'].value)
+    self.assertEqual(params['a'][0].value, m.a[0].value)
     self.assertEqual(params['b'].value, m.b.value)
 
     # check rest
-    self.assertEqual(rest['a']['1'].value, m.a['1'].value)
+    self.assertEqual(rest['a'][1].value, m.a[1].value)
 
     m2 = nnx.merge(graphdef, params, rest)
 
-    self.assertEqual(m2.a['0'].value, m.a['0'].value)
-    self.assertEqual(m2.a['1'].value, m.a['1'].value)
+    self.assertEqual(m2.a[0].value, m.a[0].value)
+    self.assertEqual(m2.a[1].value, m.a[1].value)
     self.assertEqual(m2.b.value, m.b.value)
     self.assertEqual(m2.c, 100)
 
   def test_complete_partitioning(self):
-    m = Dict(
-      a=List([nnx.Param(1), nnx.Param(2), nnx.Variable(3)]),
-      b=Dict(c=nnx.Param(1), d=nnx.BatchStat(2)),
+    m = nnx.Dict(
+      a=nnx.List([nnx.Param(1), nnx.Param(2), nnx.Variable(3)]),
+      b=nnx.Dict(c=nnx.Param(1), d=nnx.BatchStat(2)),
     )
 
     # no error
     nnx.split(m, nnx.Param, nnx.BatchStat, nnx.Variable)
 
   def test_complete_partitioning_plus_ellipsis(self):
-    m = Dict(
-      a=List([nnx.Param(1), nnx.Param(2), nnx.Variable(3)]),
-      b=Dict(c=nnx.Param(1), d=nnx.BatchStat(2)),
+    m = nnx.Dict(
+      a=nnx.List([nnx.Param(1), nnx.Param(2), nnx.Variable(3)]),
+      b=nnx.Dict(c=nnx.Param(1), d=nnx.BatchStat(2)),
     )
 
     # no error if additional ... is passed at the end
     nnx.split(m, nnx.Param, nnx.BatchStat, nnx.Variable, ...)
 
   def test_inclomplete_partition_error(self):
-    m = Dict(
-      a=List([nnx.Param(1), nnx.Param(2), nnx.Variable(3)]),
-      b=Dict(c=nnx.Param(1), d=nnx.BatchStat(2)),
+    m = nnx.Dict(
+      a=nnx.List([nnx.Param(1), nnx.Param(2), nnx.Variable(3)]),
+      b=nnx.Dict(c=nnx.Param(1), d=nnx.BatchStat(2)),
     )
 
     with self.assertRaisesRegex(
@@ -102,9 +76,9 @@ class TestPartitioning(absltest.TestCase):
       nnx.split(m, nnx.Param)
 
   def test_ellipsis_not_last_error(self):
-    m = Dict(
-      a=List([nnx.Param(1), nnx.Param(2), nnx.Variable(3)]),
-      b=Dict(c=nnx.Param(1), d=nnx.BatchStat(2)),
+    m = nnx.Dict(
+      a=nnx.List([nnx.Param(1), nnx.Param(2), nnx.Variable(3)]),
+      b=nnx.Dict(c=nnx.Param(1), d=nnx.BatchStat(2)),
     )
 
     with self.assertRaisesRegex(
@@ -113,8 +87,8 @@ class TestPartitioning(absltest.TestCase):
       nnx.split(m, ..., nnx.Param)
 
   def test_update_from(self):
-    m = Dict(
-      a=List([nnx.Param(1), nnx.BatchStat(3)]),
+    m = nnx.Dict(
+      a=nnx.List([nnx.Param(1), nnx.BatchStat(3)]),
       b=nnx.Param(2),
       c=100,
     )
@@ -132,15 +106,13 @@ class TestPartitioning(absltest.TestCase):
     self.assertEqual(m.c, 100)
 
   def test_update_from_with_array_leaf(self):
-    m = Dict(
-      a=List([nnx.Param(1), nnx.BatchStat(3)]),
+    m = nnx.Dict(
+      a=nnx.List([nnx.Param(1), nnx.BatchStat(3)]),
       b=nnx.Param(2),
       c=nnx.Variable(jax.numpy.array(100)),
     )
 
-    graphdef, state = nnx.split(
-      m,
-    )
+    graphdef, state = nnx.split(m)
     state = jax.tree.map(lambda x: x * 2, state)
 
     nnx.update(m, state)
@@ -151,8 +123,8 @@ class TestPartitioning(absltest.TestCase):
     self.assertEqual(m.c.value, 200)
 
   def test_grad_example(self):
-    m = Dict(
-      a=List([nnx.Param(1.0), nnx.BatchStat(-10)]),
+    m = nnx.Dict(
+      a=nnx.List([nnx.Param(1.0), nnx.BatchStat(-10)]),
       b=nnx.Param(2.0),
       c=100,
     )
@@ -171,21 +143,21 @@ class TestPartitioning(absltest.TestCase):
     self.assertEqual(m.c, 100)
 
   def test_get_paritition(self):
-    m = Dict(
-      a=List([nnx.Param(10.0), nnx.Param(20.0)]),
+    m = nnx.Dict(
+      a=nnx.List([nnx.Param(10.0), nnx.Param(20.0)]),
       b=nnx.Param(10.0),
       c=7,
       d=5.0,
     )
 
     # test Variables not shared
-    self.assertIsNot(vars(m.a)['0'], vars(m)['b'])
+    self.assertIsNot(vars(m.a)[0], vars(m)['b'])
 
     state = nnx.state(m, nnx.Variable)
-    self.assertEqual(state['a']['0'].value, m.a['0'].value)
-    self.assertEqual(state['a']['1'].value, m.a['1'].value)
+    self.assertEqual(state['a'][0].value, m.a[0].value)
+    self.assertEqual(state['a'][1].value, m.a[1].value)
     self.assertEqual(state['b'].value, m.b.value)
-    self.assertIsNot(state['b'], state['a']['0'])
+    self.assertIsNot(state['b'], state['a'][0])
     self.assertLen(nnx.to_flat_state(state), 3)
 
 

--- a/tests/nnx/state_test.py
+++ b/tests/nnx/state_test.py
@@ -67,7 +67,10 @@ class StateTest(absltest.TestCase):
   def test_integer_access(self):
     class Foo(nnx.Module):
       def __init__(self, *, rngs: nnx.Rngs):
-        self.layers = [nnx.Linear(1, 2, rngs=rngs), nnx.Linear(2, 3, rngs=rngs)]
+        self.layers = nnx.List([
+          nnx.Linear(1, 2, rngs=rngs),
+          nnx.Linear(2, 3, rngs=rngs)
+        ])
 
     module = Foo(rngs=nnx.Rngs(0))
     state = nnx.state(module)


### PR DESCRIPTION
# What does this PR do?

* Adds `nnx.Static` and `nnx.static`
* Attributes are now allowed to change status between `data` and `static` as long as they're not overriding a class type hint annotation of `nnx.Data` or `nnx.Static`.
* Reintroduced `nnx.Dict` and `nnx.List` to enable containers of mixed data and static types.
