### PR TITLE
feat(nnx): add preferred_element_type to recurrent cells

### DIFF
--- a/flax/nnx/nn/recurrent.py
+++ b/flax/nnx/nn/recurrent.py
@@ -109,6 +109,25 @@ class LSTMCell(RNNCellBase):
 
   where x is the input, h is the output of the previous time step, and c is
   the memory.
+
+  Args:
+    in_features: number of input features.
+    hidden_features: number of hidden features.
+    gate_fn: activation function for the gates (default: sigmoid).
+    activation_fn: activation function for the output (default: tanh).
+    kernel_init: initializer function for the weight matrix.
+    recurrent_kernel_init: initializer function for the recurrent weight matrix.
+    bias_init: initializer function for the bias.
+    dtype: the dtype of the computation (default: infer from input and params).
+    param_dtype: the dtype passed to parameter initializers (default: float32).
+    carry_init: optional carry initializer.
+    promote_dtype: function to promote the dtype of the arrays to the desired
+      dtype.
+    keep_rngs: whether to store the input rngs as attribute.
+    rngs: rng key.
+    preferred_element_type: Optional parameter controls the data type output by
+      the dot product. This argument is passed to ``dot_general`` function.
+      See ``jax.lax.dot`` for details.
   """
 
   def __init__(
@@ -130,6 +149,7 @@ class LSTMCell(RNNCellBase):
     kernel_metadata: Mapping[str, Any] = MappingProxyType({}),
     recurrent_kernel_metadata: Mapping[str, Any] = MappingProxyType({}),
     bias_metadata: Mapping[str, Any] = MappingProxyType({}),
+    preferred_element_type: Dtype | None = None,
   ):
     self.in_features = in_features
     self.hidden_features = hidden_features
@@ -137,6 +157,7 @@ class LSTMCell(RNNCellBase):
     self.activation_fn = activation_fn
     self.dtype = dtype
     self.param_dtype = param_dtype
+    self.preferred_element_type = preferred_element_type
     self.promote_dtype = promote_dtype
     self.rngs: rnglib.RngStream | None
     if keep_rngs:
@@ -154,6 +175,7 @@ class LSTMCell(RNNCellBase):
       dtype=self.dtype,
       param_dtype=self.param_dtype,
       promote_dtype=self.promote_dtype,
+      preferred_element_type=self.preferred_element_type,
       rngs=rngs,
       kernel_metadata=kernel_metadata,
     )
@@ -168,6 +190,7 @@ class LSTMCell(RNNCellBase):
       dtype=self.dtype,
       param_dtype=self.param_dtype,
       promote_dtype=self.promote_dtype,
+      preferred_element_type=self.preferred_element_type,
       rngs=rngs,
       kernel_metadata=recurrent_kernel_metadata,
       bias_metadata=bias_metadata,
@@ -298,6 +321,9 @@ class OptimizedLSTMCell(RNNCellBase):
           the kernels that transform the hidden state.
         bias_metadata: Optional metadata dictionary to set when initializing
           the bias of layers that transform the hidden state.
+        preferred_element_type: Optional parameter controls the data type output by
+          the dot product. This argument is passed to ``dot_general`` function.
+          See ``jax.lax.dot`` for details.
     """
 
   def __init__(
@@ -319,6 +345,7 @@ class OptimizedLSTMCell(RNNCellBase):
     kernel_metadata: Mapping[str, Any] = MappingProxyType({}),
     recurrent_kernel_metadata: Mapping[str, Any] = MappingProxyType({}),
     bias_metadata: Mapping[str, Any] = MappingProxyType({}),
+    preferred_element_type: Dtype | None = None,
   ):
     self.in_features = in_features
     self.hidden_features = hidden_features
@@ -326,6 +353,7 @@ class OptimizedLSTMCell(RNNCellBase):
     self.activation_fn = activation_fn
     self.dtype = dtype
     self.param_dtype = param_dtype
+    self.preferred_element_type = preferred_element_type
     self.promote_dtype = promote_dtype
     self.rngs: rnglib.RngStream | None
     if keep_rngs:
@@ -342,6 +370,7 @@ class OptimizedLSTMCell(RNNCellBase):
       dtype=self.dtype,
       param_dtype=self.param_dtype,
       promote_dtype=self.promote_dtype,
+      preferred_element_type=self.preferred_element_type,
       rngs=rngs,
       kernel_metadata=kernel_metadata,
     )
@@ -355,6 +384,7 @@ class OptimizedLSTMCell(RNNCellBase):
       dtype=self.dtype,
       param_dtype=self.param_dtype,
       promote_dtype=self.promote_dtype,
+      preferred_element_type=self.preferred_element_type,
       rngs=rngs,
       kernel_metadata=recurrent_kernel_metadata,
       bias_metadata=bias_metadata,
@@ -462,6 +492,31 @@ class SimpleCell(RNNCellBase):
       \begin{array}{ll}
       h' = \tanh(W_i x + b_i + W_h h + h)
       \end{array}
+
+  Args:
+    in_features: number of input features.
+    hidden_features: number of hidden features.
+    dtype: the dtype of the computation (default: float32).
+    param_dtype: the dtype passed to parameter initializers (default: float32).
+    carry_init: optional carry initializer.
+    residual: whether to add the input to the output (default: False).
+    activation_fn: activation function for the output (default: tanh).
+    kernel_init: initializer function for the weight matrix.
+    recurrent_kernel_init: initializer function for the recurrent weight matrix.
+    bias_init: initializer function for the bias.
+    promote_dtype: function to promote the dtype of the arrays to the desired
+      dtype.
+    keep_rngs: whether to store the input rngs as attribute.
+    rngs: rng key.
+    kernel_metadata: Optional metadata dictionary to set when initializing
+      the weight matrix.
+    recurrent_kernel_metadata: Optional metadata dictionary to set when initializing
+      the recurrent weight matrix.
+    bias_metadata: Optional metadata dictionary to set when initializing
+      the bias.
+    preferred_element_type: Optional parameter controls the data type output by
+      the dot product. This argument is passed to ``dot_general`` function.
+      See ``jax.lax.dot`` for details.
   """
 
   def __init__(
@@ -483,6 +538,7 @@ class SimpleCell(RNNCellBase):
     kernel_metadata: Mapping[str, Any] = MappingProxyType({}),
     recurrent_kernel_metadata: Mapping[str, Any] = MappingProxyType({}),
     bias_metadata: Mapping[str, Any] = MappingProxyType({}),
+    preferred_element_type: Dtype | None = None,
   ):
     self.in_features = in_features
     self.hidden_features = hidden_features
@@ -490,6 +546,7 @@ class SimpleCell(RNNCellBase):
     self.param_dtype = param_dtype
     self.residual = residual
     self.activation_fn = activation_fn
+    self.preferred_element_type = preferred_element_type
     self.promote_dtype = promote_dtype
     self.rngs: rnglib.RngStream | None
     if keep_rngs:
@@ -507,6 +564,7 @@ class SimpleCell(RNNCellBase):
       param_dtype=self.param_dtype,
       kernel_init=recurrent_kernel_init,
       promote_dtype=self.promote_dtype,
+      preferred_element_type=self.preferred_element_type,
       rngs=rngs,
       kernel_metadata=recurrent_kernel_metadata,
     )
@@ -519,6 +577,7 @@ class SimpleCell(RNNCellBase):
       kernel_init=kernel_init,
       bias_init=bias_init,
       promote_dtype=self.promote_dtype,
+      preferred_element_type=self.preferred_element_type,
       rngs=rngs,
       kernel_metadata=kernel_metadata,
       bias_metadata=bias_metadata,
@@ -619,6 +678,9 @@ class GRUCell(RNNCellBase):
           the kernels that transform the hidden state.
         bias_metadata: Optional metadata dictionary to set when initializing
           the bias of layers that transform the input.
+        preferred_element_type: Optional parameter controls the data type output by
+          the dot product. This argument is passed to ``dot_general`` function.
+          See ``jax.lax.dot`` for details.
     """
 
   def __init__(
@@ -640,6 +702,7 @@ class GRUCell(RNNCellBase):
     kernel_metadata: Mapping[str, Any] = MappingProxyType({}),
     recurrent_kernel_metadata: Mapping[str, Any] = MappingProxyType({}),
     bias_metadata: Mapping[str, Any] = MappingProxyType({}),
+    preferred_element_type: Dtype | None = None,
   ):
     self.in_features = in_features
     self.hidden_features = hidden_features
@@ -647,6 +710,7 @@ class GRUCell(RNNCellBase):
     self.activation_fn = activation_fn
     self.dtype = dtype
     self.param_dtype = param_dtype
+    self.preferred_element_type = preferred_element_type
     self.promote_dtype = promote_dtype
     self.rngs: rnglib.RngStream | None
     if keep_rngs:
@@ -664,6 +728,7 @@ class GRUCell(RNNCellBase):
       dtype=self.dtype,
       param_dtype=self.param_dtype,
       promote_dtype=self.promote_dtype,
+      preferred_element_type=self.preferred_element_type,
       rngs=rngs,
       kernel_metadata=kernel_metadata,
       bias_metadata=bias_metadata,
@@ -677,6 +742,7 @@ class GRUCell(RNNCellBase):
       dtype=self.dtype,
       param_dtype=self.param_dtype,
       promote_dtype=self.promote_dtype,
+      preferred_element_type=self.preferred_element_type,
       rngs=rngs,
       kernel_metadata=recurrent_kernel_metadata,
     )

--- a/flax/nnx/nn/recurrent.py
+++ b/flax/nnx/nn/recurrent.py
@@ -125,6 +125,12 @@ class LSTMCell(RNNCellBase):
       dtype.
     keep_rngs: whether to store the input rngs as attribute.
     rngs: rng key.
+    kernel_metadata: Optional metadata dictionary to set when initializing
+      the weight matrix.
+    recurrent_kernel_metadata: Optional metadata dictionary to set when initializing
+      the recurrent weight matrix.
+    bias_metadata: Optional metadata dictionary to set when initializing
+      the bias.
     preferred_element_type: Optional parameter controls the data type output by
       the dot product. This argument is passed to ``dot_general`` function.
       See ``jax.lax.dot`` for details.

--- a/tests/nnx/nn/recurrent_test.py
+++ b/tests/nnx/nn/recurrent_test.py
@@ -203,6 +203,21 @@ class TestLSTMCell(absltest.TestCase):
     for c_nnx, c_linen in zip(new_carry_nnx, new_carry_linen):
       np.testing.assert_allclose(c_nnx, c_linen, atol=1e-5)
 
+  def test_preferred_element_type(self):
+    rngs = nnx.Rngs(0)
+    model = nnx.LSTMCell(
+      in_features=4,
+      hidden_features=4,
+      preferred_element_type=jnp.float16,
+      rngs=rngs,
+    )
+    carry = model.initialize_carry((1, 4), rngs=rngs)
+    x = jnp.ones((1, 4), dtype=jnp.float32)
+    (new_c, new_h), out = model(carry, x)
+    self.assertEqual(out.shape, (1, 4))
+    self.assertEqual(model.preferred_element_type, jnp.float16)
+    self.assertEqual(model.ii.preferred_element_type, jnp.float16)
+
 
 class TestRNN(absltest.TestCase):
   def test_rnn_with_lstm_cell(self):
@@ -640,6 +655,23 @@ class TestRNN(absltest.TestCase):
 
     self.assertEqual(y.shape, (8, 1))
     self.assertEqual(model.lstm.cell.recurrent_dropout.rngs.count[...], 1)
+
+
+class TestGRUCell(absltest.TestCase):
+  def test_preferred_element_type(self):
+    rngs = nnx.Rngs(0)
+    model = nnx.GRUCell(
+      in_features=4,
+      hidden_features=4,
+      preferred_element_type=jnp.float16,
+      rngs=rngs,
+    )
+    carry = model.initialize_carry((1, 4), rngs=rngs)
+    x = jnp.ones((1, 4), dtype=jnp.float32)
+    new_h, out = model(carry, x)
+    self.assertEqual(out.shape, (1, 4))
+    self.assertEqual(model.preferred_element_type, jnp.float16)
+    self.assertEqual(model.dense_i.preferred_element_type, jnp.float16)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## What does this PR do?

adds `preferred_element_type` parameter to the recurrent cell classes in `flax/nnx/nn/recurrent.py` : `LSTMCell`, `OptimizedLSTMCell`, `SimpleCell`, and `GRUCell`.

split from [#5179](https://github.com/google/flax/pull/5179) for easier review.

**changes:**
- adds `preferred_element_type: Dtype | None = None` to `__init__` of all 4 cell types
- forwards `preferred_element_type` to all internal `Linear` layer instantiations
- adds class-level docstring `Args` sections for `LSTMCell` and `SimpleCell`
- adds `preferred_element_type` doc entry to `OptimizedLSTMCell` and `GRUCell` existing `Args`

**tests:**
- adds `test_preferred_element_type` for `LSTMCell` and `GRUCell` in `recurrent_test.py`

## Checklist
- [ ] This PR fixes a minor issue (e.g.: typo or small bug) or improves the docs (you can dismiss the other checks if that's the case).
- [ ] This change is discussed in a Github issue/[discussion](https://github.com/google/flax/discussions) (please add a link).
- [x] The documentation and docstrings adhere to the [documentation guidelines](https://github.com/google/flax/blob/main/docs/README.md#how-to-write-code-documentation).
- [x] This change includes necessary high-coverage tests. (No quality testing = no merge!)