### PR TITLE
Document LSTMCell carry as the (c, h) tuple it actually is

### DIFF
--- a/flax/linen/recurrent.py
+++ b/flax/linen/recurrent.py
@@ -136,7 +136,8 @@ class LSTMCell(RNNCellBase):
     r"""A long short-term memory (LSTM) cell.
 
     Args:
-      carry: the hidden state of the LSTM cell,
+      carry: a tuple ``(c, h)`` of the cell state ``c`` and the hidden
+        state ``h``, both of shape ``(*batch, features)``. Typically
         initialized using ``LSTMCell.initialize_carry``.
       inputs: an ndarray with the input for the current time step.
         All dimensions except the final are considered batch dimensions.
@@ -285,8 +286,9 @@ class OptimizedLSTMCell(RNNCellBase):
     r"""An optimized long short-term memory (LSTM) cell.
 
     Args:
-      carry: the hidden state of the LSTM cell, initialized using
-        ``LSTMCell.initialize_carry``.
+      carry: a tuple ``(c, h)`` of the cell state ``c`` and the hidden
+        state ``h``, both of shape ``(*batch, features)``. Typically
+        initialized using ``OptimizedLSTMCell.initialize_carry``.
       inputs: an ndarray with the input for the current time step. All
         dimensions except the final are considered batch dimensions.
 

--- a/flax/nnx/nn/recurrent.py
+++ b/flax/nnx/nn/recurrent.py
@@ -201,7 +201,8 @@ class LSTMCell(RNNCellBase):
     r"""A long short-term memory (LSTM) cell.
 
     Args:
-      carry: the hidden state of the LSTM cell,
+      carry: a tuple ``(c, h)`` of the cell state ``c`` and the hidden
+        state ``h``, both of shape ``(*batch, features)``. Typically
         initialized using ``LSTMCell.initialize_carry``.
       inputs: an ndarray with the input for the current time step.
         All dimensions except the final are considered batch dimensions.
@@ -382,8 +383,9 @@ class OptimizedLSTMCell(RNNCellBase):
     r"""An optimized long short-term memory (LSTM) cell.
 
     Args:
-      carry: the hidden state of the LSTM cell, initialized using
-        ``LSTMCell.initialize_carry``.
+      carry: a tuple ``(c, h)`` of the cell state ``c`` and the hidden
+        state ``h``, both of shape ``(*batch, features)``. Typically
+        initialized using ``OptimizedLSTMCell.initialize_carry``.
       inputs: an ndarray with the input for the current time step.
         All dimensions except the final are considered batch dimensions.
 


### PR DESCRIPTION
## Summary

The `LSTMCell.__call__` docstring described `carry` only as "the hidden state of the LSTM cell", which is misleading: `carry` is actually a tuple `(c, h)` of the cell state and the hidden state, as `initialize_carry` and the implementation both make clear (`return (c, h)` and `c, h = carry`).

This PR spells out the contract in the docstring:

> carry: a tuple `(c, h)` of the cell state `c` and the hidden state `h`, both of shape `(*batch, features)`. Typically initialized using `LSTMCell.initialize_carry`.

Applied to all four affected `__call__` docstrings for parity:

- `flax/linen/recurrent.py` LSTMCell
- `flax/linen/recurrent.py` OptimizedLSTMCell
- `flax/nnx/nn/recurrent.py` LSTMCell
- `flax/nnx/nn/recurrent.py` OptimizedLSTMCell

The `OptimizedLSTMCell` docstrings previously pointed at `LSTMCell.initialize_carry`; those references are also updated to `OptimizedLSTMCell.initialize_carry` to match the class users actually have a handle to.

Fixes #4124.

## Test plan

- [x] Pure docstring change, no runtime behavior modified.
- [x] No public API changes.
- [x] Wording matches the implementation (`c, h = carry`, `return (new_c, new_h), new_h`) and `initialize_carry` shapes.