### PR TITLE
Fix MGUCell hidden state update

### DIFF
--- a/flax/linen/recurrent.py
+++ b/flax/linen/recurrent.py
@@ -624,7 +624,7 @@ class MGUCell(RNNCellBase):
       \begin{array}{ll}
       f = \sigma(W_{if} x + b_{if} + W_{hf} h) \\
       n = \tanh(W_{in} x + b_{in} + f * (W_{hn} h + b_{hn})) \\
-      h' = (1 - f) * n + f * h \\
+      h' = (1 - f) * h + f * n \\
       \end{array}
 
   where x is the input and h is the output of the previous time step.
@@ -636,7 +636,7 @@ class MGUCell(RNNCellBase):
       \begin{array}{ll}
       f = \sigma(W_{if} x + b_{if} + W_{hf} h) \\
       n = \tanh(W_{in} x + b_{in} + W_{hn} h) \\
-      h' = (1 - f) * n + f * h \\
+      h' = (1 - f) * h + f * n \\
       \end{array}
 
   Example usage::
@@ -726,7 +726,7 @@ class MGUCell(RNNCellBase):
     n = self.activation_fn(
       dense_i(name="in", bias_init=self.activation_bias_init)(inputs) + x
     )
-    new_h = (1.0 - f) * n + f * h
+    new_h = (1.0 - f) * h + f * n
     return new_h, new_h
 
   @nowrap

--- a/tests/linen/linen_test.py
+++ b/tests/linen/linen_test.py
@@ -1243,8 +1243,12 @@ class RecurrentTest(parameterized.TestCase):
     np.testing.assert_allclose(y, y_opt, rtol=1e-6)
     check_eq(lstm_params, lstm_opt_params)
 
-  def test_mgu_reset_gate(self):
-    module = nn.MGUCell(features=4, reset_gate=False)
+  @parameterized.parameters(
+    {'reset_gate': True},
+    {'reset_gate': False},
+  )
+  def test_mgu_cell_matches_manual_recurrence(self, reset_gate):
+    module = nn.MGUCell(features=4, reset_gate=reset_gate)
     rng = random.key(0)
     rng, key1, key2 = random.split(rng, 3)
     x = random.normal(key1, (2, 3))
@@ -1252,20 +1256,28 @@ class RecurrentTest(parameterized.TestCase):
     (carry, y), v = module.init_with_output(key2, carry0, x)
 
     self.assertIn('kernel', v['params']['hn'])
-    self.assertNotIn('bias', v['params']['hn'])
+    if reset_gate:
+      self.assertIn('bias', v['params']['hn'])
+    else:
+      self.assertNotIn('bias', v['params']['hn'])
 
     f = jax.nn.sigmoid(
       jnp.dot(x, v['params']['if']['kernel'])
       + v['params']['if']['bias'].reshape(1, -1)
       + jnp.dot(carry0, v['params']['hf']['kernel'])
     )
+    recurrent_update = jnp.dot(carry0, v['params']['hn']['kernel'])
+    if reset_gate:
+      recurrent_update += v['params']['hn']['bias'].reshape(1, -1)
+      recurrent_update *= f
     n = jax.nn.tanh(
       jnp.dot(x, v['params']['in']['kernel'])
       + v['params']['in']['bias'].reshape(1, -1)
-      + jnp.dot(carry0, v['params']['hn']['kernel'])
+      + recurrent_update
     )
-    expected_out = (1 - f) * n + f * carry0
+    expected_out = (1 - f) * carry0 + f * n
     np.testing.assert_allclose(y, expected_out)
+    np.testing.assert_allclose(carry, expected_out)
 
 
 class IdsTest(absltest.TestCase):


### PR DESCRIPTION
# What does this PR do?

Fixes #4608.

This fixes the `nn.MGUCell` hidden-state update equation to match the Minimal Gated Unit recurrence.

The current implementation computes:

```python
h' = (1 - f) * n + f * h
```
but according to the MGU formulation, the gate should mix the previous hidden state and candidate activation as:

```python
h' = (1 - f) * h + f * n
```
This PR updates the implementation and the displayed equation in the MGUCell docstring.

It also expands the existing MGU regression test so the cell output is checked against a manually computed recurrence for both:

```python
reset_gate=True
reset_gate=False
```

Tested with:
```python
python -m pytest tests/linen/linen_test.py -k mgu -q
```
Result:2 passed, 99 deselected
