### PR TITLE
Support for python 3.14

### DIFF
--- a/.github/workflows/flax_test.yml
+++ b/.github/workflows/flax_test.yml
@@ -63,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.11', '3.12', '3.13']
+        python-version: ['3.11', '3.12', '3.13', '3.14']
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: Set up Python ${{ matrix.python-version }}
@@ -159,3 +159,30 @@ jobs:
            "description": "'$status'",
            "context": "github-actions/Build"
            }'
+
+  # This is a temporary workflow to test flax on Python 3.14 and
+  # skipping deps like tensorstore, tensorflow etc
+  tests-python314:
+    name: Run Tests on Python 3.14
+    needs: [pre-commit, commit-count]
+    runs-on: ubuntu-24.04-16core
+    steps:
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+    - name: Setup uv
+      uses: astral-sh/setup-uv@887a942a15af3a7626099df99e897a18d9e5ab3a # v5.1.0
+      with:
+        version: "0.9.2"
+        python-version: "3.14"
+        activate-environment: true
+        enable-cache: true
+
+    - name: Install dependencies
+      run: |
+        uv pip install jax msgpack treescope rich typing_extensions PyYAML optax cloudpickle
+        uv pip install pytest pytest-custom_exit_code pytest-xdist pytest-cov
+        uv pip install -e . --no-deps
+    - name: Test with pytest
+      run: |
+        export XLA_FLAGS='--xla_force_host_platform_device_count=4'
+        find tests/ -name "*.py" | grep -vE 'checkpoint|integr|io|tensorboard' | xargs pytest -n auto
+

--- a/flax/linen/module.py
+++ b/flax/linen/module.py
@@ -1061,7 +1061,7 @@ class Module(ModuleBase):
     3. Generate a hash function (if not provided by cls).
     """
     # Check reserved attributes have expected type annotations.
-    annotations = dict(cls.__dict__.get('__annotations__', {}))
+    annotations = inspect.get_annotations(cls)
     if annotations.get('parent', _ParentType) != _ParentType:
       raise errors.ReservedModuleAttributeError(annotations)
     if annotations.get('name', str) not in ('str', str, Optional[str]):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,8 +17,8 @@ dependencies = [
     "jax>=0.7.1",
     "msgpack",
     "optax",
-    "orbax-checkpoint",
-    "tensorstore",
+    "orbax-checkpoint; python_version<'3.14'",  # temporary skip orbax-checkpoint for py3.14
+    "tensorstore; python_version<'3.14'",  # temporary skip tensorstore for py3.14
     "rich>=11.1",
     "typing_extensions>=4.2",
     "PyYAML>=5.4.1",


### PR DESCRIPTION
Adapted the way to access `__annotations__` object. Flax linen code relies on `cls.__dict__["__annotations__"]`, but in Python 3.14+ `cls.__dict__` does not contain `__annotation__` key anymore.

In this PR we access the class annotations for modifications directly as `cls.__annotations__` which is fine according to:

> If for some reason [inspect.get_annotations()](https://docs.python.org/3/library/inspect.html#inspect.get_annotations) isn’t viable for your use case, you may access the __annotations__ data member manually. Best practice for this changed in Python 3.10 as well: as of Python 3.10, o.__annotations__ is guaranteed to always work on Python functions, classes, and modules. If you’re certain the object you’re examining is one of these three specific objects, you may simply use o.__annotations__ to get at the object’s annotations dict. 

(https://docs.python.org/3/howto/annotations.html#accessing-the-annotations-dict-of-an-object-in-python-3-10-and-newer)

Fixes https://github.com/google/flax/issues/5027

Currently, we are blocked with `tensorstore` and `tensorflow` not yet made their 3.14 releases. We run the CI without the tests requiring these packages.
