### PR TITLE
Docs: Fix typo and clarify introduction in Functional API section

### DIFF
--- a/docs_nnx/nnx_basics.ipynb
+++ b/docs_nnx/nnx_basics.ipynb
@@ -453,7 +453,7 @@
     "\n",
     "The Flax NNX Functional API establishes a clear boundary between reference/object semantics and value/pytree semantics. It also allows the same amount of fine-grained control over the state that Flax Linen and Haiku users are used to. The Flax NNX Functional API consists of three basic methods:  `nnx.split`, `nnx.merge`, and `nnx.update`.\n",
     "\n",
-    "Below, we define a `StatefulLinear` `Module`. In the following sections, we will use this module to demonstrate the Functional API methods (`nnx.split`, `nnx.merge`, and `nnx.update`). It contains:\n",
+    "Below is an example of `StatefulLinear` `Module` that uses the Functional API. It contains:\n",
     "\n",
     "- Some `Param` Variables; and\n",
     "- A custom `Count` Variable type, which is used to track the integer scalar state that increases on every forward pass."

--- a/docs_nnx/nnx_basics.md
+++ b/docs_nnx/nnx_basics.md
@@ -224,7 +224,7 @@ How do Flax NNX transforms achieve this? To understand how Flax NNX objects inte
 
 The Flax NNX Functional API establishes a clear boundary between reference/object semantics and value/pytree semantics. It also allows the same amount of fine-grained control over the state that Flax Linen and Haiku users are used to. The Flax NNX Functional API consists of three basic methods:  `nnx.split`, `nnx.merge`, and `nnx.update`.
 
-Below, we define a `StatefulLinear` `Module`. In the following sections, we will use this module to demonstrate the Functional API methods (`nnx.split`, `nnx.merge`, and `nnx.update`). It contains:
+Below is an example of `StatefulLinear` `Module` that uses the Functional API. It contains:
 
 - Some `Param` Variables; and
 - A custom `Count` Variable type, which is used to track the integer scalar state that increases on every forward pass.


### PR DESCRIPTION
# What does this PR do?

This PR improves the documentation for the Flax NNX Functional API (`docs_nnx/nnx_basics.ipynb`).

Specifically, it:
1. **Fixes a typo**: Corrected "example of of" to "define a".
2. **Clarifies the introduction**: The original text stated that the example code "uses the Functional API". However, the immediate code block only defines the class and does not yet use `split`, `merge`, or `update`. I updated the text to clarify that we are defining a module *to be used* in the following sections to demonstrate the API.


## Checklist
- [x] This PR fixes a minor issue (e.g.: typo or small bug) or improves the docs (you can dismiss the other checks if that's the case).
- [ ] This change is discussed in a Github issue/[discussion](https://github.com/google/flax/discussions) (please add a link).
- [ ] The documentation and docstrings adhere to the [documentation guidelines](https://github.com/google/flax/blob/main/docs/README.md#how-to-write-code-documentation).
- [ ] This change includes necessary high-coverage tests. (No quality testing = no merge!)
