### PR TITLE
Add docstrings to nnx filterlib filter classes

### DIFF
--- a/flax/nnx/filterlib.py
+++ b/flax/nnx/filterlib.py
@@ -78,6 +78,14 @@ def _has_tag(x: tp.Any) -> tp.TypeGuard[HasTag]:
 
 @dataclasses.dataclass(frozen=True)
 class WithTag:
+  """Filter that matches values with a string ``tag`` attribute equal to the given tag.
+
+  Used by ``RngKey`` and ``RngCount``. See
+  `Using Filters <https://flax.readthedocs.io/en/latest/guides/filters_guide.html>`__.
+
+  Attributes:
+    tag: The string tag to match against a value's ``tag`` attribute.
+  """
   tag: str
 
   def __call__(self, path: PathParts, x: tp.Any):
@@ -89,6 +97,15 @@ class WithTag:
 
 @dataclasses.dataclass(frozen=True)
 class PathContains:
+  """Filter that matches values whose associated path contains the given key.
+
+  See `Using Filters <https://flax.readthedocs.io/en/latest/guides/filters_guide.html>`__.
+
+  Attributes:
+    key: The key to look for in the value's path.
+    exact: If ``True``, ``key`` must equal a path element exactly. If ``False``,
+      matches when ``key`` is contained in the string form of any path element.
+  """
   key: Key | str
   exact: bool = True
 
@@ -121,6 +138,14 @@ class PathIn:
 
 @dataclasses.dataclass(frozen=True)
 class OfType:
+  """Filter that matches values that are instances of ``type``, or that have a
+  ``type`` attribute that is an instance of ``type``.
+
+  See `Using Filters <https://flax.readthedocs.io/en/latest/guides/filters_guide.html>`__.
+
+  Attributes:
+    type: The type to match values against.
+  """
   type: type
 
   def __call__(self, path: PathParts, x: tp.Any):
@@ -131,6 +156,10 @@ class OfType:
 
 
 class Any:
+  """Filter that matches values matching any of the inner filters.
+
+  See `Using Filters <https://flax.readthedocs.io/en/latest/guides/filters_guide.html>`__.
+  """
   def __init__(self, *filters: Filter):
     self.predicates = tuple(
       to_predicate(collection_filter) for collection_filter in filters
@@ -150,6 +179,10 @@ class Any:
 
 
 class All:
+  """Filter that matches values matching all of the inner filters.
+
+  See `Using Filters <https://flax.readthedocs.io/en/latest/guides/filters_guide.html>`__.
+  """
   def __init__(self, *filters: Filter):
     self.predicates = tuple(
       to_predicate(collection_filter) for collection_filter in filters
@@ -169,6 +202,10 @@ class All:
 
 
 class Not:
+  """Filter that matches values that do not match the inner filter.
+
+  See `Using Filters <https://flax.readthedocs.io/en/latest/guides/filters_guide.html>`__.
+  """
   def __init__(self, collection_filter: Filter, /):
     self.predicate = to_predicate(collection_filter)
 
@@ -186,6 +223,10 @@ class Not:
 
 
 class Everything:
+  """Filter that matches all values.
+
+  See `Using Filters <https://flax.readthedocs.io/en/latest/guides/filters_guide.html>`__.
+  """
   def __call__(self, path: PathParts, x: tp.Any):
     return True
 
@@ -200,6 +241,10 @@ class Everything:
 
 
 class Nothing:
+  """Filter that matches no values.
+
+  See `Using Filters <https://flax.readthedocs.io/en/latest/guides/filters_guide.html>`__.
+  """
   def __call__(self, path: PathParts, x: tp.Any):
     return False
 


### PR DESCRIPTION
# What does this PR do?

The filter classes in `flax.nnx.filterlib` (`WithTag`, `PathContains`, `OfType`, `Any`, `All`, `Not`, `Everything`, `Nothing`) are exported and appear in the NNX API reference but currently render with no docstrings. This adds a docstring to each, with descriptions based on the [Filters guide](https://flax.readthedocs.io/en/latest/guides/filters_guide.html) and `Attributes:` sections for the dataclass filters. Docs only, no behavioral changes.

Part of #5161.

## Checklist
- [x] This PR fixes a minor issue (e.g.: typo or small bug) or improves the docs (you can dismiss the other checks if that's the case).
- [x] This change is discussed in a Github issue/[discussion](https://github.com/google/flax/discussions) (please add a link): #5161
- [x] The documentation and docstrings adhere to the [documentation guidelines](https://github.com/google/flax/blob/main/docs/README.md#how-to-write-code-documentation).
- [ ] This change includes necessary high-coverage tests. (No quality testing = no merge!)

cc @vfdev-5

Rendered docs: https://flax--5474.org.readthedocs.build/en/5474/api_reference/flax.nnx/filterlib.html
