### PR TITLE
fix: correct typo 'seperate' to 'separate'

### DIFF
--- a/flax/core/scope.py
+++ b/flax/core/scope.py
@@ -127,7 +127,7 @@ def _fold_in_static(
   m = hashlib.sha1()
   for x in data:
     if config.flax_fix_rng_separator:
-      # encode seperate to avoid collisions like for example: ("ab", "c") and ("a", "bc")
+      # encode separate to avoid collisions like for example: ("ab", "c") and ("a", "bc")
       m.update(b'\00')
     if isinstance(x, str):
       m.update(x.encode('utf-8'))

--- a/tests/core/core_scope_test.py
+++ b/tests/core/core_scope_test.py
@@ -284,7 +284,7 @@ class ScopeTest(absltest.TestCase):
       init_fn(random.key(0), jax.ShapeDtypeStruct((8, 4), jnp.float32))
 
   @config.temp_flip_flag('fix_rng_separator', True)
-  def test_fold_in_static_seperator(self):
+  def test_fold_in_static_separator(self):
     x = LazyRng(random.key(0), ('ab', 'c'))
     y = LazyRng(random.key(0), ('a', 'bc'))
     self.assertFalse(np.all(x.as_jax_rng() == y.as_jax_rng()))


### PR DESCRIPTION
Fixes typo 'seperate' to 'separate' in scope.py comment and test function name.