### PR TITLE
fix: remove superfluous `jax.Ref` standalone statement

### DIFF
--- a/flax/nnx/variablelib.py
+++ b/flax/nnx/variablelib.py
@@ -477,7 +477,7 @@ class HijaxVariableMeta(type):
       return isinstance(ty, AbstractVariable)
     return False
 
-jax.Ref
+
 class HijaxVariable(
   tp.Generic[A], reprlib.Representable, metaclass=HijaxVariableMeta
 ):  # type: ignore


### PR DESCRIPTION
# What does this PR do?

This PR removes a superfluous `jax.Ref` standalone statement that got introduced in https://github.com/google/flax/commit/b5db513f012bd2de51b9529e553cc92dc16c0b3e. 

## Checklist
- [x] This PR fixes a minor issue (e.g.: typo or small bug) or improves the docs (you can dismiss the other checks if that's the case).
- [ ] This change is discussed in a Github issue/[discussion](https://github.com/google/flax/discussions) (please add a link).
- [ ] The documentation and docstrings adhere to the [documentation guidelines](https://github.com/google/flax/blob/main/docs/README.md#how-to-write-code-documentation).
- [ ] This change includes necessary high-coverage tests. (No quality testing = no merge!)