### PR TITLE
Fix broken error-message formatting in flax.nnx

### DIFF
--- a/flax/nnx/filterlib.py
+++ b/flax/nnx/filterlib.py
@@ -52,7 +52,7 @@ def to_predicate(filter: Filter) -> Predicate:
   elif isinstance(filter, (list, tuple)):
     return Any(*filter)
   else:
-    raise TypeError(f'Invalid collection filter: {filter:!r}. ')
+    raise TypeError(f'Invalid collection filter: {filter!r}. ')
 
 def filters_to_predicates(
   filters: tp.Sequence[Filter],

--- a/flax/nnx/variablelib.py
+++ b/flax/nnx/variablelib.py
@@ -2292,8 +2292,8 @@ def variable_name_from_type(
   name = typ.__name__
   if name in VariableTypeCache:
     raise ValueError(
-      'Name {name} is already registered in the registry as {VariableTypeCache[name]}. '
-      'It cannot be linked with this type {typ}.'
+      f'Name {name} is already registered in the registry as {VariableTypeCache[name]}. '
+      f'It cannot be linked with this type {typ}.'
     )
   register_variable_name(name, typ)
   return name


### PR DESCRIPTION
## Summary
- Fix malformed f-string in `filterlib.to_predicate`: `{filter:!r}` → `{filter!r}`
- Add missing `f` prefix in `variablelib.variable_name_from_type` error string

Both bugs cause error paths to crash with confusing secondary errors instead of showing the intended messages.

## Steps to reproduce

**`to_predicate`** (raises `ValueError: Invalid format specifier '!r'` instead of the intended `TypeError`):
```python
import flax.nnx.filterlib as filterlib

filterlib.to_predicate(37)
```

**`variable_name_from_type`** (shows literal `{name}` placeholders instead of actual values):
```python
from flax.nnx import Variable
from flax.nnx.variablelib import variable_name_from_type

class params(Variable):
    pass

variable_name_from_type(params, allow_register=True)
```

## Test plan
- [x] Verified both fixes produce correct error messages on Flax 0.12.5, Python 3.11, CPU-only