### PR TITLE
only copy dicts on State.__getitem__

### DIFF
--- a/flax/nnx/statelib.py
+++ b/flax/nnx/statelib.py
@@ -256,9 +256,9 @@ class State(MutableMapping[K, V], reprlib.Representable):
 
   def __getitem__(self, key: K) -> State | V:  # type: ignore
     value = self._mapping[key]
-    if isinstance(value, tp.Mapping):
+    if isinstance(value, dict):
       return type(self)(value, _copy=False)
-    return value
+    return value  # type: ignore[return-value]
 
   def __getattr__(self, key: K) -> State | V:  # type: ignore[misc]
     if '_mapping' not in vars(self) or key not in self._mapping:


### PR DESCRIPTION
# What does this PR do?

Small fix to only wrap dicts as `State` in `__getitem__`.