### PR TITLE
Add tests, docstrings and validation to metrics.py

### DIFF
--- a/tests/nnx/metrics_test.py
+++ b/tests/nnx/metrics_test.py
@@ -156,5 +156,177 @@ class TestMetrics(parameterized.TestCase):
       accuracy.update(logits=logits, labels=labels)
 
 
+class TestAverage(parameterized.TestCase):
+
+  def test_initial_compute_nan(self):
+    avg = nnx.metrics.Average()
+    self.assertTrue(jnp.isnan(avg.compute()))
+
+  def test_single_batch(self):
+    avg = nnx.metrics.Average()
+    avg.update(values=jnp.array([1, 2, 3, 4]))
+    np.testing.assert_allclose(avg.compute(), 2.5, rtol=1e-6)
+
+  def test_multiple_batches(self):
+    avg = nnx.metrics.Average()
+    avg.update(values=jnp.array([1, 2, 3, 4]))
+    avg.update(values=jnp.array([3, 2, 1, 0]))
+    np.testing.assert_allclose(avg.compute(), 2.0, rtol=1e-6)
+
+  def test_reset(self):
+    avg = nnx.metrics.Average()
+    avg.update(values=jnp.array([1, 2, 3]))
+    avg.reset()
+    self.assertTrue(jnp.isnan(avg.compute()))
+
+  def test_custom_argname(self):
+    avg = nnx.metrics.Average('loss')
+    avg.update(loss=jnp.array([10, 20]))
+    np.testing.assert_allclose(avg.compute(), 15.0, rtol=1e-6)
+
+  def test_missing_argname(self):
+    avg = nnx.metrics.Average('loss')
+    with self.assertRaisesRegex(TypeError, "Expected keyword argument 'loss'"):
+      avg.update(values=jnp.array([1, 2]))
+
+  def test_scalar_float(self):
+    avg = nnx.metrics.Average()
+    avg.update(values=5.0)
+    np.testing.assert_allclose(avg.compute(), 5.0, rtol=1e-6)
+
+  def test_scalar_int(self):
+    avg = nnx.metrics.Average()
+    avg.update(values=3)
+    np.testing.assert_allclose(avg.compute(), 3.0, rtol=1e-6)
+
+
+class TestWelford(parameterized.TestCase):
+
+  def test_multiple_batches(self):
+    wf = nnx.metrics.Welford()
+    batch1 = jnp.array([1.0, 2.0, 3.0, 4.0])
+    batch2 = jnp.array([3.0, 2.0, 1.0, 0.0])
+    wf.update(values=batch1)
+    wf.update(values=batch2)
+    all_values = jnp.concatenate([batch1, batch2])
+    stats = wf.compute()
+    np.testing.assert_allclose(stats.mean, all_values.mean(), rtol=1e-6)
+    np.testing.assert_allclose(
+      stats.standard_deviation, all_values.std(), rtol=1e-5
+    )
+    expected_sem = all_values.std() / jnp.sqrt(all_values.size)
+    np.testing.assert_allclose(
+      stats.standard_error_of_mean, expected_sem, rtol=1e-5
+    )
+
+  def test_reset(self):
+    wf = nnx.metrics.Welford()
+    wf.update(values=jnp.array([1.0, 2.0, 3.0]))
+    wf.reset()
+    stats = wf.compute()
+    np.testing.assert_allclose(stats.mean, 0.0, atol=0)
+    self.assertTrue(jnp.isnan(stats.standard_error_of_mean))
+    self.assertTrue(jnp.isnan(stats.standard_deviation))
+
+  def test_custom_argname(self):
+    wf = nnx.metrics.Welford('loss')
+    wf.update(loss=jnp.array([1.0, 2.0, 3.0]))
+    stats = wf.compute()
+    np.testing.assert_allclose(stats.mean, 2.0, rtol=1e-6)
+
+  def test_missing_argname(self):
+    wf = nnx.metrics.Welford('loss')
+    with self.assertRaisesRegex(TypeError, "Expected keyword argument 'loss'"):
+      wf.update(values=jnp.array([1.0]))
+
+
+class TestAccuracy(parameterized.TestCase):
+
+  def test_multiclass_int64_labels(self):
+    logits = jnp.array([[0.0, 1.0], [1.0, 0.0]])
+    labels = np.array([1, 0], dtype=np.int64)
+    labels = jnp.asarray(labels)
+    acc = nnx.metrics.Accuracy()
+    acc.update(logits=logits, labels=labels)
+    np.testing.assert_allclose(acc.compute(), 1.0, rtol=1e-6)
+
+  def test_invalid_label_dtype(self):
+    logits = jnp.array([[0.0, 1.0]])
+    labels = jnp.array([1.0])
+    acc = nnx.metrics.Accuracy()
+    with self.assertRaisesRegex(ValueError, 'labels.dtype'):
+      acc.update(logits=logits, labels=labels)
+
+  def test_threshold_type_error(self):
+    with self.assertRaisesRegex(TypeError, 'float'):
+      nnx.metrics.Accuracy(threshold=1)
+
+
+class TestMultiMetric(parameterized.TestCase):
+
+  @parameterized.parameters('reset', 'update', 'compute', 'split')
+  def test_reserved_name_error(self, name):
+    with self.assertRaisesRegex(ValueError, 'reserved'):
+      nnx.MultiMetric(**{name: nnx.metrics.Average()})
+
+  @parameterized.parameters('_metric_names', '_expected_kwargs')
+  def test_internal_name_error(self, name):
+    with self.assertRaisesRegex(ValueError, 'reserved'):
+      nnx.MultiMetric(**{name: nnx.metrics.Average()})
+
+  def test_unmatched_kwarg_error(self):
+    metrics = nnx.MultiMetric(
+      loss=nnx.metrics.Average(),
+      score=nnx.metrics.Average('score'),
+    )
+    # Guard: validation must be active for this test.
+    self.assertEqual(
+      metrics._expected_kwargs, {'values', 'score'}
+    )
+    with self.assertRaisesRegex(
+      TypeError, 'Unexpected keyword argument'
+    ):
+      metrics.update(
+        values=jnp.array([1.0]),
+        score=jnp.array([2.0]),
+        typo_kwarg=jnp.array([3.0]),
+      )
+
+  def test_compute_returns_dict(self):
+    metrics = nnx.MultiMetric(
+      loss=nnx.metrics.Average(),
+      score=nnx.metrics.Average('score'),
+    )
+    metrics.update(values=jnp.array([1, 2, 3]), score=jnp.array([4, 5, 6]))
+    result = metrics.compute()
+    self.assertIsInstance(result, dict)
+    self.assertEqual(set(result.keys()), {'loss', 'score'})
+    np.testing.assert_allclose(result['loss'], 2.0, rtol=1e-6)
+    np.testing.assert_allclose(result['score'], 5.0, rtol=1e-6)
+
+  def test_split_merge(self):
+    metrics = nnx.MultiMetric(
+      loss=nnx.metrics.Average(),
+    )
+    metrics.update(values=jnp.array([1.0, 2.0, 3.0]))
+    graphdef, state = metrics.split()
+    restored = nnx.merge(graphdef, state)
+    self.assertEqual(restored._metric_names, ['loss'])
+    self.assertEqual(
+      restored._expected_kwargs, {'values'}
+    )
+    np.testing.assert_allclose(
+      restored.compute()['loss'], 2.0, rtol=1e-6
+    )
+
+  def test_validation_disabled_with_var_keyword(self):
+    metrics = nnx.MultiMetric(
+      accuracy=nnx.metrics.Accuracy(),
+      loss=nnx.metrics.Average(),
+    )
+    # Accuracy.update has **_, so validation is disabled.
+    self.assertIsNone(metrics._expected_kwargs)
+
+
 if __name__ == '__main__':
   absltest.main()


### PR DESCRIPTION
# What does this PR do?

Addresses the TODO at `flax/nnx/training/metrics.py` line 26 (`# TODO: add tests and docstrings`) and the MultiMetric validation TODOs at lines 389 and 410.

### Changes

**`flax/nnx/training/metrics.py`**
- Add docstring to `Statistics` dataclass (the only public class missing one)
- Add reserved name validation in `MultiMetric.__init__` — prevents metric names that shadow methods (`reset`, `update`, `compute`, `split`) or internal attributes (`_metric_names`, `_expected_kwargs`)
- Add unmatched kwarg detection in `MultiMetric.update` — catches typos by validating keyword arguments against the expected set derived from underlying metrics via `inspect.signature`
- Update `MultiMetric.update` docstring to document the new `TypeError` behavior

**`tests/nnx/metrics_test.py`** — 25 new tests across 4 new test classes:
- `TestAverage`: initial NaN, single/multiple batch, reset, custom argname, missing argname, scalar float/int
- `TestWelford`: multiple batches (mean + std + SEM), reset (all 3 stats), custom argname, missing argname
- `TestAccuracy`: int64 label conversion, invalid float labels, threshold type error
- `TestMultiMetric`: reserved name errors (parameterized over all 4), internal name errors (parameterized over 2), unmatched kwarg with guard assertion, compute dict structure, split/merge preservation, validation-disabled-with-var-keyword

## Checklist
- [ ] This PR fixes a minor issue (e.g.: typo or small bug) or improves the docs (you can dismiss the other checks if that's the case).
- [ ] This change is discussed in a Github issue/[discussion](https://github.com/google/flax/discussions) (please add a link).
- [x] The documentation and docstrings adhere to the [documentation guidelines](https://github.com/google/flax/blob/main/docs/README.md#how-to-write-code-documentation).
- [x] This change includes necessary high-coverage tests. (No quality testing = no merge!)
