### PR TITLE
Remove optax pin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     # keep in sync with jax-version in .github/workflows/build.yml
     "jax>=0.8.1",
     "msgpack",
-    "optax==0.2.6",
+    "optax",
     "orbax-checkpoint",
     "tensorstore",
     "rich>=11.1",


### PR DESCRIPTION
This PR will eventually turn the optax pin in #5225 to a range. For the moment, however, it removes the restrictions entirely to review what exactly the CI errors were. 