### PR TITLE
update bridge wrappers from maxtext

### DIFF
--- a/flax/nnx/pytreelib.py
+++ b/flax/nnx/pytreelib.py
@@ -21,6 +21,7 @@ import threading
 import typing as tp
 from abc import ABCMeta
 from copy import deepcopy
+import warnings
 
 from flax.nnx import variablelib
 import jax
@@ -453,10 +454,20 @@ class Pytree(reprlib.Representable, metaclass=PytreeMeta):
   # Backward compatibility with PR #4863
   @property
   def _object__nodes(self):
+    warnings.warn(
+      "'_object__nodes' is deprecated, use '_pytree__nodes' instead.",
+      DeprecationWarning,
+      stacklevel=2,
+    )
     return self._pytree__nodes
 
   @property
   def _object__state(self):
+    warnings.warn(
+      "'_object__state' is deprecated, use '_pytree__state' instead.",
+      DeprecationWarning,
+      stacklevel=2,
+    )
     return self._pytree__state
 
   if not tp.TYPE_CHECKING:

--- a/tests/nnx/bridge/wrappers_test.py
+++ b/tests/nnx/bridge/wrappers_test.py
@@ -113,7 +113,7 @@ class TestCompatibility(absltest.TestCase):
     # lazy_init only initialized param w inside dot(), so calling __call__ should fail
     with self.assertRaises(flax.errors.ScopeParamNotFoundError):
       y = model(x)
-    assert isinstance(model.rngs, nnx.Rngs)
+    assert isinstance(model.to_nnx__rngs, nnx.Rngs)
 
   def test_linen_to_nnx_mutable(self):
     class Foo(nn.Module):
@@ -367,15 +367,16 @@ class TestCompatibility(absltest.TestCase):
         self.count = Count(jnp.array(0))
       def __call__(self):
         self.count += 1
-        self.count_nonzero = Count(jnp.array(1))
+        self.count_nonzero = nnx.Intermediate(jnp.array(1))
 
     model = bridge.ToLinen(Counter, skip_rng=True)
     variables = model.init(jax.random.key(0))
     assert variables['Count']['count'] == 0
 
-    _, updates = model.apply(variables, mutable=['Count'])
+    _, updates = model.apply(variables, mutable=['Count', 'intermediates'])
     assert updates['Count']['count'] == 1
-    assert updates['Count']['count_nonzero'] == 1
+    assert updates['intermediates']['count_nonzero'] == 1
+    del updates['intermediates']
     _ = model.apply(variables | updates)
 
   def test_nnx_to_linen_transforms(self):
@@ -524,23 +525,6 @@ class TestCompatibility(absltest.TestCase):
     # TODO: add when we can safely `lazy_init` the NNX module inside `ToLinen` without
     # messing up the stateful part of the NNX module.
     pass
-
-  def test_to_linen_abtract_init(self):
-    test = self
-    class Foo(nnx.Module):
-      def __init__(self, *, rngs: nnx.Rngs):
-        self.a = jnp.array(0.)
-
-      def __call__(self):
-        return self.a
-
-    model = bridge.ToLinen(Foo)
-    y = model.apply({})
-    self.assertIsInstance(y, jax.ShapeDtypeStruct)
-
-    model = bridge.ToLinen(Foo, abstract_init=False)
-    y = model.apply({})
-    self.assertIsInstance(y, jax.Array)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
# What does this PR do?
Many fixes but here are some important ones:
* `ToLinen` no longer uses supports `abstract_init` as this prevent partial initialization, this means means `ToLinen` object should preferably be called inside `jit` or similar so JAX/XLA's Dead Code Elimination prevents reallocating the entire model. 
* `ToNNX` now takes into account the parent Linen Module (if any) to propagate its `mutable` property.

