### PR TITLE
Fixed broken nnx.statelib.diff

### DIFF
--- a/flax/nnx/statelib.py
+++ b/flax/nnx/statelib.py
@@ -725,7 +725,7 @@ def diff(state: State, other: State) -> State:
 
   self_flat = to_flat_state(state)
   other_flat = to_flat_state(other)
-  diff = {k: v for k, v in self_flat.items() if k not in other_flat}
+  diff = {k: v for k, v in self_flat if k not in other_flat.paths}
 
   return from_flat_state(diff)
 


### PR DESCRIPTION
Description:
- Fixed broken nnx.statelib.diff
- Added a test

Repro code:
```python
import flax.nnx as nnx

class MLPs(nnx.Module):
  def __init__(self, dim, rngs: nnx.Rngs, n=4):
    self.layers = nnx.List()
    for _ in range(n):
      self.layers.append(nnx.Linear(dim, dim, rngs=rngs, use_bias=False))

  def __call__(self, x):
    for layer in self.layers:
      x = layer(x)
    return x


model = MLPs(4, rngs=nnx.Rngs(0))
new_model = MLPs(4, rngs=nnx.Rngs(1), n=5)
state = nnx.state(model)
new_state = nnx.state(new_model)
nnx.statelib.diff(new_state, state)

# AttributeError: 'FlatState' object has no attribute 'items'
```
