### PR TITLE
docs: Document `allow_duplicates` argument of `nnx.to_arrays`.

### DIFF
--- a/flax/nnx/graph.py
+++ b/flax/nnx/graph.py
@@ -2634,7 +2634,8 @@ def to_arrays(
     >>> frozen_node = nnx.to_arrays(node)
     >>> assert isinstance(frozen_node[0], jax.Array)
 
-  If the structure contains duplicate array refs, a ValueError is raised::
+  If ``allow_duplicates`` is ``False`` and the structure contains duplicate
+  array refs, raises ``ValueError``::
 
     >>> shared_array = jax.new_ref(jnp.array(1.0))
     >>> node = [shared_array, shared_array]
@@ -2660,8 +2661,12 @@ def to_arrays(
   Args:
     node: A structure potentially containing array refs.
     only: A Filter to specify which array refs to freeze.
+    allow_duplicates: If True, allow duplicate array refs.
   Returns:
     A structure with the frozen arrays.
+  Raises:
+    ValueError: If duplicate array refs are found and `allow_duplicates` is
+      False.
   """
   if not allow_duplicates and (
     all_duplicates := find_duplicates(node, only=only)


### PR DESCRIPTION
# What does this PR do?

Adds documentation for the `allow_duplicates: bool` argument of `nnx.to_arrays`, which was previously undocumented.

## Checklist
- [x] This PR fixes a minor issue (e.g.: typo or small bug) or improves the docs (you can dismiss the other checks if that's the case).
- [ ] This change is discussed in a Github issue/[discussion](https://github.com/google/flax/discussions) (please add a link).
- [ ] The documentation and docstrings adhere to the [documentation guidelines](https://github.com/google/flax/blob/main/docs/README.md#how-to-write-code-documentation).
- [ ] This change includes necessary high-coverage tests. (No quality testing = no merge!)
