### PR TITLE
improve hijax guide

### DIFF
--- a/.github/workflows/flax_test.yml
+++ b/.github/workflows/flax_test.yml
@@ -76,6 +76,8 @@ jobs:
     - name: Install standalone dependencies only
       run: |
         uv sync
+        # temp install jax nightly
+        uv pip install -U --pre jax jaxlib -i https://us-python.pkg.dev/ml-oss-artifacts-published/jax/simple/ --reinstall
     - name: Test importing Flax
       run: |
         uv run --no-sync python -c "import flax"
@@ -118,16 +120,16 @@ jobs:
         else
           uv pip install "jax==${{ matrix.jax-version }}" "jaxlib==${{ matrix.jax-version }}"
         fi
+        if [[ "${{ matrix.test-type }}" == "pytest" ]]; then
+          uv pip install -U tensorflow-datasets
+        fi
+        # temp install jax nightly
+        uv pip install -U --pre jax jaxlib -i https://us-python.pkg.dev/ml-oss-artifacts-published/jax/simple/ --reinstall
     - name: Test with ${{ matrix.test-type }}
       run: |
         if [[ "${{ matrix.test-type }}" == "doctest" ]]; then
-          # TODO(cgarciae): Remove this once dm-haiku 0.0.14 is released
-          uv pip install -U git+https://github.com/google-deepmind/dm-haiku.git
-          # https://github.com/google/flax/issues/5162
-          uv pip install "numpy<2.4.0"
           uv run --no-sync tests/run_all_tests.sh --only-doctest
         elif [[ "${{ matrix.test-type }}" == "pytest" ]]; then
-          uv pip install -U tensorflow-datasets
           uv run --no-sync tests/run_all_tests.sh --only-pytest
         elif [[ "${{ matrix.test-type }}" == "pytype" ]]; then
           uv run --no-sync tests/run_all_tests.sh --only-pytype

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ uv.lock
 
 # custom
 /tmp-files
+.agent/rules/flax.md
+.github/copilot-instructions.md
+.env

--- a/docs_nnx/api_reference/flax.nnx/graph.rst
+++ b/docs_nnx/api_reference/flax.nnx/graph.rst
@@ -31,11 +31,5 @@ graph
 
 .. autofunction:: find_duplicates
 .. autofunction:: pure
-.. autofunction:: as_immutable_vars
-.. autofunction:: as_mutable_vars
-.. autofunction:: as_hijax_vars
-.. autofunction:: as_pytree_vars
-.. autofunction:: as_ref_vars
-.. autofunction:: as_array_vars
 .. autofunction:: flatten
 .. autofunction:: unflatten

--- a/docs_nnx/hijax/hijax.ipynb
+++ b/docs_nnx/hijax/hijax.ipynb
@@ -5,7 +5,7 @@
    "id": "15c2d208",
    "metadata": {},
    "source": [
-    "# Hijax Variable"
+    "# Hijax"
    ]
   },
   {
@@ -20,7 +20,50 @@
     "import jax.numpy as jnp\n",
     "import optax\n",
     "\n",
-    "current_mode = nnx.using_hijax()"
+    "current_mode = nnx.var_defaults().hijax # ignore: only needed for testing"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "d1aaa0ec",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0.85250294\n",
+      "0.8165137\n",
+      "0.7814907\n"
+     ]
+    }
+   ],
+   "source": [
+    "nnx.var_defaults(hijax=True)\n",
+    "\n",
+    "rngs = nnx.Rngs(0)\n",
+    "model = nnx.Linear(2, 3, rngs=rngs)\n",
+    "optimizer = nnx.Optimizer(model, optax.adamw(1e-2), wrt=nnx.Param)\n",
+    "\n",
+    "@jax.jit\n",
+    "def train_step(x, y):\n",
+    "  loss_fn = lambda m: jnp.mean((m(x) - y) ** 2)\n",
+    "  loss, grads = jax.value_and_grad(loss_fn)(nnx.vars_as(model, mutable=False))  # tmp fix for jax.grad\n",
+    "  optimizer.update(model, grads)\n",
+    "  return loss\n",
+    "\n",
+    "x, y = rngs.uniform((4, 2)), rngs.uniform((4, 3))\n",
+    "for _ in range(3):\n",
+    "  print(train_step(x, y))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "04458d66",
+   "metadata": {},
+   "source": [
+    "## Hijax Variable"
    ]
   },
   {
@@ -33,7 +76,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 3,
    "id": "396a07a3",
    "metadata": {},
    "outputs": [
@@ -47,7 +90,7 @@
     }
    ],
    "source": [
-    "v = nnx.Variable(jnp.array(0), is_hijax=True)\n",
+    "v = nnx.Variable(jnp.array(0), hijax=True)\n",
     "\n",
     "@jax.jit\n",
     "def inc(v):\n",
@@ -58,7 +101,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "id": "2ab7d801",
    "metadata": {},
    "outputs": [
@@ -70,11 +113,21 @@
       "    \u001b[39;22mjit[\n",
       "      name=inc\n",
       "      jaxpr={ \u001b[34;1mlambda \u001b[39;22m; a\u001b[35m:Variable()\u001b[39m. \u001b[34;1mlet\n",
-      "          \u001b[39;22mb\u001b[35m:i32[]\u001b[39m = get_variable[avals=(ShapedArray(int32[], weak_type=True),)] a\n",
+      "          \u001b[39;22mb\u001b[35m:i32[]\u001b[39m = get_variable[\n",
+      "            avals=(ShapedArray(int32[], weak_type=True),)\n",
+      "            has_qdd=True\n",
+      "            treedef=PyTreeDef(CustomNode(Variable[(('eager_sharding', True), ('hijax', True), ('mutable', True), ('ref', False))], [*]))\n",
+      "            var_type=<class 'flax.nnx.variablelib.Variable'>\n",
+      "          ] a\n",
       "          c\u001b[35m:i32[]\u001b[39m = add b 1:i32[]\n",
-      "          _\u001b[35m:i32[]\u001b[39m = get_variable[avals=(ShapedArray(int32[], weak_type=True),)] a\n",
+      "          _\u001b[35m:i32[]\u001b[39m = get_variable[\n",
+      "            avals=(ShapedArray(int32[], weak_type=True),)\n",
+      "            has_qdd=True\n",
+      "            treedef=PyTreeDef(CustomNode(Variable[(('eager_sharding', True), ('hijax', True), ('mutable', True), ('ref', False))], [*]))\n",
+      "            var_type=<class 'flax.nnx.variablelib.Variable'>\n",
+      "          ] a\n",
       "          set_variable[\n",
-      "            treedef=PyTreeDef(CustomNode(Variable[(('has_ref', False), ('is_hijax', True), ('is_mutable', True))], [*]))\n",
+      "            treedef=PyTreeDef(CustomNode(Variable[(('eager_sharding', True), ('hijax', True), ('mutable', True), ('ref', False))], [*]))\n",
       "            var_type=<class 'flax.nnx.variablelib.Variable'>\n",
       "          ] a c\n",
       "        \u001b[34;1min \u001b[39;22m() }\n",
@@ -84,7 +137,7 @@
     }
    ],
    "source": [
-    "v = nnx.Variable(jnp.array(0), is_hijax=True)\n",
+    "v = nnx.Variable(jnp.array(0), hijax=True)\n",
     "print(jax.make_jaxpr(inc)(v))"
    ]
   },
@@ -98,7 +151,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "id": "fcd0de3f",
    "metadata": {},
    "outputs": [
@@ -108,17 +161,17 @@
      "text": [
       "\u001b[38;2;79;201;177mVariable\u001b[0m\u001b[38;2;255;213;3m(\u001b[0m\u001b[38;2;105;105;105m # 2 (8 B)\u001b[0m\n",
       "  \u001b[38;2;156;220;254mvalue\u001b[0m\u001b[38;2;212;212;212m=\u001b[0m\u001b[38;2;255;213;3m{\u001b[0m\u001b[38;2;207;144;120m'a'\u001b[0m: Array(0, dtype=int32, weak_type=True), \u001b[38;2;207;144;120m'b'\u001b[0m: Array(2, dtype=int32, weak_type=True)\u001b[38;2;255;213;3m}\u001b[0m,\n",
-      "  \u001b[38;2;156;220;254mis_hijax\u001b[0m\u001b[38;2;212;212;212m=\u001b[0m\u001b[38;2;86;156;214mTrue\u001b[0m\n",
+      "  \u001b[38;2;156;220;254mhijax\u001b[0m\u001b[38;2;212;212;212m=\u001b[0m\u001b[38;2;86;156;214mTrue\u001b[0m\n",
       "\u001b[38;2;255;213;3m)\u001b[0m\n",
       "\u001b[38;2;79;201;177mVariable\u001b[0m\u001b[38;2;255;213;3m(\u001b[0m\u001b[38;2;105;105;105m # 2 (8 B)\u001b[0m\n",
       "  \u001b[38;2;156;220;254mvalue\u001b[0m\u001b[38;2;212;212;212m=\u001b[0m\u001b[38;2;255;213;3m{\u001b[0m\u001b[38;2;207;144;120m'a'\u001b[0m: Array(1, dtype=int32, weak_type=True), \u001b[38;2;207;144;120m'b'\u001b[0m: Array(4, dtype=int32, weak_type=True)\u001b[38;2;255;213;3m}\u001b[0m,\n",
-      "  \u001b[38;2;156;220;254mis_hijax\u001b[0m\u001b[38;2;212;212;212m=\u001b[0m\u001b[38;2;86;156;214mTrue\u001b[0m\n",
+      "  \u001b[38;2;156;220;254mhijax\u001b[0m\u001b[38;2;212;212;212m=\u001b[0m\u001b[38;2;86;156;214mTrue\u001b[0m\n",
       "\u001b[38;2;255;213;3m)\u001b[0m\n"
      ]
     }
    ],
    "source": [
-    "v = nnx.Variable({'a': jnp.array(0), 'b': jnp.array(2)}, is_hijax=True)\n",
+    "v = nnx.Variable({'a': jnp.array(0), 'b': jnp.array(2)}, hijax=True)\n",
     "\n",
     "@jax.jit\n",
     "def inc_and_double(v):\n",
@@ -138,7 +191,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "id": "0d83a130",
    "metadata": {},
    "outputs": [
@@ -148,11 +201,11 @@
      "text": [
       "Before: \u001b[38;2;79;201;177mVariable\u001b[0m\u001b[38;2;255;213;3m(\u001b[0m\u001b[38;2;105;105;105m\u001b[0m\n",
       "  \u001b[38;2;156;220;254mvalue\u001b[0m\u001b[38;2;212;212;212m=\u001b[0m\u001b[38;2;255;213;3m{\u001b[0m\u001b[38;2;255;213;3m}\u001b[0m,\n",
-      "  \u001b[38;2;156;220;254mis_hijax\u001b[0m\u001b[38;2;212;212;212m=\u001b[0m\u001b[38;2;86;156;214mTrue\u001b[0m\n",
+      "  \u001b[38;2;156;220;254mhijax\u001b[0m\u001b[38;2;212;212;212m=\u001b[0m\u001b[38;2;86;156;214mTrue\u001b[0m\n",
       "\u001b[38;2;255;213;3m)\u001b[0m\n",
       "After: \u001b[38;2;79;201;177mVariable\u001b[0m\u001b[38;2;255;213;3m(\u001b[0m\u001b[38;2;105;105;105m # 1 (4 B)\u001b[0m\n",
       "  \u001b[38;2;156;220;254mvalue\u001b[0m\u001b[38;2;212;212;212m=\u001b[0m\u001b[38;2;255;213;3m{\u001b[0m\u001b[38;2;207;144;120m'y_mean'\u001b[0m: Array(-1.1782329, dtype=float32)\u001b[38;2;255;213;3m}\u001b[0m,\n",
-      "  \u001b[38;2;156;220;254mis_hijax\u001b[0m\u001b[38;2;212;212;212m=\u001b[0m\u001b[38;2;86;156;214mTrue\u001b[0m\n",
+      "  \u001b[38;2;156;220;254mhijax\u001b[0m\u001b[38;2;212;212;212m=\u001b[0m\u001b[38;2;86;156;214mTrue\u001b[0m\n",
       "\u001b[38;2;255;213;3m)\u001b[0m\n"
      ]
     }
@@ -161,7 +214,7 @@
     "rngs = nnx.Rngs(0)\n",
     "x = rngs.uniform((4, 5))\n",
     "w = rngs.normal((5, 3))\n",
-    "metrics = nnx.Variable({}, is_hijax=True)\n",
+    "metrics = nnx.Variable({}, hijax=True)\n",
     "\n",
     "@jax.jit\n",
     "def linear(x, w, metrics: nnx.Variable):\n",
@@ -176,7 +229,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "id": "0a55df94",
    "metadata": {},
    "outputs": [
@@ -186,14 +239,14 @@
      "text": [
       "\u001b[38;2;79;201;177mVariable\u001b[0m\u001b[38;2;255;213;3m(\u001b[0m\u001b[38;2;105;105;105m # 3 (12 B)\u001b[0m\n",
       "  \u001b[38;2;156;220;254mvalue\u001b[0m\u001b[38;2;212;212;212m=\u001b[0mArray([1, 2, 3], dtype=int32),\n",
-      "  \u001b[38;2;156;220;254mis_hijax\u001b[0m\u001b[38;2;212;212;212m=\u001b[0m\u001b[38;2;86;156;214mTrue\u001b[0m\n",
+      "  \u001b[38;2;156;220;254mhijax\u001b[0m\u001b[38;2;212;212;212m=\u001b[0m\u001b[38;2;86;156;214mTrue\u001b[0m\n",
       "\u001b[38;2;255;213;3m)\u001b[0m\n"
      ]
     }
    ],
    "source": [
     "# set default Variable mode for the rest of the guide\n",
-    "nnx.use_hijax(True)\n",
+    "nnx.var_defaults(hijax=True)\n",
     "\n",
     "variable = nnx.Variable(jnp.array([1, 2, 3]))\n",
     "\n",
@@ -210,7 +263,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "id": "b7b1f421",
    "metadata": {},
    "outputs": [
@@ -218,17 +271,17 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "nnx.as_immutable_vars(model) = \u001b[38;2;79;201;177mLinear\u001b[0m\u001b[38;2;255;213;3m(\u001b[0m\u001b[38;2;105;105;105m # Param: 3 (12 B)\u001b[0m\n",
-      "  \u001b[38;2;156;220;254mkernel\u001b[0m\u001b[38;2;212;212;212m=\u001b[0m\u001b[38;2;79;201;177mParam\u001b[0m\u001b[38;2;255;213;3m(\u001b[0m\u001b[38;2;105;105;105m\u001b[0m\n",
+      "nnx.vars_as(model, mutable=False) = \u001b[38;2;79;201;177mLinear\u001b[0m\u001b[38;2;255;213;3m(\u001b[0m\u001b[38;2;105;105;105m # Param: 3 (12 B)\u001b[0m\n",
+      "  \u001b[38;2;156;220;254mkernel\u001b[0m\u001b[38;2;212;212;212m=\u001b[0m\u001b[38;2;79;201;177mParam\u001b[0m\u001b[38;2;255;213;3m(\u001b[0m\u001b[38;2;105;105;105m # 3 (12 B)\u001b[0m\n",
       "    \u001b[38;2;156;220;254mvalue\u001b[0m\u001b[38;2;212;212;212m=\u001b[0m\u001b[38;2;79;201;177mArray\u001b[0m\u001b[38;2;255;213;3m(\u001b[0m\u001b[38;2;156;220;254mshape\u001b[0m\u001b[38;2;212;212;212m=\u001b[0m\u001b[38;2;255;213;3m(\u001b[0m\u001b[38;2;182;207;169m1\u001b[0m, \u001b[38;2;182;207;169m3\u001b[0m\u001b[38;2;255;213;3m)\u001b[0m, \u001b[38;2;156;220;254mdtype\u001b[0m\u001b[38;2;212;212;212m=\u001b[0mdtype('float32')\u001b[38;2;255;213;3m)\u001b[0m,\n",
-      "    \u001b[38;2;156;220;254mis_mutable\u001b[0m\u001b[38;2;212;212;212m=\u001b[0m\u001b[38;2;86;156;214mFalse\u001b[0m,\n",
-      "    \u001b[38;2;156;220;254mwas_hijax\u001b[0m\u001b[38;2;212;212;212m=\u001b[0m\u001b[38;2;86;156;214mTrue\u001b[0m\n",
+      "    \u001b[38;2;156;220;254mhijax\u001b[0m\u001b[38;2;212;212;212m=\u001b[0m\u001b[38;2;86;156;214mTrue\u001b[0m,\n",
+      "    \u001b[38;2;156;220;254mmutable\u001b[0m\u001b[38;2;212;212;212m=\u001b[0m\u001b[38;2;86;156;214mFalse\u001b[0m\n",
       "  \u001b[38;2;255;213;3m)\u001b[0m\n",
       "\u001b[38;2;255;213;3m)\u001b[0m\n",
-      "nnx.as_mutable_vars(model) = \u001b[38;2;79;201;177mLinear\u001b[0m\u001b[38;2;255;213;3m(\u001b[0m\u001b[38;2;105;105;105m # Param: 3 (12 B)\u001b[0m\n",
-      "  \u001b[38;2;156;220;254mkernel\u001b[0m\u001b[38;2;212;212;212m=\u001b[0m\u001b[38;2;79;201;177mParam\u001b[0m\u001b[38;2;255;213;3m(\u001b[0m\u001b[38;2;105;105;105m\u001b[0m\n",
+      "nnx.vars_as(model, mutable=True) = \u001b[38;2;79;201;177mLinear\u001b[0m\u001b[38;2;255;213;3m(\u001b[0m\u001b[38;2;105;105;105m # Param: 3 (12 B)\u001b[0m\n",
+      "  \u001b[38;2;156;220;254mkernel\u001b[0m\u001b[38;2;212;212;212m=\u001b[0m\u001b[38;2;79;201;177mParam\u001b[0m\u001b[38;2;255;213;3m(\u001b[0m\u001b[38;2;105;105;105m # 3 (12 B)\u001b[0m\n",
       "    \u001b[38;2;156;220;254mvalue\u001b[0m\u001b[38;2;212;212;212m=\u001b[0m\u001b[38;2;79;201;177mArray\u001b[0m\u001b[38;2;255;213;3m(\u001b[0m\u001b[38;2;156;220;254mshape\u001b[0m\u001b[38;2;212;212;212m=\u001b[0m\u001b[38;2;255;213;3m(\u001b[0m\u001b[38;2;182;207;169m1\u001b[0m, \u001b[38;2;182;207;169m3\u001b[0m\u001b[38;2;255;213;3m)\u001b[0m, \u001b[38;2;156;220;254mdtype\u001b[0m\u001b[38;2;212;212;212m=\u001b[0mdtype('float32')\u001b[38;2;255;213;3m)\u001b[0m,\n",
-      "    \u001b[38;2;156;220;254mis_hijax\u001b[0m\u001b[38;2;212;212;212m=\u001b[0m\u001b[38;2;86;156;214mTrue\u001b[0m\n",
+      "    \u001b[38;2;156;220;254mhijax\u001b[0m\u001b[38;2;212;212;212m=\u001b[0m\u001b[38;2;86;156;214mTrue\u001b[0m\n",
       "  \u001b[38;2;255;213;3m)\u001b[0m\n",
       "\u001b[38;2;255;213;3m)\u001b[0m\n"
      ]
@@ -244,13 +297,13 @@
     "\n",
     "model = Linear(1, 3, rngs=nnx.Rngs(0))\n",
     "\n",
-    "print(f\"{nnx.as_immutable_vars(model) = !s}\")\n",
-    "print(f\"{nnx.as_mutable_vars(model) = !s}\")"
+    "print(f\"{nnx.vars_as(model, mutable=False) = !s}\")\n",
+    "print(f\"{nnx.vars_as(model, mutable=True) = !s}\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "id": "594cb65e",
    "metadata": {},
    "outputs": [
@@ -264,8 +317,8 @@
    ],
    "source": [
     "v = nnx.Variable(jnp.array(0))\n",
-    "v_immut = nnx.as_immutable_vars(v)\n",
-    "assert not v_immut.is_mutable\n",
+    "v_immut = nnx.vars_as(v, mutable=False)\n",
+    "assert not v_immut.mutable\n",
     "\n",
     "try:\n",
     "  v_immut[...] += 1  # raises an error\n",
@@ -283,7 +336,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "id": "fcd4fb4f",
    "metadata": {},
    "outputs": [
@@ -293,7 +346,8 @@
      "text": [
       "\u001b[38;2;79;201;177mVariable\u001b[0m\u001b[38;2;255;213;3m(\u001b[0m\u001b[38;2;105;105;105m # 1 (4 B)\u001b[0m\n",
       "  \u001b[38;2;156;220;254mvalue\u001b[0m\u001b[38;2;212;212;212m=\u001b[0mArray(0, dtype=int32, weak_type=True),\n",
-      "  \u001b[38;2;156;220;254mhas_ref\u001b[0m\u001b[38;2;212;212;212m=\u001b[0m\u001b[38;2;86;156;214mTrue\u001b[0m\n",
+      "  \u001b[38;2;156;220;254mhijax\u001b[0m\u001b[38;2;212;212;212m=\u001b[0m\u001b[38;2;86;156;214mTrue\u001b[0m,\n",
+      "  \u001b[38;2;156;220;254mref\u001b[0m\u001b[38;2;212;212;212m=\u001b[0m\u001b[38;2;86;156;214mTrue\u001b[0m\n",
       "\u001b[38;2;255;213;3m)\u001b[0m\n",
       "Ref(0, dtype=int32, weak_type=True)\n"
      ]
@@ -301,15 +355,15 @@
    ],
    "source": [
     "v = nnx.Variable(jnp.array(0))\n",
-    "v_ref = nnx.as_ref_vars(v)\n",
-    "assert v_ref.has_ref\n",
+    "v_ref = nnx.vars_as(v, ref=True)\n",
+    "assert v_ref.ref\n",
     "print(v_ref)\n",
     "print(v_ref.get_raw_value())"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "id": "18256668",
    "metadata": {},
    "outputs": [
@@ -319,23 +373,25 @@
      "text": [
       "immutable = \u001b[38;2;79;201;177mVariable\u001b[0m\u001b[38;2;255;213;3m(\u001b[0m\u001b[38;2;105;105;105m # 1 (4 B)\u001b[0m\n",
       "  \u001b[38;2;156;220;254mvalue\u001b[0m\u001b[38;2;212;212;212m=\u001b[0mArray(0, dtype=int32, weak_type=True),\n",
-      "  \u001b[38;2;156;220;254mis_mutable\u001b[0m\u001b[38;2;212;212;212m=\u001b[0m\u001b[38;2;86;156;214mFalse\u001b[0m,\n",
-      "  \u001b[38;2;156;220;254mhad_ref\u001b[0m\u001b[38;2;212;212;212m=\u001b[0m\u001b[38;2;86;156;214mTrue\u001b[0m\n",
+      "  \u001b[38;2;156;220;254mhad_ref\u001b[0m\u001b[38;2;212;212;212m=\u001b[0m\u001b[38;2;86;156;214mTrue\u001b[0m,\n",
+      "  \u001b[38;2;156;220;254mhijax\u001b[0m\u001b[38;2;212;212;212m=\u001b[0m\u001b[38;2;86;156;214mTrue\u001b[0m,\n",
+      "  \u001b[38;2;156;220;254mmutable\u001b[0m\u001b[38;2;212;212;212m=\u001b[0m\u001b[38;2;86;156;214mFalse\u001b[0m\n",
       "\u001b[38;2;255;213;3m)\u001b[0m\n",
       "mutable = \u001b[38;2;79;201;177mVariable\u001b[0m\u001b[38;2;255;213;3m(\u001b[0m\u001b[38;2;105;105;105m # 1 (4 B)\u001b[0m\n",
       "  \u001b[38;2;156;220;254mvalue\u001b[0m\u001b[38;2;212;212;212m=\u001b[0mArray(0, dtype=int32, weak_type=True),\n",
-      "  \u001b[38;2;156;220;254mhas_ref\u001b[0m\u001b[38;2;212;212;212m=\u001b[0m\u001b[38;2;86;156;214mTrue\u001b[0m\n",
+      "  \u001b[38;2;156;220;254mhijax\u001b[0m\u001b[38;2;212;212;212m=\u001b[0m\u001b[38;2;86;156;214mTrue\u001b[0m,\n",
+      "  \u001b[38;2;156;220;254mref\u001b[0m\u001b[38;2;212;212;212m=\u001b[0m\u001b[38;2;86;156;214mTrue\u001b[0m\n",
       "\u001b[38;2;255;213;3m)\u001b[0m\n"
      ]
     }
    ],
    "source": [
-    "v_immut = nnx.as_immutable_vars(v_ref)\n",
-    "assert not v_immut.has_ref\n",
+    "v_immut = nnx.vars_as(v_ref, mutable=False)\n",
+    "assert not v_immut.ref\n",
     "print(\"immutable =\", v_immut)\n",
     "\n",
-    "v_ref = nnx.as_mutable_vars(v_immut)\n",
-    "assert v_ref.has_ref\n",
+    "v_ref = nnx.vars_as(v_immut, mutable=True)\n",
+    "assert v_ref.ref\n",
     "print(\"mutable =\", v_ref)"
    ]
   },
@@ -349,7 +405,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "id": "5400fe58",
    "metadata": {},
    "outputs": [],
@@ -376,7 +432,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
    "id": "566c4249",
    "metadata": {},
    "outputs": [
@@ -402,7 +458,7 @@
     "    model =  nnx.merge(graphdef, params, nondiff)\n",
     "    return ((model(x) - y) ** 2).mean()\n",
     "\n",
-    "  loss, grads = jax.value_and_grad(loss_fn)(nnx.as_immutable_vars(params))  # lojax Variables for jax.grad\n",
+    "  loss, grads = jax.value_and_grad(loss_fn)(nnx.vars_as(params, mutable=False))  # immutable for jax.grad\n",
     "  optimizer.update(model, grads)\n",
     "\n",
     "  return loss\n",
@@ -422,7 +478,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 14,
    "id": "d8136be4",
    "metadata": {},
    "outputs": [],
@@ -462,7 +518,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 15,
    "id": "c6062d19",
    "metadata": {},
    "outputs": [
@@ -487,7 +543,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 16,
    "id": "8bb1e9e7",
    "metadata": {},
    "outputs": [
@@ -496,9 +552,9 @@
      "output_type": "stream",
      "text": [
       "model.linear = \u001b[38;2;79;201;177mLinear\u001b[0m\u001b[38;2;255;213;3m(\u001b[0m\u001b[38;2;105;105;105m # Param: 128 (512 B)\u001b[0m\n",
-      "  \u001b[38;2;156;220;254mkernel\u001b[0m\u001b[38;2;212;212;212m=\u001b[0m\u001b[38;2;79;201;177mParam\u001b[0m\u001b[38;2;255;213;3m(\u001b[0m\u001b[38;2;105;105;105m\u001b[0m\n",
+      "  \u001b[38;2;156;220;254mkernel\u001b[0m\u001b[38;2;212;212;212m=\u001b[0m\u001b[38;2;79;201;177mParam\u001b[0m\u001b[38;2;255;213;3m(\u001b[0m\u001b[38;2;105;105;105m # 128 (512 B)\u001b[0m\n",
       "    \u001b[38;2;156;220;254mvalue\u001b[0m\u001b[38;2;212;212;212m=\u001b[0m\u001b[38;2;79;201;177mArray\u001b[0m\u001b[38;2;255;213;3m(\u001b[0m\u001b[38;2;156;220;254mshape\u001b[0m\u001b[38;2;212;212;212m=\u001b[0m\u001b[38;2;255;213;3m(\u001b[0m\u001b[38;2;182;207;169m2\u001b[0m, \u001b[38;2;182;207;169m64\u001b[0m\u001b[38;2;255;213;3m)\u001b[0m, \u001b[38;2;156;220;254mdtype\u001b[0m\u001b[38;2;212;212;212m=\u001b[0mdtype('float32')\u001b[38;2;255;213;3m)\u001b[0m,\n",
-      "    \u001b[38;2;156;220;254mis_hijax\u001b[0m\u001b[38;2;212;212;212m=\u001b[0m\u001b[38;2;86;156;214mTrue\u001b[0m\n",
+      "    \u001b[38;2;156;220;254mhijax\u001b[0m\u001b[38;2;212;212;212m=\u001b[0m\u001b[38;2;86;156;214mTrue\u001b[0m\n",
       "  \u001b[38;2;255;213;3m)\u001b[0m\n",
       "\u001b[38;2;255;213;3m)\u001b[0m\n"
      ]
@@ -507,9 +563,9 @@
    "source": [
     "@jax.jit\n",
     "def create_model(rngs):\n",
-    "  return nnx.as_immutable_vars(Block(2, 64, 3, rngs=rngs))\n",
+    "  return nnx.vars_as((Block(2, 64, 3, rngs=rngs)), hijax=False)\n",
     "\n",
-    "model = nnx.as_mutable_vars(create_model(nnx.Rngs(0)))\n",
+    "model = nnx.vars_as(create_model(nnx.Rngs(0)), hijax=True)\n",
     "\n",
     "print(\"model.linear =\", model.linear)"
    ]
@@ -524,7 +580,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 17,
    "id": "045d03c1",
    "metadata": {},
    "outputs": [
@@ -555,7 +611,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 18,
    "id": "bc2e87e5",
    "metadata": {},
    "outputs": [
@@ -563,31 +619,40 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "None\n"
+      "None\n",
+      "\u001b[38;2;79;201;177mHasShared\u001b[0m\u001b[38;2;255;213;3m(\u001b[0m\u001b[38;2;105;105;105m # Variable: 1 (4 B)\u001b[0m\n",
+      "  \u001b[38;2;156;220;254ma\u001b[0m\u001b[38;2;212;212;212m=\u001b[0m\u001b[38;2;79;201;177mVariable\u001b[0m\u001b[38;2;255;213;3m(\u001b[0m\u001b[38;2;105;105;105m # 1 (4 B)\u001b[0m\n",
+      "    \u001b[38;2;156;220;254mvalue\u001b[0m\u001b[38;2;212;212;212m=\u001b[0mArray(0, dtype=int32, weak_type=True),\n",
+      "    \u001b[38;2;156;220;254mhijax\u001b[0m\u001b[38;2;212;212;212m=\u001b[0m\u001b[38;2;86;156;214mTrue\u001b[0m\n",
+      "  \u001b[38;2;255;213;3m)\u001b[0m,\n",
+      "  \u001b[38;2;156;220;254mb\u001b[0m\u001b[38;2;212;212;212m=\u001b[0m\u001b[38;2;79;201;177mVariable\u001b[0m\u001b[38;2;255;213;3m(\u001b[0m\u001b[38;2;105;105;105m # 1 (4 B)\u001b[0m\n",
+      "    \u001b[38;2;156;220;254mvalue\u001b[0m\u001b[38;2;212;212;212m=\u001b[0mArray(0, dtype=int32, weak_type=True),\n",
+      "    \u001b[38;2;156;220;254mhijax\u001b[0m\u001b[38;2;212;212;212m=\u001b[0m\u001b[38;2;86;156;214mTrue\u001b[0m\n",
+      "  \u001b[38;2;255;213;3m)\u001b[0m\n",
+      "\u001b[38;2;255;213;3m)\u001b[0m\n"
      ]
     }
    ],
    "source": [
     "# NOTE: doesn't currently fail on the jax side\n",
-    "class Shared(nnx.Pytree):\n",
+    "class HasShared(nnx.Pytree):\n",
     "  def __init__(self):\n",
     "    self.a = nnx.Variable(jnp.array(0))\n",
     "    self.b = self.a\n",
-    "    self.c = Linear(1, 1, rngs=nnx.Rngs(0))\n",
-    "    self.d = self.c\n",
     "\n",
     "@jax.jit\n",
-    "def g(pytree):\n",
-    "  ...\n",
+    "def g(has_shared):\n",
+    "  has_shared.a[...] = 5\n",
     "\n",
-    "shared = Shared()\n",
+    "has_shared = HasShared()\n",
     "\n",
-    "print(get_error(g, shared))"
+    "print(get_error(g, has_shared))\n",
+    "print(has_shared)  # updates don't propagate"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 19,
    "id": "6298f3d9",
    "metadata": {},
    "outputs": [
@@ -596,21 +661,20 @@
      "output_type": "stream",
      "text": [
       "Duplicates found:\n",
-      "- [('a',), ('b',)]\n",
-      "- [('c',), ('d',)]\n"
+      "- [('a',), ('b',)]\n"
      ]
     }
    ],
    "source": [
     "print(\"Duplicates found:\")\n",
-    "if (all_duplicates := nnx.find_duplicates(shared)):\n",
+    "if (all_duplicates := nnx.find_duplicates(has_shared)):\n",
     "  for duplicates in all_duplicates:\n",
     "    print(\"-\", duplicates)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 20,
    "id": "00854d38",
    "metadata": {},
    "outputs": [
@@ -618,13 +682,15 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "before: \u001b[38;2;79;201;177mVariable\u001b[0m\u001b[38;2;255;213;3m(\u001b[0m\u001b[38;2;105;105;105m # 1 (4 B)\u001b[0m\n",
-      "  \u001b[38;2;156;220;254mvalue\u001b[0m\u001b[38;2;212;212;212m=\u001b[0mArray(0, dtype=int32, weak_type=True),\n",
-      "  \u001b[38;2;156;220;254mis_hijax\u001b[0m\u001b[38;2;212;212;212m=\u001b[0m\u001b[38;2;86;156;214mTrue\u001b[0m\n",
-      "\u001b[38;2;255;213;3m)\u001b[0m\n",
-      "after: \u001b[38;2;79;201;177mVariable\u001b[0m\u001b[38;2;255;213;3m(\u001b[0m\u001b[38;2;105;105;105m # 1 (4 B)\u001b[0m\n",
-      "  \u001b[38;2;156;220;254mvalue\u001b[0m\u001b[38;2;212;212;212m=\u001b[0mArray(10, dtype=int32, weak_type=True),\n",
-      "  \u001b[38;2;156;220;254mis_hijax\u001b[0m\u001b[38;2;212;212;212m=\u001b[0m\u001b[38;2;86;156;214mTrue\u001b[0m\n",
+      "\u001b[38;2;79;201;177mHasShared\u001b[0m\u001b[38;2;255;213;3m(\u001b[0m\u001b[38;2;105;105;105m # Variable: 1 (4 B)\u001b[0m\n",
+      "  \u001b[38;2;156;220;254ma\u001b[0m\u001b[38;2;212;212;212m=\u001b[0m\u001b[38;2;79;201;177mVariable\u001b[0m\u001b[38;2;255;213;3m(\u001b[0m\u001b[38;2;105;105;105m # 1 (4 B)\u001b[0m\n",
+      "    \u001b[38;2;156;220;254mvalue\u001b[0m\u001b[38;2;212;212;212m=\u001b[0mArray(5, dtype=int32, weak_type=True),\n",
+      "    \u001b[38;2;156;220;254mhijax\u001b[0m\u001b[38;2;212;212;212m=\u001b[0m\u001b[38;2;86;156;214mTrue\u001b[0m\n",
+      "  \u001b[38;2;255;213;3m)\u001b[0m,\n",
+      "  \u001b[38;2;156;220;254mb\u001b[0m\u001b[38;2;212;212;212m=\u001b[0m\u001b[38;2;79;201;177mVariable\u001b[0m\u001b[38;2;255;213;3m(\u001b[0m\u001b[38;2;105;105;105m # 1 (4 B)\u001b[0m\n",
+      "    \u001b[38;2;156;220;254mvalue\u001b[0m\u001b[38;2;212;212;212m=\u001b[0mArray(5, dtype=int32, weak_type=True),\n",
+      "    \u001b[38;2;156;220;254mhijax\u001b[0m\u001b[38;2;212;212;212m=\u001b[0m\u001b[38;2;86;156;214mTrue\u001b[0m\n",
+      "  \u001b[38;2;255;213;3m)\u001b[0m\n",
       "\u001b[38;2;255;213;3m)\u001b[0m\n"
      ]
     }
@@ -632,26 +698,23 @@
    "source": [
     "@jax.jit\n",
     "def h(graphdef, state):\n",
-    "  obj = nnx.merge(graphdef, state)\n",
-    "  obj.a[...] += 10\n",
+    "  has_shared = nnx.merge(graphdef, state)\n",
+    "  has_shared.a[...] = 5\n",
     "\n",
-    "graphdef, state = nnx.split(shared)\n",
-    "print(\"before:\", state.a) # split deduplicates the state\n",
-    "\n",
+    "graphdef, state = nnx.split(has_shared)\n",
     "h(graphdef, state)\n",
-    "\n",
-    "print(\"after:\", shared.a)"
+    "print(has_shared)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 21,
    "id": "195296c8",
    "metadata": {},
    "outputs": [],
    "source": [
     "# clean up for CI tests\n",
-    "_ = nnx.use_hijax(current_mode)"
+    "_ = nnx.var_defaults(hijax=current_mode)"
    ]
   }
  ],

--- a/docs_nnx/hijax/index.rst
+++ b/docs_nnx/hijax/index.rst
@@ -1,10 +1,6 @@
 Hijax (experimental)
 ====================
 
-
-
-----
-
 Basic usage
 ^^^^^^^^^^^^
 
@@ -13,14 +9,14 @@ Basic usage
   import jax
   import jax.numpy as jnp
 
-  current_mode = nnx.using_hijax()
+  current_mode = nnx.var_defaults().hijax
 
 .. testcode::
 
   from flax import nnx
   import optax
 
-  nnx.use_hijax(True)
+  nnx.var_defaults(hijax=True)
 
   class Model(nnx.Module):
     def __init__(self, din, dmid, dout, rngs: nnx.Rngs):
@@ -42,11 +38,11 @@ Basic usage
     def loss_fn(params):
       model = nnx.merge(graphdef, params, nondiff)
       return ((model(x, rngs) - y) ** 2).mean()
-    loss, grads = jax.value_and_grad(loss_fn)(nnx.as_immutable_vars(params))
+    loss, grads = jax.value_and_grad(loss_fn)(nnx.vars_as(params, mutable=False))
     optimizer.update(model, grads)  # in-place updates
     return loss
 
-  nnx.use_hijax(current_mode)  # clean up for CI tests
+  nnx.var_defaults(hijax=current_mode)  # clean up for CI tests
 
 
 ----

--- a/examples/nnx_toy_examples/hijax_basic.py
+++ b/examples/nnx_toy_examples/hijax_basic.py
@@ -54,7 +54,7 @@ class MLP(nnx.Module):
     self.count[...] += 1
     return self.linear2(jax.nn.relu(self.linear1(x)) * 0.5)
 
-nnx.use_hijax(True)
+nnx.var_defaults(hijax=True)
 
 model = MLP(din=1, dhidden=32, dout=1, rngs=nnx.Rngs(0))
 optimizer = nnx.Optimizer(model, optax.sgd(learning_rate=0.1), wrt=nnx.Param)
@@ -68,7 +68,7 @@ def train_step(model, optimizer, x, y):
     model = nnx.merge(graphdef, params, nondiff)
     return jnp.mean((y - model(x)) ** 2)
 
-  grads = jax.grad(loss_fn)(nnx.as_immutable_vars(params))
+  grads = jax.grad(loss_fn)(nnx.vars_as(params, is_mutable=False))
   optimizer.update(model, grads)
 
 @jax.jit

--- a/examples/nnx_toy_examples/hijax_demo.py
+++ b/examples/nnx_toy_examples/hijax_demo.py
@@ -206,7 +206,7 @@ class SGD(nnx.Pytree):
 
 
 # ## Training
-nnx.use_hijax(True)
+nnx.var_defaults(hijax=True)
 
 rngs = nnx.Rngs(params=0, dropout=1)
 model = Model(
@@ -238,7 +238,7 @@ def train_step(model: Model, optimizer: SGD, rngs: nnx.Rngs, x, y):
 
   # For the time being we have to use 'immutable'
   # as 'jax.grad' doesn't support QDD types yet.
-  grads = jax.grad(loss_fn)(nnx.as_immutable_vars(params))
+  grads = jax.grad(loss_fn)(nnx.vars_as(params, is_mutable=False))
   # 'update' mutates the optimizer's state and the params in place
   # so we don't need to return anything 🚀
   optimizer.update(params, grads)

--- a/flax/nnx/__init__.py
+++ b/flax/nnx/__init__.py
@@ -73,12 +73,7 @@ from .graph import split_context as split_context
 from .graph import MergeContext as MergeContext
 from .graph import merge_context as merge_context
 from .graph import variables as variables
-from .graph import as_ref_vars as as_ref_vars
-from .graph import as_array_vars as as_array_vars
-from .graph import as_hijax_vars as as_hijax_vars
-from .graph import as_pytree_vars as as_pytree_vars
-from .graph import as_immutable_vars as as_immutable_vars
-from .graph import as_mutable_vars as as_mutable_vars
+from .graph import vars_as as vars_as
 from .graph import pure as pure
 from .graph import cached_partial as cached_partial
 from .graph import flatten as flatten
@@ -206,10 +201,7 @@ from .variablelib import with_metadata as with_metadata
 from .variablelib import variable_type_from_name as variable_type_from_name
 from .variablelib import variable_name_from_type as variable_name_from_type
 from .variablelib import register_variable_name as register_variable_name
-from .variablelib import use_eager_sharding as use_eager_sharding
-from .variablelib import using_eager_sharding as using_eager_sharding
-from .variablelib import use_hijax as use_hijax
-from .variablelib import using_hijax as using_hijax
+from .variablelib import use_eager_sharding as use_eager_sharding, using_eager_sharding as using_eager_sharding, var_defaults as var_defaults
 from .visualization import display as display
 from .extract import to_tree as to_tree
 from .extract import from_tree as from_tree

--- a/flax/nnx/nn/normalization.py
+++ b/flax/nnx/nn/normalization.py
@@ -371,8 +371,8 @@ class BatchNorm(Module):
     reduction_axes = tuple(i for i in range(x.ndim) if i not in feature_axes)
 
     # Promote dtypes for input and all Variables
-    scale = self.scale[...] if self.scale else None
-    bias = self.bias[...] if self.bias else None
+    scale = self.scale[...] if self.scale is not None else None
+    bias = self.bias[...] if self.bias is not None else None
     x, mean, var, scale, bias = self.promote_dtype(
       (x, self.mean[...], self.var[...], scale, bias), dtype=self.dtype
     )

--- a/tests/nnx/integration_test.py
+++ b/tests/nnx/integration_test.py
@@ -460,7 +460,7 @@ class TestIntegration(absltest.TestCase):
       nnx.update(model, restored_pure_dict)
       assert model(x).shape == (3, 4)  # The model still works!
 
-  @nnx.use_hijax(True)
+  @nnx.var_defaults(hijax=True)
   def test_example_mutable_arrays(self):
     class Model(nnx.Module):
       def __init__(self, din, dmid, dout, rngs: nnx.Rngs):
@@ -483,7 +483,9 @@ class TestIntegration(absltest.TestCase):
         model =  nnx.merge(graphdef, params, nondiff)
         return ((model(x) - y) ** 2).mean()  # call methods directly
 
-      loss, grads = jax.value_and_grad(loss_fn)(nnx.as_immutable_vars(params))
+      loss, grads = jax.value_and_grad(loss_fn)(
+        nnx.vars_as(params, mutable=False)
+      )
       optimizer.update(model, grads)  # in-place updates
 
       return loss

--- a/tests/nnx/spmd_test.py
+++ b/tests/nnx/spmd_test.py
@@ -245,7 +245,7 @@ class TestSPMD(parameterized.TestCase):
 
   @parameterized.product(use_hijax=[True, False])
   def test_logical_rules(self, use_hijax):
-    self.enter_context(nnx.use_hijax(use_hijax))
+    self.enter_context(nnx.var_defaults(hijax=use_hijax))
     class Foo(nnx.Module):
 
       def __init__(self):

--- a/tests/nnx/transforms_test.py
+++ b/tests/nnx/transforms_test.py
@@ -509,7 +509,7 @@ class TestEvalShape(absltest.TestCase):
     self.assertIsInstance(abs_model.kernel.get_value(), jax.ShapeDtypeStruct)
 
   def test_eval_shape_mutable_array(self):
-    with nnx.use_hijax(True):
+    with nnx.var_defaults(hijax=True):
       abs_model = nnx.eval_shape(lambda: nnx.Linear(1, 2, rngs=nnx.Rngs(0)))
     self.assertIsInstance(abs_model, nnx.Linear)
     self.assertIsInstance(abs_model.kernel.get_value(), jax.ShapeDtypeStruct)

--- a/tests/nnx/variable_test.py
+++ b/tests/nnx/variable_test.py
@@ -109,29 +109,29 @@ class TestVariable(parameterized.TestCase):
       self.assertEqual(p1 == p2, v1 == v2)
 
   def test_mutable_array_context(self):
-    initial_mode = nnx.using_hijax()
-    with nnx.use_hijax(False):
+    initial_mode = nnx.var_defaults().hijax
+    with nnx.var_defaults(hijax=False):
       v = nnx.Variable(jnp.array(1.0))
-      self.assertEqual(nnx.using_hijax(), False)
+      self.assertEqual(nnx.var_defaults().hijax, False)
       self.assertNotIsInstance(v[...], jax.Ref)
 
-      with nnx.use_hijax(True):
+      with nnx.var_defaults(hijax=True):
         v = nnx.Variable(jnp.array(1.0))
-        self.assertEqual(nnx.using_hijax(), True)
+        self.assertEqual(nnx.var_defaults().hijax, True)
         self.assertIsInstance(v[...], jax.Array)
 
       v = nnx.Variable(jnp.array(2.0))
       self.assertIsInstance(v[...], jax.Array)
-      self.assertEqual(nnx.using_hijax(), False)
+      self.assertEqual(nnx.var_defaults().hijax, False)
 
-      nnx.use_hijax(True)
+      nnx.var_defaults(hijax=True)
 
       v = nnx.Variable(jnp.array(0.0))
-      self.assertEqual(nnx.using_hijax(), True)
+      self.assertEqual(nnx.var_defaults().hijax, True)
       self.assertIsInstance(v[...], jax.Array)
 
     v = nnx.Variable(jnp.array(1.0))
-    self.assertEqual(nnx.using_hijax(), initial_mode)
+    self.assertEqual(nnx.var_defaults().hijax, initial_mode)
     self.assertIsInstance(v[...], jax.Array)
 
   def test_get_set_metadata(self):
@@ -139,9 +139,9 @@ class TestVariable(parameterized.TestCase):
     self.assertEqual(
         v.get_metadata(),
         {
-            'is_hijax': False,
-            'has_ref': False,
-            'is_mutable': True,
+            'hijax': False,
+            'ref': False,
+            'mutable': True,
             'eager_sharding': True,
         },
     )
@@ -151,9 +151,9 @@ class TestVariable(parameterized.TestCase):
     v.set_metadata({
         'b': 3,
         'c': 4,
-        'is_hijax': False,
-        'has_ref': False,
-        'is_mutable': True,
+        'hijax': False,
+        'ref': False,
+        'mutable': True,
         'eager_sharding': True,
     })
     self.assertEqual(
@@ -161,9 +161,9 @@ class TestVariable(parameterized.TestCase):
         {
             'b': 3,
             'c': 4,
-            'is_hijax': False,
-            'has_ref': False,
-            'is_mutable': True,
+            'hijax': False,
+            'ref': False,
+            'mutable': True,
             'eager_sharding': True,
         },
     )
@@ -190,9 +190,9 @@ class TestVariable(parameterized.TestCase):
     self.assertEqual(v_metadata['foo'], 'bar')
     self.assertEqual(p_metadata['foo'], 'bar')
     # Check that default metadata is preserved
-    self.assertIn('is_hijax', v_metadata)
-    self.assertIn('has_ref', v_metadata)
-    self.assertIn('is_mutable', v_metadata)
+    self.assertIn('hijax', v_metadata)
+    self.assertIn('ref', v_metadata)
+    self.assertIn('mutable', v_metadata)
 
     self.assertNotIn('differentiable', m.v.get_metadata())
     self.assertNotIn('differentiable', m.p.get_metadata())


### PR DESCRIPTION
## Summary of Changes

This PR introduces significant refactoring to `flax.nnx` to standardize variable metadata, improve Hijax support, and consolidate APIs. It also includes fixes for type hinting and documentation.

### Key Changes

*   **Variable Metadata Standardization:**
    *   Renamed metadata keys for consistency:
        *   `is_hijax` → `hijax`
        *   `has_ref` → `ref`
        *   `is_mutable` → `mutable`

*   **New `var_defaults` API:**
    *   Introduced `nnx.var_defaults()` to replace `nnx.use_hijax()` and `nnx.using_hijax()`.
    *   This unified API serves as:
        *   A context manager: `with nnx.var_defaults(hijax=True): ...`
        *   A decorator: `@nnx.var_defaults(hijax=True)`
        *   A configuration accessor: `defaults = nnx.var_defaults()`

*   **Unified Variable Conversion API:**
    *   Consolidated multiple conversion functions into a single `nnx.vars_as()` function:
        *   `nnx.as_ref_vars(...)` → `nnx.vars_as(..., ref=True)`
        *   `nnx.as_immutable_vars(...)` → `nnx.vars_as(..., mutable=False)`
        *   `nnx.as_mutable_vars(...)` → `nnx.vars_as(..., mutable=True)`
        *   `nnx.as_hijax_vars(...)` → `nnx.vars_as(..., hijax=True)`

### Fixes & Improvements

*   **Type Hinting (Mypy):**
    *   Resolved `Ref` redefinition errors in `flax/nnx/variablelib.py`.
    *   Fixed `@tp.overload` value shadowing for `var_defaults`.
    *   Corrected `property` usage on non-method attributes.
*   **Documentation:**
    *   Fixed indentation in `recursive_map` docstring in `flax/nnx/graph.py`.
    *   Fixed RST transition syntax error in `docs_nnx/hijax/index.rst`.

### Testing

*   Updated integration and unit tests (`integration_test.py`, `mutable_array_test.py`, `spmd_test.py`, `variable_test.py`) to utilize the new `vars_as` and `var_defaults` APIs.
*   Added comprehensive tests for the `var_defaults` context manager, including nesting behavior.
*   Verified changes with `./tests/run_all_tests.sh --only-mypy` and `./tests/run_all_tests.sh --only-doctest`.
