### PR TITLE
fix general guides landing page

### DIFF
--- a/docs_nnx/guides/index.rst
+++ b/docs_nnx/guides/index.rst
@@ -4,5 +4,5 @@ Guides
 .. toctree::
    :maxdepth: 2
 
-   index_basic
-   index_advanced
+   ../guides_basic
+   ../guides_advanced


### PR DESCRIPTION
# What does this PR do?

Fixes #5138 by fixing the location of `../guides_basic` and `../guides_advanced` with respect the location of `index.rst`. The link https://flax.readthedocs.io/en/latest/guides/index.html is still used in some other guides like https://github.com/rcrowe-google/Learning-JAX , so it would be nice to keep the link updated.

### Before
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/1af64edf-ed57-4594-8c5a-0f2c82991f0e" />

### After
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/91f00992-31ca-4241-8975-f07de3ad9053" />


## Checklist
- [x] This PR fixes a minor issue (e.g.: typo or small bug) or improves the docs (you can dismiss the other checks if that's the case).
- [x] This change is discussed in a Github issue/[discussion](https://github.com/google/flax/discussions) (please add a link).
- [ ] The documentation and docstrings adhere to the [documentation guidelines](https://github.com/google/flax/blob/main/docs/README.md#how-to-write-code-documentation).
- [ ] This change includes necessary high-coverage tests. (No quality testing = no merge!)
