### PR TITLE
Fix ValueError when `nnx.jit` is used with `nnx.custom_vjp`

### DIFF
--- a/flax/nnx/transforms/compilation.py
+++ b/flax/nnx/transforms/compilation.py
@@ -113,7 +113,10 @@ class JitFn:
   ctxtag: tp.Hashable
 
   def __post_init__(self):
-    functools.update_wrapper(self, self.f)
+    # Prevent overwriting our ctxtag info with the child function's
+    orig_ctxtag = self.ctxtag
+    functools.update_wrapper(self, self.f, updated=())
+    self.ctxtag = orig_ctxtag
 
   def __call__(self, *pure_args, **pure_kwargs):
     args, kwargs = extract.from_tree(


### PR DESCRIPTION
Resolves #5044. 