### PR TITLE
Fixed attribute visualization in __treescope_repr__

### DIFF
--- a/flax/nnx/pytreelib.py
+++ b/flax/nnx/pytreelib.py
@@ -685,7 +685,7 @@ class Pytree(reprlib.Representable, metaclass=PytreeMeta):
   def __treescope_repr__(self, path, subtree_renderer):
     from flax import nnx
 
-    if OBJECT_CONTEXT.node_stats is None:
+    if OBJECT_CONTEXT.node_stats is None or id(self) not in OBJECT_CONTEXT.node_stats:
       node_stats: dict[int, dict[type[Variable], SizeBytes]] = {}
       _collect_stats(self, node_stats)
       OBJECT_CONTEXT.node_stats = node_stats


### PR DESCRIPTION
Fixes #5004

This PR fixes the following warning/error:
```
Traceback (most recent call last):
  File "/usr/local/lib/python3.12/dist-packages/treescope/renderers.py", line 290, in _render_subtree
    maybe_result = handler(node=node, path=path, subtree_renderer=rec)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/treescope/_internal/handlers/custom_type_handlers.py", line 65, in handle_via_treescope_repr_method
    return treescope_repr_method(path, subtree_renderer)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/flax/nnx/pytreelib.py", line 695, in __treescope_repr__
    stats = OBJECT_CONTEXT.node_stats[id(self)]
            ~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^
KeyError: 132628205053824
```
which is reproducible in ipython env when `__treescope_repr__ ` is called. 

The implementation of `__treescope_repr__ ` mostly similar to the implementation of `__nnx_repr__` which already handles this situation:
https://github.com/google/flax/blob/fd118b124f4721345d9a0b1e1c843475de39638d/flax/nnx/pytreelib.py#L623-L629
vs 
https://github.com/google/flax/blob/fd118b124f4721345d9a0b1e1c843475de39638d/flax/nnx/pytreelib.py#L685-L691

