### PR TITLE
add promote_dtype to all standard layers

### DIFF
--- a/flax/nnx/nn/lora.py
+++ b/flax/nnx/nn/lora.py
@@ -17,10 +17,9 @@ import typing as tp
 
 from flax.nnx import rnglib, variablelib
 from flax.nnx.module import Module
-from flax.nnx.nn import initializers
+from flax.nnx.nn import initializers, dtypes
 from flax.nnx.nn.linear import Linear
-from flax.nnx.nn.dtypes import promote_dtype
-from flax.typing import Dtype, Initializer
+from flax.typing import Dtype, Initializer, PromoteDtypeFn
 import jax
 import jax.numpy as jnp
 
@@ -75,6 +74,11 @@ class LoRA(Module):
     b_initializer: initializer function for the fan-out matrices. Default to
       `zero initializer`.
     lora_param_type: the type of the LoRA params.
+    promote_dtype: function to promote the dtype of all input array arguments
+      (including Variables accessed through ``self``) to the desired dtype. The
+      function should accept a tuple of ``(inputs, lora_a, lora_b)`` and a ``dtype``
+      keyword argument, and return a tuple of arrays with the promoted dtype.
+    rngs: rng key.
   """
 
   def __init__(
@@ -89,6 +93,7 @@ class LoRA(Module):
     a_initializer: Initializer = default_a_initializer,
     b_initializer: Initializer = default_b_initializer,
     lora_param_type: tp.Type[variablelib.Variable] = LoRAParam,
+    promote_dtype: PromoteDtypeFn = dtypes.promote_dtype,
     rngs: rnglib.Rngs,
   ):
     self.in_features = in_features
@@ -97,6 +102,7 @@ class LoRA(Module):
     self.param_dtype = param_dtype
     self.lora_param_type = lora_param_type
     self.base_module = base_module
+    self.promote_dtype = promote_dtype
 
     self.lora_a = lora_param_type(
       a_initializer(rngs.params(), (in_features, lora_rank), param_dtype)
@@ -106,7 +112,7 @@ class LoRA(Module):
     )
 
   def __call__(self, x: jax.Array):
-    x, lora_a, lora_b = promote_dtype(
+    x, lora_a, lora_b = self.promote_dtype(
       (x, self.lora_a[...], self.lora_b[...]), dtype=self.dtype
     )
     out = x @ lora_a @ lora_b
@@ -154,33 +160,36 @@ class LoRALinear(Linear):
     b_initializer: initializer function for the fan-out matrices. Default to
       `zero initializer`.
     lora_param_type: the type of the LoRA params.
+    lora_promote_dtype: function to promote the dtype for the LoRA submodule.
   """
 
   def __init__(
-      self,
-      in_features: int,
-      out_features: int,
-      *,
-      lora_rank: int,
-      lora_dtype: tp.Optional[Dtype] = None,
-      lora_param_dtype: Dtype = jnp.float32,
-      a_initializer: Initializer = default_a_initializer,
-      b_initializer: Initializer = default_b_initializer,
-      lora_param_type: tp.Type[variablelib.Variable] = LoRAParam,
-      rngs: rnglib.Rngs,
-      **kwargs,
+    self,
+    in_features: int,
+    out_features: int,
+    *,
+    lora_rank: int,
+    lora_dtype: tp.Optional[Dtype] = None,
+    lora_param_dtype: Dtype = jnp.float32,
+    a_initializer: Initializer = default_a_initializer,
+    b_initializer: Initializer = default_b_initializer,
+    lora_param_type: tp.Type[variablelib.Variable] = LoRAParam,
+    lora_promote_dtype: PromoteDtypeFn = dtypes.promote_dtype,
+    rngs: rnglib.Rngs,
+    **kwargs,
   ):
     super().__init__(in_features, out_features, rngs=rngs, **kwargs)
     self.lora = LoRA(
-        in_features,
-        lora_rank,
-        out_features,
-        dtype=lora_dtype,
-        param_dtype=lora_param_dtype,
-        a_initializer=a_initializer,
-        b_initializer=b_initializer,
-        lora_param_type=lora_param_type,
-        rngs=rngs,
+      in_features,
+      lora_rank,
+      out_features,
+      dtype=lora_dtype,
+      param_dtype=lora_param_dtype,
+      a_initializer=a_initializer,
+      b_initializer=b_initializer,
+      lora_param_type=lora_param_type,
+      promote_dtype=lora_promote_dtype,
+      rngs=rngs,
     )
 
   def __call__(self, x: jax.Array):

--- a/flax/nnx/nn/recurrent.py
+++ b/flax/nnx/nn/recurrent.py
@@ -27,16 +27,12 @@ import jax.numpy as jnp
 from flax import nnx
 from flax.nnx import filterlib, rnglib
 from flax.nnx.module import Module
-from flax.nnx.nn import initializers
+from flax.nnx.nn import initializers, dtypes
 from flax.nnx.nn.linear import Linear
 from flax.nnx.nn.activations import sigmoid
 from flax.nnx.nn.activations import tanh
 from flax.nnx.transforms import iteration
-from flax.typing import (
-    Dtype,
-    Initializer,
-    Shape
-)
+from flax.typing import Dtype, Initializer, PromoteDtypeFn, Shape
 
 default_kernel_init = initializers.lecun_normal()
 default_bias_init = initializers.zeros_init()
@@ -126,6 +122,7 @@ class LSTMCell(RNNCellBase):
     dtype: Dtype | None = None,
     param_dtype: Dtype = jnp.float32,
     carry_init: Initializer | None = None,
+    promote_dtype: PromoteDtypeFn = dtypes.promote_dtype,
     keep_rngs: bool = False,
     rngs: rnglib.Rngs,
   ):
@@ -135,6 +132,7 @@ class LSTMCell(RNNCellBase):
     self.activation_fn = activation_fn
     self.dtype = dtype
     self.param_dtype = param_dtype
+    self.promote_dtype = promote_dtype
     self.rngs: rnglib.RngStream | None
     if keep_rngs:
       self.rngs = rngs.carry.fork()
@@ -150,6 +148,7 @@ class LSTMCell(RNNCellBase):
       kernel_init=kernel_init,
       dtype=self.dtype,
       param_dtype=self.param_dtype,
+      promote_dtype=self.promote_dtype,
       rngs=rngs,
     )
 
@@ -162,6 +161,7 @@ class LSTMCell(RNNCellBase):
       bias_init=bias_init,
       dtype=self.dtype,
       param_dtype=self.param_dtype,
+      promote_dtype=self.promote_dtype,
       rngs=rngs,
     )
 
@@ -294,6 +294,7 @@ class OptimizedLSTMCell(RNNCellBase):
     dtype: Dtype | None = None,
     param_dtype: Dtype = jnp.float32,
     carry_init: Initializer | None = None,
+    promote_dtype: PromoteDtypeFn = dtypes.promote_dtype,
     keep_rngs: bool = False,
     rngs: rnglib.Rngs,
   ):
@@ -303,6 +304,7 @@ class OptimizedLSTMCell(RNNCellBase):
     self.activation_fn = activation_fn
     self.dtype = dtype
     self.param_dtype = param_dtype
+    self.promote_dtype = promote_dtype
     self.rngs: rnglib.RngStream | None
     if keep_rngs:
       self.rngs = rngs.carry.fork()
@@ -317,6 +319,7 @@ class OptimizedLSTMCell(RNNCellBase):
       kernel_init=kernel_init,
       dtype=self.dtype,
       param_dtype=self.param_dtype,
+      promote_dtype=self.promote_dtype,
       rngs=rngs,
     )
 
@@ -328,6 +331,7 @@ class OptimizedLSTMCell(RNNCellBase):
       bias_init=bias_init,
       dtype=self.dtype,
       param_dtype=self.param_dtype,
+      promote_dtype=self.promote_dtype,
       rngs=rngs,
     )
 
@@ -448,6 +452,7 @@ class SimpleCell(RNNCellBase):
     kernel_init: Initializer = initializers.lecun_normal(),
     recurrent_kernel_init: Initializer = initializers.orthogonal(),
     bias_init: Initializer = initializers.zeros_init(),
+    promote_dtype: PromoteDtypeFn = dtypes.promote_dtype,
     keep_rngs: bool = False,
     rngs: rnglib.Rngs,
   ):
@@ -457,6 +462,7 @@ class SimpleCell(RNNCellBase):
     self.param_dtype = param_dtype
     self.residual = residual
     self.activation_fn = activation_fn
+    self.promote_dtype = promote_dtype
     self.rngs: rnglib.RngStream | None
     if keep_rngs:
       self.rngs = rngs.carry.fork()
@@ -472,6 +478,7 @@ class SimpleCell(RNNCellBase):
       dtype=self.dtype,
       param_dtype=self.param_dtype,
       kernel_init=recurrent_kernel_init,
+      promote_dtype=self.promote_dtype,
       rngs=rngs,
     )
     self.dense_i = Linear(
@@ -482,6 +489,7 @@ class SimpleCell(RNNCellBase):
       param_dtype=self.param_dtype,
       kernel_init=kernel_init,
       bias_init=bias_init,
+      promote_dtype=self.promote_dtype,
       rngs=rngs,
     )
 
@@ -584,6 +592,7 @@ class GRUCell(RNNCellBase):
     dtype: Dtype | None = None,
     param_dtype: Dtype = jnp.float32,
     carry_init: Initializer | None = None,
+    promote_dtype: PromoteDtypeFn = dtypes.promote_dtype,
     keep_rngs: bool = False,
     rngs: rnglib.Rngs,
   ):
@@ -593,6 +602,7 @@ class GRUCell(RNNCellBase):
     self.activation_fn = activation_fn
     self.dtype = dtype
     self.param_dtype = param_dtype
+    self.promote_dtype = promote_dtype
     self.rngs: rnglib.RngStream | None
     if keep_rngs:
       self.rngs = rngs.carry.fork()
@@ -608,6 +618,7 @@ class GRUCell(RNNCellBase):
       bias_init=bias_init,
       dtype=self.dtype,
       param_dtype=self.param_dtype,
+      promote_dtype=self.promote_dtype,
       rngs=rngs,
     )
 
@@ -618,6 +629,7 @@ class GRUCell(RNNCellBase):
       kernel_init=recurrent_kernel_init,
       dtype=self.dtype,
       param_dtype=self.param_dtype,
+      promote_dtype=self.promote_dtype,
       rngs=rngs,
     )
 


### PR DESCRIPTION
Adds the `promote_dtype` argument to remaining layers. If the layer has submodules it creates an argument per submodule type and forwards it to the sumodule's `promote_dtype`.