### PR TITLE
Document None defaults for MultiHeadAttention args

### DIFF
--- a/flax/linen/attention.py
+++ b/flax/linen/attention.py
@@ -351,14 +351,18 @@ class MultiHeadDotProductAttention(Module):
       should be divisible by the number of heads.
     dtype: The dtype of the computation (default: infer from inputs and params)
     param_dtype: The dtype passed to parameter initializers (default: float32)
-    qkv_features: Dimension of the key, query, and value.
-    out_features: Dimension of the last projection
+    qkv_features: Dimension of the key, query, and value. If None,
+      ``inputs_q.shape[-1]`` is used.
+    out_features: Dimension of the last projection. If None,
+      ``inputs_q.shape[-1]`` is used.
     broadcast_dropout: Use a broadcasted dropout along batch dims.
     dropout_rate: Dropout rate.
     deterministic: If False, the attention weight is masked randomly using
-      dropout, whereas if True, the attention weights are deterministic.
+      dropout, whereas if True, the attention weights are deterministic. If
+      None, the ``deterministic`` argument passed to ``__call__`` is used
+      instead.
     precision: Numerical precision of the computation see ``jax.lax.Precision``
-      for details.
+      for details. If None, ``jax.lax.Precision.DEFAULT`` is used.
     kernel_init: Initializer for the kernel of the Dense layers.
     out_kernel_init: Optional Initializer for the kernel of the output Dense layer,
       if None, ``kernel_init`` will be used.
@@ -753,14 +757,18 @@ class MultiHeadAttention(MultiHeadDotProductAttention):
       should be divisible by the number of heads.
     dtype: the dtype of the computation (default: infer from inputs and params)
     param_dtype: the dtype passed to parameter initializers (default: float32)
-    qkv_features: dimension of the key, query, and value.
-    out_features: dimension of the last projection
+    qkv_features: dimension of the key, query, and value. If None,
+      ``inputs_q.shape[-1]`` is used.
+    out_features: dimension of the last projection. If None,
+      ``inputs_q.shape[-1]`` is used.
     broadcast_dropout: bool: use a broadcasted dropout along batch dims.
     dropout_rate: dropout rate
     deterministic: if false, the attention weight is masked randomly using
-      dropout, whereas if true, the attention weights are deterministic.
+      dropout, whereas if true, the attention weights are deterministic. If
+      None, the ``deterministic`` argument passed to ``__call__`` is used
+      instead.
     precision: numerical precision of the computation see ``jax.lax.Precision``
-      for details.
+      for details. If None, ``jax.lax.Precision.DEFAULT`` is used.
     kernel_init: initializer for the kernel of the Dense layers.
     bias_init: initializer for the bias of the Dense layers.
     use_bias: bool: whether pointwise QKVO dense transforms use bias.

--- a/flax/nnx/nn/attention.py
+++ b/flax/nnx/nn/attention.py
@@ -349,8 +349,10 @@ class MultiHeadAttention(Module):
     num_heads: number of attention heads. Features (i.e. inputs_q.shape[-1])
       should be divisible by the number of heads.
     in_features: int or tuple with number of input features.
-    qkv_features: dimension of the key, query, and value.
-    out_features: dimension of the last projection.
+    qkv_features: dimension of the key, query, and value. If None, it defaults
+      to ``in_features``.
+    out_features: dimension of the last projection. If None, it defaults to
+      ``in_features``.
     in_kv_features: number of input features for computing key and value.
     num_kv_heads: number of key and value heads. If None, it defaults to
       ``num_heads``. If set to a value smaller than ``num_heads``, Grouped Query
@@ -361,9 +363,11 @@ class MultiHeadAttention(Module):
     broadcast_dropout: bool: use a broadcasted dropout along batch dims.
     dropout_rate: dropout rate
     deterministic: if false, the attention weight is masked randomly using
-      dropout, whereas if true, the attention weights are deterministic.
+      dropout, whereas if true, the attention weights are deterministic. If
+      None, the ``deterministic`` argument passed to ``__call__`` is used
+      instead.
     precision: numerical precision of the computation see `jax.lax.Precision`
-      for details.
+      for details. If None, ``jax.lax.Precision.DEFAULT`` is used.
     kernel_init: initializer for the kernel of the Dense layers.
     out_kernel_init: optional initializer for the kernel of the output Dense layer,
       if None, the kernel_init is used.


### PR DESCRIPTION
## Summary

Several `MultiHeadAttention` attributes accept `None`, but the docstring did not say what happens when you pass it. This fills in the gaps for the four args called out in #4182:

- `qkv_features`: defaults to `inputs_q.shape[-1]` (linen) / `in_features` (nnx).
- `out_features`: defaults to `inputs_q.shape[-1]` (linen) / `in_features` (nnx).
- `deterministic`: falls back to the `deterministic` argument passed to `__call__`.
- `precision`: uses `jax.lax.Precision.DEFAULT`.

Applied symmetrically to `flax/linen/attention.py` (`MultiHeadDotProductAttention` and its `MultiHeadAttention` alias) and the NNX twin in `flax/nnx/nn/attention.py`.

Pure docstring change, no behavior change.

Fixes #4182

## Test plan

- [x] `python3 -c 'import ast; ast.parse(...)'` on both files (parses clean).
- [x] Style matches surrounding entries in each docstring (linen uses sentence case, nnx uses lower case).