### PR TITLE
feat(nnx): add Grouped Query Attention (GQA) support

### DIFF
--- a/tests/nnx/nn/attention_test.py
+++ b/tests/nnx/nn/attention_test.py
@@ -298,6 +298,61 @@ class TestKVFeatures(parameterized.TestCase):
 
     self.assertIsNotNone(layer(x, y))
 
+class TestGQADotProductAttention(parameterized.TestCase):
+
+  def test_gqa_shapes(self):
+    B, T, S = 2, 4, 5
+    D = 8
+    num_heads_q = 6
+    num_heads_kv = 3
+
+    k1, k2, k3 = jax.random.split(jax.random.key(0), 3)
+    query = jax.random.normal(k1, (B, T, num_heads_q, D))
+    key   = jax.random.normal(k2, (B, S, num_heads_kv, D))
+    value = jax.random.normal(k3, (B, S, num_heads_kv, D))
+
+    output = nnx.dot_product_attention(query, key, value)
+    expected_shape = (B, T, num_heads_q, D)
+    self.assertEqual(output.shape, expected_shape)
+
+  def test_gqa_invalid_heads(self):
+    B, T, D = 1, 4, 8
+    query = jnp.ones((B, T, 5, D))
+    key   = jnp.ones((B, T, 2, D))
+    value = key
+
+    with self.assertRaisesRegex(ValueError, "must be a multiple"):
+        nnx.dot_product_attention(query, key, value)
+
+  def test_gqa_parity_with_jax(self):
+    class DummyModule(nnx.Module):
+      pass
+
+    dummy_module = DummyModule()
+
+    B, T, S, D = 2, 8, 8, 16
+    num_heads_q = 4
+    num_heads_kv = 2
+
+    rng = jax.random.key(42)
+    k1, k2, k3 = jax.random.split(rng, 3)
+
+    query = jax.random.normal(k1, (B, T, num_heads_q, D))
+    key   = jax.random.normal(k2, (B, S, num_heads_kv, D))
+    value = jax.random.normal(k3, (B, S, num_heads_kv, D))
+
+    jax_out = jax.nn.dot_product_attention(query, key, value)
+
+    # NNX should handle broadcasting internally
+    nnx_out = nnx.dot_product_attention(
+      query, key, value,
+      module=dummy_module
+    )
+
+    np.testing.assert_allclose(nnx_out, jax_out, atol=1e-3, rtol=1e-3)
+
 
 if __name__ == '__main__':
   absltest.main()
+
+


### PR DESCRIPTION
# What does this PR do?

This PR adds support for Grouped Query Attention (GQA) to nnx.dot_product_attention.

Previously, nnx.dot_product_attention required the number of heads in Query, Key, and Value to be identical. This caused a shape mismatch error when trying to use GQA configurations (where multiple Query heads share a single Key/Value head).

Changes Implemented:

- Added broadcasting logic in dot_product_attention_weights to repeat Key heads to match Query heads.
- Added broadcasting logic in dot_product_attention to repeat Value heads to match the Attention Weights.
- Added a validation check to ensure query_heads is divisible by key_heads (raising a clear ValueError if not).
- Added a new test file tests/nnx/nn/gqa_test.py covering valid GQA shapes and invalid configuration handling.

This change brings nnx into parity with jax.nn.dot_product_attention, enabling modern architectures (like Llama 3) to be implemented in NNX.

Fixes #5177

## Checklist
- [ ] This PR fixes a minor issue (e.g.: typo or small bug) or improves the docs (you can dismiss the other checks if that's the case).
- [x] This change is discussed in a Github issue/[discussion](https://github.com/google/flax/discussions) (please add a link).
- [x] The documentation and docstrings adhere to the [documentation guidelines](https://github.com/google/flax/blob/main/docs/README.md#how-to-write-code-documentation).
- [x] This change includes necessary high-coverage tests. (No quality testing = no merge!)
