### PR TITLE
always differentiate standalone Variables in nnx.grad

### DIFF
--- a/flax/nnx/graph.py
+++ b/flax/nnx/graph.py
@@ -2583,7 +2583,7 @@ def pop(
     return states
 
 
-def clone(node: Node) -> Node:
+def clone(node: Node, variables: bool = True) -> Node:
   """Create a deep copy of the given graph node.
 
   Example usage::
@@ -2597,11 +2597,13 @@ def clone(node: Node) -> Node:
 
   Args:
     node: A graph node object.
+    variables: If ``True`` (default) copies of the :class:`Variable` objects are created,
+      otherwise the Variables are shared between the original and cloned node.
   Returns:
     A deep copy of the :class:`Module` object.
   """
   graphdef, state = split(node)
-  return merge(graphdef, state, copy=True)
+  return merge(graphdef, state, copy=variables)
 
 
 def _mutable_like(path, x):

--- a/flax/nnx/statelib.py
+++ b/flax/nnx/statelib.py
@@ -256,9 +256,9 @@ class State(MutableMapping[K, V], reprlib.Representable):
 
   def __getitem__(self, key: K) -> State | V:  # type: ignore
     value = self._mapping[key]
-    if isinstance(value, tp.Mapping):
+    if isinstance(value, dict):
       return type(self)(value, _copy=False)
-    return value
+    return value  # type: ignore[return-value]
 
   def __getattr__(self, key: K) -> State | V:  # type: ignore[misc]
     if '_mapping' not in vars(self) or key not in self._mapping:

--- a/flax/nnx/transforms/autodiff.py
+++ b/flax/nnx/transforms/autodiff.py
@@ -139,7 +139,7 @@ def _grad_general(
     def _grad_split_fn(
       ctx: graph.SplitContext, path, prefix: DiffState | None, value
     ):
-      if prefix is None:
+      if prefix is None or (prefix.argnum == -1 and isinstance(value, variablelib.Variable)):
         nondiff_states.append(None)
         return extract.NodeStates.from_split(*ctx.split(value))
       else:


### PR DESCRIPTION
# What does this PR do?

Allows standalone Variables to be differentiated against when using integers in `argnums` for `nnx.grad`. In the current behavior if you pass a standalone Variable (or nested inside a pytree) to an argument with an interger `argnum` only `Param` Variables will be differentiable.