### PR TITLE
fix(nnx): ensure PathContains('') matches all paths

### DIFF
--- a/flax/nnx/filterlib.py
+++ b/flax/nnx/filterlib.py
@@ -93,6 +93,8 @@ class PathContains:
   exact: bool = True
 
   def __call__(self, path: PathParts, x: tp.Any):
+    if self.key == '':
+      return True
     if self.exact:
       return self.key in path
     return any(str(self.key) in str(part) for part in path)

--- a/tests/nnx/filters_test.py
+++ b/tests/nnx/filters_test.py
@@ -36,5 +36,18 @@ class TestFilters(absltest.TestCase):
     self.assertIn('backbone2', backbones_state)
     self.assertNotIn('head', backbones_state)
 
+  def test_path_contains_empty_string(self):
+    class Model(nnx.Module):
+      def __init__(self):
+        self.a = nnx.Param(1)
+        self.b = nnx.Param(2)
+
+    model = Model()
+    state = nnx.state(model, nnx.PathContains(''))
+
+    self.assertLen(state, 2)
+    self.assertIn('a', state)
+    self.assertIn('b', state)
+
 if __name__ == '__main__':
   absltest.main()


### PR DESCRIPTION


# What does this PR do?

Title: feat(nnx): support PathContains('') as wildcard (User Ergonomics)

Description:

Problem Overview
This PR addresses the usability friction highlighted in Issue #4660.

Currently, nnx.PathContains('') returns an empty state. While this is technically correct given the underlying tuple implementation (checking if '' is inside the tuple), it contradicts the strong intuition users bring from Python strings and other systems where "empty string" implies "match all" or "root".

As noted in the issue, users expect '' to behave like a wildcard. When it silently fails, it leads to confusion and debugging time.

The Improvement
I have updated PathContains to explicitly handle '' as a wildcard.

Old Behavior: PathContains('') -> Returns Empty (Matches nothing).

New Behavior: PathContains('') -> Returns Identity (Matches everything).

This effectively makes PathContains('') an alias for PathContains(True) or ..., but using the syntax users naturally try first.

Implementation
I modified PathContains.__call__ in flax/nnx/filterlib.py to return True immediately if self.key is ''. This incurs negligible overhead but aligns the API with user expectations.

Verification
-New Unit Test: Added test_path_contains_empty_string in filters_test.py which confirms '' now captures the full state.

-Existing Tests: All existing filter tests pass; this change is backward compatible as '' previously matched nothing useful.

(Relates to #4660)

Fixes #4660

## Checklist
- [x] This PR fixes a minor issue (e.g.: typo or small bug) or improves the docs (you can dismiss the other checks if that's the case).
- [x] This change is discussed in a Github issue/[discussion](https://github.com/google/flax/discussions) (please add a link).
- [ ] The documentation and docstrings adhere to the [documentation guidelines](https://github.com/google/flax/blob/main/docs/README.md#how-to-write-code-documentation).
- [x] This change includes necessary high-coverage tests. (No quality testing = no merge!)
