### PR TITLE
feat(nnx): add out_sharding to recurrent cells

### DIFF
--- a/flax/nnx/nn/recurrent.py
+++ b/flax/nnx/nn/recurrent.py
@@ -544,8 +544,7 @@ class SimpleCell(RNNCellBase):
         initialized using ``SimpleCell.initialize_carry``.
       inputs: an ndarray with the input for the current time step.
         All dimensions except the final are considered batch dimensions.
-      out_sharding: the sharding of the output. If None, the output is not
-        sharded.
+      out_sharding: sharding to apply to the output of each Linear layer.
 
     Returns:
       A tuple with the new carry and the output.

--- a/tests/nnx/nn/recurrent_test.py
+++ b/tests/nnx/nn/recurrent_test.py
@@ -647,8 +647,10 @@ class TestCellSharding(absltest.TestCase):
     """Test that out_sharding correctly applies sharding to cell outputs."""
     rngs = nnx.Rngs(0)
     devices = np.array(jax.devices())
-    mesh = jax.sharding.Mesh(devices, axis_names=('x',))
-    sharding = jax.sharding.NamedSharding(mesh, jax.sharding.PartitionSpec())
+    mesh = jax.sharding.Mesh(
+        devices, axis_names=('x',), axis_types=(jax.sharding.AxisType.Explicit,)
+    )
+    sharding = jax.sharding.NamedSharding(mesh, jax.sharding.PartitionSpec('x',))
 
     cell_types = [
       (nnx.SimpleCell, {'in_features': 4, 'hidden_features': 4}),
@@ -657,13 +659,15 @@ class TestCellSharding(absltest.TestCase):
       (nnx.GRUCell, {'in_features': 4, 'hidden_features': 4}),
     ]
 
+    batch_size = jax.device_count()
     for cell_cls, kwargs in cell_types:
       with self.subTest(cell_cls=cell_cls.__name__):
         model = cell_cls(**kwargs, rngs=rngs)
-        carry = model.initialize_carry((1, 4), rngs=rngs)
-        x = jnp.ones((1, 4))
+        carry = model.initialize_carry((batch_size, 4), rngs=rngs)
+        x = jnp.ones((batch_size, 4))
 
-        new_carry, y = model(carry, x, out_sharding=sharding)
+        with mesh:
+          new_carry, y = model(carry, x, out_sharding=sharding)
 
         # Verify the output has the expected sharding
         self.assertTrue(

--- a/tests/nnx/nn/recurrent_test.py
+++ b/tests/nnx/nn/recurrent_test.py
@@ -643,9 +643,13 @@ class TestRNN(absltest.TestCase):
 
 
 class TestCellSharding(absltest.TestCase):
-  def test_out_sharding_signature(self):
+  def test_out_sharding(self):
+    """Test that out_sharding correctly applies sharding to cell outputs."""
     rngs = nnx.Rngs(0)
-    
+    devices = np.array(jax.devices())
+    mesh = jax.sharding.Mesh(devices, axis_names=('x',))
+    sharding = jax.sharding.NamedSharding(mesh, jax.sharding.PartitionSpec())
+
     cell_types = [
       (nnx.SimpleCell, {'in_features': 4, 'hidden_features': 4}),
       (nnx.LSTMCell, {'in_features': 4, 'hidden_features': 4}),
@@ -658,9 +662,15 @@ class TestCellSharding(absltest.TestCase):
         model = cell_cls(**kwargs, rngs=rngs)
         carry = model.initialize_carry((1, 4), rngs=rngs)
         x = jnp.ones((1, 4))
-        # Just verify it accepts out_sharding=None without error
-        out = model(carry, x, out_sharding=None)
-        self.assertLen(out, 2)  # All cells return (new_carry, output) or equivalent structure
+
+        new_carry, y = model(carry, x, out_sharding=sharding)
+
+        # Verify the output has the expected sharding
+        self.assertTrue(
+            y.sharding.is_equivalent_to(sharding, ndim=y.ndim),
+            f'{cell_cls.__name__}: output sharding {y.sharding} is not '
+            f'equivalent to requested sharding {sharding}',
+        )
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## What does this PR do?

adds `out_sharding` parameter to the `__call__` methods of recurrent cell classes in `flax/nnx/nn/recurrent.py`: `LSTMCell`, `OptimizedLSTMCell`, `SimpleCell`, and `GRUCell`.

split from [#5179](https://github.com/google/flax/pull/5179) for easier review.

**changes:**
- adds `*, out_sharding=None` to `__call__` of all 4 cell types
- forwards `out_sharding` to all internal `Linear.__call__()` invocations
- adds `__call__` docstrings with `out_sharding` documented for `SimpleCell` 

**tests:**
- adds `test_out_sharding_signature` for `SimpleCell` in `recurrent_test.py`

## Checklist
- [ ] This PR fixes a minor issue (e.g.: typo or small bug) or improves the docs (you can dismiss the other checks if that's the case).
- [ ] This change is discussed in a Github issue/[discussion](https://github.com/google/flax/discussions) (please add a link).
- [x] The documentation and docstrings adhere to the [documentation guidelines](https://github.com/google/flax/blob/main/docs/README.md#how-to-write-code-documentation).
- [x] This change includes necessary high-coverage tests. (No quality testing = no merge!)