### PR TITLE
Fix update doctest for graph_updates=False default

### DIFF
--- a/flax/nnx/graphlib.py
+++ b/flax/nnx/graphlib.py
@@ -2483,7 +2483,7 @@ def update(node, state: tp.Any, /, *states: tp.Any) -> None:
     >>> prev_loss = loss_fn(model, x, y)
 
     >>> grads = nnx.grad(loss_fn)(model, x, y)
-    >>> new_state = jax.tree.map(lambda p, g: p - 0.1*g, nnx.state(model), grads)
+    >>> new_state = jax.tree.map(lambda p, g: p - 0.1*g, nnx.state(model), nnx.state(grads))
     >>> nnx.update(model, new_state)
     >>> assert loss_fn(model, x, y) < prev_loss
 


### PR DESCRIPTION
With graph_updates=False, nnx.grad returns a graph node rather than a State, so nnx.state() must be called on grads before passing to jax.tree.map. This adds that call. 
