### PR TITLE
refactor: add missing type hints to flax/core/scope.py

### DIFF
--- a/flax/core/scope.py
+++ b/flax/core/scope.py
@@ -102,7 +102,7 @@ class LazyRng(struct.PyTreeNode):
     else:
       return LazyRng(rng, suffix)
 
-  def clear_suffix(self):
+  def clear_suffix(self) -> None:
     key = self.rng
     return LazyRng(key, ())
 
@@ -326,7 +326,7 @@ class Variable(Generic[T]):
   content and can be assigned to for mutation.
   """
 
-  def __init__(self, scope: 'Scope', collection: str, name: str, unbox: bool):
+  def __init__(self, scope: 'Scope', collection: str, name: str, unbox: bool) -> None:
     """Initializes a variable.
 
     Args:
@@ -471,7 +471,7 @@ class Scope:
     """Returns true if this scope is invalidated as a result of `Scope.temporary`."""
     return self._invalid
 
-  def _check_valid(self):
+  def _check_valid(self) -> None:
     if self._invalid:
       raise errors.InvalidScopeError(self.name)
 


### PR DESCRIPTION
# What does this PR do?

**This PR adds missing type annotations (`-> None`) to `__init__`, `clear_suffix`, and `_check_valid` methods in `flax/core/scope.py`.**


Fixes # (issue)

## Checklist
- [x] This PR fixes a minor issue (e.g.: typo or small bug) or improves the docs (you can dismiss the other checks if that's the case).
- [ ] This change is discussed in a Github issue/[discussion](https://github.com/google/flax/discussions) (please add a link).
- [ ] The documentation and docstrings adhere to the [documentation guidelines](https://github.com/google/flax/blob/main/docs/README.md#how-to-write-code-documentation).
- [ ] This change includes necessary high-coverage tests. (No quality testing = no merge!)
