### PR TITLE
Add Rngs KeylessInitializers

### DIFF
--- a/docs_nnx/guides/flax_gspmd.ipynb
+++ b/docs_nnx/guides/flax_gspmd.ipynb
@@ -37,13 +37,11 @@
     }
    ],
    "source": [
-    "from typing import *\n",
     "from functools import partial\n",
     "\n",
-    "import numpy as np\n",
     "import jax\n",
     "from jax import numpy as jnp\n",
-    "from jax.sharding import Mesh, PartitionSpec, NamedSharding, AxisType, reshard\n",
+    "from jax.sharding import PartitionSpec as P, NamedSharding, AxisType\n",
     "import optax\n",
     "from flax import nnx\n",
     "\n",
@@ -82,7 +80,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -105,7 +103,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
@@ -150,11 +148,15 @@
     }
    ],
    "source": [
+    "rngs = nnx.Rngs(0)\n",
+    "\n",
     "with jax.set_mesh(auto_mesh):\n",
-    "  w = nnx.Param(nnx.initializers.lecun_normal()(jax.random.key(0), (4, 8)),\n",
-    "                sharding_names=(None, 'model'))\n",
-    "  print(w.value.sharding.spec)\n",
-    "  jax.debug.visualize_array_sharding(w.value)  # already sharded!"
+    "  w = nnx.Param(\n",
+    "    rngs.lecun_normal()((4, 8)),\n",
+    "    sharding_names=(None, 'model')\n",
+    "  )\n",
+    "  print(w.sharding.spec)\n",
+    "  jax.debug.visualize_array_sharding(w)  # already sharded!"
    ]
   },
   {
@@ -170,7 +172,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -182,8 +184,9 @@
     "                    kernel_init=nnx.with_partitioning(init_fn, (None, 'model')))\n",
     "\n",
     "with jax.set_mesh(auto_mesh):\n",
-    "  linear = init_sharded_linear(jax.random.key(0))\n",
-    "  assert linear.kernel.sharding.spec == PartitionSpec(None, 'model') # already sharded!"
+    "  key= rngs()\n",
+    "  linear = init_sharded_linear(key)\n",
+    "  assert linear.kernel.sharding.spec == P(None, 'model') # already sharded!"
    ]
   },
   {
@@ -201,7 +204,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -252,7 +255,7 @@
     "# In this case, ('data', None) @ (None, 'model') = ('data', 'model')\n",
     "with jax.set_mesh(auto_mesh):\n",
     "  # Create your input data, sharded along `data` dimension, as in data parallelism\n",
-    "  x = jax.device_put(jnp.ones((16, 4)), PartitionSpec('data', None))\n",
+    "  x = jax.device_put(jnp.ones((16, 4)), P('data', None))\n",
     "  \n",
     "  # Run the model forward function, jitted\n",
     "  y = jax.jit(lambda m, x: m(x))(linear, x)\n",
@@ -278,7 +281,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -298,8 +301,8 @@
     "  def __call__(self, x: jax.Array):\n",
     "    y = self.dot1(x)\n",
     "    y = jax.nn.relu(y)\n",
-    "    y = jax.lax.with_sharding_constraint(y, PartitionSpec('data', 'model'))\n",
-    "    z = jnp.dot(y, self.w2.value)\n",
+    "    y = jax.lax.with_sharding_constraint(y, P('data', 'model'))\n",
+    "    z = jnp.dot(y, self.w2[...])\n",
     "    return z\n",
     "\n",
     "class MultiDotReluDot(nnx.Module):\n",
@@ -327,18 +330,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "1.2834555\n",
-      "0.8552339\n",
-      "0.6534006\n",
-      "0.5418401\n",
-      "0.38069054\n"
+      "1.251457\n",
+      "0.8495563\n",
+      "0.6590716\n",
+      "0.5399748\n",
+      "0.39150265\n"
      ]
     }
    ],
@@ -356,10 +359,8 @@
     "\n",
     "with jax.set_mesh(auto_mesh):\n",
     "  # Training data\n",
-    "  input = jax.device_put(jax.random.normal(jax.random.key(1), (8, 1024)),\n",
-    "                         PartitionSpec('data', None))\n",
-    "  label = jax.device_put(jax.random.normal(jax.random.key(2), (8, 1024)),\n",
-    "                         PartitionSpec('data', None))\n",
+    "  input = jax.device_put(rngs.normal((8, 1024)), P('data', None))\n",
+    "  label = jax.device_put(rngs.normal((8, 1024)), P('data', None))\n",
     "  # Model and optimizer\n",
     "  model = MultiDotReluDot(1024, 2, rngs=nnx.Rngs(0))\n",
     "  optimizer = nnx.Optimizer(model, optax.adam(1e-3), wrt=nnx.Param)\n",
@@ -381,9 +382,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "13 ms ± 588 μs per loop (mean ± std. dev. of 7 runs, 100 loops each)\n"
+     ]
+    }
+   ],
    "source": [
     "%%timeit\n",
     "\n",
@@ -408,7 +417,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
@@ -453,7 +462,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -477,8 +486,8 @@
     "    y = self.dot1(x)\n",
     "    y = jax.nn.relu(y)\n",
     "    # Unfortunately the logical aliasing doesn't work on lower-level JAX calls.\n",
-    "    y = jax.lax.with_sharding_constraint(y, PartitionSpec('data', None))\n",
-    "    z = jnp.dot(y, self.w2.value)\n",
+    "    y = jax.lax.with_sharding_constraint(y, P('data', None))\n",
+    "    z = jnp.dot(y, self.w2[...])\n",
     "    return z\n",
     "\n",
     "class LogicalMultiDotReluDot(nnx.Module):\n",
@@ -504,7 +513,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -514,14 +523,14 @@
     "  logical_output = logical_model(input)\n",
     "\n",
     "# Check out their equivalency with some easier-to-read sharding descriptions.\n",
-    "assert logical_model.layers.dot1.kernel.value.sharding.is_equivalent_to(\n",
-    "  NamedSharding(auto_mesh, PartitionSpec(None, None, 'model')), ndim=3\n",
+    "assert logical_model.layers.dot1.kernel.sharding.is_equivalent_to(\n",
+    "  NamedSharding(auto_mesh, P(None, None, 'model')), ndim=3\n",
     ")\n",
-    "assert logical_model.layers.w2.value.sharding.is_equivalent_to(\n",
-    "  NamedSharding(auto_mesh, PartitionSpec(None, 'model', None)), ndim=3\n",
+    "assert logical_model.layers.w2.sharding.is_equivalent_to(\n",
+    "  NamedSharding(auto_mesh, P(None, 'model', None)), ndim=3\n",
     ")\n",
     "assert logical_output.sharding.is_equivalent_to(\n",
-    "  NamedSharding(auto_mesh, PartitionSpec('data', None)), ndim=2\n",
+    "  NamedSharding(auto_mesh, P('data', None)), ndim=2\n",
     ")"
    ]
   },
@@ -584,19 +593,19 @@
     "    init_fn = nnx.initializers.lecun_normal()\n",
     "    self.dot1 = nnx.Linear(\n",
     "      depth, depth,\n",
-    "      kernel_init=partial(init_fn, out_sharding=PartitionSpec(None, 'model')),\n",
+    "      kernel_init=partial(init_fn, out_sharding=P(None, 'model')),\n",
     "      use_bias=False,\n",
     "      rngs=rngs)\n",
     "    self.w2 = nnx.Param(\n",
-    "      init_fn(rngs.params(), (depth, depth), out_sharding=PartitionSpec('model', None)),\n",
+    "      init_fn(rngs.params(), (depth, depth), out_sharding=P('model', None)),\n",
     "    )\n",
-    "    self.b2 = nnx.Param(jnp.zeros((depth, ), out_sharding=PartitionSpec(None,)))\n",
+    "    self.b2 = nnx.Param(jnp.zeros((depth, ), out_sharding=P(None,)))\n",
     "\n",
     "  def __call__(self, x: jax.Array):\n",
     "    y = self.dot1(x)\n",
     "    y = jax.nn.relu(y)\n",
-    "    z = jnp.dot(y, self.w2.value, out_sharding=PartitionSpec('data', None))\n",
-    "    z = z + self.b2.value\n",
+    "    z = jnp.dot(y, self.w2[...], out_sharding=P('data', None))\n",
+    "    z = z + self.b2\n",
     "    return z\n",
     "\n",
     "\n",
@@ -618,8 +627,8 @@
     "\n",
     "with jax.set_mesh(explicit_mesh):\n",
     "  model = ExplicitMultiDotReluDot(1024, 2, rngs=nnx.Rngs(0))\n",
-    "  x = jax.device_put(jax.random.normal(jax.random.key(1), (8, 1024)), \n",
-    "                     NamedSharding(explicit_mesh, PartitionSpec('data', None)))\n",
+    "  x = jax.device_put(rngs.normal((8, 1024)),\n",
+    "                     NamedSharding(explicit_mesh, P('data', None)))\n",
     "  y = model(x)\n",
     "\n",
     "print(model.layers.dot1.kernel.sharding.spec)\n",
@@ -636,7 +645,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {
@@ -685,7 +694,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.7"
+   "version": "3.11.9"
   }
  },
  "nbformat": 4,

--- a/flax/nnx/rnglib.py
+++ b/flax/nnx/rnglib.py
@@ -21,8 +21,10 @@ from jax import random
 import jax.numpy as jnp
 
 from flax import errors, struct
+from flax import typing
 from flax.nnx import graph
 from flax.nnx import variablelib
+from flax.nnx.nn import initializers
 from flax.nnx.variablelib import Variable
 from flax.nnx import filterlib
 from flax.nnx.pytreelib import Pytree
@@ -32,6 +34,50 @@ F = tp.TypeVar('F', bound=tp.Callable[..., tp.Any])
 Counts = list[int]
 AxesValue = tp.Union[int, None]
 SplitPattern = tp.Union[AxesValue, tuple[AxesValue, ...]]
+OutShardingType: tp.TypeAlias = (
+  jax.sharding.NamedSharding | jax.sharding.PartitionSpec | None
+)
+Fargs = tp.ParamSpec('Fargs')
+
+
+@tp.runtime_checkable
+class KeylessInitializer(tp.Protocol):
+  def __call__(
+    self,
+    shape: typing.Shape,
+    dtype: tp.Any | None = None,
+    out_sharding: OutShardingType = None,
+  ) -> jax.Array:
+    raise NotImplementedError
+
+
+def _to_keyless(
+  initializer_constructor: tp.Callable[Fargs, jax.nn.initializers.Initializer],
+) -> tp.Callable[Fargs, KeylessInitializer]:
+  raise NotImplementedError
+
+
+def _function_to_method(random_f):
+  def rngs_random_method(self: Rngs | RngStream, *args, **kwargs) -> jax.Array:
+    return random_f(self(), *args, **kwargs)
+
+  return rngs_random_method
+
+
+def _initializer_to_method(
+  initializer_constructor: tp.Callable[Fargs, jax.nn.initializers.Initializer],
+):
+  def rngs_initializer_method(
+    self: Rngs | RngStream, *args: Fargs.args, **kwargs: Fargs.kwargs
+  ) -> KeylessInitializer:
+    init_fn = initializer_constructor(*args, **kwargs)
+
+    def rngs_keyless_initializer(*init_args, **init_kwargs):
+      return init_fn(self(), *init_args, **init_kwargs)
+
+    return rngs_keyless_initializer
+
+  return rngs_initializer_method
 
 
 class RngState(Variable[jax.Array]):
@@ -84,6 +130,9 @@ class RngStream(Pytree):
       key = random.split(key, split)
     return type(self)(key, tag=self.tag)
 
+  # ----------------------------------------------------------
+  # random functions
+  # ----------------------------------------------------------
   if tp.TYPE_CHECKING:
     bits = staticmethod(functools.partial(random.bits, random.key(0)))
     uniform = staticmethod(
@@ -176,120 +225,88 @@ class RngStream(Pytree):
       functools.partial(random.multinomial, random.key(0))
     )
   else:
+    bits = _function_to_method(random.bits)
+    uniform = _function_to_method(random.uniform)
+    randint = _function_to_method(random.randint)
+    permutation = _function_to_method(random.permutation)
+    choice = _function_to_method(random.choice)
+    normal = _function_to_method(random.normal)
+    multivariate_normal = _function_to_method(random.multivariate_normal)
+    truncated_normal = _function_to_method(random.truncated_normal)
+    bernoulli = _function_to_method(random.bernoulli)
+    beta = _function_to_method(random.beta)
+    cauchy = _function_to_method(random.cauchy)
+    dirichlet = _function_to_method(random.dirichlet)
+    exponential = _function_to_method(random.exponential)
+    gamma = _function_to_method(random.gamma)
+    loggamma = _function_to_method(random.loggamma)
+    poisson = _function_to_method(random.poisson)
+    gumbel = _function_to_method(random.gumbel)
+    categorical = _function_to_method(random.categorical)
+    laplace = _function_to_method(random.laplace)
+    logistic = _function_to_method(random.logistic)
+    pareto = _function_to_method(random.pareto)
+    t = _function_to_method(random.t)
+    chisquare = _function_to_method(random.chisquare)
+    f = _function_to_method(random.f)
+    rademacher = _function_to_method(random.rademacher)
+    maxwell = _function_to_method(random.maxwell)
+    double_sided_maxwell = _function_to_method(random.double_sided_maxwell)
+    weibull_min = _function_to_method(random.weibull_min)
+    orthogonal = _function_to_method(random.orthogonal)
+    generalized_normal = _function_to_method(random.generalized_normal)
+    ball = _function_to_method(random.ball)
+    rayleigh = _function_to_method(random.rayleigh)
+    wald = _function_to_method(random.wald)
+    geometric = _function_to_method(random.geometric)
+    triangular = _function_to_method(random.triangular)
+    lognormal = _function_to_method(random.lognormal)
+    binomial = _function_to_method(random.binomial)
+    multinomial = _function_to_method(random.multinomial)
 
-    def bits(self, *args, **kwargs):
-      return random.bits(self(), *args, **kwargs)
-
-    def uniform(self, *args, **kwargs):
-      return random.uniform(self(), *args, **kwargs)
-
-    def randint(self, *args, **kwargs):
-      return random.randint(self(), *args, **kwargs)
-
-    def permutation(self, *args, **kwargs):
-      return random.permutation(self(), *args, **kwargs)
-
-    def choice(self, *args, **kwargs):
-      return random.choice(self(), *args, **kwargs)
-
-    def normal(self, *args, **kwargs):
-      return random.normal(self(), *args, **kwargs)
-
-    def multivariate_normal(self, *args, **kwargs):
-      return random.multivariate_normal(self(), *args, **kwargs)
-
-    def truncated_normal(self, *args, **kwargs):
-      return random.truncated_normal(self(), *args, **kwargs)
-
-    def bernoulli(self, *args, **kwargs):
-      return random.bernoulli(self(), *args, **kwargs)
-
-    def beta(self, *args, **kwargs):
-      return random.beta(self(), *args, **kwargs)
-
-    def cauchy(self, *args, **kwargs):
-      return random.cauchy(self(), *args, **kwargs)
-
-    def dirichlet(self, *args, **kwargs):
-      return random.dirichlet(self(), *args, **kwargs)
-
-    def exponential(self, *args, **kwargs):
-      return random.exponential(self(), *args, **kwargs)
-
-    def gamma(self, *args, **kwargs):
-      return random.gamma(self(), *args, **kwargs)
-
-    def loggamma(self, *args, **kwargs):
-      return random.loggamma(self(), *args, **kwargs)
-
-    def poisson(self, *args, **kwargs):
-      return random.poisson(self(), *args, **kwargs)
-
-    def gumbel(self, *args, **kwargs):
-      return random.gumbel(self(), *args, **kwargs)
-
-    def categorical(self, *args, **kwargs):
-      return random.categorical(self(), *args, **kwargs)
-
-    def laplace(self, *args, **kwargs):
-      return random.laplace(self(), *args, **kwargs)
-
-    def logistic(self, *args, **kwargs):
-      return random.logistic(self(), *args, **kwargs)
-
-    def pareto(self, *args, **kwargs):
-      return random.pareto(self(), *args, **kwargs)
-
-    def t(self, *args, **kwargs):
-      return random.t(self(), *args, **kwargs)
-
-    def chisquare(self, *args, **kwargs):
-      return random.chisquare(self(), *args, **kwargs)
-
-    def f(self, *args, **kwargs):
-      return random.f(self(), *args, **kwargs)
-
-    def rademacher(self, *args, **kwargs):
-      return random.rademacher(self(), *args, **kwargs)
-
-    def maxwell(self, *args, **kwargs):
-      return random.maxwell(self(), *args, **kwargs)
-
-    def double_sided_maxwell(self, *args, **kwargs):
-      return random.double_sided_maxwell(self(), *args, **kwargs)
-
-    def weibull_min(self, *args, **kwargs):
-      return random.weibull_min(self(), *args, **kwargs)
-
-    def orthogonal(self, *args, **kwargs):
-      return random.orthogonal(self(), *args, **kwargs)
-
-    def generalized_normal(self, *args, **kwargs):
-      return random.generalized_normal(self(), *args, **kwargs)
-
-    def ball(self, *args, **kwargs):
-      return random.ball(self(), *args, **kwargs)
-
-    def rayleigh(self, *args, **kwargs):
-      return random.rayleigh(self(), *args, **kwargs)
-
-    def wald(self, *args, **kwargs):
-      return random.wald(self(), *args, **kwargs)
-
-    def geometric(self, *args, **kwargs):
-      return random.geometric(self(), *args, **kwargs)
-
-    def triangular(self, *args, **kwargs):
-      return random.triangular(self(), *args, **kwargs)
-
-    def lognormal(self, *args, **kwargs):
-      return random.lognormal(self(), *args, **kwargs)
-
-    def binomial(self, *args, **kwargs):
-      return random.binomial(self(), *args, **kwargs)
-
-    def multinomial(self, *args, **kwargs):
-      return random.multinomial(self(), *args, **kwargs)
+  # ----------------------------------------------------------
+  # initializers
+  # ----------------------------------------------------------
+  if tp.TYPE_CHECKING:
+    # skip constant
+    delta_orthogonal = staticmethod(_to_keyless(initializers.delta_orthogonal))
+    glorot_normal = staticmethod(_to_keyless(initializers.glorot_normal))
+    glorot_uniform = staticmethod(_to_keyless(initializers.glorot_uniform))
+    he_normal = staticmethod(_to_keyless(initializers.he_normal))
+    he_uniform = staticmethod(_to_keyless(initializers.he_uniform))
+    kaiming_normal = staticmethod(_to_keyless(initializers.kaiming_normal))
+    kaiming_uniform = staticmethod(_to_keyless(initializers.kaiming_uniform))
+    lecun_normal = staticmethod(_to_keyless(initializers.lecun_normal))
+    lecun_uniform = staticmethod(_to_keyless(initializers.lecun_uniform))
+    # skip normal as it conflicts with jax.random.normal
+    # skip ones
+    # skip orthogonal as it conflicts with jax.random.orthogonal
+    # skip truncated_normal as it conflicts with jax.random.truncated_normal
+    # skip uniform as it conflicts with jax.random.uniform
+    variance_scaling = staticmethod(_to_keyless(initializers.variance_scaling))
+    xavier_normal = staticmethod(_to_keyless(initializers.xavier_normal))
+    xavier_uniform = staticmethod(_to_keyless(initializers.xavier_uniform))
+    # skip zeros
+  else:
+    # skip constant
+    delta_orthogonal = _initializer_to_method(initializers.delta_orthogonal)
+    glorot_normal = _initializer_to_method(initializers.glorot_normal)
+    glorot_uniform = _initializer_to_method(initializers.glorot_uniform)
+    he_normal = _initializer_to_method(initializers.he_normal)
+    he_uniform = _initializer_to_method(initializers.he_uniform)
+    kaiming_normal = _initializer_to_method(initializers.kaiming_normal)
+    kaiming_uniform = _initializer_to_method(initializers.kaiming_uniform)
+    lecun_normal = _initializer_to_method(initializers.lecun_normal)
+    lecun_uniform = _initializer_to_method(initializers.lecun_uniform)
+    # skip normal as it conflicts with jax.random.normal
+    # skip ones
+    # skip orthogonal as it conflicts with jax.random.orthogonal
+    # skip truncated_normal as it conflicts with jax.random.truncated_normal
+    # skip uniform as it conflicts with jax.random.uniform
+    variance_scaling = _initializer_to_method(initializers.variance_scaling)
+    xavier_normal = _initializer_to_method(initializers.xavier_normal)
+    xavier_uniform = _initializer_to_method(initializers.xavier_uniform)
+    # skip zeros
 
 
 RngValue = tp.Union[int, jax.Array]
@@ -392,6 +409,88 @@ class Rngs(Pytree):
   def __call__(self):
     return self.default()
 
+  def __iter__(self) -> tp.Iterator[str]:
+    for name, stream in vars(self).items():
+      if isinstance(stream, RngStream):
+        yield name
+
+  def __len__(self) -> int:
+    return sum(
+      1 for stream in vars(self).values() if isinstance(stream, RngStream)
+    )
+
+  def __contains__(self, name: tp.Any) -> bool:
+    return name in vars(self)
+
+  def items(self):
+    for name, stream in vars(self).items():
+      if isinstance(stream, RngStream):
+        yield name, stream
+
+  def fork(
+    self,
+    /,
+    *,
+    split: tp.Mapping[filterlib.Filter, int | tuple[int, ...]]
+    | int
+    | tuple[int, ...]
+    | None = None,
+  ):
+    """Returns a new Rngs object with new unique RNG keys.
+
+    Example::
+      >>> from flax import nnx
+      ...
+      >>> rngs = nnx.Rngs(params=1, dropout=2)
+      >>> new_rngs = rngs.fork()
+      ...
+      >>> assert rngs.params() != new_rngs.params()
+
+    ``split`` can be used to split the keys of the newly created ``Rngs`` object::
+
+      >>> rngs = nnx.Rngs(params=1, dropout=2)
+      >>> new_rngs = rngs.fork(split=5)
+      ...
+      >>> assert new_rngs.params.key.shape == (5,)
+      >>> assert new_rngs.dropout.key.shape == (5,)
+
+    ``split`` also accepts a mapping of
+    `Filters <https://flax.readthedocs.io/en/latest/guides/filters_guide.html>`__  to
+    split sizes or None to control which streams are split and how they are split::
+
+      >>> rngs = nnx.Rngs(params=1, dropout=2, noise=3)
+      >>> new_rngs = rngs.fork(split={
+      ...  'params': 5,      # split params into 5 keys
+      ...  'dropout': None,  # don't split dropout
+      ...  ...: (2, 5),      # split anything else into 2x5 keys
+      ... })
+      ...
+      >>> assert new_rngs.params.key.shape == (5,)
+      >>> assert new_rngs.dropout.key.shape == ()
+      >>> assert new_rngs.noise.key.shape == (2, 5)
+    """
+    if split is None:
+      split = {}
+    elif isinstance(split, int):
+      split = {...: split}
+    elif isinstance(split, tuple):
+      split = {...: split}
+
+    split_predicates = {filterlib.to_predicate(k): v for k, v in split.items()}
+    keys: dict[str, RngStream] = {}
+    for name, stream in self.items():
+      for predicate, num_splits in split_predicates.items():
+        if predicate((), stream):
+          keys[name] = stream.fork(split=num_splits)
+          break
+      else:
+        keys[name] = stream.fork()
+
+    return Rngs(**keys)
+
+  # ----------------------------------------------------------
+  # random functions
+  # ----------------------------------------------------------
   if tp.TYPE_CHECKING:
     bits = staticmethod(functools.partial(random.bits, random.key(0)))
     uniform = staticmethod(
@@ -484,199 +583,88 @@ class Rngs(Pytree):
       functools.partial(random.multinomial, random.key(0))
     )
   else:
+    bits = _function_to_method(random.bits)
+    uniform = _function_to_method(random.uniform)
+    randint = _function_to_method(random.randint)
+    permutation = _function_to_method(random.permutation)
+    choice = _function_to_method(random.choice)
+    normal = _function_to_method(random.normal)
+    multivariate_normal = _function_to_method(random.multivariate_normal)
+    truncated_normal = _function_to_method(random.truncated_normal)
+    bernoulli = _function_to_method(random.bernoulli)
+    beta = _function_to_method(random.beta)
+    cauchy = _function_to_method(random.cauchy)
+    dirichlet = _function_to_method(random.dirichlet)
+    exponential = _function_to_method(random.exponential)
+    gamma = _function_to_method(random.gamma)
+    loggamma = _function_to_method(random.loggamma)
+    poisson = _function_to_method(random.poisson)
+    gumbel = _function_to_method(random.gumbel)
+    categorical = _function_to_method(random.categorical)
+    laplace = _function_to_method(random.laplace)
+    logistic = _function_to_method(random.logistic)
+    pareto = _function_to_method(random.pareto)
+    t = _function_to_method(random.t)
+    chisquare = _function_to_method(random.chisquare)
+    f = _function_to_method(random.f)
+    rademacher = _function_to_method(random.rademacher)
+    maxwell = _function_to_method(random.maxwell)
+    double_sided_maxwell = _function_to_method(random.double_sided_maxwell)
+    weibull_min = _function_to_method(random.weibull_min)
+    orthogonal = _function_to_method(random.orthogonal)
+    generalized_normal = _function_to_method(random.generalized_normal)
+    ball = _function_to_method(random.ball)
+    rayleigh = _function_to_method(random.rayleigh)
+    wald = _function_to_method(random.wald)
+    geometric = _function_to_method(random.geometric)
+    triangular = _function_to_method(random.triangular)
+    lognormal = _function_to_method(random.lognormal)
+    binomial = _function_to_method(random.binomial)
+    multinomial = _function_to_method(random.multinomial)
 
-    def bits(self, *args, **kwargs):
-      return self.default.bits(*args, **kwargs)
-
-    def uniform(self, *args, **kwargs):
-      return self.default.uniform(*args, **kwargs)
-
-    def randint(self, *args, **kwargs):
-      return self.default.randint(*args, **kwargs)
-
-    def permutation(self, *args, **kwargs):
-      return self.default.permutation(*args, **kwargs)
-
-    def choice(self, *args, **kwargs):
-      return self.default.choice(*args, **kwargs)
-
-    def normal(self, *args, **kwargs):
-      return self.default.normal(*args, **kwargs)
-
-    def multivariate_normal(self, *args, **kwargs):
-      return self.default.multivariate_normal(*args, **kwargs)
-
-    def truncated_normal(self, *args, **kwargs):
-      return self.default.truncated_normal(*args, **kwargs)
-
-    def bernoulli(self, *args, **kwargs):
-      return self.default.bernoulli(*args, **kwargs)
-
-    def beta(self, *args, **kwargs):
-      return self.default.beta(*args, **kwargs)
-
-    def cauchy(self, *args, **kwargs):
-      return self.default.cauchy(*args, **kwargs)
-
-    def dirichlet(self, *args, **kwargs):
-      return self.default.dirichlet(*args, **kwargs)
-
-    def exponential(self, *args, **kwargs):
-      return self.default.exponential(*args, **kwargs)
-
-    def gamma(self, *args, **kwargs):
-      return self.default.gamma(*args, **kwargs)
-
-    def loggamma(self, *args, **kwargs):
-      return self.default.loggamma(*args, **kwargs)
-
-    def poisson(self, *args, **kwargs):
-      return self.default.poisson(*args, **kwargs)
-
-    def gumbel(self, *args, **kwargs):
-      return self.default.gumbel(*args, **kwargs)
-
-    def categorical(self, *args, **kwargs):
-      return self.default.categorical(*args, **kwargs)
-
-    def laplace(self, *args, **kwargs):
-      return self.default.laplace(*args, **kwargs)
-
-    def logistic(self, *args, **kwargs):
-      return self.default.logistic(*args, **kwargs)
-
-    def pareto(self, *args, **kwargs):
-      return self.default.pareto(*args, **kwargs)
-
-    def t(self, *args, **kwargs):
-      return self.default.t(*args, **kwargs)
-
-    def chisquare(self, *args, **kwargs):
-      return self.default.chisquare(*args, **kwargs)
-
-    def f(self, *args, **kwargs):
-      return self.default.f(*args, **kwargs)
-
-    def rademacher(self, *args, **kwargs):
-      return self.default.rademacher(*args, **kwargs)
-
-    def maxwell(self, *args, **kwargs):
-      return self.default.maxwell(*args, **kwargs)
-
-    def double_sided_maxwell(self, *args, **kwargs):
-      return self.default.double_sided_maxwell(*args, **kwargs)
-
-    def weibull_min(self, *args, **kwargs):
-      return self.default.weibull_min(*args, **kwargs)
-
-    def orthogonal(self, *args, **kwargs):
-      return self.default.orthogonal(*args, **kwargs)
-
-    def generalized_normal(self, *args, **kwargs):
-      return self.default.generalized_normal(*args, **kwargs)
-
-    def ball(self, *args, **kwargs):
-      return self.default.ball(*args, **kwargs)
-
-    def rayleigh(self, *args, **kwargs):
-      return self.default.rayleigh(*args, **kwargs)
-
-    def wald(self, *args, **kwargs):
-      return self.default.wald(*args, **kwargs)
-
-    def geometric(self, *args, **kwargs):
-      return self.default.geometric(*args, **kwargs)
-
-    def triangular(self, *args, **kwargs):
-      return self.default.triangular(*args, **kwargs)
-
-    def lognormal(self, *args, **kwargs):
-      return self.default.lognormal(*args, **kwargs)
-
-    def binomial(self, *args, **kwargs):
-      return self.default.binomial(*args, **kwargs)
-
-    def multinomial(self, *args, **kwargs):
-      return self.default.multinomial(*args, **kwargs)
-
-  def __iter__(self) -> tp.Iterator[str]:
-    for name, stream in vars(self).items():
-      if isinstance(stream, RngStream):
-        yield name
-
-  def __len__(self) -> int:
-    return sum(
-      1 for stream in vars(self).values() if isinstance(stream, RngStream)
-    )
-
-  def __contains__(self, name: tp.Any) -> bool:
-    return name in vars(self)
-
-  def items(self):
-    for name, stream in vars(self).items():
-      if isinstance(stream, RngStream):
-        yield name, stream
-
-  def fork(
-    self,
-    /,
-    *,
-    split: tp.Mapping[filterlib.Filter, int | tuple[int, ...]]
-    | int
-    | tuple[int, ...]
-    | None = None,
-  ):
-    """Returns a new Rngs object with new unique RNG keys.
-
-    Example::
-      >>> from flax import nnx
-      ...
-      >>> rngs = nnx.Rngs(params=1, dropout=2)
-      >>> new_rngs = rngs.fork()
-      ...
-      >>> assert rngs.params() != new_rngs.params()
-
-    ``split`` can be used to split the keys of the newly created ``Rngs`` object::
-
-      >>> rngs = nnx.Rngs(params=1, dropout=2)
-      >>> new_rngs = rngs.fork(split=5)
-      ...
-      >>> assert new_rngs.params.key.shape == (5,)
-      >>> assert new_rngs.dropout.key.shape == (5,)
-
-    ``split`` also accepts a mapping of
-    `Filters <https://flax.readthedocs.io/en/latest/guides/filters_guide.html>`__  to
-    split sizes or None to control which streams are split and how they are split::
-
-      >>> rngs = nnx.Rngs(params=1, dropout=2, noise=3)
-      >>> new_rngs = rngs.fork(split={
-      ...  'params': 5,      # split params into 5 keys
-      ...  'dropout': None,  # don't split dropout
-      ...  ...: (2, 5),      # split anything else into 2x5 keys
-      ... })
-      ...
-      >>> assert new_rngs.params.key.shape == (5,)
-      >>> assert new_rngs.dropout.key.shape == ()
-      >>> assert new_rngs.noise.key.shape == (2, 5)
-    """
-    if split is None:
-      split = {}
-    elif isinstance(split, int):
-      split = {...: split}
-    elif isinstance(split, tuple):
-      split = {...: split}
-
-    split_predicates = {filterlib.to_predicate(k): v for k, v in split.items()}
-    keys: dict[str, RngStream] = {}
-    for name, stream in self.items():
-      for predicate, num_splits in split_predicates.items():
-        if predicate((), stream):
-          keys[name] = stream.fork(split=num_splits)
-          break
-      else:
-        keys[name] = stream.fork()
-
-    return Rngs(**keys)
+  # ----------------------------------------------------------
+  # initializers
+  # ----------------------------------------------------------
+  if tp.TYPE_CHECKING:
+    # skip constant
+    delta_orthogonal = staticmethod(_to_keyless(initializers.delta_orthogonal))
+    glorot_normal = staticmethod(_to_keyless(initializers.glorot_normal))
+    glorot_uniform = staticmethod(_to_keyless(initializers.glorot_uniform))
+    he_normal = staticmethod(_to_keyless(initializers.he_normal))
+    he_uniform = staticmethod(_to_keyless(initializers.he_uniform))
+    kaiming_normal = staticmethod(_to_keyless(initializers.kaiming_normal))
+    kaiming_uniform = staticmethod(_to_keyless(initializers.kaiming_uniform))
+    lecun_normal = staticmethod(_to_keyless(initializers.lecun_normal))
+    lecun_uniform = staticmethod(_to_keyless(initializers.lecun_uniform))
+    # skip normal as it conflicts with jax.random.normal
+    # skip ones
+    # skip orthogonal as it conflicts with jax.random.orthogonal
+    # skip truncated_normal as it conflicts with jax.random.truncated_normal
+    # skip uniform as it conflicts with jax.random.uniform
+    variance_scaling = staticmethod(_to_keyless(initializers.variance_scaling))
+    xavier_normal = staticmethod(_to_keyless(initializers.xavier_normal))
+    xavier_uniform = staticmethod(_to_keyless(initializers.xavier_uniform))
+    # skip zeros
+  else:
+    # skip constant
+    delta_orthogonal = _initializer_to_method(initializers.delta_orthogonal)
+    glorot_normal = _initializer_to_method(initializers.glorot_normal)
+    glorot_uniform = _initializer_to_method(initializers.glorot_uniform)
+    he_normal = _initializer_to_method(initializers.he_normal)
+    he_uniform = _initializer_to_method(initializers.he_uniform)
+    kaiming_normal = _initializer_to_method(initializers.kaiming_normal)
+    kaiming_uniform = _initializer_to_method(initializers.kaiming_uniform)
+    lecun_normal = _initializer_to_method(initializers.lecun_normal)
+    lecun_uniform = _initializer_to_method(initializers.lecun_uniform)
+    # skip normal as it conflicts with jax.random.normal
+    # skip ones
+    # skip orthogonal as it conflicts with jax.random.orthogonal
+    # skip truncated_normal as it conflicts with jax.random.truncated_normal
+    # skip uniform as it conflicts with jax.random.uniform
+    variance_scaling = _initializer_to_method(initializers.variance_scaling)
+    xavier_normal = _initializer_to_method(initializers.xavier_normal)
+    xavier_uniform = _initializer_to_method(initializers.xavier_uniform)
+    # skip zeros
 
 
 StreamBackup = (

--- a/tests/nnx/rngs_test.py
+++ b/tests/nnx/rngs_test.py
@@ -193,12 +193,27 @@ class TestRngs(absltest.TestCase):
     np.testing.assert_allclose(y1, y2)
 
   def test_random_helpers(self):
-    rngs = nnx.Rngs(0)
+    rngs = nnx.Rngs(0, params=1)
 
-    x1 = rngs.normal((2, 3))
-    x2 = rngs.default.normal((2, 3))
+    x_nnx = rngs.normal((2, 3))
+    x_jax = jax.random.normal(jax.random.fold_in(jax.random.key(0), 0), (2, 3))
+    np.testing.assert_allclose(x_nnx, x_jax)
 
-    self.assertFalse(jnp.allclose(x1, x2))
+    x_nnx = rngs.params.uniform((2, 3))
+    x_jax = jax.random.uniform(jax.random.fold_in(jax.random.key(1), 0), (2, 3))
+    np.testing.assert_allclose(x_nnx, x_jax)
+
+    x_nnx = rngs.lecun_normal()((2, 3))
+    x_jax = jax.nn.initializers.lecun_normal()(
+      jax.random.fold_in(jax.random.key(0), 1), (2, 3)
+    )
+    np.testing.assert_allclose(x_nnx, x_jax)
+
+    x_nnx = rngs.params.lecun_uniform()((2, 3))
+    x_jax = jax.nn.initializers.lecun_uniform()(
+      jax.random.fold_in(jax.random.key(1), 1), (2, 3)
+    )
+    np.testing.assert_allclose(x_nnx, x_jax)
 
 if __name__ == '__main__':
   absltest.main()


### PR DESCRIPTION
# What does this PR do?

* Adds initializer constructors from `jax.nn.initializers` as methods to `Rngs` and `RngsStream` that return `KeylessInitializer`s, these follow the `Initializer` protocol without the leading `key` argument. Example

```python
rngs = nnx.Rngs(0, param=1)
w = rngs.lecun_normal()((4, 8)) # from default
z = rngs.params.lecun_uniform()((6, 10))
```
* Also updates the `flax_gspmd` guide to use the `Rngs` initializer plus some other small change such as aliasing `PartitionSpec` as `P` and using `[...]` instead of `.value`.