### PR TITLE
Add intermediate value captures (extends #4925)

### DIFF
--- a/docs_nnx/guides/extracting_intermediates.ipynb
+++ b/docs_nnx/guides/extracting_intermediates.ipynb
@@ -1,0 +1,574 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "0fa991e8",
+   "metadata": {},
+   "source": [
+    "# Extracting intermediate values\n",
+    "\n",
+    "This guide will show you how to extract intermediate values from a module.\n",
+    "Consider a toy neural network with two pieces: a \"feature\" component that embeds\n",
+    "inputs in some feature space, and a \"loss\" component that operates on those features.\n",
+    "We'll want to log these feature components during training to identify any issues with\n",
+    "the feature extraction. To do this, we can use the `Module.sow` method."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "e4c7c65b",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "W0317 18:04:12.704562 2028538 cpp_gen_intrinsics.cc:74] Empty bitcode string provided for eigen. Optimizations relying on this IR will be disabled.\n"
+     ]
+    }
+   ],
+   "source": [
+    "from flax import nnx\n",
+    "import jax\n",
+    "import jax.numpy as jnp\n",
+    "from functools import partial\n",
+    "\n",
+    "class Foo(nnx.Module):\n",
+    "  def __init__(self, *, rngs: nnx.Rngs):\n",
+    "    self.dense1 = nnx.Linear(8, 32, rngs=rngs)\n",
+    "    self.dense2 = nnx.Linear(32, 1, rngs=rngs)\n",
+    "\n",
+    "  def features(self, x, rngs= None):\n",
+    "      feature = nnx.relu(self.dense1(x))\n",
+    "      self.sow(nnx.Intermediate, 'features', feature)\n",
+    "      return feature\n",
+    "\n",
+    "  def loss(self, x_features, y_features):\n",
+    "    return jnp.sum((x_features - y_features)**2)\n",
+    "\n",
+    "  def __call__(self, x, y):\n",
+    "    return self.loss(self.features(x), self.features(y))\n",
+    "\n",
+    "# Instantiate the model.\n",
+    "rngs = nnx.Rngs(0)\n",
+    "model = Foo(rngs=rngs)\n",
+    "\n",
+    "# Dummy input for testing\n",
+    "x, y = rngs.normal((2,8))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c56dd826",
+   "metadata": {},
+   "source": [
+    "Here, `self.sow` will store intermediate values under the key `'features'` in a collection associated with the\n",
+    "`nnx.Intermediate` type. If you want to log values to multiple different collections, you can use different subclasses of `nnx.Intermediate`\n",
+    "for each collection.\n",
+    "\n",
+    "Now, we can wrap the module with the `nnx.capture` decorator, which wraps any `Callable` accepting a module as its argument (which includes `nnx.Module`s, their methods, or ordinary functions) to return both the resulting loss as well as any intermediate values stored to the `nnx.Intermediate` collection:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "c508f8f3",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "State({\n",
+       "  'features': Intermediate(\n",
+       "    value=((32,), (32,))\n",
+       "  )\n",
+       "})"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "capturing_model = nnx.capture(model, nnx.Intermediate)\n",
+    "result, intms = capturing_model(x, y)\n",
+    "jax.tree.map(lambda a: a.shape, intms)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d2f2f609",
+   "metadata": {},
+   "source": [
+    "Note that, by default, sow appends values every time it is called. We can see\n",
+    "this in the *features* intermediate values logged above. It contains a tuple with one element for the call on `x` and one for the call on `y`. To override the default append behavior, specify `init_fn` and `reduce_fn` - see `Module.sow()`.\n",
+    "\n",
+    "## How `nnx.capture` Works\n",
+    "\n",
+    "`nnx.capture` works by temporarily installing a set of mutable capture buffers on every module in the graph before calling the wrapped function, then harvesting those buffers afterward. Before calling the wrapped function, `capture` walks the entire module graph with `iter_modules`. For each module it sets a `__captures__` attribute: a tuple of Variable instances, one per requested `var_type`. Each Variable holds a plain `dict` that maps sow-key → accumulated value.\n",
+    "\n",
+    "We can see this `__captures__` tuple by printing out the module contents during a `nnx.capture` call:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "1e5c2ae7",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Captures: (Intermediate(\n",
+      "  value={}\n",
+      "),)\n"
+     ]
+    }
+   ],
+   "source": [
+    "@nnx.capture(nnx.Intermediate)\n",
+    "def print_captures(model):\n",
+    "      print(\"Captures:\", model.__captures__)\n",
+    "_, intms = print_captures(nnx.Module())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2daab2c9",
+   "metadata": {},
+   "source": [
+    "`Module.sow` looks for the Variable in the `__captures__` tuple whose type matches `variable_type`, then writes its value into that dict using `reduce_fn`.\n",
+    "\n",
+    "If no matching type is found, `sow` silently returns `False` without logging the value. This can be used to capture only a subset of the sown values. For example:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "159a909b-0c3a-411e-9ccb-98ddecd5720e",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "State({\n",
+       "  'gets_sown': Metric1(\n",
+       "    value=((2,),)\n",
+       "  )\n",
+       "})"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "class Metric1(nnx.Intermediate):\n",
+    "    pass\n",
+    "\n",
+    "class Metric2(nnx.Intermediate):\n",
+    "    pass\n",
+    "\n",
+    "@nnx.capture(Metric1)\n",
+    "def get_captures(model):\n",
+    "    model.sow(Metric1, 'gets_sown', jnp.ones(2))\n",
+    "    model.sow(Metric2, 'gets_ignored', jnp.ones(2))\n",
+    "_, intms = get_captures(nnx.Module())\n",
+    "jax.tree.map(lambda a: a.shape, intms)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1328ce66",
+   "metadata": {},
+   "source": [
+    "## Capturing all intermediate values\n",
+    "\n",
+    "To observe the output of each method without manually adding calls to `sow`, we can call `nnx.capture` with the `method_outputs` argument. This will automatically `sow` the output of each method using the given variable type, including methods of sub-modules."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "47781215",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "State({\n",
+       "  '__call__': Intermediate(\n",
+       "    value=((),)\n",
+       "  ),\n",
+       "  'dense1': {\n",
+       "    '__call__': Intermediate(\n",
+       "      value=((32,), (32,))\n",
+       "    )\n",
+       "  },\n",
+       "  'features': Intermediate(\n",
+       "    value=((32,), (32,))\n",
+       "  ),\n",
+       "  'loss': Intermediate(\n",
+       "    value=((),)\n",
+       "  )\n",
+       "})"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "class Foo(nnx.Module):\n",
+    "  def __init__(self, *, rngs: nnx.Rngs):\n",
+    "    self.dense1 = nnx.Linear(8, 32, rngs=rngs)\n",
+    "    self.dense2 = nnx.Linear(32, 1, rngs=rngs)\n",
+    "\n",
+    "  def features(self, x, rngs= None):\n",
+    "      feature = nnx.relu(self.dense1(x))\n",
+    "      return feature\n",
+    "\n",
+    "  def loss(self, x_features, y_features):\n",
+    "    return jnp.sum((x_features - y_features)**2)\n",
+    "\n",
+    "  def __call__(self, x, y):\n",
+    "    return self.loss(self.features(x), self.features(y))\n",
+    "\n",
+    "model = Foo(rngs=nnx.Rngs(0))\n",
+    "capturing_model = nnx.capture(model, nnx.Intermediate, method_outputs=nnx.Intermediate)\n",
+    "result, intms = capturing_model(x, y)\n",
+    "jax.tree.map(lambda a: a.shape, intms)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "eee2809a",
+   "metadata": {},
+   "source": [
+    "This pattern should be considered the \"sledge hammer\" approach to capturing intermediates. As a debugging and inspection tool it is very useful, but using the other patterns described in this guide will give you more fine-grained control over what intermediates you want to extract. We can also combine the `method_output_type` argument with manual calls to sow to capture both layer outputs and computations mid-layer.\n",
+    "\n",
+    "## Extracting gradients of intermediate values\n",
+    "\n",
+    "For debugging purposes, it can be useful to extract the gradients of intermediate values. This is a little tricky: jax doesn't have a stable mechanism for sowing information from the backward pass into to objects from the forward pass. Instead, we record the gradients of intermediate values using the `Module.perturb` method as follows:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "id": "84911b66",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "State({\n",
+       "  'grad_of_x': Perturbation( # 1 (4 B)\n",
+       "    value=Array(3., dtype=float32, weak_type=True)\n",
+       "  ),\n",
+       "  'activations': Intermediate( # 1 (4 B)\n",
+       "    value=(Array(1., dtype=float32, weak_type=True),)\n",
+       "  )\n",
+       "})"
+      ]
+     },
+     "execution_count": 30,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "class Model(nnx.Module):\n",
+    "  def __call__(self, x):\n",
+    "    x2 = self.perturb('grad_of_x', x)\n",
+    "    self.sow(nnx.Intermediate, 'activations', x2)\n",
+    "    return 3 * x2\n",
+    "\n",
+    "model = Model()\n",
+    "\n",
+    "def train_step(model, x):\n",
+    "    _, perturbations = nnx.capture(model, nnx.Perturbation)(x)\n",
+    "    def loss(model, perturbations, x):\n",
+    "        return nnx.capture(model, nnx.Intermediate, init=perturbations)(x)\n",
+    "\n",
+    "    (grads, perturb_grads), sowed = nnx.grad(loss, argnums=(0, 1), has_aux=True)(model, perturbations, x)\n",
+    "    return nnx.merge_state(perturb_grads, sowed)\n",
+    "\n",
+    "train_step(model, 1.0)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7dc978af",
+   "metadata": {},
+   "source": [
+    "There are four steps:\n",
+    "\n",
+    "**Step One: Initialize *perturbations* of the model**.\n",
+    "\n",
+    "We do this with a call to `nnx.capture(model, nnx.Perturbation)`. Before the call, `capture` installs `__captures__` on the module — a tuple containing one empty `Perturbation` buffer (as described in \"How `nnx.capture` Works\" above). When `self.perturb` runs, it checks `__captures__` for a matching `Perturbation` Variable, initialises the slot to `zeros_like(value)`, and returns `zeros + x`. After the call, `__captures__` is removed and the filled buffer is returned as `perturbations`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "5f4fda80",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "before perturb: (Perturbation(\n",
+      "  value={}\n",
+      "),)\n",
+      "after  perturb: (Perturbation( # 1 (4 B)\n",
+      "  value={'grad_of_x': Array(0., dtype=float32, weak_type=True)}\n",
+      "),)\n",
+      "\u001b[38;2;79;201;177mState\u001b[0m\u001b[38;2;255;213;3m({\u001b[0m\u001b[38;2;105;105;105m\u001b[0m\n",
+      "  \u001b[38;2;156;220;254m'grad_of_x'\u001b[0m\u001b[38;2;212;212;212m: \u001b[0m\u001b[38;2;79;201;177mPerturbation\u001b[0m\u001b[38;2;255;213;3m(\u001b[0m\u001b[38;2;105;105;105m # 1 (4 B)\u001b[0m\n",
+      "    \u001b[38;2;156;220;254mvalue\u001b[0m\u001b[38;2;212;212;212m=\u001b[0mArray(0., dtype=float32, weak_type=True)\n",
+      "  \u001b[38;2;255;213;3m)\u001b[0m\n",
+      "\u001b[38;2;255;213;3m})\u001b[0m\n"
+     ]
+    }
+   ],
+   "source": [
+    "class Model(nnx.Module):\n",
+    "  def __call__(self, x):\n",
+    "    print(\"before perturb:\", self.__captures__)\n",
+    "    x2 = self.perturb('grad_of_x', x)\n",
+    "    print(\"after  perturb:\", self.__captures__)\n",
+    "    self.sow(nnx.Intermediate, 'activations', x2)\n",
+    "    # sow is a no-op: Intermediate is not in __captures__, so it returns False silently\n",
+    "    return 3 * x2\n",
+    "\n",
+    "model = Model()\n",
+    "_, perturbations = nnx.capture(model, nnx.Perturbation)(1.0)\n",
+    "print(perturbations)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2b4e1d98",
+   "metadata": {},
+   "source": [
+    "There are only two differences between `sow` and `perturb`:\n",
+    "\n",
+    "- The `nnx.Variable` tag used for values written with `self.perturb` is `nnx.Perturbation` rather than `nnx.Intermediate`.\n",
+    "    \n",
+    "- `perturb` returns the logged value. You must use this returned value rather than the original value for the gradient capturing machinery to work.\n",
+    "\n",
+    "The `var_types` argument to `capture` restricts which of the logged values we want to return. Because we only want the intermediates logged with `self.perturb` statements, we only capture `nnx.Perturbation` types.\n",
+    "\n",
+    "**Step Two: Run the model again, but add in these perturbations**.\n",
+    "\n",
+    "Call `capture` again with `init=perturbations`. `capture` first builds a mapping from module path to the Variables in `init`, then uses it to pre-populate `__captures__`. Now `__captures__` has *two* buffers: an empty `Intermediate` buffer (from `var_types`) and a `Perturbation` buffer pre-populated from `init`. `self.perturb` finds the pre-populated buffer and returns `x + perturbation`; `self.sow` writes into the `Intermediate` buffer as normal."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "a4087d73",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "before perturb: (Intermediate(\n",
+      "  value={}\n",
+      "), Perturbation( # 1 (4 B)\n",
+      "  value={'grad_of_x': Array(0., dtype=float32, weak_type=True)}\n",
+      "))\n",
+      "after  sow:     (Intermediate( # 1 (4 B)\n",
+      "  value={'activations': (Array(1., dtype=float32, weak_type=True),)}\n",
+      "), Perturbation( # 1 (4 B)\n",
+      "  value={'grad_of_x': Array(0., dtype=float32, weak_type=True)}\n",
+      "))\n"
+     ]
+    }
+   ],
+   "source": [
+    "class Model(nnx.Module):\n",
+    "  def __call__(self, x):\n",
+    "    print(\"before perturb:\", self.__captures__)\n",
+    "    x2 = self.perturb('grad_of_x', x)\n",
+    "    self.sow(nnx.Intermediate, 'activations', x2)\n",
+    "    print(\"after  sow:    \", self.__captures__)\n",
+    "    return 3 * x2\n",
+    "\n",
+    "model = Model()\n",
+    "_, interms = nnx.capture(model, nnx.Intermediate, init=perturbations)(1.0)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "63e2ba59",
+   "metadata": {},
+   "source": [
+    "This changes the behavior of `x2 = self.perturb('name', x)` to essentially be `x2 = x + perturbations['name']`. The gradient of our output with respect to `x` will be the same as the gradient with respect to the perturbation, because JAX can differentiate through the addition with respect to the perturbation value stored in the capture dict.\n",
+    "\n",
+    "**Step Three: Take gradients**.\n",
+    "\n",
+    "Specifically, take the gradient of this second `capture` call with respect to the perturbation arguments. JAX traces through exactly the same `__captures__` setup as Step Two, but with abstract (traced) array values instead of concrete ones. This will give us the same values as the gradients with respect to the intermediate variables. If we want to track intermediate variables in the forward pass at the same time, we'll need to return the intermediate values output of the `capture` call as well, so we'll need to pass `has_aux=True` to `nnx.grad`.\n",
+    "\n",
+    "**Step Four: Combine intermediate states**\n",
+    "\n",
+    "Merge the `State` object we get from the perturbation gradients with the `State` object for forward intermediates with `nnx.merge_state(perturb_grads, sowed)`. At this point `__captures__` no longer exists on any module — it was cleaned up at the end of the `capture` call in Step Three."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "23ccf952",
+   "metadata": {},
+   "source": [
+    "## NNX Transforms and Capturing\n",
+    "\n",
+    "`nnx.capture` composes with NNX transforms such as `nnx.vmap`. The main thing to keep in mind is that perturbations must be initialized with a run that has the same batch structure as the training step that will consume them.\n",
+    "\n",
+    "Consider a model that calls both `sow` and `perturb`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 34,
+   "id": "7c8f8d83",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class Foo(nnx.Module):\n",
+    "  def __init__(self, dim):\n",
+    "    self.w = nnx.Param(jax.random.normal(jax.random.key(0), dim))\n",
+    "\n",
+    "  def __call__(self, x):\n",
+    "    x = self.perturb('grad_of_x', x)\n",
+    "    y = jnp.dot(x, self.w)\n",
+    "    self.sow(nnx.Intermediate, 'y', y)\n",
+    "    return y"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "786278eb",
+   "metadata": {},
+   "source": [
+    "The training step vmaps `loss_grad` over a batch of inputs and perturbations, while the model weights are shared across the batch (`in_axes=None`):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "id": "8ac86ed1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "@nnx.jit\n",
+    "def train_step(model, x):\n",
+    "  _, perturbations = init_perturbations(model, x)\n",
+    "  def loss_grad(model, perturbations, x):\n",
+    "    def loss(model, perturbations, x):\n",
+    "      loss, interms = nnx.capture(model, nnx.Intermediate, init=perturbations)(x)\n",
+    "      return loss, interms\n",
+    "    (grads, perturb_grads), sowed = nnx.grad(loss, argnums=(0, 1), has_aux=True)(model, perturbations, x)\n",
+    "    return grads, nnx.merge_state(perturb_grads, sowed)\n",
+    "  return nnx.vmap(loss_grad, in_axes=(None, 0, 0))(model, perturbations, x)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3de42b97-9923-436f-9db0-d9aeedc259ad",
+   "metadata": {},
+   "source": [
+    "After every training step, we can sum the gradients and pass them to an `Optimizer` to adjust the model, as usual. But we can also look at the full batch of sown values and perturbations.\n",
+    "\n",
+    "Because `train_step` expects `perturbations` to have a leading batch axis (axis 0), the perturbation initialization run must also produce a batched `perturbations` state. We do this inside an `init_perturbations` method that splits the model and vmaps the run with `in_axes=(0, None, 0)` for `(intermediates, params, x)`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
+   "id": "76c291c8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "@nnx.capture(nnx.Perturbation)\n",
+    "def init_perturbations(model, x):\n",
+    "    graphdef, intms, params = nnx.split(model, nnx.Intermediate, nnx.Param)\n",
+    "    def forward(intms, params, x):\n",
+    "      return nnx.merge(graphdef, intms, params)(x)\n",
+    "    return nnx.vmap(forward, in_axes=(0, None, 0))(intms, params, x)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "981642f6",
+   "metadata": {},
+   "source": [
+    "Putting it together:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 37,
+   "id": "7a741ca4",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "State({\n",
+       "  'grad_of_x': Perturbation(\n",
+       "    value=(3, 4)\n",
+       "  ),\n",
+       "  'y': Intermediate(\n",
+       "    value=((3,),)\n",
+       "  )\n",
+       "})"
+      ]
+     },
+     "execution_count": 37,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "model, x = Foo(4), jnp.ones((3, 4))\n",
+    "_, intermediates = train_step(model, x)\n",
+    "jax.tree.map(lambda a: a.shape, intermediates)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "027216c7",
+   "metadata": {},
+   "source": [
+    "The pattern generalises: whenever a transform introduces a new batch axis over which `capture` runs, initialize perturbations with a matching vmapped pre-run so that the `init=perturbations` argument inside the transform has the correct shape."
+   ]
+  }
+ ],
+ "metadata": {
+  "jupytext": {
+   "formats": "ipynb,md",
+   "main_language": "python"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs_nnx/guides/extracting_intermediates.md
+++ b/docs_nnx/guides/extracting_intermediates.md
@@ -1,0 +1,261 @@
+---
+jupyter:
+  jupytext:
+    formats: ipynb,md
+    main_language: python
+    text_representation:
+      extension: .md
+      format_name: markdown
+      format_version: '1.3'
+      jupytext_version: 1.13.8
+---
+
+# Extracting intermediate values
+
+This guide will show you how to extract intermediate values from a module.
+Consider a toy neural network with two pieces: a "feature" component that embeds
+inputs in some feature space, and a "loss" component that operates on those features.
+We'll want to log these feature components during training to identify any issues with
+the feature extraction. To do this, we can use the `Module.sow` method.
+
+```python
+from flax import nnx
+import jax
+import jax.numpy as jnp
+from functools import partial
+
+class Foo(nnx.Module):
+  def __init__(self, *, rngs: nnx.Rngs):
+    self.dense1 = nnx.Linear(8, 32, rngs=rngs)
+    self.dense2 = nnx.Linear(32, 1, rngs=rngs)
+
+  def features(self, x, rngs= None):
+      feature = nnx.relu(self.dense1(x))
+      self.sow(nnx.Intermediate, 'features', feature)
+      return feature
+
+  def loss(self, x_features, y_features):
+    return jnp.sum((x_features - y_features)**2)
+
+  def __call__(self, x, y):
+    return self.loss(self.features(x), self.features(y))
+
+# Instantiate the model.
+rngs = nnx.Rngs(0)
+model = Foo(rngs=rngs)
+
+# Dummy input for testing
+x, y = rngs.normal((2,8))
+```
+
+Here, `self.sow` will store intermediate values under the key `'features'` in a collection associated with the
+`nnx.Intermediate` type. If you want to log values to multiple different collections, you can use different subclasses of `nnx.Intermediate`
+for each collection.
+
+Now, we can wrap the module with the `nnx.capture` decorator, which wraps any `Callable` accepting a module as its argument (which includes `nnx.Module`s, their methods, or ordinary functions) to return both the resulting loss as well as any intermediate values stored to the `nnx.Intermediate` collection:
+
+```python
+capturing_model = nnx.capture(model, nnx.Intermediate)
+result, intms = capturing_model(x, y)
+jax.tree.map(lambda a: a.shape, intms)
+```
+
+Note that, by default, sow appends values every time it is called. We can see
+this in the *features* intermediate values logged above. It contains a tuple with one element for the call on `x` and one for the call on `y`. To override the default append behavior, specify `init_fn` and `reduce_fn` - see `Module.sow()`.
+
+## How `nnx.capture` Works
+
+`nnx.capture` works by temporarily installing a set of mutable capture buffers on every module in the graph before calling the wrapped function, then harvesting those buffers afterward. Before calling the wrapped function, `capture` walks the entire module graph with `iter_modules`. For each module it sets a `__captures__` attribute: a tuple of Variable instances, one per requested `var_type`. Each Variable holds a plain `dict` that maps sow-key → accumulated value.
+
+We can see this `__captures__` tuple by printing out the module contents during a `nnx.capture` call:
+
+```python
+@nnx.capture(nnx.Intermediate)
+def print_captures(model):
+      print("Captures:", model.__captures__)
+_, intms = print_captures(nnx.Module())
+```
+
+`Module.sow` looks for the Variable in the `__captures__` tuple whose type matches `variable_type`, then writes its value into that dict using `reduce_fn`.
+
+If no matching type is found, `sow` silently returns `False` without logging the value. This can be used to capture only a subset of the sown values. For example:
+
+```python
+class Metric1(nnx.Intermediate):
+    pass
+
+class Metric2(nnx.Intermediate):
+    pass
+
+@nnx.capture(Metric1)
+def get_captures(model):
+    model.sow(Metric1, 'gets_sown', jnp.ones(2))
+    model.sow(Metric2, 'gets_ignored', jnp.ones(2))
+_, intms = get_captures(nnx.Module())
+jax.tree.map(lambda a: a.shape, intms)
+```
+
+## Capturing all intermediate values
+
+To observe the output of each method without manually adding calls to `sow`, we can call `nnx.capture` with the `method_outputs` argument. This will automatically `sow` the output of each method using the given variable type, including methods of sub-modules.
+
+```python
+class Foo(nnx.Module):
+  def __init__(self, *, rngs: nnx.Rngs):
+    self.dense1 = nnx.Linear(8, 32, rngs=rngs)
+    self.dense2 = nnx.Linear(32, 1, rngs=rngs)
+
+  def features(self, x, rngs= None):
+      feature = nnx.relu(self.dense1(x))
+      return feature
+
+  def loss(self, x_features, y_features):
+    return jnp.sum((x_features - y_features)**2)
+
+  def __call__(self, x, y):
+    return self.loss(self.features(x), self.features(y))
+
+model = Foo(rngs=nnx.Rngs(0))
+capturing_model = nnx.capture(model, nnx.Intermediate, method_outputs=nnx.Intermediate)
+result, intms = capturing_model(x, y)
+jax.tree.map(lambda a: a.shape, intms)
+```
+
+This pattern should be considered the "sledge hammer" approach to capturing intermediates. As a debugging and inspection tool it is very useful, but using the other patterns described in this guide will give you more fine-grained control over what intermediates you want to extract. We can also combine the `method_output_type` argument with manual calls to sow to capture both layer outputs and computations mid-layer.
+
+## Extracting gradients of intermediate values
+
+For debugging purposes, it can be useful to extract the gradients of intermediate values. This is a little tricky: jax doesn't have a stable mechanism for sowing information from the backward pass into to objects from the forward pass. Instead, we record the gradients of intermediate values using the `Module.perturb` method as follows:
+
+```python
+class Model(nnx.Module):
+  def __call__(self, x):
+    x2 = self.perturb('grad_of_x', x)
+    self.sow(nnx.Intermediate, 'activations', x2)
+    return 3 * x2
+
+model = Model()
+
+def train_step(model, x):
+    _, perturbations = nnx.capture(model, nnx.Perturbation)(x)
+    def loss(model, perturbations, x):
+        return nnx.capture(model, nnx.Intermediate, init=perturbations)(x)
+
+    (grads, perturb_grads), sowed = nnx.grad(loss, argnums=(0, 1), has_aux=True)(model, perturbations, x)
+    return nnx.merge_state(perturb_grads, sowed)
+
+train_step(model, 1.0)
+```
+
+There are four steps:
+
+**Step One: Initialize *perturbations* of the model**.
+
+We do this with a call to `nnx.capture(model, nnx.Perturbation)`. Before the call, `capture` installs `__captures__` on the module — a tuple containing one empty `Perturbation` buffer (as described in "How `nnx.capture` Works" above). When `self.perturb` runs, it checks `__captures__` for a matching `Perturbation` Variable, initialises the slot to `zeros_like(value)`, and returns `zeros + x`. After the call, `__captures__` is removed and the filled buffer is returned as `perturbations`.
+
+```python
+class Model(nnx.Module):
+  def __call__(self, x):
+    print("before perturb:", self.__captures__)
+    x2 = self.perturb('grad_of_x', x)
+    print("after  perturb:", self.__captures__)
+    self.sow(nnx.Intermediate, 'activations', x2)
+    # sow is a no-op: Intermediate is not in __captures__, so it returns False silently
+    return 3 * x2
+
+model = Model()
+_, perturbations = nnx.capture(model, nnx.Perturbation)(1.0)
+print(perturbations)
+```
+
+There are only two differences between `sow` and `perturb`:
+
+- The `nnx.Variable` tag used for values written with `self.perturb` is `nnx.Perturbation` rather than `nnx.Intermediate`.
+    
+- `perturb` returns the logged value. You must use this returned value rather than the original value for the gradient capturing machinery to work.
+
+The `var_types` argument to `capture` restricts which of the logged values we want to return. Because we only want the intermediates logged with `self.perturb` statements, we only capture `nnx.Perturbation` types.
+
+**Step Two: Run the model again, but add in these perturbations**.
+
+Call `capture` again with `init=perturbations`. `capture` first builds a mapping from module path to the Variables in `init`, then uses it to pre-populate `__captures__`. Now `__captures__` has *two* buffers: an empty `Intermediate` buffer (from `var_types`) and a `Perturbation` buffer pre-populated from `init`. `self.perturb` finds the pre-populated buffer and returns `x + perturbation`; `self.sow` writes into the `Intermediate` buffer as normal.
+
+```python
+class Model(nnx.Module):
+  def __call__(self, x):
+    print("before perturb:", self.__captures__)
+    x2 = self.perturb('grad_of_x', x)
+    self.sow(nnx.Intermediate, 'activations', x2)
+    print("after  sow:    ", self.__captures__)
+    return 3 * x2
+
+model = Model()
+_, interms = nnx.capture(model, nnx.Intermediate, init=perturbations)(1.0)
+```
+
+This changes the behavior of `x2 = self.perturb('name', x)` to essentially be `x2 = x + perturbations['name']`. The gradient of our output with respect to `x` will be the same as the gradient with respect to the perturbation, because JAX can differentiate through the addition with respect to the perturbation value stored in the capture dict.
+
+**Step Three: Take gradients**.
+
+Specifically, take the gradient of this second `capture` call with respect to the perturbation arguments. JAX traces through exactly the same `__captures__` setup as Step Two, but with abstract (traced) array values instead of concrete ones. This will give us the same values as the gradients with respect to the intermediate variables. If we want to track intermediate variables in the forward pass at the same time, we'll need to return the intermediate values output of the `capture` call as well, so we'll need to pass `has_aux=True` to `nnx.grad`.
+
+**Step Four: Combine intermediate states**
+
+Merge the `State` object we get from the perturbation gradients with the `State` object for forward intermediates with `nnx.merge_state(perturb_grads, sowed)`. At this point `__captures__` no longer exists on any module — it was cleaned up at the end of the `capture` call in Step Three.
+
+
+## NNX Transforms and Capturing
+
+`nnx.capture` composes with NNX transforms such as `nnx.vmap`. The main thing to keep in mind is that perturbations must be initialized with a run that has the same batch structure as the training step that will consume them.
+
+Consider a model that calls both `sow` and `perturb`:
+
+```python
+class Foo(nnx.Module):
+  def __init__(self, dim):
+    self.w = nnx.Param(jax.random.normal(jax.random.key(0), dim))
+
+  def __call__(self, x):
+    x = self.perturb('grad_of_x', x)
+    y = jnp.dot(x, self.w)
+    self.sow(nnx.Intermediate, 'y', y)
+    return y
+```
+
+The training step vmaps `loss_grad` over a batch of inputs and perturbations, while the model weights are shared across the batch (`in_axes=None`):
+
+```python
+@nnx.jit
+def train_step(model, x):
+  _, perturbations = init_perturbations(model, x)
+  def loss_grad(model, perturbations, x):
+    def loss(model, perturbations, x):
+      loss, interms = nnx.capture(model, nnx.Intermediate, init=perturbations)(x)
+      return loss, interms
+    (grads, perturb_grads), sowed = nnx.grad(loss, argnums=(0, 1), has_aux=True)(model, perturbations, x)
+    return grads, nnx.merge_state(perturb_grads, sowed)
+  return nnx.vmap(loss_grad, in_axes=(None, 0, 0))(model, perturbations, x)
+```
+
+After every training step, we can sum the gradients and pass them to an `Optimizer` to adjust the model, as usual. But we can also look at the full batch of sown values and perturbations.
+
+Because `train_step` expects `perturbations` to have a leading batch axis (axis 0), the perturbation initialization run must also produce a batched `perturbations` state. We do this inside an `init_perturbations` method that splits the model and vmaps the run with `in_axes=(0, None, 0)` for `(intermediates, params, x)`.
+
+```python
+@nnx.capture(nnx.Perturbation)
+def init_perturbations(model, x):
+    graphdef, intms, params = nnx.split(model, nnx.Intermediate, nnx.Param)
+    def forward(intms, params, x):
+      return nnx.merge(graphdef, intms, params)(x)
+    return nnx.vmap(forward, in_axes=(0, None, 0))(intms, params, x)
+```
+
+Putting it together:
+
+```python
+model, x = Foo(4), jnp.ones((3, 4))
+_, intermediates = train_step(model, x)
+jax.tree.map(lambda a: a.shape, intermediates)
+```
+
+The pattern generalises: whenever a transform introduces a new batch axis over which `capture` runs, initialize perturbations with a matching vmapped pre-run so that the `init=perturbations` argument inside the transform has the correct shape.

--- a/docs_nnx/guides_advanced.rst
+++ b/docs_nnx/guides_advanced.rst
@@ -9,3 +9,4 @@ Advanced Guides
    guides/performance
    guides/bridge_guide
    guides/surgery
+   guides/extracting_intermediates

--- a/flax/nnx/__init__.py
+++ b/flax/nnx/__init__.py
@@ -49,6 +49,7 @@ from .helpers import Sequential as Sequential
 from .helpers import TrainState as TrainState
 from .module import M as M
 from .module import Module as Module
+from .module import capture as capture
 from .module import view as view
 from .module import view_info as view_info
 from .module import with_attributes as with_attributes

--- a/flax/nnx/graphlib.py
+++ b/flax/nnx/graphlib.py
@@ -2570,7 +2570,7 @@ def pop(
     ...     self.linear2 = nnx.Linear(3, 4, rngs=rngs)
     ...   def __call__(self, x):
     ...     x = self.linear1(x)
-    ...     self.sow(nnx.Intermediate, 'i', x)
+    ...     self.i = nnx.Intermediate(x)
     ...     x = self.linear2(x)
     ...     return x
 
@@ -2581,7 +2581,7 @@ def pop(
     >>> assert hasattr(model, 'i')
 
     >>> intermediates = nnx.pop(model, nnx.Intermediate)
-    >>> assert intermediates['i'][0].shape == (1, 3)
+    >>> assert intermediates['i'].shape == (1, 3)
     >>> assert not hasattr(model, 'i')
 
   Args:

--- a/flax/nnx/module.py
+++ b/flax/nnx/module.py
@@ -23,11 +23,15 @@ import jax.numpy as jnp
 from flax.nnx import (
   filterlib,
   graphlib,
+  pytreelib,
 )
 from flax.nnx import variablelib as variableslib
 from flax.nnx.pytreelib import Pytree, PytreeMeta
 from flax.nnx.graphlib import GraphState
+from flax.nnx.statelib import split_state, State
+import functools as ft
 from flax.typing import Key, Path, PathParts
+from collections.abc import MutableMapping
 import warnings
 
 A = tp.TypeVar('A')
@@ -87,16 +91,14 @@ class Module(Pytree, metaclass=ModuleMeta):
       reduce_fn: tp.Callable[[B, A], B] = tuple_reduce,
       init_fn: tp.Callable[[], B] = tuple_init,  # type: ignore
   ) -> bool:
-    """``sow()`` can be used to collect intermediate values without
-    the overhead of explicitly passing a container through each Module call.
-    ``sow()`` stores a value in a new ``Module`` attribute, denoted by ``name``.
-    The value will be wrapped by a :class:`Variable` of type ``variable_type``,
-    which can be useful to filter for in :func:`split`, :func:`state` and
-    :func:`pop`.
+    """Store intermediate values during module execution for later extraction.
 
-    By default the values are stored in a tuple and each stored value
-    is appended at the end. This way all intermediates can be tracked when
-    the same module is called multiple times.
+    Used with :func:`nnx.capture` decorator to collect intermediate values without
+    explicitly passing containers through module calls. Values are stored under
+    the specified ``name`` in a collection associated with ``variable_type``.
+
+    By default, values are appended to a tuple, allowing multiple values to be
+    tracked when the same module is called multiple times.
 
     Example usage::
 
@@ -107,87 +109,79 @@ class Module(Pytree, metaclass=ModuleMeta):
       ...   def __init__(self, rngs):
       ...     self.linear1 = nnx.Linear(2, 3, rngs=rngs)
       ...     self.linear2 = nnx.Linear(3, 4, rngs=rngs)
-      ...   def __call__(self, x, add=0):
+      ...   def __call__(self, x):
       ...     x = self.linear1(x)
-      ...     self.sow(nnx.Intermediate, 'i', x+add)
+      ...     self.sow(nnx.Intermediate, 'features', x)
       ...     x = self.linear2(x)
       ...     return x
 
-      >>> x = jnp.ones((1, 2))
+      >>> # With the capture decorator, sow returns intermediates
       >>> model = Model(rngs=nnx.Rngs(0))
-      >>> assert not hasattr(model, 'i')
+      >>> @nnx.capture(nnx.Intermediate)
+      ... def forward(model, x):
+      ...   return model(x)
+      >>> result, intermediates = forward(model, jnp.ones(2))
+      >>> assert 'features' in intermediates
 
-      >>> y = model(x)
-      >>> assert hasattr(model, 'i')
-      >>> assert len(model.i) == 1 # tuple of length 1
-      >>> assert model.i[0].shape == (1, 3)
-
-      >>> y = model(x, add=1)
-      >>> assert len(model.i) == 2 # tuple of length 2
-      >>> assert (model.i[0] + 1 == model.i[1]).all()
-
-    Alternatively, a custom init/reduce function can be passed::
+    Custom init/reduce functions can be passed to control accumulation::
 
       >>> class Model(nnx.Module):
       ...   def __init__(self, rngs):
-      ...     self.linear1 = nnx.Linear(2, 3, rngs=rngs)
-      ...     self.linear2 = nnx.Linear(3, 4, rngs=rngs)
+      ...     self.linear = nnx.Linear(2, 3, rngs=rngs)
       ...   def __call__(self, x):
-      ...     x = self.linear1(x)
+      ...     x = self.linear(x)
       ...     self.sow(nnx.Intermediate, 'sum', x,
       ...              init_fn=lambda: 0,
       ...              reduce_fn=lambda prev, curr: prev+curr)
-      ...     self.sow(nnx.Intermediate, 'product', x,
-      ...              init_fn=lambda: 1,
-      ...              reduce_fn=lambda prev, curr: prev*curr)
-      ...     x = self.linear2(x)
       ...     return x
-
-      >>> x = jnp.ones((1, 2))
-      >>> model = Model(rngs=nnx.Rngs(0))
-
-      >>> y = model(x)
-      >>> assert (model.sum[...] == model.product[...]).all()
-      >>> intermediate = model.sum[...]
-
-      >>> y = model(x)
-      >>> assert (model.sum[...] == intermediate*2).all()
-      >>> assert (model.product[...] == intermediate**2).all()
 
     Args:
       variable_type: The :class:`Variable` type for the stored value.
-        Typically :class:`Intermediate` is used to indicate an
-        intermediate value.
-      name: A string denoting the ``Module`` attribute name, where
-        the sowed value is stored.
+        Typically :class:`Intermediate` or a subclass is used.
+      name: A string key for storing the value in the collection.
       value: The value to be stored.
-      reduce_fn: The function used to combine the existing value with the new
-        value. The default is to append the value to a tuple.
-      init_fn: For the first value stored, ``reduce_fn`` will be passed the result
-        of ``init_fn`` together with the value to be stored. The default is an
-        empty tuple.
+      reduce_fn: Function to combine existing and new values. Default appends
+        to a tuple.
+      init_fn: Function providing initial value for first ``reduce_fn`` call.
+        Default is an empty tuple.
     """
     if isinstance(variable_type, str):
       variable_type = variableslib.variable_type_from_name(
           variable_type, allow_register=True
       )
 
-    if hasattr(self, name):
-      variable = getattr(self, name)
-      if not isinstance(variable, variableslib.Variable):
-        raise ValueError(
-          f"Expected '{name}' to be a Variable, got {type(variable).__name__}"
-        )
-      elif type(variable) != variable_type:
-        raise ValueError(
-          f"Expected '{name}' to be of type '{variable_type.__name__}', "
-          f"got '{type(variable).__name__}'"
-        )
-      variable.set_value(reduce_fn(variable.get_value(), value))
+    if hasattr(self, '__captures__'):
+      for var in self.__captures__:
+        if type(var) == variable_type:
+          if name in var:
+            var[name] = reduce_fn(var[name], value)
+          else:
+            var[name] = reduce_fn(init_fn(), value)
+          return True
+      else:
+        return False
+    elif hasattr(self, name):
+        variable = getattr(self, name)
+        if not isinstance(variable, variableslib.Variable):
+          raise ValueError(
+            f"Expected '{name}' to be a Variable, got {type(variable).__name__}"
+          )
+        elif type(variable) != variable_type:
+          raise ValueError(
+            f"Expected '{name}' to be of type '{variable_type.__name__}', "
+            f"got '{type(variable).__name__}'"
+          )
+        variable.set_value(reduce_fn(variable.get_value(), value))
     else:
       reduced_value = reduce_fn(init_fn(), value)
       setattr(self, name, variable_type(reduced_value))
-
+    warnings.warn(
+        """Using 'Module.sow()' outside of 'nnx.capture()' is deprecated; see
+        https://flax.readthedocs.io/en/stable/capturing_intermediates.html for more information.
+        """,
+        DeprecationWarning,
+        stacklevel=2,
+      )
     return True
 
   def perturb(
@@ -198,20 +192,20 @@ class Module(Pytree, metaclass=ModuleMeta):
           str | type[variableslib.Variable[tp.Any]]
       ) = variableslib.Perturbation,
   ):
-    """Add an zero-value variable ("perturbation") to the intermediate value.
+    """Extract gradients of intermediate values during training.
 
-    The gradient of ``value`` would be the same as the gradient of this
-    perturbation variable. Therefore, if you define your loss function with
-    both params and perturbations as standalone arguments, you can get the
-    intermediate gradients of ``value`` by running ``jax.grad`` on the
-    perturbation variable.
+    Used with :func:`nnx.capture` to record intermediate values in the forward pass
+    and their gradients in the backward pass. Returns the value plus whatever perturbation
+    is stored under ``name`` in the current capture context, allowing gradient computation via ``nnx.grad``.
 
-    Since the shape of the perturbation value depends on the shape of the input,
-    a perturbation variable is only created after you run a sample input through
-    the model once.
+    The workflow has four steps:
+    1. Initialize perturbations with ``nnx.capture(model, nnx.Perturbation)``
+    2. Run model with ``nnx.capture(model, nnx.Intermediate, init=perturbations)``
+    3. Take gradients with respect to perturbations using ``nnx.grad``
+    4. Combine results with ``nnx.merge_state(perturb_grads, intermediates)``
 
     .. note::
-      This creates extra dummy variables of the same size as ``value``, thus
+      This creates extra variables of the same size as ``value``, thus
       occupies more memory. Use it only to debug gradients in training.
 
     Example usage::
@@ -220,54 +214,67 @@ class Module(Pytree, metaclass=ModuleMeta):
       >>> import jax.numpy as jnp
 
       >>> class Model(nnx.Module):
-      ...   def __init__(self, rngs):
-      ...     self.linear1 = nnx.Linear(2, 3, rngs=rngs)
-      ...     self.linear2 = nnx.Linear(3, 4, rngs=rngs)
       ...   def __call__(self, x):
-      ...     x = self.linear1(x)
-      ...     x = self.perturb('xgrad', x)
-      ...     x = self.linear2(x)
-      ...     return x
+      ...     x2 = self.perturb('grad_of_x', x)
+      ...     return 3 * x2
 
-      >>> x = jnp.ones((1, 2))
-      >>> y = jnp.ones((1, 4))
-      >>> model = Model(rngs=nnx.Rngs(0))
-      >>> assert not hasattr(model, 'xgrad')  # perturbation requires a sample input run
-      >>> _ = model(x)
-      >>> assert model.xgrad.shape == (1, 3)   # same as the intermediate value
-      >>> graphdef, params, perturbations = nnx.split(model, nnx.Param, nnx.Perturbation)
+      >>> model = Model()
+      >>> x = 1.0
 
-      >>> # Take gradients on the Param and Perturbation variables
-      >>> @nnx.grad(argnums=(0, 1))
-      ... def grad_loss(params, perturbations, inputs, targets):
-      ...   model = nnx.merge(graphdef, params, perturbations)
-      ...   return jnp.mean((model(inputs) - targets) ** 2)
+      >>> # Step 1: Initialize perturbations
+      >>> forward = nnx.capture(model, nnx.Perturbation)
+      >>> _, perturbations = forward(x)
 
-      >>> (grads, perturbations) = grad_loss(params, perturbations, x, y)
-      >>> # `perturbations.xgrad[...]` is the intermediate gradient
-      >>> assert not jnp.array_equal(perturbations.xgrad[...], jnp.zeros((1, 3)))
+      >>> # Steps 2-4: Capture gradients
+      >>> def train_step(model, perturbations, x):
+      ...   def loss(model, perturbations, x):
+      ...     return nnx.capture(model, nnx.Intermediate, init=perturbations)(x)
+      ...   (grads, perturb_grads), sowed = nnx.grad(loss, argnums=(0, 1), has_aux=True)(model, perturbations, x)
+      ...   return nnx.merge_state(perturb_grads, sowed)
+
+      >>> metrics = train_step(model, perturbations, x)
+      >>> # metrics contains gradients of intermediate values
 
     Args:
-      name: A string denoting the ``Module`` attribute name for the
-        perturbation value.
-      value: The value to take intermediate gradient.
+      name: A string key for storing the perturbation value.
+      value: The intermediate value to capture gradients for. You must use
+        the returned value (not the original) for gradient capturing to work.
       variable_type: The :class:`Variable` type for the stored perturbation.
-        Defaulted at :class:`nnx.Perturbation`.
+        Default is :class:`nnx.Perturbation`.
     """
     if isinstance(variable_type, str):
       variable_type = variableslib.variable_type_from_name(
           variable_type, allow_register=True
       )
-    if not hasattr(self, name):
-      zeros = jax.tree.map(jnp.zeros_like, value)
-      setattr(self, name, variable_type(zeros))
-    old_value: variableslib.Variable[tp.Any] = getattr(self, name)
-    if not isinstance(old_value, variable_type):
-      raise ValueError(
-        f"Expected '{name}' to be of type '{variable_type.__name__}', "
-        f"got '{type(old_value).__name__}'"
-      )
-    return old_value[...] + value
+
+    if hasattr(self, '__captures__'):
+      for var in self.__captures__:
+        if type(var) == variable_type:
+          if name not in var:
+            zeros = jax.tree.map(jnp.zeros_like, value)
+            var[name] = zeros
+          old_value = var[name]
+          return old_value + value
+      else:
+        return value
+    elif hasattr(self, name):
+      var = getattr(self, name)
+      if not isinstance(var, variable_type):
+        raise ValueError(
+          f"Expected '{name}' to be of type '{variable_type.__name__}', "
+          f"got '{type(var).__name__}'"
+        )
+      old_value = var.get_value()
+    else:
+      old_value = jax.tree.map(jnp.zeros_like, value)
+      setattr(self, name, variable_type(old_value))
+    warnings.warn("""
+      Using 'Module.perturb()' outside of 'nnx.capture()' is deprecated; see
+      https://flax.readthedocs.io/en/stable/capturing_intermediates.html for more information.
+      """,
+      DeprecationWarning,
+      stacklevel=2)
+    return old_value + value
 
   def iter_modules(self) -> tp.Iterator[tuple[PathParts, Module]]:
     """
@@ -759,3 +766,226 @@ def iter_modules(
       yield path, value
 
 iter_children = graphlib.iter_children
+
+P = tp.ParamSpec("P")
+R = tp.TypeVar("R")
+
+@tp.overload
+def capture(
+  fn: tp.Callable[P, R],
+  *var_types: type[variableslib.Variable],
+  init: tp.Optional[State] = None,
+  method_outputs: tp.Optional[type[variableslib.Variable]] = None
+) -> tp.Callable[P, tuple[R, State]]: ...
+
+@tp.overload
+def capture(
+  fn: type[variableslib.Variable],
+  *var_types: type[variableslib.Variable],
+  init: tp.Optional[State] = None,
+  method_outputs: tp.Optional[type[variableslib.Variable]] = None
+) -> tp.Callable[[tp.Callable[P, R]], tp.Callable[P, tuple[R, State]]]: ...
+
+def capture(fn: tp.Callable[P, R] | type[variableslib.Variable], *var_types: type[variableslib.Variable],
+  init : tp.Optional[State] = None,
+  method_outputs : tp.Optional[type[variableslib.Variable]] = None
+) -> tp.Callable[P, tuple[R, State]] | tp.Callable[[tp.Callable[P, R]], tp.Callable[P, tuple[R, State]]]:
+    """Wraps a function to capture intermediate values from a module during execution.
+
+    This function wraps a `Callable`, executing it while collecting intermediate values that were stored using
+    ``Module.sow()`` or ``Module.perturb()``.
+
+    The `fn` argument can be either a function, a Module instance, or a bound method.
+    If `fn` is a function, its first argument should be the module in which intermediate values are to be recorded.
+    If `fn` is a bound method, the module used for storage is inferred from the instance.
+    If `fn` is a Module, its `__call__` method will be wrapped.
+
+    Args:
+      fn: The `Callable` to wrap.
+      var_types: Variable types to capture. If None, defaults to [].
+      init: MutableMapping used to initialize perturbation values. This is useful for gradient extraction.
+      method_outputs: If provided, automatically sows the output of each method
+        in the module and its submodules using this variable type.
+
+    Returns:
+      A wrapped function that returns
+      a tuple of (result, *intermediates) where result is the output of the function
+      and each intermediate is a State containing the captured values with the corresponding type in `var_types`.
+
+    Example with manual sowing::
+
+      class Foo(nnx.Module):
+        def __call__(self, x):
+          self.sow(nnx.Intermediate, 'features', x)
+          return x
+
+      model = Foo(rngs=nnx.Rngs(0))
+      forward = nnx.capture(model, nnx.Intermediate)
+      result, intermediates = forward(x)
+      # intermediates['features'] contains the sowed value
+
+    Example with method outputs::
+
+      class Foo(nnx.Module):
+        def features(self, x):
+          return x
+        def classifier(self, x):
+          return x
+        def __call__(self, x):
+          return self.classifier(self.features(x))
+
+      model = Foo(rngs=nnx.Rngs(0))
+      result, intermediates = nnx.capture(
+        model, method_output_type=nnx.Intermediate)(x)
+      # intermediates contains outputs of features(), classifier(), and __call__()
+
+    Example with gradient extraction::
+
+      class Model(nnx.Module):
+        def __call__(self, x):
+          x2 = self.perturb('grad_of_x', x)
+          return 3 * x2
+
+      model = Model()
+      forward = nnx.capture(lambda model, x: model(x), nnx.Perturbation) # Initialize perturbations
+      _, perturbations = forward_capture(model, x)
+
+      # Compute gradients with respect to perturbations
+      loss = nnx.capture(forward, init=perturbations)
+      grads, sowed = nnx.grad(loss, has_aux=True)(model, perturbations, x)
+    """
+
+    # Handle partial evaluation when first arg is a Variable type
+    if isinstance(fn, type) and issubclass(fn, variableslib.Variable):
+      # Partial application: return a function that waits for the actual fn
+      all_var_types = (fn,) + var_types
+      def partial_capture(actual_fn: tp.Callable[P, R] | Module) -> tp.Callable[P, tuple[R, State]]:
+        return capture(actual_fn, *all_var_types, init=init, method_outputs=method_outputs)
+      return partial_capture
+
+    # Handle bound methods and callable Modules
+    module_instance = None
+    if inspect.ismethod(fn) and isinstance(fn.__self__, Module):
+      module_instance = fn.__self__
+    elif isinstance(fn, Module):
+      module_instance = fn
+
+    ft.wraps(fn)
+    def wrapper(*fn_args, **kwargs):
+      if module_instance is None:
+        module = fn_args[0]
+      else:
+        module = module_instance
+
+      # Extract initial values from state
+      state_by_path = _collect_state_by_path(init) if init else {}
+
+      # Initialize __captures__ as a tuple of Variables (one per type)
+      for path, m in iter_modules(module):
+        # Create initial dicts for each variable type
+        initial_dicts = {}
+        for var_type in var_types:
+          initial_dicts[var_type] = {}
+
+        # Populate from state if available
+        if path in state_by_path:
+          for name, var in state_by_path[path].items():
+            var_type = type(var)
+            if var_type not in initial_dicts:
+              initial_dicts[var_type] = {}
+            initial_dicts[var_type][name] = var.get_value()
+
+        # Create the captures tuple
+        captures_tuple = tuple(k(v) for (k,v) in initial_dicts.items())
+        m.__captures__ = pytreelib.data(captures_tuple)
+
+      # Wrap methods with capturing if required
+      if method_outputs:
+        for _, m in iter_modules(module):
+          _add_capturing(type(m), method_outputs)
+
+      try:
+        result = fn(*fn_args, **kwargs)
+      finally:
+
+        # Undo method sowing modification
+        for _, m in iter_modules(module):
+          _remove_capturing(type(m))
+
+      # Extract intermediates manually from __captures__
+      interms = State({})
+      _extract_captures(module, interms, set(var_types))
+      if len(var_types) == 0:
+          return result
+      split_states = split_state(interms, *var_types)
+      if len(var_types) == 1:
+        return result, split_states
+      else:
+        return (result, *split_states)
+
+    return wrapper
+
+def _collect_state_by_path(state):
+  """Build a mapping from module path to state Variables."""
+  state_by_path = {}
+
+  def collect(s, path_parts):
+    if isinstance(s, MutableMapping):
+      for key, value in s.items():
+        if isinstance(value, variableslib.Variable):
+          path_tuple = tuple(path_parts)
+          if path_tuple not in state_by_path:
+            state_by_path[path_tuple] = {}
+          state_by_path[path_tuple][key] = value
+        elif isinstance(value, MutableMapping):
+          collect(value, path_parts + [key])
+
+  collect(state, [])
+  return state_by_path
+
+def _navigate_to_path(state, path):
+  """Navigate to a nested path in state, creating dicts as needed."""
+  current = state
+  for part in path:
+    if part not in current:
+      current[part] = State({})
+    current = current[part]
+  return current
+
+def _extract_captures(module, state, var_types):
+  """Extract intermediates from __captures__ tuple into state dict."""
+  for path, mod in iter_modules(module):
+    if hasattr(mod, '__captures__'):
+      captures_tuple = mod.__captures__
+      for var in captures_tuple:
+        if not type(var) in var_types:
+          continue
+        current = _navigate_to_path(state, path)
+        for key, value in var.items():
+          current[key] = type(var)(value)
+      delattr(mod, '__captures__')
+
+
+def _add_capturing(cls, variable_type):
+  """Adds capturing to methods of a Module.
+  Does not instrument superclass methods."""
+  for name, method in cls.__dict__.items():
+    if callable(method) and (not name.startswith('_') or name == '__call__'):
+      if not hasattr(method, '_does_capturing'):
+        def closure(name, method): # Necessary to make 'name' immutable during iteration
+          @ft.wraps(method)
+          def wrapper(self, *args, **kwargs):
+            result = method(self, *args, **kwargs)
+            self.sow(variable_type, name, result)
+            return result
+          wrapper._does_capturing = True
+          setattr(cls, name, wrapper)
+        closure(name, method)
+  return cls
+
+def _remove_capturing(cls):
+  """Remove capturing methods from a Module."""
+  for name, method in cls.__dict__.items():
+    if hasattr(method, '_does_capturing'):
+      setattr(cls, name, method.__wrapped__)
+  return cls

--- a/flax/nnx/variablelib.py
+++ b/flax/nnx/variablelib.py
@@ -1661,10 +1661,6 @@ class Variable(tp.Generic[A], reprlib.Representable, metaclass=VariableMeta):
 
   def set_value(self, value: A, *, index: tp.Any = MISSING):
     value = jax.tree.map(lambda x: x, value)  # make a copy
-    if isinstance(value, Variable):
-      raise ValueError(
-        'Cannot set value to a Variable, use `copy_from` method instead'
-      )
     if 'on_set_value' in self._var_metadata:
       value = self._var_metadata['on_set_value'](self, value)
     # update _raw_value
@@ -1734,6 +1730,7 @@ class Variable(tp.Generic[A], reprlib.Representable, metaclass=VariableMeta):
       value = jax.new_ref(value)
       new_metadata['ref'] = True
 
+    value = jax.tree.map(lambda x: x, value)  # make a copy
     obj = self.from_metadata(value, new_metadata)
     return obj
 
@@ -2145,7 +2142,8 @@ class Cache(Variable[A]):
 
 class Intermediate(Variable[A]):
   """:class:`Variable` type that is typically used for
-  :func:`Module.sow`::
+  :func:`Module.sow`. Use :func:`nnx.capture` to retrieve
+  the sowed values::
 
     >>> from flax import nnx
     >>> import jax, jax.numpy as jnp
@@ -2162,8 +2160,8 @@ class Intermediate(Variable[A]):
     >>> model = Model(rngs=nnx.Rngs(0))
 
     >>> x = jnp.ones((1, 2))
-    >>> y = model(x)
-    >>> jax.tree.map(jnp.shape, nnx.state(model, nnx.Intermediate))
+    >>> y, intms = nnx.capture(model, nnx.Intermediate)(x)
+    >>> jax.tree.map(jnp.shape, intms)
     State({
       'i': Intermediate(
         value=((1, 3),)
@@ -2176,7 +2174,8 @@ class Intermediate(Variable[A]):
 
 class Perturbation(Intermediate[A]):
   """:class:`Variable` type that is typically used for
-  :func:`Module.perturb`::
+  :func:`Module.perturb`. Use :func:`nnx.capture` to retrieve
+  the perturbation values::
 
     >>> from flax import nnx
     >>> import jax, jax.numpy as jnp
@@ -2193,8 +2192,8 @@ class Perturbation(Intermediate[A]):
     >>> model = Model(rngs=nnx.Rngs(0))
 
     >>> x = jnp.ones((1, 2))
-    >>> y = model(x)
-    >>> jax.tree.map(jnp.shape, nnx.state(model, nnx.Perturbation))
+    >>> y, perturbations = nnx.capture(model, nnx.Perturbation)(x)
+    >>> jax.tree.map(jnp.shape, perturbations)
     State({
       'i': Perturbation(
         value=(1, 3)

--- a/tests/nnx/module_test.py
+++ b/tests/nnx/module_test.py
@@ -26,8 +26,21 @@ from flax import errors, nnx
 import jax
 import jax.numpy as jnp
 import numpy as np
+import flax
 
 A = TypeVar('A')
+
+from contextlib import contextmanager
+
+@contextmanager
+def set_graph_mode(mode):
+  old_mode = flax.config._read('nnx_graph_mode')
+  try:
+    flax.config.update('nnx_graph_mode', mode)
+    yield
+  finally:
+    flax.config.update('nnx_graph_mode', old_mode)
+
 
 class PytreeTest(absltest.TestCase):
   def test_pytree(self):
@@ -169,6 +182,196 @@ class PytreeTest(absltest.TestCase):
         'Found data in value of type',
     ):
       foo = Foo()
+
+class TestCapture(parameterized.TestCase):
+
+  def test_vmap(self):
+
+    class Foo(nnx.Module):
+      def __init__(self, dim):
+        self.w = nnx.Param(jax.random.normal(jax.random.key(0), dim))
+
+      def __call__(self, x):
+        x = self.perturb('grad_of_x', x)
+        y = jnp.dot(x, self.w)
+        self.sow(nnx.Intermediate, 'y', y)
+        return y
+
+      def pre_run(self, x):
+        graphdef, intms, params = nnx.split(model, nnx.Intermediate, nnx.Param)
+        def run(intms, params, x):
+          return nnx.merge(graphdef, intms, params)(x)
+        nnx.vmap(run, in_axes=(0, None, 0))(intms, params, x)
+
+    @nnx.jit
+    def train_step(model, perturbations, x):
+      def loss_grad(model, perturbations, x):
+        def loss(model, perturbations, x):
+          loss, interms = nnx.capture(model, nnx.Intermediate, init=perturbations)(x)
+          return loss, interms
+        (grads, perturb_grads), sowed = nnx.grad(loss, argnums=(0, 1), has_aux=True)(model, perturbations, x)
+        return grads, nnx.merge_state(perturb_grads, sowed)
+      return nnx.vmap(loss_grad, in_axes=(None, 0, 0))(model, perturbations,x)
+
+    model, x = Foo(4), jnp.ones((3, 4))
+
+    pre_run_capture = nnx.capture(model.pre_run, nnx.Perturbation)
+    _, perturbations = pre_run_capture(x)
+    _, intermediates = train_step(model, perturbations, x)
+    np.testing.assert_allclose(intermediates['grad_of_x'].get_value(),
+      jnp.broadcast_to(model.w.get_value()[None, :], (3, 4)))
+    self.assertEqual(intermediates['y'].get_value()[0].shape, (3,))
+
+
+  @parameterized.parameters(True, False)
+  def test_fwd_bwd(self, graph_mode):
+    with set_graph_mode(graph_mode):
+
+        class Foo(nnx.Module):
+          @nnx.jit
+          def __call__(self, x):
+            x = self.perturb('grad_of_x', x)
+            y = 3 * x
+            self.sow(nnx.Intermediate, 'y', y)
+            return y
+
+        model = Foo()
+
+        @nnx.jit
+        def train_step(model, perturbations, x):
+          def loss(model, perturbations, x):
+            loss, interms = nnx.capture(model, nnx.Intermediate, init=perturbations)(x)
+            return loss, interms
+          (grads, perturb_grads), sowed = nnx.grad(loss, argnums=(0, 1), has_aux=True)(model, perturbations, x)
+          return grads, nnx.merge_state(perturb_grads, sowed)
+
+        x = 1.0
+
+        forward = nnx.capture(model, nnx.Perturbation)
+        _, perturbations = forward(x)
+        grads, intermediates = train_step(model, perturbations, x)
+        self.assertEqual(intermediates['grad_of_x'], 3)
+        self.assertEqual(intermediates['y'][0], 3)
+
+  @parameterized.parameters(True, False)
+  def test_nested_modules(self, graph_mode):
+    with set_graph_mode(graph_mode):
+
+      class Foo(nnx.Module):
+        def __call__(self, x):
+          x = self.perturb('grad_of_x', x)
+          y = 3 * x
+          self.sow(nnx.Intermediate, 'y', y)
+          return y
+      class Bar(nnx.Module):
+        def __init__(self):
+          self.foos = nnx.data([Foo() for _ in range(3)])
+        def __call__(self, x):
+          for block in self.foos:
+            x = block(x)
+          return x
+
+      model = Bar()
+
+      @nnx.jit
+      def train_step(model, perturbations, x):
+        def loss(model, perturbations, x):
+          loss, interms = nnx.capture(model, nnx.Intermediate, init=perturbations)(x)
+          return loss, interms
+        (grads, perturb_grads), sowed = nnx.grad(loss, argnums=(0, 1), has_aux=True)(model, perturbations, x)
+        return grads, nnx.merge_state(perturb_grads, sowed)
+
+      x = 1.0
+
+      forward = nnx.capture(model, nnx.Perturbation)
+      _, perturbations = forward(x)
+      _, intermediates = train_step(model, perturbations, x)
+      for i in range(3):
+        self.assertEqual(intermediates['foos'][i]['grad_of_x'], 3**(3-i))
+        self.assertEqual(intermediates['foos'][i]['y'][0], 3**(i+1))
+
+  def test_method_outputs_single_module(self):
+    class Foo(nnx.Module):
+      def __init__(self, dim):
+        self.w = nnx.Param(jax.random.normal(jax.random.key(0), (dim, dim)))
+      def __call__(self, x):
+        return x @ self.w
+      def helper(self, x):
+        return jnp.sin(x)
+      def run(self, x):
+        y = self(x)
+        z = self.helper(y)
+        return (y, z)
+
+    model = Foo(8)
+    x = jnp.ones((4, 8))
+
+    run_with_capture = nnx.capture(
+      model.run,
+      nnx.Intermediate, method_outputs=nnx.Intermediate
+    )
+    (y, z), intms = run_with_capture(x)
+
+    self.assertIn('__call__', intms)
+    self.assertIn('helper', intms)
+    np.testing.assert_allclose(intms['__call__'][0], y)
+    np.testing.assert_allclose(intms['helper'][0], z)
+
+  def test_method_outputs_nested_modules(self):
+    class Inner(nnx.Module):
+      def __init__(self, dim, rngs):
+        self.w = nnx.Param(jax.random.normal(rngs.params(), (dim, dim)))
+      def __call__(self, x):
+        return x @ self.w
+      def process(self, x):
+        return jnp.sin(x)
+
+    class Outer(nnx.Module):
+      def __init__(self, rngs):
+        self.inner1 = Inner(8, rngs)
+        self.inner2 = Inner(8, rngs)
+      def __call__(self, x):
+        x = self.inner1(x)
+        x = self.inner2.process(x)
+        return x
+
+    model = Outer(nnx.Rngs(0))
+    x = jnp.ones((4, 8))
+
+    forward = nnx.capture(
+      model,
+      nnx.Intermediate, method_outputs=nnx.Intermediate
+    )
+    y, intms = forward(x)
+
+    self.assertIn('__call__', intms)
+    self.assertIn('inner1', intms)
+    self.assertIn('process', intms['inner2'])
+    self.assertEqual(intms['inner1']['__call__'][0].shape, (4, 8))
+    self.assertEqual(intms['inner2']['process'][0].shape, (4, 8))
+
+  def test_method_outputs_mixed_with_sow(self):
+    class Foo(nnx.Module):
+      def __init__(self, dim):
+        self.w = nnx.Param(jax.random.normal(jax.random.key(0), (dim, dim)))
+      def __call__(self, x):
+        x = x @ self.w
+        self.sow(nnx.Intermediate, 'intermediate', x)
+        return jnp.sin(x)
+
+    model = Foo(8)
+    x = jnp.ones((4, 8))
+
+    forward = nnx.capture(
+      model,
+      nnx.Intermediate, method_outputs=nnx.Intermediate
+    )
+    y, intms = forward(x)
+
+    self.assertIn('__call__', intms)
+    self.assertIn('intermediate', intms)
+    np.testing.assert_allclose(intms['__call__'][0], y)
+    np.testing.assert_allclose(jnp.sin(intms['intermediate'][0]), y)
 
 class SowMod(nnx.Module):
     def __init__(self, rngs: nnx.Rngs):
@@ -371,28 +574,6 @@ class TestModule(parameterized.TestCase):
     assert m.b.c.get_value() == m2.b.c.get_value()
     assert m.b.d.get_value() == m2.b.d.get_value()
 
-  def test_sow_basic(self):
-    class Foo(nnx.Module):
-      def __call__(self, x):
-        y = x + 1
-        self.sow(nnx.Intermediate, 'y', y)
-        return y
-
-    m = Foo()
-    y1 = m(2)
-    y2 = m(10)
-
-    assert y1 == 3
-    assert y2 == 11
-    assert m.y.get_value() == (3, 11)
-
-    intermediates = nnx.pop(m, nnx.Intermediate)
-
-    assert isinstance(intermediates['y'], nnx.Intermediate)
-    assert intermediates['y'].get_value() == (3, 11)
-
-    assert not hasattr(m, 'y')
-
   def test_sow_existing_non_variable_field(self):
     class Foo(nnx.Module):
       def __init__(self) -> None:
@@ -426,8 +607,7 @@ class TestModule(parameterized.TestCase):
   def test_sow_pop(self):
     x = jnp.ones((2, 4))
     model = SowMod(nnx.Rngs(42))
-    out = model(x)
-    intermediates = nnx.pop(model, nnx.Intermediate)
+    out, intermediates = nnx.capture(model, nnx.Intermediate)(x)
     attr_names = set(model._pytree__nodes)
     assert 'my_summary' not in attr_names
 
@@ -437,51 +617,11 @@ class TestModule(parameterized.TestCase):
 
     @nnx.jit
     def train_step(model, x):
-      out = model(x)
-      intermediates = nnx.pop(model, nnx.Intermediate)
+      out, intermediates = nnx.capture(model, nnx.Intermediate)(x)
       return out, intermediates
 
     train_step_fn = nnx.cached_partial(train_step, model)
     train_step_fn(x)
-
-  def test_perturb_basic(self):
-    class Foo(nnx.Module):
-      def __init__(self, rngs):
-        self.linear = nnx.Linear(10, 10, rngs=rngs)
-
-      def __call__(self, x):
-        x = self.linear(x)
-        x = self.perturb('before_multiply', x)
-        x = 4 * x
-        x = self.perturb('after_multiply', x)
-        return x
-
-    model = Foo(rngs=nnx.Rngs(0))
-    # Perturbations are not created in init time. It needs some sample input.
-    self.assertFalse(hasattr(model, 'before_multiply'))
-    self.assertFalse(hasattr(model, 'after_multiply'))
-
-    x = jax.random.uniform(jax.random.key(1), shape=(10,))
-    y = jax.random.uniform(jax.random.key(2), shape=(10,))
-    model(x)
-    np.testing.assert_array_equal(model.before_multiply, jnp.zeros_like(x))
-    np.testing.assert_array_equal(model.after_multiply, jnp.zeros_like(x))
-
-    take_gradient_filter = nnx.Any(nnx.Param, nnx.Perturbation)
-    @nnx.grad(argnums=nnx.DiffState(argnum=0, filter=take_gradient_filter))
-    def grad_loss(model, inputs, targets):
-      preds = model(inputs)
-      return jnp.square(preds - targets).mean()
-    intm_grads = grad_loss(model, x, y)
-
-    # Gradient should not be zero
-    self.assertFalse(
-      jnp.array_equal(intm_grads.before_multiply[...], jnp.zeros_like(x))
-    )
-    # activation * 4 so reverse gradient also * 4
-    np.testing.assert_allclose(
-      intm_grads.after_multiply[...] * 4, intm_grads.before_multiply[...]
-    )
 
   def test_update_static_state_submodules(self):
     class Bar(nnx.Module):
@@ -949,7 +1089,6 @@ class TestModule(parameterized.TestCase):
     obj = Block(rngs=nnx.Rngs(0))
     info_str = nnx.view_info(obj, graph=graph)
     self.assertEqual(f"{obj.__class__.__qualname__}:\n  arg1: bool | None = None\n    The first argument.\n  arg2: int | None = None\n    The second argument.\n    This has two lines.", info_str)
-
 
 class TestModuleDataclass(absltest.TestCase):
   def test_basic(self):

--- a/tests/nnx/nn/attention_test.py
+++ b/tests/nnx/nn/attention_test.py
@@ -76,8 +76,7 @@ class TestMultiHeadAttention(parameterized.TestCase):
     )
     module.set_attributes(decode=False)
 
-    _ = module(x, True)
-    intermediates = nnx.pop(module, nnx.Intermediate)
+    _, intermediates = nnx.capture(module, nnx.Intermediate)(x, True)
     assert intermediates['attention_layers'][0]['attention_weights'][
       0
     ].shape == (4, 8, 6, 6)
@@ -86,8 +85,7 @@ class TestMultiHeadAttention(parameterized.TestCase):
       0
     ].shape == (4, 8, 6, 6)
 
-    _ = module(x)
-    intermediates = nnx.pop(module, nnx.Intermediate)
+    _, intermediates = nnx.capture(module, nnx.Intermediate)(x)
     assert not intermediates  # empty
 
   def test_autoregressive_decode_with_x64(self):
@@ -194,15 +192,18 @@ class TestMultiHeadAttention(parameterized.TestCase):
       pass
 
     # nnx path with padding mask and is_causal = True (internally combines them)
-    attn_manual = nnx.dot_product_attention(
-      query=q,
-      key=k,
-      value=v,
-      mask=padding_mask,
-      is_causal=True,
-      deterministic=True,
-      module=DummyModule(),
-    )
+    dummy = DummyModule()
+    def _run(m):
+      return nnx.dot_product_attention(
+        query=q,
+        key=k,
+        value=v,
+        mask=padding_mask,
+        is_causal=True,
+        deterministic=True,
+        module=m,
+      )
+    attn_manual, _ = nnx.capture(_run, nnx.Intermediate)(dummy)
 
     np.testing.assert_allclose(attn_jax, attn_manual, atol=1e-6)
 
@@ -375,10 +376,9 @@ class TestGQADotProductAttention(parameterized.TestCase):
     jax_out = jax.nn.dot_product_attention(query, key, value)
 
     # NNX should handle broadcasting internally
-    nnx_out = nnx.dot_product_attention(
-      query, key, value,
-      module=dummy_module
-    )
+    def _run(m):
+      return nnx.dot_product_attention(query, key, value, module=m)
+    nnx_out, _ = nnx.capture(_run, nnx.Intermediate)(dummy_module)
 
     np.testing.assert_allclose(nnx_out, jax_out, atol=1e-3, rtol=1e-3)
 

--- a/tests/nnx/transforms_test.py
+++ b/tests/nnx/transforms_test.py
@@ -2800,12 +2800,11 @@ class TestScan(parameterized.TestCase):
 
     x = jnp.ones((1, 3))
     a = jnp.ones((5, 1, 3))
-    y, out = module(x, a)
+    (y, out), intermediates = nnx.capture(module, nnx.Intermediate)(x, a)
 
     assert y.shape == (1, 3)
     assert out is None
 
-    intermediates = nnx.pop(module, nnx.Intermediate)
     assert intermediates['data'][0].shape == (5, 1, 3)
 
   def test_in_axes_broadcast(self):
@@ -3247,8 +3246,7 @@ class TestScan(parameterized.TestCase):
     num_steps = 5
     model = Model(num_steps=num_steps)
     carry = CarryAsPytree(data=jnp.array(0.0))
-    carry_final = model(carry, method=Model._step)
-    intermediates = nnx.pop(model, nnx.Intermediate)
+    carry_final, intermediates = nnx.capture(model, nnx.Intermediate)(carry, method=Model._step)
     self.assertEqual(carry_final.data, num_steps)
     np.testing.assert_array_equal(
       intermediates['data'][0], 1.0 + jnp.arange(num_steps)
@@ -3260,8 +3258,7 @@ class TestScan(parameterized.TestCase):
       CarryAsPytree(data=jnp.array(10.0))
     )
 
-    carry_final = model(carry, method=Model._step2)
-    intermediates = nnx.pop(model, nnx.Intermediate)
+    carry_final, intermediates = nnx.capture(model, nnx.Intermediate)(carry, method=Model._step2)
 
     self.assertEqual(carry_final[0].data, num_steps)
     self.assertEqual(carry_final[2].data, 10 + num_steps)


### PR DESCRIPTION
This PR adds similar functionality to #4925, but uses flax Variables instead of hijax Boxes. 
- We add a `capture` decorator that makes the given function returns captured intermediate values along with the ordinary return value.
- Module methods `sow` and `perturb` can be used within `capture` to store associate values or their gradients with names without adding new attributes on the module. They are stored within variables of the appropriate type in the `__captures__` tuple. 
- `Perturb` just adds values read from the from the `__captures__` tuple to the given arguments. This means that if the `init` argument is passed to `capture` (used to pre-specify values within `__captures__`), the values in the `init` argument will be used for every `perturb` call in the code, and we can take the gradient with respect to these values to inspect values in the backward pass. 
- We also add a `sow_output` decorator that adds `sow` instructions to every method of a module and its submodules. This is useful for debugging.
- This code is tested under the transformations `vmap`, `jit`, and `grad`. 