### PR TITLE
raise on Variable inplace operators

### DIFF
--- a/flax/nnx/variablelib.py
+++ b/flax/nnx/variablelib.py
@@ -708,134 +708,82 @@ class Variable(tp.Generic[A], reprlib.Representable):
     return self.value.__ror__(other)  # type: ignore
 
   def __iadd__(self: V, other) -> V:
-    if isinstance(other, Variable):
-      other = other.value
-    value = self.value
-    if hasattr(value, '__iadd__'):
-      value.__iadd__(other)
-    else:
-      self.value = value.__add__(other)
-    return self
+    raise NotImplementedError(
+      'In-place operations are no longer supported for Variable.\n'
+      'Use `variable.value += x` instead.'
+    )
 
   def __isub__(self: V, other) -> V:
-    if isinstance(other, Variable):
-      other = other.value
-    value = self.value
-    if hasattr(value, '__isub__'):
-      value.__isub__(other)
-    else:
-      self.value = value.__sub__(other)
-    return self
+    raise NotImplementedError(
+      'In-place operations are no longer supported for Variable.\n'
+      'Use `variable.value -= x` instead.'
+    )
 
   def __imul__(self: V, other) -> V:
-    if isinstance(other, Variable):
-      other = other.value
-    value = self.value
-    if hasattr(value, '__imul__'):
-      value.__imul__(other)
-    else:
-      self.value = value.__mul__(other)
-    return self
+    raise NotImplementedError(
+      'In-place operations are no longer supported for Variable.\n'
+      'Use `variable.value *= x` instead.'
+    )
 
   def __imatmul__(self: V, other) -> V:
-    if isinstance(other, Variable):
-      other = other.value
-    value = self.value
-    if hasattr(value, '__imatmul__'):
-      value.__imatmul__(other)
-    else:
-      self.value = value.__matmul__(other)
-    return self
+    raise NotImplementedError(
+      'In-place operations are no longer supported for Variable.\n'
+      'Use `variable.value @= x` instead.'
+    )
 
   def __itruediv__(self: V, other) -> V:
-    if isinstance(other, Variable):
-      other = other.value
-    value = self.value
-    if hasattr(value, '__itruediv__'):
-      value.__itruediv__(other)
-    else:
-      self.value = value.__truediv__(other)
-    return self
+    raise NotImplementedError(
+      'In-place operations are no longer supported for Variable.\n'
+      'Use `variable.value /= x` instead.'
+    )
 
   def __ifloordiv__(self: V, other) -> V:
-    if isinstance(other, Variable):
-      other = other.value
-    value = self.value
-    if hasattr(value, '__ifloordiv__'):
-      value.__ifloordiv__(other)
-    else:
-      self.value = value.__floordiv__(other)
-    return self
+    raise NotImplementedError(
+      'In-place operations are no longer supported for Variable.\n'
+      'Use `variable.value //= x`` instead.'
+    )
 
   def __imod__(self: V, other) -> V:
-    if isinstance(other, Variable):
-      other = other.value
-    value = self.value
-    if hasattr(value, '__imod__'):
-      value.__imod__(other)
-    else:
-      self.value = value.__mod__(other)
-    return self
+    raise NotImplementedError(
+      'In-place operations are no longer supported for Variable.\n'
+      'Use `variable.value %= x` instead.'
+    )
 
   def __ipow__(self: V, other) -> V:
-    if isinstance(other, Variable):
-      other = other.value
-    value = self.value
-    if hasattr(value, '__ipow__'):
-      value.__ipow__(other)
-    else:
-      self.value = value.__pow__(other)
-    return self
+    raise NotImplementedError(
+      'In-place operations are no longer supported for Variable.\n'
+      'Use `variable.value **= x`` instead.'
+    )
 
   def __ilshift__(self: V, other) -> V:
-    if isinstance(other, Variable):
-      other = other.value
-    value = self.value
-    if hasattr(value, '__ilshift__'):
-      value.__ilshift__(other)
-    else:
-      self.value = value.__lshift__(other)
-    return self
+    raise NotImplementedError(
+      'In-place operations are no longer supported for Variable.\n'
+      'Use `variable.value <<= x`` instead.'
+    )
 
   def __irshift__(self: V, other) -> V:
-    if isinstance(other, Variable):
-      other = other.value
-    value = self.value
-    if hasattr(value, '__irshift__'):
-      value.__irshift__(other)
-    else:
-      self.value = value.__rshift__(other)
-    return self
+    raise NotImplementedError(
+      'In-place operations are no longer supported for Variable.\n'
+      'Use `variable.value >>= x`` instead.'
+    )
 
   def __iand__(self: V, other) -> V:
-    if isinstance(other, Variable):
-      other = other.value
-    value = self.value
-    if hasattr(value, '__iand__'):
-      value.__iand__(other)
-    else:
-      self.value = value.__and__(other)
-    return self
+    raise NotImplementedError(
+      'In-place operations are no longer supported for Variable.\n'
+      'Use `variable.value &= x` instead.'
+    )
 
   def __ixor__(self: V, other) -> V:
-    if isinstance(other, Variable):
-      other = other.value
-    value = self.value
-    if hasattr(value, '__ixor__'):
-      value.__ixor__(other)
-    else:
-      self.value = value.__xor__(other)
-    return self
+    raise NotImplementedError(
+      'In-place operations are no longer supported for Variable.\n'
+      'Use `variable.value ^= x` instead.'
+    )
 
   def __ior__(self: V, other) -> V:
-    if isinstance(other, Variable):
-      other = other.value
-    value = self.value
-    if hasattr(value, '__ior__'):
-      value.__ior__(other)
-    else:
-      self.value = value.__or__(other)
-    return self
+    raise NotImplementedError(
+      'In-place operations are no longer supported for Variable.\n'
+      'Use `variable.value |= x` instead.'
+    )
 
   def __neg__(self) -> A:
     return self.value.__neg__()  # type: ignore

--- a/tests/nnx/bridge/wrappers_test.py
+++ b/tests/nnx/bridge/wrappers_test.py
@@ -308,7 +308,7 @@ class TestCompatibility(absltest.TestCase):
       def __init__(self):
         self.count = Count(jnp.array(0))
       def __call__(self):
-        self.count += 1
+        self.count.value += 1
 
     model = bridge.ToLinen(Counter, skip_rng=True)
     variables = model.init(jax.random.key(0))
@@ -360,7 +360,7 @@ class TestCompatibility(absltest.TestCase):
       def __init__(self):
         self.count = Count(jnp.array(0))
       def __call__(self):
-        self.count += 1
+        self.count.value += 1
         self.count_nonzero = nnx.Intermediate(jnp.array(1))
 
     model = bridge.ToLinen(Counter, skip_rng=True)

--- a/tests/nnx/graph_utils_test.py
+++ b/tests/nnx/graph_utils_test.py
@@ -944,7 +944,7 @@ class TestGraphUtils(absltest.TestCase):
 
     @nnx.jit
     def f(v):
-      v += 1
+      v.value += 1
 
     f(v)
 
@@ -959,7 +959,7 @@ class TestGraphUtils(absltest.TestCase):
     def f(vs):
       self.assertIs(vs[0], vs[1])
       self.assertIsNot(vs[0], vs[2])
-      vs[0] += 10
+      vs[0].value += 10
 
     f(vs)
 
@@ -979,7 +979,7 @@ class TestGraphUtils(absltest.TestCase):
     @nnx.jit
     def increment_var(var, foo):
       self.assertIs(var, foo.var)
-      var += 1
+      var.value += 1
 
     increment_var(var, foo)
     self.assertEqual(foo.var.value, 2)
@@ -996,7 +996,7 @@ class TestGraphUtils(absltest.TestCase):
 
     @nnx.jit
     def stateful_linear(w, b, count, x):
-      count += 1
+      count.value += 1
       return x @ w + b[None]
 
     x = jax.random.normal(rngs(), (1, 2))

--- a/tests/nnx/transforms_test.py
+++ b/tests/nnx/transforms_test.py
@@ -1249,7 +1249,7 @@ class TestScan(absltest.TestCase):
     def stack_forward(params, x):
       w, b, count = params
       y = block_forward(w, b, x)
-      count += 1
+      count.value += 1
       return (w, b, count), y
 
     x = jnp.ones((5, 1, 3))
@@ -1297,7 +1297,7 @@ class TestScan(absltest.TestCase):
 
     @nnx.scan(in_axes=nnx.Carry, out_axes=nnx.Carry, length=3)
     def loop(foo: Foo):
-      foo.n += 1
+      foo.n.value += 1
       return foo
 
     foo2 = loop(foo)
@@ -1352,7 +1352,7 @@ class TestScan(absltest.TestCase):
     @nnx.scan(in_axes=0, out_axes=0)
     def loop(foo: Foo, x):
       x = x + 1
-      foo.n += 1
+      foo.n.value += 1
       return x
 
     ys = loop(foo, xs)
@@ -1848,7 +1848,7 @@ class TestRemat(absltest.TestCase):
 
     @nnx.remat
     def linear(w, b, count, x):
-      count += 1
+      count.value += 1
       return x @ w + b[None]
 
     def loss_fn(w, b, count, x):
@@ -2719,7 +2719,7 @@ class TestCond(absltest.TestCase):
       self.assertEqual(env.index.shape, ())
 
       def increment(env: Env):
-        env.step += 1
+        env.step.value += 1
 
       def no_nothing(env: Env):
         pass


### PR DESCRIPTION
# What does this PR do?

In place operators on Variable are no longer supported because these are not supported by Tracer and cannot be implemented in AbstractVariable. Instead users should use `.value <operator>=` e.g.

```python
variable.value += 1
```