### PR TITLE
Use `jnp.stack` instead of `np.stack` in `flax.training.common_utils.stack_forest`

### DIFF
--- a/flax/training/common_utils.py
+++ b/flax/training/common_utils.py
@@ -20,7 +20,6 @@ with helping write pmap-based data-parallel training loops.
 
 import jax
 import jax.numpy as jnp
-import numpy as np
 from jax import lax
 
 
@@ -65,7 +64,7 @@ def stack_forest(forest):
     A single pytree of the same structure whose leaves are individually
       stacked arrays.
   """
-  stack_args = lambda *args: np.stack(args)
+  stack_args = lambda *args: jnp.stack(args)
   return jax.tree_util.tree_map(stack_args, *forest)
 
 


### PR DESCRIPTION
Replaced `np.stack` with `jnp.stack` If we would like to `jax.jit` a function using `flax.training.common_utils.stack_forest`