### PR TITLE
add nnx.dataclass

### DIFF
--- a/docs_nnx/guides/pytree.ipynb
+++ b/docs_nnx/guides/pytree.ipynb
@@ -395,8 +395,8 @@
    "id": "8055b72c",
    "metadata": {},
    "source": [
-    "### Class Annotations\n",
-    "Annotations can also be added at the type level via `nnx.Static` and `nnx.Data`. This is useful for creating `dataclasses` but the mechanism also works for regular classes."
+    "### Dataclasses\n",
+    "`nnx.Pytree` dataclasses can be created by using the `nnx.dataclass` decorator. To control the status of each field, `nnx.static` and `nnx.data` can be used as `field` specifiers."
    ]
   },
   {
@@ -420,23 +420,56 @@
    "source": [
     "import dataclasses\n",
     "\n",
-    "@dataclasses.dataclass\n",
+    "@nnx.dataclass\n",
     "class Foo(nnx.Pytree):\n",
-    "  i: nnx.Data[int]\n",
-    "  s: nnx.Static[str]\n",
+    "  i: int = nnx.data()\n",
     "  x: jax.Array\n",
     "  a: int\n",
+    "  s: str = nnx.static(default='hi', kw_only=True)\n",
     "\n",
-    "@dataclasses.dataclass\n",
+    "@nnx.dataclass\n",
     "class Bar(nnx.Pytree):\n",
-    "  ls: nnx.Data[list[Foo]]\n",
+    "  ls: list[Foo] = nnx.data()\n",
     "  shapes: list[int]\n",
     "\n",
     "pytree = Bar(\n",
-    "  ls=[Foo(i, \"Hi\" + \"!\" * i, jnp.array(42 * i), hash(i)) for i in range(2)],\n",
+    "  ls=[Foo(i, jnp.array(42 * i), hash(i)) for i in range(2)],\n",
     "  shapes=[8, 16, 32]\n",
     ")\n",
     "pytree_structure(pytree)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fca51f65",
+   "metadata": {},
+   "source": [
+    "`dataclasses.dataclass` can also be used directly, however type checkers will not handle `nnx.static` and `nnx.data` correctly. To solve this `dataclasses.field` can be used by setting `metadata` with the appropriate entry for `static`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "ff54e732",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "dataclass pytree structure:\n",
+      " - pytree.a = 10\n"
+     ]
+    }
+   ],
+   "source": [
+    "@dataclasses.dataclass\n",
+    "class Bar(nnx.Pytree):\n",
+    "  a: int = dataclasses.field(metadata={'static': False}) # data\n",
+    "  b: str = dataclasses.field(metadata={'static': True})  # static\n",
+    "\n",
+    "pytree = Bar(a=10, b=\"hello\")\n",
+    "pytree_structure(pytree, title='dataclass pytree structure')"
    ]
   },
   {
@@ -457,7 +490,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "id": "509a517e",
    "metadata": {},
    "outputs": [
@@ -501,7 +534,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "id": "98e04ff9",
    "metadata": {},
    "outputs": [
@@ -534,7 +567,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
    "id": "c864d5b1",
    "metadata": {},
    "outputs": [
@@ -568,7 +601,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 14,
    "id": "628698dd",
    "metadata": {},
    "outputs": [
@@ -616,12 +649,12 @@
    "id": "37ee2429",
    "metadata": {},
    "source": [
-    "Checking for `nnx.data` or `nnx.static` annotations stored in inside nested structures that are not `nnx.Pytree` instances:"
+    "Checking for `nnx.data` or `nnx.static` annotations stored inside nested structures that are not `nnx.Pytree` instances:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 15,
    "id": "f9d69634",
    "metadata": {},
    "outputs": [
@@ -629,7 +662,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "ValueError: Found unexpected tags {'data', 'static'} on attribute 'Foo.a'. Values from nnx.data(...) and\n",
+      "ValueError: Found unexpected tags {'static', 'data'} on attribute 'Foo.a'. Values from nnx.data(...) and\n",
       "nnx.static(...) should be assigned to nnx.Pytree attributes directly, they should not be inside other structures. Got value of type '<class 'list'>' on Pytree of type '<class '__main__.Foo'>'.\n"
      ]
     }
@@ -656,7 +689,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 16,
    "id": "668db479",
    "metadata": {},
    "outputs": [
@@ -704,7 +737,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 17,
    "id": "32c46ce8",
    "metadata": {},
    "outputs": [
@@ -741,7 +774,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 18,
    "id": "c33e4862",
    "metadata": {},
    "outputs": [
@@ -778,7 +811,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 19,
    "id": "dda51b67",
    "metadata": {},
    "outputs": [
@@ -825,7 +858,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 20,
    "id": "caa01e3b",
    "metadata": {},
    "outputs": [
@@ -864,7 +897,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 21,
    "id": "d2e03753",
    "metadata": {},
    "outputs": [
@@ -929,7 +962,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 22,
    "id": "ca9f58a2",
    "metadata": {},
    "outputs": [
@@ -1003,7 +1036,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": 23,
    "id": "41398e14",
    "metadata": {},
    "outputs": [
@@ -1050,7 +1083,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 24,
    "id": "d10effba",
    "metadata": {},
    "outputs": [
@@ -1058,12 +1091,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "step = 0, loss = Array(0.7326511, dtype=float32), perturbations = \u001b[38;2;79;201;177mState\u001b[0m\u001b[38;2;255;213;3m({\u001b[0m\u001b[38;2;105;105;105m\u001b[0m\n",
+      "step = 0, loss = Array(0.7326511, dtype=float32), iterm_grads = \u001b[38;2;79;201;177mState\u001b[0m\u001b[38;2;255;213;3m({\u001b[0m\u001b[38;2;105;105;105m\u001b[0m\n",
       "  \u001b[38;2;156;220;254m'xgrad'\u001b[0m\u001b[38;2;212;212;212m: \u001b[0m\u001b[38;2;79;201;177mPerturbation\u001b[0m\u001b[38;2;255;213;3m(\u001b[0m\u001b[38;2;105;105;105m # 3 (12 B)\u001b[0m\n",
       "    \u001b[38;2;156;220;254mvalue\u001b[0m\u001b[38;2;212;212;212m=\u001b[0mArray([[-0.430146  , -0.14356601,  0.2935633 ]], dtype=float32)\n",
       "  \u001b[38;2;255;213;3m)\u001b[0m\n",
       "\u001b[38;2;255;213;3m})\u001b[0m\n",
-      "step = 1, loss = Array(0.65039134, dtype=float32), perturbations = \u001b[38;2;79;201;177mState\u001b[0m\u001b[38;2;255;213;3m({\u001b[0m\u001b[38;2;105;105;105m\u001b[0m\n",
+      "step = 1, loss = Array(0.65039134, dtype=float32), iterm_grads = \u001b[38;2;79;201;177mState\u001b[0m\u001b[38;2;255;213;3m({\u001b[0m\u001b[38;2;105;105;105m\u001b[0m\n",
       "  \u001b[38;2;156;220;254m'xgrad'\u001b[0m\u001b[38;2;212;212;212m: \u001b[0m\u001b[38;2;79;201;177mPerturbation\u001b[0m\u001b[38;2;255;213;3m(\u001b[0m\u001b[38;2;105;105;105m # 3 (12 B)\u001b[0m\n",
       "    \u001b[38;2;156;220;254mvalue\u001b[0m\u001b[38;2;212;212;212m=\u001b[0mArray([[-0.38535568, -0.11745065,  0.24441527]], dtype=float32)\n",
       "  \u001b[38;2;255;213;3m)\u001b[0m\n",
@@ -1108,7 +1141,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 25,
    "id": "a9cab639",
    "metadata": {},
    "outputs": [

--- a/flax/nnx/__init__.py
+++ b/flax/nnx/__init__.py
@@ -36,6 +36,7 @@ from .pytreelib import Pytree as Pytree
 from .pytreelib import Object as Object
 from .pytreelib import Data as Data
 from .pytreelib import Static as Static
+from .pytreelib import dataclass as dataclass
 from .pytreelib import data as data
 from .pytreelib import static as static
 from .pytreelib import register_data_type as register_data_type
@@ -209,12 +210,12 @@ from .extract import NodeStates as NodeStates
 from .summary import tabulate as tabulate
 from . import traversals as traversals
 
-# alias VariableState
-VariableState = Variable
 
 import typing as _tp
 
-if not _tp.TYPE_CHECKING:
+if _tp.TYPE_CHECKING:
+  VariableState = Variable
+else:
   def __getattr__(name):
     if name == "VariableState":
       import warnings
@@ -224,4 +225,5 @@ if not _tp.TYPE_CHECKING:
           DeprecationWarning,
           stacklevel=2,
       )
+      return Variable
     raise AttributeError(f"Module {__name__} has no attribute '{name}'")

--- a/flax/nnx/pytreelib.py
+++ b/flax/nnx/pytreelib.py
@@ -38,7 +38,7 @@ from flax.nnx import (
 )
 from flax import config
 from flax.nnx.variablelib import Variable
-from flax.typing import SizeBytes
+from flax.typing import MISSING, Missing, SizeBytes
 
 BUILDING_DOCS = 'FLAX_DOC_BUILD' in os.environ
 
@@ -52,31 +52,24 @@ Data.__doc__ = """Data marks attributes of a class as pytree data using type ann
 Data annotations must be used at the class level and will apply to all instances.
 The usage of Data is recommended when type annotations are used already present
 or required e.g. for dataclasses.
-
-Example::
-
-  from flax import nnx
-  import jax
-  import dataclasses
-
-  @dataclasses.dataclass
-  class Foo(nnx.Pytree):
-    a: nnx.Data[int]  # Annotates `a` as pytree data
-    b: str            # `b` is not pytree data
-
-  foo = Foo(a=42, b='hello')
-
-  assert jax.tree.leaves(foo) == [42]
 """
 DATA_REGISTRY: set[type] = set()
 
-
-@dataclasses.dataclass(frozen=True, slots=True)
-class DataAttr:
-  value: tp.Any
-
-
-def data(value: A, /) -> A:
+@tp.overload
+def data(value: A, /) -> A: ...
+@tp.overload
+def data(
+  *,
+  default: A = dataclasses.MISSING,  # type: ignore[assignment]
+  default_factory: tp.Callable[[], A] | None = None,  # type: ignore[assignment]
+  init: bool = True,
+  repr: bool = True,
+  hash: bool | None = None,
+  compare: bool = True,
+  metadata: tp.Mapping[str, tp.Any] | None = None,
+  kw_only: bool = False,
+) -> tp.Any: ...
+def data(value: tp.Any = MISSING, /, **kwargs) -> tp.Any:
   """Annotates a an attribute as pytree data.
 
   The return value from `data` must be directly assigned to an Object attribute
@@ -103,7 +96,20 @@ def data(value: A, /) -> A:
     A value which will register the attribute as data on assignment.
 
   """
-  return DataAttr(value)  # type: ignore[return-value]
+  if not isinstance(value, Missing) and kwargs:
+    raise TypeError(
+      'nnx.data() accepts either a single positional argument or keyword'
+      ' arguments, but not both.'
+    )
+  metadata = {'nnx_value': value}
+  if 'metadata' in kwargs and kwargs['metadata'] is not None:
+    if 'static' in kwargs['metadata']:
+      raise ValueError(
+        "Cannot use 'static' key in metadata argument for nnx.data."
+      )
+    metadata.update(kwargs.pop('metadata'))
+  metadata['static'] = False
+  return dataclasses.field(**kwargs, metadata=metadata)  # type: ignore[return-value]
 
 
 def register_data_type(type_: type, /) -> None:
@@ -191,13 +197,21 @@ The usage of Static is recommended when type annotations are used already presen
 or required e.g. for dataclasses.
 """
 
-
-@dataclasses.dataclass(frozen=True, slots=True)
-class StaticAttr:
-  value: tp.Any
-
-
-def static(value: A, /) -> A:
+@tp.overload
+def static(value: A, /) -> A: ...
+@tp.overload
+def static(
+  *,
+  default: A = dataclasses.MISSING,  # type: ignore[assignment]
+  default_factory: tp.Callable[[], A] | None = None,
+  init: bool = True,
+  repr: bool = True,
+  hash: bool | None = None,
+  compare: bool = True,
+  metadata: tp.Mapping[str, tp.Any] | None = None,
+  kw_only: bool = False,
+) -> tp.Any: ...
+def static(value: tp.Any = MISSING, /, **kwargs) -> tp.Any:
   """Annotates a an attribute as static.
 
   The return value from `static` must be directly assigned to an Object
@@ -219,8 +233,61 @@ def static(value: A, /) -> A:
 
   By default ``nnx.Pytree`` will ...
   """
-  return StaticAttr(value)  # type: ignore[return-value]
+  if not isinstance(value, Missing) and kwargs:
+    raise TypeError(
+      'nnx.static() accepts either a single positional argument or keyword'
+      ' arguments, but not both.'
+    )
+  metadata = {'nnx_value': value}
+  if 'metadata' in kwargs and kwargs['metadata'] is not None:
+    if 'static' in kwargs['metadata']:
+      raise ValueError(
+        "Cannot use 'static' key in metadata argument for nnx.static."
+      )
+    metadata.update(kwargs.pop('metadata'))
+  metadata['static'] = True
+  return dataclasses.field(**kwargs, metadata=metadata)  # type: ignore[return-value]
 
+@tp.overload
+def dataclass(cls: type[A], /) -> type[A]: ...
+@tp.overload
+def dataclass(
+  *,
+  init: bool = True,
+  eq: bool = True,
+  order: bool = False,
+  unsafe_hash: bool = False,
+  match_args: bool = True,
+  kw_only: bool = False,
+  slots: bool = False,
+  weakref_slot: bool = False,
+) -> tp.Callable[[type[A]], type[A]]: ...
+
+@tp.dataclass_transform(field_specifiers=(dataclasses.field, data, static))
+def dataclass(
+  cls=None,
+  /,
+  *,
+  init: bool = True,
+  eq: bool = True,
+  order: bool = False,
+  unsafe_hash: bool = False,
+  match_args: bool = True,
+  kw_only: bool = False,
+  slots: bool = False,
+  weakref_slot: bool = False,
+) -> tp.Any:
+  return dataclasses.dataclass(
+    cls,
+    init=init,
+    eq=eq,
+    order=order,
+    unsafe_hash=unsafe_hash,
+    match_args=match_args,
+    kw_only=kw_only,
+    slots=slots,
+    weakref_slot=weakref_slot,
+  )
 
 def _collect_stats(
   node: tp.Any, node_stats: dict[int, dict[type[Variable], SizeBytes]]
@@ -429,15 +496,65 @@ class Pytree(reprlib.Representable, metaclass=PytreeMeta):
     for name, type_ in type_hints.items():
       if isinstance(type_, str):
         if type_.startswith('nnx.Data'):
+          warnings.warn(
+            f"'Data' is deprecated, please replace:\n\n"
+            '  some_field: nnx.Data[SomeType]\n\n'
+            f'with:\n\n'
+            '  some_field: SomeType = nnx.data()\n\n',
+            DeprecationWarning,
+            stacklevel=2,
+          )
           nodes[name] = True
         elif type_.startswith('nnx.Static'):
+          warnings.warn(
+            f"'Static' is deprecated, please replace:\n\n"
+            '  some_field: nnx.Static[SomeType]\n\n'
+            f'with:\n\n'
+            '  some_field: SomeType = nnx.static()\n\n',
+            DeprecationWarning,
+            stacklevel=2,
+          )
           nodes[name] = False
       else:
         type_metadata = getattr(type_, '__metadata__', ())
         if DataAnnotation in type_metadata:
+          warnings.warn(
+            f"'Data' is deprecated, please replace:\n\n"
+            '  some_field: nnx.Data[SomeType]\n\n'
+            f'with:\n\n'
+            '  some_field: SomeType = nnx.data()\n\n',
+            DeprecationWarning,
+            stacklevel=2,
+          )
           nodes[name] = True
         elif StaticAnnotation in type_metadata:
+          warnings.warn(
+            f"'Static' is deprecated, please replace:\n\n"
+            '  some_field: nnx.Static[SomeType]\n\n'
+            f'with:\n\n'
+            '  some_field: SomeType = nnx.static()\n\n',
+            DeprecationWarning,
+            stacklevel=2,
+          )
           nodes[name] = False
+
+    for name, value in vars(cls).items():
+      if isinstance(value, dataclasses.Field) and 'static' in value.metadata:
+        if not isinstance(value.metadata['static'], bool):
+          raise ValueError(
+            f"Invalid 'static' metadata for attribute"
+            f" '{cls.__name__}.{name}': expected bool, got"
+            f' {type(value.metadata["static"]).__name__}.'
+          )
+        is_node = not value.metadata['static']
+        if name in nodes and nodes[name] != is_node:
+          raise ValueError(
+            f'Conflicting pytree annotation for attribute'
+            f" '{cls.__name__}.{name}': previously registered as"
+            f' {"data" if nodes[name] else "static"}, but found'
+            f' nnx.{"data" if is_node else "static"}(...) annotation.'
+          )
+        nodes[name] = is_node
 
     cls._pytree__nodes = graph.HashableMapping(nodes, copy=False)
 
@@ -483,15 +600,11 @@ class Pytree(reprlib.Representable, metaclass=PytreeMeta):
     )
     data: bool = False
     explicit: bool = False
-    if type(value) is DataAttr:
-      value = value.value
+    if isinstance(value, dataclasses.Field) and 'nnx_value' in value.metadata:
+      is_static = value.metadata['static']
+      value = value.metadata['nnx_value']
       if self._pytree__is_pytree:
-        data = True
-        explicit = True
-    elif type(value) is StaticAttr:
-      value = value.value
-      if self._pytree__is_pytree:
-        data = False
+        data = not is_static
         explicit = True
     elif self._pytree__is_pytree:
       data = is_data(value)
@@ -516,9 +629,9 @@ class Pytree(reprlib.Representable, metaclass=PytreeMeta):
 
     def _get_annotations(leaves):
       return {
-          'data' if type(leaf) is DataAttr else 'static'
-          for leaf in leaves
-          if type(leaf) is DataAttr or type(leaf) is StaticAttr
+        'static' if leaf.metadata['static'] else 'data'
+        for leaf in leaves
+        if isinstance(leaf, dataclasses.Field) and 'nnx_value' in leaf.metadata
       }
 
     def _has_visited(x):
@@ -563,20 +676,20 @@ class Pytree(reprlib.Representable, metaclass=PytreeMeta):
               base_pytree_type = t
               break
           raise ValueError(
-              f"Found Arrays on value of type '{type(value)}' assigned to"
-              f" static attribute '{key}' of Pytree type '{type(self)}'. Static"
-              ' attributes should not contain Array values. Consider one of'
-              ' the following options:\n\n1. If the attribute is meant to be'
-              ' static, either remove the Array value or wrap it in a static'
-              ' container (e.g., using `nnx.static(...)`).\n2. If the'
-              ' attribute is meant to be data, wrap the value with nnx.data on'
-              f' assignment:\n\n  _.{key} = nnx.data(...)\n\n3. Alternatively,'
-              ' annotate the class attribute with nnx.Data:\n\n  class'
-              f' {type(self).__name__}({base_pytree_type.__name__}):\n   '
-              f' {key}: nnx.Data[{type(value).__name__}]\n\n4. Disable pytree'
-              ' for this class:\n\n  class'
-              f' {type(self).__name__}({base_pytree_type.__name__},'
-              ' pytree=False):\n\n'
+            f"Found Arrays on value of type '{type(value)}' assigned to"
+            f" static attribute '{key}' of Pytree type '{type(self)}'. Static"
+            ' attributes should not contain Array values. Consider one of'
+            ' the following options:\n\n1. If the attribute is meant to be'
+            ' static, either remove the Array value or wrap it in a static'
+            ' container (e.g., using `nnx.static(...)`).\n2. If the'
+            ' attribute is meant to be data, wrap the value with nnx.data on'
+            f' assignment:\n\n  _.{key} = nnx.data(...)\n\n3. Alternatively,'
+            ' annotate the class attribute with nnx.data:\n\n  class'
+            f' {type(self).__name__}({base_pytree_type.__name__}):\n   '
+            f' {key}: {type(value).__name__} = nnx.data()\n\n4. Disable pytree'
+            ' for this class:\n\n  class'
+            f' {type(self).__name__}({base_pytree_type.__name__},'
+            ' pytree=False):\n\n'
           )
       # check no data in static attributes after __init__
       elif not current_is_data:
@@ -586,20 +699,20 @@ class Pytree(reprlib.Representable, metaclass=PytreeMeta):
             base_pytree_type = t
             break
         raise ValueError(
-            f'Found unexpected Arrays on value of type {type(value)} in static'
-            f" attribute '{key}' of Pytree type '{type(self)}'. This is an"
-            ' error starting from Flax version 0.12.0.\nConsider one of the'
-            ' following options:\n\n1. If the attribute is meant to be static,'
-            ' either remove the Array value or wrap it in a static'
-            ' container.\n2. Wrap the value with nnx.data on'
-            f' assignment:\n\n  _.{key} = nnx.data(...)\n\n3. Annotate the'
-            ' class attribute with nnx.Data:\n\n  class'
-            f' {type(self).__name__}({base_pytree_type.__name__}):\n    {key}:'
-            f' nnx.Data[{type(value).__name__}]\n\n4. If the container is a'
-            ' list or dict, try using nnx.List(...) or nnx.Dict(...)'
-            ' instead.\n5. Disable pytree for this class:\n\n  class'
-            f' {type(self).__name__}({base_pytree_type.__name__},'
-            f' pytree=False):\n\n'
+          f'Found unexpected Arrays on value of type {type(value)} in static'
+          f" attribute '{key}' of Pytree type '{type(self)}'. This is an"
+          ' error starting from Flax version 0.12.0.\nConsider one of the'
+          ' following options:\n\n1. If the attribute is meant to be static,'
+          ' either remove the Array value or wrap it in a static'
+          ' container.\n2. Wrap the value with nnx.data on'
+          f' assignment:\n\n  _.{key} = nnx.data(...)\n\n3. Annotate the'
+          ' class attribute with nnx.data:\n\n  class'
+          f' {type(self).__name__}({base_pytree_type.__name__}):\n    {key}:'
+          f' {type(value).__name__} = nnx.data()\n\n4. If the container is a'
+          ' list or dict, try using nnx.List(...) or nnx.Dict(...)'
+          ' instead.\n5. Disable pytree for this class:\n\n  class'
+          f' {type(self).__name__}({base_pytree_type.__name__},'
+          f' pytree=False):\n\n'
         )
     if tags := _get_annotations(leaves):
       raise ValueError(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -191,6 +191,8 @@ filterwarnings = [
     "ignore:.*Sharding info not provided when restoring.*:UserWarning",
     # UserWarning: pkg_resources is deprecated as an API.
     "ignore:.*pkg_resources is deprecated as an API.*:UserWarning",
+    # DeprecationWarning: 'Data' is deprecated, please replace:
+    "ignore:.*[Data|Static]' is deprecated, please replace.*:DeprecationWarning",
 ]
 
 [tool.coverage.report]

--- a/tests/nnx/mutable_array_test.py
+++ b/tests/nnx/mutable_array_test.py
@@ -47,7 +47,7 @@ class TestObject(absltest.TestCase):
 
   def test_pytree_data_typehint(self):
     class Foo(nnx.Module):
-      node: nnx.Data[jax.Array]
+      node: jax.Array = nnx.data()
 
       def __init__(self):
         self.node = jnp.array(1)
@@ -74,14 +74,14 @@ class TestObject(absltest.TestCase):
     assert m.meta == 1
 
   def test_pytree_dataclass(self):
-    @dataclasses.dataclass
+    @nnx.dataclass
     class Foo(nnx.Module):
-      node: nnx.Data[jax.Array]
+      node: jax.Array = nnx.data()
       meta: int
       meta2: int = 3
       meta3: int = 4
       meta4: int = 5
-      node2: nnx.Data[int] = 6
+      node2: int = nnx.data(default=6)
 
     m = Foo(node=jnp.array(1), meta=1)
 
@@ -504,9 +504,9 @@ class TestMutableArrayNNXTransforms(absltest.TestCase):
     self.assertIsInstance(m_out2.kernel.raw_value, jax.Ref)
 
   def test_jit_mutable(self):
-    @dataclasses.dataclass
+    @nnx.dataclass
     class Foo(nnx.Pytree):
-      a: nnx.Data[jax.Ref]
+      a: jax.Ref = nnx.data()
 
     m1 = Foo(a=jax.new_ref(1))
 

--- a/tests/nnx/transforms_test.py
+++ b/tests/nnx/transforms_test.py
@@ -2829,9 +2829,9 @@ class TestCond(absltest.TestCase):
             step=nnx.Variable(jnp.array(0)), reward=nnx.Variable(jnp.array(0.0))
         )
 
-    @dataclasses.dataclass
+    @nnx.dataclass
     class Foo(nnx.Pytree):
-      timestep: nnx.Data[TimeStep]
+      timestep: TimeStep = nnx.data()
 
       def update(self):
         def reward_2(self: Foo):


### PR DESCRIPTION
Adds `nnx.dataclass` and allows `nnx.data` and `nnx.static` to be used as field specifiers. `nnx.Data` and `nnx.Static` are deprecated, the main reason is because python currently turns type annotations into strings when forward references are involved and there is no good solution for detecting the annotations.