### PR TITLE
Pin doc deps to lower versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,6 +79,7 @@ docs = [
     "sphinx-book-theme",
     "Pygments>=2.6.1",
     "ipykernel",
+    "tqdm==4.67.1",
     "myst_nb",
     "nbstripout",
     "recommonmark",


### PR DESCRIPTION
This PR attempts to fix the doctests that have been failing lately by pinning ipython. 