### PR TITLE
[CI] Fix doctest job by pinning ipython to 9.9.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,7 +79,7 @@ docs = [
     "sphinx-book-theme",
     "Pygments>=2.6.1",
     "ipykernel",
-    "ipython==9.9.0"
+    "ipython==9.9.0",
     "myst_nb",
     "nbstripout",
     "recommonmark",


### PR DESCRIPTION
Inspecting logs of failed job vs passing job, here is the python packages version difference:

Package       | Log 1 - Fail (Feb 3) | Log 2 - Pass (Jan 30) | Difference
 ------------- | ------------- | -------------- | ----------
ipython       | 9.10.0        | 9.9.0          | +0.1.0
rich          | 14.3.2        | 14.3.1         | +0.0.1
wcwidth       | 0.5.3         | 0.5.2          | +0.0.1
wrapt         | 2.1.1         | 2.0.1          | +0.1.0 
coverage      | 7.13.3        | 7.13.2         | +0.0.1
babel         | 2.18.0        | 2.17.0         | +0.1.0
numpy (final) | 2.4.2         | 2.4.1          | +0.0.1 

```

Source: https://www.kimi.com/share/19c249cb-3362-81a6-8000-00006b942ed6