### PR TITLE
Add out_sharding docstrings to linear layer call  methods

### DIFF
--- a/flax/nnx/nn/linear.py
+++ b/flax/nnx/nn/linear.py
@@ -251,6 +251,11 @@ class LinearGeneral(Module):
 
     Args:
       inputs: The nd-array to be transformed.
+      out_sharding: Optional sharding specification (e.g.,
+        ``jax.sharding.PartitionSpec``) for the output array. When using JAX's
+        explicit sharding mode with a mesh context with ``AxisType.Explicit``.
+        If ``None`` (default), the compiler automatically determines output
+        sharding.
 
     Returns:
       The transformed input.
@@ -398,6 +403,11 @@ class Linear(Module):
 
     Args:
       inputs: The nd-array to be transformed.
+      out_sharding: Optional sharding specification (e.g.,
+        ``jax.sharding.PartitionSpec``) for the output array. When using JAX's
+        explicit sharding mode with a mesh context with ``AxisType.Explicit``.
+        If ``None`` (default), the compiler automatically determines output
+        sharding.
 
     Returns:
       The transformed input.
@@ -532,6 +542,11 @@ class Einsum(Module):
         the rhs being the learnable kernel. Exactly one of ``einsum_str``
         in the constructor argument and call argument must be not None,
         while the other must be None.
+      out_sharding: Optional sharding specification (e.g.,
+        ``jax.sharding.PartitionSpec``) for the output array. When using JAX's
+        explicit sharding mode with a mesh context with ``AxisType.Explicit``.
+        If ``None`` (default), the compiler automatically determines output
+        sharding.
 
     Returns:
       The transformed input.


### PR DESCRIPTION
# What does this PR do?
Add `out_sharding` docstrings to linear layers (`Linear`, `LinearGeneral`, `Einsum`) call  methods.

Fixes # (issue)

## Checklist
- [x] This PR fixes a minor issue (e.g.: typo or small bug) or improves the docs (you can dismiss the other checks if that's the case).
- [ ] This change is discussed in a Github issue/[discussion](https://github.com/google/flax/discussions) (please add a link).
- [x] The documentation and docstrings adhere to the [documentation guidelines](https://github.com/google/flax/blob/main/docs/README.md#how-to-write-code-documentation).
- [ ] This change includes necessary high-coverage tests. (No quality testing = no merge!)
