### PR TITLE
Raise a clear error when pooling window_shape has too many dimensions

### DIFF
--- a/flax/linen/pooling.py
+++ b/flax/linen/pooling.py
@@ -43,6 +43,14 @@ def pool(inputs, init, reduce_fn, window_shape, strides, padding):
     The output of the reduction for each window slice.
   """
   num_batch_dims = inputs.ndim - (len(window_shape) + 1)
+  if num_batch_dims < 0:
+    raise ValueError(
+      f'window_shape {window_shape} has too many dimensions for input with '
+      f'shape {inputs.shape}. Pooling expects inputs laid out as '
+      '(batch_dims..., spatial_dims..., features), so window_shape must have '
+      'one entry per spatial dimension, which is at most inputs.ndim - 1 '
+      f'entries ({inputs.ndim - 1} for this input).'
+    )
   strides = strides or (1,) * len(window_shape)
   assert len(window_shape) == len(
     strides

--- a/tests/linen/linen_test.py
+++ b/tests/linen/linen_test.py
@@ -134,6 +134,16 @@ class PoolTest(parameterized.TestCase):
 
     assert y.shape == (16, 16, 3)
 
+  def test_pooling_window_shape_too_long_raises(self):
+    # window_shape must have at most inputs.ndim - 1 entries, one per spatial
+    # dimension. A longer window_shape should raise a clear error instead of a
+    # cryptic internal assertion (see GitHub issue #4494).
+    x = jnp.zeros((4, 3), dtype=jnp.float32)
+    with self.assertRaisesRegex(
+      ValueError, 'window_shape .* too many dimensions'
+    ):
+      nn.max_pool(x, (2, 2, 2))
+
 
 class NormalizationTest(parameterized.TestCase):
   def test_layer_norm_mask(self):


### PR DESCRIPTION
Fixes #4494

The pooling helpers (avg_pool, max_pool, min_pool) expect inputs laid out as (batch_dims..., spatial_dims..., features) and a window_shape with one entry per spatial dimension. Internally pool computes num_batch_dims as inputs.ndim - (len(window_shape) + 1).

When window_shape has more entries than the input has spatial dimensions, num_batch_dims goes negative. The function then keeps going and the user hits a confusing internal assertion. For example, max_pool(jnp.zeros((4, 3)), (2, 2, 2)) currently fails with AssertionError: len((4, 3)) != len((2, 2, 2, 1)), which gives no hint about the expected dimension layout. The linked issue describes exactly this confusion: it is not clear from the behavior or the error how window_shape relates to the input dimensions.

This change adds an explicit guard at the top of pool that raises a ValueError describing the expected (batch_dims..., spatial_dims..., features) layout and the maximum number of window_shape entries allowed for the given input. Valid pooling calls are unaffected since the new branch only triggers when window_shape was already too long to produce a meaningful result.

Verification: added tests/linen/linen_test.py::PoolTest::test_pooling_window_shape_too_long_raises which fails on main with the old cryptic assertion and passes with this change. Ran python -m pytest tests/linen/linen_test.py::PoolTest -q on CPU, all 11 cases pass. ruff check on the changed files reports no issues.