### PR TITLE
Fix bug in graph overhead benchmark

### DIFF
--- a/benchmarks/nnx_graph_overhead.py
+++ b/benchmarks/nnx_graph_overhead.py
@@ -58,9 +58,9 @@ class MLP(nnx.Module):
   def __init__(self, din, dhidden, dout, depth, *, rngs: nnx.Rngs):
     self.count = Count(jnp.array(0))
     self.linear_in = Block(din, dhidden, rngs=rngs)
-    self.intermediates = [
+    self.intermediates = nnx.List([
       Block(dhidden, dhidden, rngs=rngs) for _ in range(depth - 2)
-    ]
+    ])
     self.linear_out = Block(dhidden, dout, rngs=rngs)
 
   def __call__(self, x):


### PR DESCRIPTION
The `nnx_graph_overhead.py` benchmark currently throws the following error:

```
Found unexpected Arrays on value of type <class 'list'> in static attribute 'intermediates'.
```

We just need to wrap the intermediates list in `nnx.List`. 