### PR TITLE
support explicit sharding in eager sharding

### DIFF
--- a/flax/core/spmd.py
+++ b/flax/core/spmd.py
@@ -32,6 +32,9 @@ def get_pspec(sharding_names, sharding_rules = None) -> PartitionSpec:
     return PartitionSpec(*from_sharding_rules(sharding_names, rules))
   return PartitionSpec(*sharding_names)
 
+def _apply_sharding(value, sharding):
+  with jax.disable_jit(False):
+    return jax.jit(lambda x: x, out_shardings=sharding)(value)
 
 def shard_value(value, sharding_names, sharding_rules, mesh):
   if not sharding_names:
@@ -43,8 +46,8 @@ def shard_value(value, sharding_names, sharding_rules, mesh):
       'For more guidance, see https://flax.readthedocs.io/en/latest/flip/4844-var-eager-sharding.html.')
   pspec = get_pspec(sharding_names, sharding_rules)
   if mesh is not None:
-    jax.lax.with_sharding_constraint(value, NamedSharding(mesh, pspec))
-  return jax.lax.with_sharding_constraint(value, pspec)
+    return _apply_sharding(value, NamedSharding(mesh, pspec))
+  return _apply_sharding(value, pspec)
 
 
 

--- a/tests/nnx/spmd_test.py
+++ b/tests/nnx/spmd_test.py
@@ -76,7 +76,7 @@ class TestSPMD(parameterized.TestCase):
 
     mesh = jax.make_mesh((1, 1), ('model', 'data'))
 
-    with mesh:
+    with jax.set_mesh(mesh):
       m: Foo = nnx.merge(*create_module())  # type: ignore[invalid-annotation]
 
     assert m.w.shape == (8, 2)
@@ -224,6 +224,58 @@ class TestSPMD(parameterized.TestCase):
     assert len(jax.tree.leaves(abs_state)) == 1
     assert jax.tree.leaves(abs_state)[0].sharding.is_equivalent_to(
       NamedSharding(mesh, P(None, 'model')), ndim=2)
+
+  def test_explicit_sharding(self):
+    mesh = jax.make_mesh(
+      (2, 2),
+      ('row', 'col'),
+      axis_types=(jax.sharding.AxisType.Auto, jax.sharding.AxisType.Explicit),
+    )
+    v = nnx.Variable(
+      jnp.ones((4, 4)),
+      sharding_names=('row', 'col'),
+      mesh=mesh,
+    )
+    self.assertEqual(v.sharding.mesh, mesh)
+    self.assertEqual(
+      v.sharding.spec,
+      P('row', 'col'),
+    )
+
+  def test_explicit_sharding_disable_jit(self):
+    mesh = jax.make_mesh(
+      (2, 2),
+      ('row', 'col'),
+      axis_types=(jax.sharding.AxisType.Auto, jax.sharding.AxisType.Explicit),
+    )
+    with jax.disable_jit(True):
+      v = nnx.Variable(
+        jnp.ones((4, 4)),
+        sharding_names=('row', 'col'),
+        mesh=mesh,
+      )
+    self.assertEqual(v.sharding.mesh, mesh)
+    self.assertEqual(
+      v.sharding.spec,
+      P('row', 'col'),
+    )
+
+  def test_explicit_sharding_mesh_context(self):
+    mesh = jax.make_mesh(
+      (2, 2),
+      ('row', 'col'),
+      axis_types=(jax.sharding.AxisType.Auto, jax.sharding.AxisType.Explicit),
+    )
+    with jax.set_mesh(mesh):
+      v = nnx.Variable(
+        jnp.ones((4, 4)),
+        sharding_names=('row', 'col'),
+      )
+    self.assertEqual(v.sharding.mesh, mesh)
+    self.assertEqual(
+      v.sharding.spec,
+      P('row', 'col'),
+    )
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
# What does this PR do?

Adds support for explicit sharding in Variable's eager sharding. Instead of using `with_sharding_constraint`, the `shard_value` function now uses `jax.jit` over a simple identity function to shard the output using `out_shardings`.

```python
from flax import nnx
import jax
import jax.numpy as jnp

mesh = jax.make_mesh(
  (2, 2),
  ('row', 'col'),
  axis_types=(jax.sharding.AxisType.Auto, jax.sharding.AxisType.Explicit),
)
v = nnx.Variable(
  jnp.ones((4, 4)),
  sharding_names=('row', 'col'),
  mesh=mesh,
)
```   