### PR TITLE
Use nnx split during tabulate (clone of #5069)

### DIFF
--- a/flax/nnx/rnglib.py
+++ b/flax/nnx/rnglib.py
@@ -57,6 +57,7 @@ def _to_keyless(
 
 
 def _function_to_method(random_f):
+  @functools.wraps(random_f)
   def rngs_random_method(self: Rngs | RngStream, *args, **kwargs) -> jax.Array:
     return random_f(self(), *args, **kwargs)
 


### PR DESCRIPTION
This is clone of #5069. Internal CI got confused about 5069 already having been merged, so this is a workaround. 