### PR TITLE
Fix PyTreeNode + Generic losing __parameters__ when Generic is last in bases

### DIFF
--- a/flax/struct.py
+++ b/flax/struct.py
@@ -228,6 +228,7 @@ class PyTreeNode:
   """
 
   def __init_subclass__(cls, **kwargs):
+    super().__init_subclass__()
     dataclass(cls, **kwargs)  # pytype: disable=wrong-arg-types
 
   def __init__(self, *args, **kwargs):


### PR DESCRIPTION
Fixes #5233
Fixes #5277

PyTreeNode.__init_subclass__ was not calling super().__init_subclass__(), breaking the cooperative inheritance chain that Generic relies on to set __parameters__. Added the missing super call and a test.