### PR TITLE
Update README to use fully qualified `nnx.Linear` in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,10 +100,10 @@ Example of an MLP:
 ```py
 class MLP(nnx.Module):
   def __init__(self, din: int, dmid: int, dout: int, *, rngs: nnx.Rngs):
-    self.linear1 = Linear(din, dmid, rngs=rngs)
+    self.linear1 = nnx.Linear(din, dmid, rngs=rngs)
     self.dropout = nnx.Dropout(rate=0.1, rngs=rngs)
     self.bn = nnx.BatchNorm(dmid, rngs=rngs)
-    self.linear2 = Linear(dmid, dout, rngs=rngs)
+    self.linear2 = nnx.Linear(dmid, dout, rngs=rngs)
 
   def __call__(self, x: jax.Array):
     x = nnx.gelu(self.dropout(self.bn(self.linear1(x))))


### PR DESCRIPTION
# What does this PR do?

Follow-up of #4386.

This pull request makes a minor update to the example MLP code in the `README.md` file to clarify usage of the `nnx` module prefix for the `Linear` layers. This helps ensure consistency and clarity in the example code.

- Documentation fix:
  * Updated the MLP example in `README.md` to use `nnx.Linear` instead of `Linear` for both `linear1` and `linear2` layer definitions.

<!-- Fixes # (issue) -->

## Checklist
- [x] This PR fixes a minor issue (e.g.: typo or small bug) or improves the docs (you can dismiss the other checks if that's the case).
- [ ] This change is discussed in a Github issue/[discussion](https://github.com/google/flax/discussions) (please add a link).
- [x] The documentation and docstrings adhere to the [documentation guidelines](https://github.com/google/flax/blob/main/docs/README.md#how-to-write-code-documentation).
- [ ] This change includes necessary high-coverage tests. (No quality testing = no merge!)
