### PR TITLE
Add sharding propagation support in nnx.eval_shape (clone of #5111)

### DIFF
--- a/flax/nnx/transforms/transforms.py
+++ b/flax/nnx/transforms/transforms.py
@@ -242,7 +242,7 @@ def _to_variable(node):
       if global_mesh.axis_sizes == ():
         global_mesh = None
       mesh = var.get_metadata("mesh", None) or global_mesh
-      if mesh is not None:
+      if mesh is not None and (not hasattr(var, 'sharding') or var.sharding is None):
         pspec = get_var_pspec(var)
         sharding = jax.sharding.NamedSharding(mesh=mesh, spec=pspec)
         var.set_value(jax.ShapeDtypeStruct(shape=var.shape, dtype=var.dtype, sharding=sharding))
@@ -284,7 +284,9 @@ def eval_shape(
 
   Similar to ``jax.eval_shape``, it computes the shape/dtype of a function `f` without
     performing any floating point operations (FLOPs) which can be expensive. This can be
-    useful for performing shape inference, for example.
+    useful for performing shape inference, for example. Unlike `jax.eval_shape`,
+    `nnx.eval_shape` will automatically compute the expected sharding based on Flax sharding metadata
+    for all Variables not using explicit sharding.
 
   Args:
     f: the function to evaluate.
@@ -292,7 +294,7 @@ def eval_shape(
     graph: if True, use graph-mode (default). If False, use tree-mode.
       If None, uses the value of ``nnx_graph_mode`` config.
     **kwargs: keyword arguments to ``f``.
-  """
+"""
   f_call, _, was_bound = _resolve_bound_callable(f)
 
   if was_bound:

--- a/tests/nnx/spmd_test.py
+++ b/tests/nnx/spmd_test.py
@@ -359,6 +359,18 @@ class TestSPMD(parameterized.TestCase):
       self.assertEqual(v.sharding.mesh, mesh)
       self.assertEqual(v.sharding.spec, P('row', 'col'))
 
+  def test_eval_shape_with_explicit_sharding(self):
+    axis_types = (jax.sharding.AxisType.Explicit, jax.sharding.AxisType.Explicit)
+    mesh1 = jax.make_mesh((2, 2), ("a", "b"), axis_types)
+    class Model(nnx.Module):
+        def __init__(self):
+          self.p1 = nnx.Param(
+            reshard(jnp.ones((4,4)), NamedSharding(mesh1, P('a', 'b'))),
+            mesh=mesh1)
+
+    abs_model = nnx.eval_shape(lambda: Model())
+    self.assertEqual(abs_model.p1.sharding.spec, P('a', 'b'))
+
   def test_eval_shape_with_sharding0(self):
     # based on https://github.com/google/flax/issues/5110
     mesh1 = jax.make_mesh((2, 2), ("a", "b"), (jax.sharding.AxisType.Auto, jax.sharding.AxisType.Auto))


### PR DESCRIPTION
Fixes #5110, clone of #5111 but rebased against current main. 