### PR TITLE
Removed kernel_init/bias_init atttributes from popular layers

### DIFF
--- a/flax/nnx/nn/attention.py
+++ b/flax/nnx/nn/attention.py
@@ -355,10 +355,6 @@ class MultiHeadAttention(Module):
     self.dropout_rate = dropout_rate
     self.deterministic = deterministic
     self.precision = precision
-    self.kernel_init = kernel_init
-    self.out_kernel_init = out_kernel_init
-    self.bias_init = bias_init
-    self.out_bias_init = out_bias_init
     self.use_bias = use_bias
     self.attention_fn = attention_fn
     self.decode = decode
@@ -381,8 +377,8 @@ class MultiHeadAttention(Module):
       out_features=(self.num_heads, self.head_dim),
       dtype=self.dtype,
       param_dtype=self.param_dtype,
-      kernel_init=self.kernel_init,
-      bias_init=self.bias_init,
+      kernel_init=kernel_init,
+      bias_init=bias_init,
       use_bias=self.use_bias,
       precision=self.precision,
       dot_general=self.qkv_dot_general,
@@ -421,8 +417,8 @@ class MultiHeadAttention(Module):
       in_features=(self.num_heads, self.head_dim),
       out_features=self.out_features,
       axis=(-2, -1),
-      kernel_init=self.out_kernel_init or self.kernel_init,
-      bias_init=self.out_bias_init or self.bias_init,
+      kernel_init=out_kernel_init or kernel_init,
+      bias_init=out_bias_init or bias_init,
       use_bias=self.use_bias,
       dtype=self.dtype,
       param_dtype=self.param_dtype,

--- a/flax/nnx/nn/linear.py
+++ b/flax/nnx/nn/linear.py
@@ -171,8 +171,6 @@ class LinearGeneral(Module):
     self.use_bias = use_bias
     self.dtype = dtype
     self.param_dtype = param_dtype
-    self.kernel_init = kernel_init
-    self.bias_init = bias_init
     self.precision = precision
     self.dot_general = dot_general
     self.dot_general_cls = dot_general_cls
@@ -205,7 +203,7 @@ class LinearGeneral(Module):
         np.prod(shape[-n_out_features:]),
       )
       flat_shape = jax.tree.map(int, flat_shape)
-      kernel = self.kernel_init(rng, flat_shape, dtype)
+      kernel = kernel_init(rng, flat_shape, dtype)
       if isinstance(kernel, variablelib.VariableMetadata):
         kernel.raw_value = jnp.reshape(kernel.raw_value, shape)
       else:
@@ -228,7 +226,7 @@ class LinearGeneral(Module):
 
       def bias_init_wrap(rng, shape, dtype):
         flat_shape = (int(np.prod(shape)),)
-        bias = self.bias_init(rng, flat_shape, dtype)
+        bias = bias_init(rng, flat_shape, dtype)
         if isinstance(bias, variablelib.VariableMetadata):
           bias.raw_value = jnp.reshape(bias.raw_value, shape)
         else:
@@ -375,8 +373,6 @@ class Linear(Module):
     self.dtype = dtype
     self.param_dtype = param_dtype
     self.precision = precision
-    self.kernel_init = kernel_init
-    self.bias_init = bias_init
     self.dot_general = dot_general
     self.promote_dtype = promote_dtype
     self.preferred_element_type = preferred_element_type
@@ -494,8 +490,6 @@ class Einsum(Module):
     self.dtype = dtype
     self.param_dtype = param_dtype
     self.precision = precision
-    self.kernel_init = kernel_init
-    self.bias_init = bias_init
     self.promote_dtype = promote_dtype
     self.einsum_op = einsum_op
     self.preferred_element_type = preferred_element_type
@@ -739,8 +733,6 @@ class Conv(Module):
     self.dtype = dtype
     self.param_dtype = param_dtype
     self.precision = precision
-    self.kernel_init = kernel_init
-    self.bias_init = bias_init
     self.conv_general_dilated = conv_general_dilated
     self.promote_dtype = promote_dtype
     self.preferred_element_type = preferred_element_type
@@ -989,8 +981,6 @@ class ConvTranspose(Module):
     self.dtype = dtype
     self.param_dtype = param_dtype
     self.precision = precision
-    self.kernel_init = kernel_init
-    self.bias_init = bias_init
     self.transpose_kernel = transpose_kernel
     self.promote_dtype = promote_dtype
     self.preferred_element_type = preferred_element_type
@@ -1002,13 +992,13 @@ class ConvTranspose(Module):
 
     self.kernel_shape = kernel_shape
     self.kernel = nnx.Param(
-      self.kernel_init(rngs.params(), kernel_shape, self.param_dtype)
+      kernel_init(rngs.params(), kernel_shape, self.param_dtype)
     )
 
     self.bias: nnx.Param | None
     if self.use_bias:
       self.bias = nnx.Param(
-        self.bias_init(rngs.params(), (self.out_features,), self.param_dtype)
+        bias_init(rngs.params(), (self.out_features,), self.param_dtype)
       )
     else:
       self.bias = nnx.data(None)
@@ -1222,7 +1212,6 @@ class Embed(Module):
     self.features = features
     self.dtype = dtype or self.embedding.value.dtype
     self.param_dtype = param_dtype
-    self.embedding_init = embedding_init
     self.promote_dtype = promote_dtype
 
   def __call__(self, inputs: Array) -> Array:

--- a/flax/nnx/nn/normalization.py
+++ b/flax/nnx/nn/normalization.py
@@ -321,8 +321,6 @@ class BatchNorm(Module):
     self.param_dtype = param_dtype
     self.use_bias = use_bias
     self.use_scale = use_scale
-    self.bias_init = bias_init
-    self.scale_init = scale_init
     self.axis_name = axis_name
     self.axis_index_groups = axis_index_groups
     self.use_fast_variance = use_fast_variance
@@ -490,8 +488,6 @@ class LayerNorm(Module):
     self.param_dtype = param_dtype
     self.use_bias = use_bias
     self.use_scale = use_scale
-    self.bias_init = bias_init
-    self.scale_init = scale_init
     self.reduction_axes = reduction_axes
     self.feature_axes = feature_axes
     self.axis_name = axis_name
@@ -611,7 +607,6 @@ class RMSNorm(Module):
     self.dtype = dtype
     self.param_dtype = param_dtype
     self.use_scale = use_scale
-    self.scale_init = scale_init
     self.reduction_axes = reduction_axes
     self.feature_axes = feature_axes
     self.axis_name = axis_name
@@ -793,8 +788,6 @@ class GroupNorm(Module):
     self.param_dtype = param_dtype
     self.use_bias = use_bias
     self.use_scale = use_scale
-    self.bias_init = bias_init
-    self.scale_init = scale_init
     self.reduction_axes = reduction_axes
     self.axis_name = axis_name
     self.axis_index_groups = axis_index_groups
@@ -958,8 +951,6 @@ class InstanceNorm(Module):
     self.param_dtype = param_dtype
     self.use_bias = use_bias
     self.use_scale = use_scale
-    self.bias_init = bias_init
-    self.scale_init = scale_init
     self.feature_axes = feature_axes
     self.axis_name = axis_name
     self.axis_index_groups = axis_index_groups


### PR DESCRIPTION
Description:
- Removed kernel_init/bias_init atttributes from popular layers
- Added tests

Note about recurrent layers like LSTM, we are storing carry_init in self to be used in initialize_carry method: https://github.com/google/flax/blob/771eadb1986e59a5a2dd82a14188fd1cd7b3849f/flax/nnx/nn/recurrent.py#L224-L225
I'm not sure how we could remove self.carry_init and keep BC for initialize_carry method.
Alternatively, we could add carry_init arg to initialize_carry method and also remove carry_init arg from ctor, but this would be BC-breaking...