### PR TITLE
Add 'opt_sharding' option for Variables

### DIFF
--- a/docs_nnx/guides/flax_gspmd.ipynb
+++ b/docs_nnx/guides/flax_gspmd.ipynb
@@ -132,7 +132,7 @@
     "\n",
     "Let's begin by sharding the simplest component possible - a Flax variable.\n",
     "\n",
-    "When you define a Flax variable, you can pass in a metadata field called `out_sharding`, to specify how the underlying JAX array should be sharded. This field should be a tuple of names, each of which refer to how an axis of the array should be sharded. This sharding will also apply to any `nnx.Optimizer` created from the variable. To specify a different sharding for optimization, use the `opt_sharding` metadata field. \n",
+    "When you define a Flax variable, you can pass in a metadata field called `optimizer_sharding`, to specify how the underlying JAX array should be sharded. This field should be a tuple of names, each of which refer to how an axis of the array should be sharded. This sharding will also apply to any `nnx.Optimizer` created from the variable. To specify a different sharding for optimization, use the `opt_sharding` metadata field. \n",
     "\n",
     "**You must have an existing device mesh** and create a sharding-annotated `nnx.Variable` within its scope. This allows the result variable to be sharded accordingly on those devices. The device mesh can be your actual accelerator mesh, or a dummy fake CPU mesh like in this notebook."
    ]

--- a/docs_nnx/guides/flax_gspmd.md
+++ b/docs_nnx/guides/flax_gspmd.md
@@ -71,7 +71,7 @@ nnx.Param(jnp.ones(4,4), out_sharding=(None, 'model'), eager_sharding=True, mesh
 
 Let's begin by sharding the simplest component possible - a Flax variable.
 
-When you define a Flax variable, you can pass in a metadata field called `out_sharding`, to specify how the underlying JAX array should be sharded. This field should be a tuple of names, each of which refer to how an axis of the array should be sharded. This sharding will also apply to any `nnx.Optimizer` created from the variable. To specify a different sharding for optimization, use the `opt_sharding` metadata field. 
+When you define a Flax variable, you can pass in a metadata field called `optimizer_sharding`, to specify how the underlying JAX array should be sharded. This field should be a tuple of names, each of which refer to how an axis of the array should be sharded. This sharding will also apply to any `nnx.Optimizer` created from the variable. To specify a different sharding for optimization, use the `opt_sharding` metadata field. 
 
 **You must have an existing device mesh** and create a sharding-annotated `nnx.Variable` within its scope. This allows the result variable to be sharded accordingly on those devices. The device mesh can be your actual accelerator mesh, or a dummy fake CPU mesh like in this notebook.
 

--- a/flax/nnx/training/optimizer.py
+++ b/flax/nnx/training/optimizer.py
@@ -50,8 +50,8 @@ def to_opt_state(tree):
   def _to_opt_state(x):
     if isinstance(x, Variable):
       opt_metadata = x.get_metadata()
-      if 'opt_sharding' in opt_metadata:
-        opt_metadata['out_sharding'] = opt_metadata.pop('opt_sharding')
+      if 'optimizer_sharding' in opt_metadata:
+        opt_metadata['out_sharding'] = opt_metadata.pop('optimizer_sharding')
       opt_state = OptVariable(x.get_value(), **opt_metadata)  # type: ignore
     else:
       opt_state = OptArray(x)

--- a/tests/nnx/spmd_test.py
+++ b/tests/nnx/spmd_test.py
@@ -94,7 +94,7 @@ class TestSPMD(parameterized.TestCase):
     mesh = jax.make_mesh((2, 2), ("row", "col"),
                          axis_types=(jax.sharding.AxisType.Auto, jax.sharding.AxisType.Auto))
     with jax.set_mesh(mesh):
-      model = nnx.Linear(4, 2, rngs=nnx.Rngs(0), kernel_metadata={'opt_sharding': ('row', 'col')})
+      model = nnx.Linear(4, 2, rngs=nnx.Rngs(0), kernel_metadata={'optimizer_sharding': ('row', 'col')})
       optimizer = nnx.Optimizer(model, optax.adam(1e-3), wrt=nnx.Param)
 
       assert model.kernel.sharding.is_equivalent_to(


### PR DESCRIPTION
This PR lets the 'opt_sharding' metadata key shard Variables' state differently from their optimizer state. 