### PR TITLE
docs(nnx): add missing functional args to Conv and LinearGeneral

### DIFF
--- a/flax/nnx/nn/linear.py
+++ b/flax/nnx/nn/linear.py
@@ -133,6 +133,10 @@ class LinearGeneral(Module):
     param_dtype: the dtype passed to parameter initializers (default: float32).
     kernel_init: initializer function for the weight matrix.
     bias_init: initializer function for the bias.
+    dot_general: dot product function (default: None). If neither this nor
+        ``dot_general_cls`` are provided, ``jax.lax.dot_general`` is used.
+    dot_general_cls: dot product function class to instantiate a dot product function
+    as ``dot_general = dot_general_cls()`` (default: None).
     precision: numerical precision of the computation see ``jax.lax.Precision``
       for details.
     promote_dtype: function to promote the dtype of the arrays to the desired
@@ -688,6 +692,8 @@ class Conv(Module):
           be the same shape as the convolution weight matrix.
     dtype: the dtype of the computation (default: infer from input and params).
     param_dtype: the dtype passed to parameter initializers (default: float32).
+    conv_general_dilated: the convolution function to use (default:
+      ``jax.lax.conv_general_dilated``).
     precision: numerical precision of the computation see ``jax.lax.Precision``
       for details.
     kernel_init: initializer for the convolutional kernel.


### PR DESCRIPTION
# What does this PR do?

## Description
This PR updates the docstrings for `Conv` and `LinearGeneral` to include functional arguments that were present in `__init__` but missing from the API reference.

## Changes
- **LinearGeneral:** Added `dot_general` and `dot_general_cls` to the `Args` list.
- **Conv:** Added `conv_general_dilated` to the `Args` list.

## Related Issues
- Contributes to the documentation cleanup initiative.

Great, you are contributing to Flax!


Fixes # (issue)

## Checklist
- [x] This PR fixes a minor issue (e.g.: typo or small bug) or improves the docs (you can dismiss the other checks if that's the case).
- [ ] This change is discussed in a Github issue/[discussion](https://github.com/google/flax/discussions) (please add a link).
- [ ] The documentation and docstrings adhere to the [documentation guidelines](https://github.com/google/flax/blob/main/docs/README.md#how-to-write-code-documentation).
- [ ] This change includes necessary high-coverage tests. (No quality testing = no merge!)
