### PR TITLE
Make `nnx.pop` remove sown attributes.

### DIFF
--- a/flax/nnx/graph.py
+++ b/flax/nnx/graph.py
@@ -1899,7 +1899,7 @@ class MergeContext:
       )
 
     elif static_cache is not None:
-      assert isinstance(graphdef.nodes[0], NodeDef)
+      assert isinstance(graphdef.nodes[0], NodeDef) or isinstance(graphdef.nodes[0], VariableDef)
       assert ctx is not None
       if (outer_index := graphdef.nodes[0].outer_index) is not None:
         outer_index_outer_ref = ctx.outer_index_outer_ref

--- a/flax/nnx/pytreelib.py
+++ b/flax/nnx/pytreelib.py
@@ -936,7 +936,17 @@ class Pytree(reprlib.Representable, metaclass=PytreeMeta):
   def _graph_node_pop_key(self, key: str):
     if not isinstance(key, str):
       raise KeyError(f'Invalid key: {key!r}')
-    return vars(self).pop(key)
+    delattr(self, key)
+    return self
+
+  def __delattr__(self, name: str) -> None:
+    if name in self._pytree__nodes:
+      if isinstance(self._pytree__nodes._mapping, tp.MutableMapping):
+        del self._pytree__nodes._mapping[name]
+      else:
+        self._pytree__nodes._mapping = {k: v for k, v in self._pytree__nodes.items() if k != name}
+
+    super().__delattr__(name)
 
   @staticmethod
   def _graph_node_create_empty(node_type: tp.Type[P]) -> P:


### PR DESCRIPTION
Fixes #5130
This does not remove the Fingerprint check (also mentioned in the issue). This just fixes the pop bug. 