### PR TITLE
Added a note in nnx.jit about arg donation

### DIFF
--- a/flax/nnx/transforms/compilation.py
+++ b/flax/nnx/transforms/compilation.py
@@ -186,6 +186,19 @@ def jit(
   Lifted version of ``jax.jit`` that can handle Modules / graph nodes as
   arguments.
 
+  .. note::
+    If jitted function has a model and an optimizer as inputs, we can
+    reduce accelerator's memory usage if we specify them in
+    ``donate_argnums`` or ``donate_argnames``:
+
+      >>> from flax import nnx
+      >>>
+      >>> @nnx.jit(donate_argnames=("model", "optimizer"))
+      ... def func(model: nnx.Module, optimizer: nnx.Optimizer, other_args):
+      ...   pass
+
+    For details please see `this discussion <https://github.com/google/flax/issues/5026>`_.
+
   Args:
     fun: Function to be jitted. ``fun`` should be a pure function, as
       side-effects may only be executed once.


### PR DESCRIPTION
There were several issues opened about GPU memory consumption by Flax vs PyTorch that:
- https://github.com/google/flax/issues/5026
- https://github.com/google/flax/issues/4848

I added a note in `nnx.jit` about arguments donation to reduce the memory usage:

https://flax--5031.org.readthedocs.build/en/5031/api_reference/flax.nnx/transforms.html#flax.nnx.jit

