### PR TITLE
Add 'prefix' argument to temp_flip_flag function

### DIFF
--- a/flax/configurations.py
+++ b/flax/configurations.py
@@ -75,19 +75,20 @@ class Config:
     return f'Config({values_repr}\n)'
 
   @contextmanager
-  def temp_flip_flag(self, var_name: str, var_value: bool):
+  def temp_flip_flag(self, var_name: str, var_value: bool, prefix='flax'):
     """Context manager to temporarily flip feature flags for test functions.
 
     Args:
-      var_name: the config variable name (without the 'flax_' prefix)
+      var_name: the config variable name (without its prefix like 'flax_')
       var_value: the boolean value to set var_name to temporarily
+      prefix: the prefix of the config variable name (default: 'flax')
     """
-    old_value = getattr(self, f'flax_{var_name}')
+    old_value = getattr(self, prefix + '_' + var_name)
     try:
-      self.update(f'flax_{var_name}', var_value)
+      self.update(prefix + '_' + var_name, var_value)
       yield
     finally:
-      self.update(f'flax_{var_name}', old_value)
+      self.update(prefix + '_' + var_name, old_value)
 
 
 config = Config()


### PR DESCRIPTION
New functionality needs to often be tested in both graph mode and tree mode. Currently, setting graph mode is not possible with the `temp_flip_flag` function. This PR allows it to be used. 