### PR TITLE
Add __eq__ for variables

### DIFF
--- a/flax/nnx/variablelib.py
+++ b/flax/nnx/variablelib.py
@@ -777,6 +777,11 @@ class Variable(tp.Generic[A], reprlib.Representable, metaclass=VariableMeta):
       other = other.value
     return self.value.__ror__(other)  # type: ignore
 
+  def __eq__(self, other) -> bool:
+    if isinstance(other, Variable):
+      other = other.value
+    return self.value.__eq__(other)  # type: ignore
+
   def __iadd__(self: V, other) -> V:
     raise NotImplementedError(
       'In-place operations are no longer supported for Variable.\n'

--- a/tests/nnx/variable_test.py
+++ b/tests/nnx/variable_test.py
@@ -88,6 +88,7 @@ class TestVariable(absltest.TestCase):
     result = v1 + v2
 
     self.assertEqual(result, 5)
+    self.assertFalse(v1 == v2)
 
     v1[...] += v2
 


### PR DESCRIPTION
This PR gives variables __eq__ in the same way they have __sub__ and all the other binary ops. 