### PR TITLE
Set Mode with Tests

### DIFF
--- a/flax/nnx/__init__.py
+++ b/flax/nnx/__init__.py
@@ -47,6 +47,9 @@ from .helpers import Sequential as Sequential
 from .helpers import TrainState as TrainState
 from .module import M as M
 from .module import Module as Module
+from .module import set_mode as set_mode
+from .module import train_mode as train_mode
+from .module import eval_mode as eval_mode
 from .module import iter_children as iter_children, iter_modules as iter_modules
 from .graph import merge as merge
 from .graph import UpdateContext as UpdateContext

--- a/flax/nnx/nn/normalization.py
+++ b/flax/nnx/nn/normalization.py
@@ -392,6 +392,21 @@ class BatchNorm(Module):
       self.epsilon,
     )
 
+  def set_mode(
+      self,
+      use_running_average: bool | None = None,
+      **kwargs,
+  ) -> dict:
+    """Class method used by ``nnx.set_mode``.
+
+    Args:
+      use_running_average: if True, the stored batch statistics will be
+        used instead of computing the batch statistics on the input.
+    """
+    if use_running_average is not None:
+      self.use_running_average = use_running_average
+    return kwargs
+
 
 class LayerNorm(Module):
   """Layer normalization (https://arxiv.org/abs/1607.06450).

--- a/flax/nnx/nn/stochastic.py
+++ b/flax/nnx/nn/stochastic.py
@@ -153,3 +153,17 @@ class Dropout(Module):
     mask = random.bernoulli(key, p=keep_prob, shape=broadcast_shape)
     mask = jnp.broadcast_to(mask, inputs.shape)
     return lax.select(mask, inputs / keep_prob, jnp.zeros_like(inputs))
+
+  def set_mode(
+      self,
+      deterministic: bool | None = None,
+      **kwargs,
+  ) -> dict:
+    """Class method used by ``nnx.set_mode``.
+
+    Args:
+      deterministic: if True, disables dropout masking.
+    """
+    if deterministic is not None:
+      self.deterministic = deterministic
+    return kwargs

--- a/tests/nnx/integration_test.py
+++ b/tests/nnx/integration_test.py
@@ -28,6 +28,59 @@ A = tp.TypeVar('A')
 
 
 class TestIntegration(absltest.TestCase):
+
+  def test_basic_set_mode_example(self):
+    class Model(nnx.Module):
+
+      def __init__(self, din, dmid, dout, rngs: nnx.Rngs):
+        self.linear = nnx.Linear(din, dmid, rngs=rngs)
+        self.bn = nnx.BatchNorm(dmid, rngs=rngs)
+        self.dropout = nnx.Dropout(0.2, rngs=rngs)
+        self.linear_out = nnx.Linear(dmid, dout, rngs=rngs)
+
+      def __call__(self, x):
+        x = nnx.relu(self.dropout(self.bn(self.linear(x))))
+        return self.linear_out(x)
+
+    model = Model(2, 64, 3, rngs=nnx.Rngs(0))  # eager initialization
+    train_model = nnx.set_mode(
+        model, deterministic=False, use_running_average=False
+    )
+    eval_model = nnx.set_mode(
+        model, deterministic=True, use_running_average=True
+    )
+    optimizer = nnx.Optimizer(train_model, optax.adam(1e-3), wrt=nnx.Param)
+
+    self.assertEqual(train_model.dropout.deterministic, False)
+    self.assertEqual(train_model.bn.use_running_average, False)
+    self.assertEqual(eval_model.dropout.deterministic, True)
+    self.assertEqual(eval_model.bn.use_running_average, True)
+    self.assertIs(train_model.dropout.rngs.count, eval_model.dropout.rngs.count)
+
+    @nnx.jit  # automatic state management for JAX transforms
+    def train_step(model, optimizer, x, y):
+      def loss_fn(model):
+        y_pred = model(x)
+        return jnp.mean((y_pred - y) ** 2)
+
+      loss, grads = nnx.value_and_grad(loss_fn)(model)
+      optimizer.update(model, grads)  # in-place updates
+
+      return loss
+
+    @nnx.jit
+    def eval_step(model, x, y):
+      y_pred = model(x)
+      return jnp.mean((y_pred - y) ** 2)
+
+    x = jax.random.normal(jax.random.key(0), (8, 2))
+    y = jax.random.normal(jax.random.key(1), (8, 3))
+
+    train_step(train_model, optimizer, x, y)
+    self.assertEqual(train_model.dropout.rngs.count.value, 1)
+    eval_step(eval_model, x, y)
+    self.assertEqual(train_model.dropout.rngs.count.value, 1)
+
   def test_shared_modules(self):
     class Block(nnx.Module):
       def __init__(self, linear: nnx.Linear, *, rngs):
@@ -78,6 +131,56 @@ class TestIntegration(absltest.TestCase):
     assert model.block1.linear.bias is not None
     assert model.block1.bn is not model.block2.bn
 
+  def test_shared_modules_set_mode(self):
+    class Block(nnx.Module):
+      def __init__(self, linear: nnx.Linear, *, rngs):
+        self.linear = linear
+        self.bn = nnx.BatchNorm(2, rngs=rngs)
+
+      def __call__(self, x):
+        x = self.linear(x)
+        x = self.bn(x)
+        return nnx.relu(x)
+
+    class Model(nnx.Module):
+      def __init__(self, *, rngs):
+        shared = nnx.Linear(2, 2, rngs=rngs)
+        self.block1 = Block(shared, rngs=rngs)
+        self.block2 = Block(shared, rngs=rngs)
+
+      def __call__(self, x):
+        x = self.block1(x)
+        x = self.block2(x)
+        return x
+
+    @nnx.jit
+    def train_step(model: Model, x, y):
+      @nnx.grad
+      def loss_fn(model: Model):
+        y_pred = model(x)
+        return jnp.mean((y - y_pred) ** 2)
+
+      grads = loss_fn(model)
+      nnx.update(
+        model,
+        jax.tree.map(
+          lambda w, g: w - 0.1 * g, nnx.state(model, nnx.Param), grads
+        ),
+      )
+
+    model = Model(rngs=nnx.Rngs(0))
+
+    x = np.random.uniform(size=(4, 2))
+    y = np.random.uniform(size=(4, 2))
+    new_model = nnx.set_mode(model, use_running_average=False)
+
+    for _i in range(3):
+      train_step(model, x, y)
+
+    assert new_model.block1.linear is new_model.block2.linear
+    assert new_model.block1.linear.bias is not None
+    assert new_model.block1.bn is not new_model.block2.bn
+
   def test_shared_modules_pure(self):
     class Block(nnx.Module):
       def __init__(self, linear: nnx.Linear, *, rngs: nnx.Rngs):
@@ -127,6 +230,65 @@ class TestIntegration(absltest.TestCase):
     y = np.random.uniform(size=(4, 2))
 
     for _i in range(3):
+      graphdef, state = train_step(state, graphdef, x, y)
+
+    model = nnx.merge(graphdef, state)
+
+    assert model.block1.linear.bias is not None
+    assert model.block2.linear.bias is not None
+    assert model.block1.linear.kernel is model.block2.linear.kernel
+    assert model.block1.linear.bias is model.block2.linear.bias
+    assert model.block1.bn is not model.block2.bn
+
+  def test_shared_modules_pure_set_mode(self):
+    class Block(nnx.Module):
+      def __init__(self, linear: nnx.Linear, *, rngs: nnx.Rngs):
+        self.linear = linear
+        self.bn = nnx.BatchNorm(2, rngs=rngs)
+
+      def __call__(self, x):
+        x = self.linear(x)
+        x = self.bn(x)
+        return nnx.relu(x)
+
+    class Model(nnx.Module):
+      def __init__(self, *, rngs: nnx.Rngs):
+        shared = nnx.Linear(2, 2, rngs=rngs)
+        self.block1 = Block(shared, rngs=rngs)
+        self.block2 = Block(shared, rngs=rngs)
+
+      def __call__(self, x):
+        x = self.block1(x)
+        x = self.block2(x)
+        return x
+
+    @jax.jit
+    def train_step(state: nnx.State, graphdef: nnx.GraphDef[Model], x, y):
+      model = nnx.merge(graphdef, state)
+      new_model = nnx.set_mode(model, use_running_average=False)
+
+      @nnx.grad
+      def loss_fn(model: Model):
+        y_pred = model(x)
+        return jnp.mean((y - y_pred) ** 2)
+
+      grads = loss_fn(new_model)
+      nnx.update(
+        new_model,
+        jax.tree.map(
+          lambda w, g: w - 0.1 * g, nnx.state(new_model, nnx.Param), grads
+        ),
+      )
+
+      return nnx.split(new_model)
+
+    graphdef: nnx.GraphDef[Model]
+    graphdef, state = nnx.split(Model(rngs=nnx.Rngs(0)))
+
+    x = np.random.uniform(size=(4, 2))
+    y = np.random.uniform(size=(4, 2))
+
+    for _ in range(3):
       graphdef, state = train_step(state, graphdef, x, y)
 
     model = nnx.merge(graphdef, state)

--- a/tests/nnx/module_test.py
+++ b/tests/nnx/module_test.py
@@ -649,6 +649,48 @@ class TestModule(absltest.TestCase):
       raise_if_not_found=False,
     )
 
+  def test_set_mode(self):
+    class Block(nnx.Module):
+      def __init__(self, din, dout, *, rngs: nnx.Rngs):
+        self.linear = nnx.Linear(din, dout, rngs=rngs)
+        self.dropout = nnx.Dropout(0.5, deterministic=False, rngs=rngs)
+        self.batch_norm = nnx.BatchNorm(
+          10, use_running_average=False, rngs=rngs
+        )
+
+    block = Block(2, 5, rngs=nnx.Rngs(0))
+    assert block.dropout.deterministic == False
+    assert block.batch_norm.use_running_average == False
+
+    new_block = nnx.set_mode(block, deterministic=True, use_running_average=True)
+    assert new_block.dropout.deterministic == True
+    assert new_block.batch_norm.use_running_average == True
+    assert new_block.linear.kernel is block.linear.kernel
+
+    block = Block(2, 5, rngs=nnx.Rngs(0))
+    new_block = nnx.set_mode(block, only=nnx.Dropout, deterministic=True)
+    # Only the dropout will be modified
+    assert new_block.dropout.deterministic == True
+    assert new_block.batch_norm.use_running_average == False
+
+  def test_set_mode_error(self):
+    class Block(nnx.Module):
+      def __init__(self, din, dout, *, rngs: nnx.Rngs):
+        self.linear = nnx.Linear(din, dout, rngs=rngs)
+        self.dropout = nnx.Dropout(0.5, deterministic=False, rngs=rngs)
+        self.batch_norm = nnx.BatchNorm(
+          10, use_running_average=False, rngs=rngs
+        )
+    block = Block(2, 5, rngs=nnx.Rngs(0))
+
+    with self.assertRaisesRegex(
+        ValueError,
+        (
+            "Unused keys found in set_mode: \\['unknown'\\]"
+        ),
+    ):
+      nnx.set_mode(block, deterministic=True, use_running_average=True, unknown=True)
+
   def test_cloud_pickle(self):
     class Model(nnx.Module):
       def __init__(self, din, dmid, dout, rngs: nnx.Rngs):

--- a/tests/nnx/nn/stochastic_test.py
+++ b/tests/nnx/nn/stochastic_test.py
@@ -87,3 +87,25 @@ class TestStochastic:
       match='`deterministic` is False, but no `rngs` argument was provided to Dropout',
     ):
       m(x)
+
+  def test_dropout_arg_override_set_mode(self):
+    m = nnx.Dropout(rate=0.5)
+    x = jnp.ones((1, 10))
+
+    # deterministic call arg provided
+    m(x, deterministic=True)
+    # deterministic constructor arg provided
+    new_m = nnx.set_mode(m, deterministic=True)
+    y = new_m(x)
+    # both deterministic call and constructor arg provided
+    with pytest.raises(AssertionError):
+      np.testing.assert_allclose(
+        y, new_m(x, deterministic=False, rngs=nnx.Rngs(dropout=0))
+      )
+    # no rng arg provided
+    new_m = nnx.set_mode(m, deterministic=False)
+    with pytest.raises(
+      ValueError,
+      match='`deterministic` is False, but no `rngs` argument was provided to Dropout',
+    ):
+      new_m(x)


### PR DESCRIPTION
# What does this PR do?
Implements the set_mode function based on graph.recursive_map
Implements set_mode as a class method in MultiheadAttention, Batchnorm, and Dropout
Implements set_train and set_eval based on set_mode
Adds tests for set_mode

Fixes # (issue)

## Checklist
- [ ] This PR fixes a minor issue (e.g.: typo or small bug) or improves the docs (you can dismiss the other checks if that's the case).
- [ ] This change is discussed in a Github issue/[discussion](https://github.com/google/flax/discussions) (please add a link).
- [ x] The documentation and docstrings adhere to the [documentation guidelines](https://github.com/google/flax/blob/main/docs/README.md#how-to-write-code-documentation).
- [ x] This change includes necessary high-coverage tests. (No quality testing = no merge!)
