### PR TITLE
Move orbax-export to optional deps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,6 @@ dependencies = [
     "typing_extensions>=4.2",
     "PyYAML>=5.4.1",
     "treescope>=0.1.7",
-    "orbax-export>=0.0.8",
 ]
 classifiers = [
     "Development Status :: 3 - Alpha",
@@ -92,6 +91,7 @@ docs = [
     "einops",
     "kagglehub>=0.3.3",
     "ipywidgets>=8.1.5",
+    "orbax-export>=0.0.8",
 ]
 dev = [
     "nanobind>=2.5.0",


### PR DESCRIPTION
Fixes #5352 by moving the orbax-export line of `pyproject.toml` to the `docs` section. 