### PR TITLE
Implement instance norm in NNX

### DIFF
--- a/docs_nnx/api_reference/flax.nnx/nn/normalization.rst
+++ b/docs_nnx/api_reference/flax.nnx/nn/normalization.rst
@@ -19,3 +19,7 @@ Normalization
 .. flax_module::
   :module: flax.nnx
   :class: GroupNorm
+
+.. flax_module::
+  :module: flax.nnx
+  :class: InstanceNorm

--- a/flax/nnx/__init__.py
+++ b/flax/nnx/__init__.py
@@ -122,6 +122,7 @@ from .nn.normalization import BatchNorm as BatchNorm
 from .nn.normalization import LayerNorm as LayerNorm
 from .nn.normalization import RMSNorm as RMSNorm
 from .nn.normalization import GroupNorm as GroupNorm
+from .nn.normalization import InstanceNorm as InstanceNorm
 from .nn.stochastic import Dropout as Dropout
 from .rnglib import Rngs as Rngs
 from .rnglib import RngStream as RngStream

--- a/flax/nnx/nn/normalization.py
+++ b/flax/nnx/nn/normalization.py
@@ -843,11 +843,14 @@ class InstanceNorm(Module):
   Normalization). i.e. applies a transformation that maintains the mean activation
   within each channel within each example close to 0 and the activation standard
   deviation close to 1.
+
   .. note::
     This normalization operation is identical to LayerNorm and GroupNorm; the
     difference is simply which axes are reduced and the shape of the feature axes
     (i.e. the shape of the learnable scale and bias parameters).
+
   Example usage::
+
     >>> from flax import nnx
     >>> import jax
     >>> import numpy as np
@@ -872,6 +875,7 @@ class InstanceNorm(Module):
     >>> np.testing.assert_allclose(y, y2, atol=1e-7)
     >>> y3 = nnx.GroupNorm(5, num_groups=x.shape[-1], rngs=nnx.Rngs(0))(x)
     >>> np.testing.assert_allclose(y, y3, atol=1e-7)
+
   Args:
     num_features: the number of input features/channels.
     epsilon: A small float added to variance to avoid dividing by zero.
@@ -950,10 +954,12 @@ class InstanceNorm(Module):
 
   def __call__(self, x, *, mask: tp.Optional[jax.Array] = None):
     """Applies instance normalization on the input.
+
     Args:
       x: the inputs
-      mask: Binary array of shape broadcastable to ``inputs`` tensor, indicating
+      mask: Binary array of shape broadcastable to ``inputs`` array, indicating
         the positions for which the mean and variance should be computed.
+
     Returns:
       Normalized inputs (the same shape as inputs).
     """

--- a/flax/nnx/nn/normalization.py
+++ b/flax/nnx/nn/normalization.py
@@ -859,12 +859,10 @@ class InstanceNorm(Module):
     >>> layer = nnx.InstanceNorm(5, rngs=nnx.Rngs(0))
     >>> nnx.state(layer, nnx.Param)
     State({
-      'bias': VariableState( # 5 (20 B)
-        type=Param,
+      'bias': Param( # 5 (20 B)
         value=Array([0., 0., 0., 0., 0.], dtype=float32)
       ),
-      'scale': VariableState( # 5 (20 B)
-        type=Param,
+      'scale': Param( # 5 (20 B)
         value=Array([1., 1., 1., 1., 1.], dtype=float32)
       )
     })


### PR DESCRIPTION
Relates to #4623 - Brings the Instance Norm implementation into NNX from Linen.

Created this PR at the request of @vfdev-5 to merge the instance norm implementation separately from spectral norm.
