### PR TITLE
Added missing functions to graph.rst

### DIFF
--- a/docs_nnx/api_reference/flax.nnx/graph.rst
+++ b/docs_nnx/api_reference/flax.nnx/graph.rst
@@ -26,3 +26,10 @@ graph
 
 .. autofunction:: update_context
 .. autofunction:: current_update_context
+
+.. autofunction:: find_duplicates
+.. autofunction:: pure
+.. autofunction:: to_refs
+.. autofunction:: to_arrays
+.. autofunction:: flatten
+.. autofunction:: unflatten

--- a/flax/nnx/__init__.py
+++ b/flax/nnx/__init__.py
@@ -64,6 +64,8 @@ from .graph import to_arrays as to_arrays
 from .graph import to_refs as to_refs
 from .graph import pure as pure
 from .graph import cached_partial as cached_partial
+from .graph import flatten as flatten
+from .graph import unflatten as unflatten
 from .nn import initializers as initializers
 from .nn.activations import celu as celu
 from .nn.activations import elu as elu

--- a/flax/nnx/graph.py
+++ b/flax/nnx/graph.py
@@ -2612,6 +2612,7 @@ def to_arrays(
   """Converts a structure of array refs to regular arrays.
 
   Example::
+
     >>> from flax import nnx
     >>> import jax
     >>> import jax.numpy as jnp
@@ -2875,6 +2876,7 @@ def iter_graph(node: tp.Any, /) -> tp.Iterator[tuple[PathParts, tp.Any]]:
   root. Repeated nodes are visited only once. Leaves include static values.
 
   Example::
+
     >>> from flax import nnx
     >>> import jax.numpy as jnp
     ...


### PR DESCRIPTION
Docs update: Added missing functions to graph.rst
Now rendered docs for the functions starting from: 
- https://flax--4922.org.readthedocs.build/en/4922/api_reference/flax.nnx/graph.html#flax.nnx.find_duplicates
vs the current docs:
- https://flax.readthedocs.io/en/latest/api_reference/flax.nnx/graph.html