### PR TITLE
feat: add `nnx.set_metadata` to in-place change metadata of the state variables of `nnx.Module`s

### DIFF
--- a/docs_nnx/api_reference/flax.nnx/graph.rst
+++ b/docs_nnx/api_reference/flax.nnx/graph.rst
@@ -16,6 +16,7 @@ graph
 .. autofunction:: iter_graph
 .. autofunction:: clone
 .. autofunction:: call
+.. autofunction:: set_metadata
 .. autofunction:: cached_partial
 
 .. autoclass:: GraphDef

--- a/flax/nnx/__init__.py
+++ b/flax/nnx/__init__.py
@@ -61,6 +61,7 @@ from .graph import graphdef as graphdef
 from .graph import iter_graph as iter_graph
 from .graph import find_duplicates as find_duplicates
 from .graph import call as call
+from .graph import set_metadata as set_metadata
 from .graph import SplitContext as SplitContext
 from .graph import split_context as split_context
 from .graph import MergeContext as MergeContext

--- a/tests/nnx/variable_test.py
+++ b/tests/nnx/variable_test.py
@@ -133,6 +133,24 @@ class TestVariable(absltest.TestCase):
     x = v.get_metadata('x', default=10)
     self.assertEqual(x, 10)
 
+  def test_set_module_metadata(self):
+    class Module(nnx.Module):
+      def __init__(self):
+        self.v = nnx.Variable(jnp.array(0.0))
+        self.p = nnx.Param(jnp.array(1.0))
+
+    m = Module()
+    self.assertTrue('foo' not in m.v.get_metadata())
+    self.assertTrue('foo' not in m.p.get_metadata())
+    nnx.set_metadata(m, foo='bar')
+    self.assertTrue(m.v.get_metadata() == {'foo': 'bar'})
+    self.assertTrue(m.p.get_metadata() == {'foo': 'bar'})
+
+    self.assertTrue('differentiable' not in m.v.get_metadata())
+    self.assertTrue('differentiable' not in m.p.get_metadata())
+    nnx.set_metadata(m, differentiable=False, only=nnx.Param)
+    self.assertTrue(m.v.get_metadata() == {'foo': 'bar'})
+    self.assertTrue(m.p.get_metadata() == {'foo': 'bar', 'differentiable': False})
 
 if __name__ == '__main__':
   absltest.main()


### PR DESCRIPTION
@cgarciae I've put up the PR as discussed in #4995.
~Additionally, I've added a new filter (`IsDifferentiable`) that lets you split a state into a differentiable and a non-differentiable part. I could imagine that may be in some cases easier to express than through types of variables. If you don't like this, I'm happy to remove it.~

Please let me know what you think :) 

## Checklist
- [ ] This PR fixes a minor issue (e.g.: typo or small bug) or improves the docs (you can dismiss the other
      checks if that's the case).
- [x] This change is discussed in a Github issue/
      [discussion](https://github.com/google/flax/discussions) (please add a
      link).
- [x] The documentation and docstrings adhere to the
      [documentation guidelines](https://github.com/google/flax/blob/main/docs/README.md#how-to-write-code-documentation).
- [x] This change includes necessary high-coverage tests.
      (No quality testing = no merge!)
