### PR TITLE
Document spmd_axis_name and transform_metadata in nnx.vmap

### DIFF
--- a/flax/nnx/transforms/iteration.py
+++ b/flax/nnx/transforms/iteration.py
@@ -424,6 +424,10 @@ def vmap(
       axis so that parallel collectives can be applied.
     axis_size: Optional, an integer indicating the size of the axis to be
       mapped. If not provided, the mapped axis size is inferred from arguments.
+    spmd_axis_name: Optional, axis name added to any pjit sharding constraints
+      appearing in ``f``. See also
+      https://github.com/google/flax/blob/main/flax/linen/partitioning.py.
+    transform_metadata: Optional mapping of metadata for the transform.
     graph: If ``True`` (default), uses graph-mode which supports the full
       NNX feature set including shared references and reference semantics.
       If ``False``, uses tree-mode which treats Modules as regular JAX


### PR DESCRIPTION
The `nnx.vmap` signature accepts `spmd_axis_name` and `transform_metadata` keyword arguments, but neither appears in the docstring `Args:` section. This makes them invisible to anyone reading `help(nnx.vmap)` or the rendered API reference, even though both are forwarded to `jax.vmap` and `_update_variable_sharding_metadata` respectively and are user-visible knobs.

This adds entries for both arguments in the existing `Args:` block, placed in their signature order between `axis_size` and `graph`. The wording for `spmd_axis_name` mirrors the canonical description already used in `flax/linen/transforms.py` and `flax/core/lift.py`, and the wording for `transform_metadata` matches what the sibling `nnx.pmap` docstring lower in the same file uses.

No behavior change. The three existing doctests under `flax/nnx/transforms/iteration.py` continue to pass.