### PR TITLE
Add RoPE embeddings

### DIFF
--- a/docs_nnx/api_reference/flax.nnx/nn/attention.rst
+++ b/docs_nnx/api_reference/flax.nnx/nn/attention.rst
@@ -8,7 +8,12 @@ Attention
   :module: flax.nnx
   :class: MultiHeadAttention
 
+.. flax_module::
+  :module: flax.nnx
+  :class: RoPE
+
 .. autofunction:: combine_masks
 .. autofunction:: dot_product_attention
+.. autofunction:: dot_product_attention_with_rope
 .. autofunction:: make_attention_mask
 .. autofunction:: make_causal_mask

--- a/flax/nnx/__init__.py
+++ b/flax/nnx/__init__.py
@@ -115,6 +115,8 @@ from .nn.activations import PReLU as PReLU
 from .nn.attention import MultiHeadAttention as MultiHeadAttention
 from .nn.attention import combine_masks as combine_masks
 from .nn.attention import dot_product_attention as dot_product_attention
+from .nn.attention import dot_product_attention_with_rope as dot_product_attention_with_rope
+from .nn.attention import RoPE as RoPE
 from .nn.attention import make_attention_mask as make_attention_mask
 from .nn.attention import make_causal_mask as make_causal_mask
 from .nn.recurrent import RNNCellBase as RNNCellBase

--- a/flax/nnx/nn/attention.py
+++ b/flax/nnx/nn/attention.py
@@ -332,6 +332,144 @@ def dot_product_attention(
   return out
 
 
+class RoPE(Module):
+  """Rotary Position Embedding (RoPE).
+
+  Precomputes and stores cosine and sine frequency tensors for rotary
+  positional encoding as described in "RoFormer: Enhanced Transformer
+  with Rotary Position Embedding" (https://arxiv.org/abs/2104.09864).
+
+  Example usage::
+
+    >>> from flax import nnx
+    >>> import functools
+    >>> rope = nnx.RoPE(embedding_size=64, max_seq_len=128)
+    >>> layer = nnx.MultiHeadAttention(
+    ...     num_heads=8, in_features=512, qkv_features=512,
+    ...     attention_fn=functools.partial(
+    ...         nnx.dot_product_attention_with_rope, rope=rope),
+    ...     decode=False, rngs=nnx.Rngs(0))
+
+  Args:
+    theta: Base frequency for sinusoidal functions. Default is 10000.
+    embedding_size: Optional. Size of each embedding vector (i.e. head_dim). Must be
+      even. If provided together with ``max_seq_len``, sin/cos tables are
+      precomputed and cached as module Variables.
+    max_seq_len: Optional. Maximum sequence length for precomputed frequencies. Must
+      be provided together with ``embedding_size``.
+  """
+
+  def __init__(
+    self,
+    theta: float = 10000.0,
+    embedding_size: int | None = None,
+    max_seq_len: int | None = None,
+  ):
+    self.theta = theta
+    self.cached_sin: nnx.Variable | None
+    self.cached_cos: nnx.Variable | None
+    if (embedding_size is None) != (max_seq_len is None):
+      raise ValueError('Either both `embedding_size` and `max_seq_len` or none of them must be provided.')
+    if embedding_size is not None and max_seq_len is not None:
+      positions = jnp.arange(float(max_seq_len))
+      sin, cos = self._rotation_for(embedding_size, positions)
+      self.cached_sin = nnx.Variable(sin)
+      self.cached_cos = nnx.Variable(cos)
+    else:
+      self.cached_sin = None
+      self.cached_cos = None
+
+  @staticmethod
+  def _rotate_half(x: Array) -> Array:
+    d_2 = x.shape[-1] // 2
+    return jnp.concatenate([-x[..., d_2:], x[..., :d_2]], axis=-1)
+
+  def _rotation_for(self, embedding_size: int, input_positions: Array):
+    seq_len = input_positions.shape[-1]
+    if embedding_size <= 0 or embedding_size % 2 != 0:
+      raise ValueError('`embedding_size` must be positive and even.')
+    freqs = 1.0 / (
+      self.theta ** (jnp.arange(0.0, embedding_size, 2) / embedding_size)
+    )
+    freqs_outer = jnp.outer(input_positions, freqs)
+    return jnp.sin(freqs_outer), jnp.cos(freqs_outer)
+
+  def __call__(self, x: Array, input_positions: Array | None = None) -> Array:
+    """Apply rotary positional encoding.
+
+    Args:
+      x: Input array of shape ``(..., seq_length, embedding_size)``.
+      input_positions: Optional position array of shape ``(..., seq_len,)``.
+        If ``None`` and precomputed tables exist (i.e. ``embedding_size``
+        and ``max_seq_len`` were given at init), the cached tables are
+        used. Otherwise positions default to ``jnp.arange(seq_len)``.
+
+    Returns:
+      Array of same shape with RoPE applied.
+    """
+    seq_len, embedding_size = x.shape[-2:]
+    if input_positions is None and self.cached_sin is not None and self.cached_cos is not None:
+      sin = self.cached_sin.value[:seq_len]
+      cos = self.cached_cos.value[:seq_len]
+    else:
+      if input_positions is None:
+        input_positions = jnp.arange(float(seq_len))
+      elif input_positions.shape[-1] != seq_len:
+        raise ValueError('`input_positions` must have the same seq_len as `x`.')
+      sin, cos = self._rotation_for(embedding_size, input_positions)
+    cos = jnp.concatenate([cos, cos], axis=-1)
+    sin = jnp.concatenate([sin, sin], axis=-1)
+    # Broadcast sin/cos to match any leading batch dims of x.
+    n_prefix = x.ndim - cos.ndim
+    if n_prefix > 0:
+      cos = jnp.reshape(cos, (1,) * n_prefix + cos.shape)
+      sin = jnp.reshape(sin, (1,) * n_prefix + sin.shape)
+    return x * cos + self._rotate_half(x) * sin
+
+
+def dot_product_attention_with_rope(
+  query: Array,
+  key: Array,
+  value: Array,
+  *,
+  rope: RoPE,
+  input_positions: Array | None = None,
+  **kwargs,
+) -> Array:
+  """Dot-product attention with Rotary Position Embedding applied to query and key.
+
+  This function has the same signature as :func:`dot_product_attention`
+  (plus a ``rope`` keyword argument) and can be used as the ``attention_fn``
+  of :class:`MultiHeadAttention` via ``functools.partial``::
+
+    attention_fn=functools.partial(dot_product_attention_with_rope, rope=rope)
+
+  Args:
+    query: queries of shape ``[batch..., q_length, num_heads, head_dim]``.
+    key: keys of shape ``[batch..., kv_length, num_heads, head_dim]``.
+    value: values of shape ``[batch..., kv_length, num_heads, v_dim]``.
+    rope: A :class:`RoPE` module instance.
+    input_positions: Optional position array of shape ``(..., seq_len,)``.
+      If ``None`` and precomputed tables exist (i.e. ``embedding_size``
+      and ``max_seq_len`` were given at init), the cached tables are
+      used. Otherwise positions default to ``jnp.arange(seq_len)``.
+    **kwargs: Additional keyword arguments forwarded to
+      :func:`dot_product_attention`.
+
+  Returns:
+    Output of shape ``[batch..., q_length, num_heads, v_dim]``.
+  """
+  # query/key: [batch..., seq_length, num_heads, head_dim]
+  # RoPE.__call__ expects (..., seq_length, head_dim), so vmap over heads.
+  if input_positions is None:
+    apply = jax.vmap(rope, in_axes=-2, out_axes=-2)
+  else:
+    apply = jax.vmap(rope, in_axes=(-2, -1), out_axes=(-2, -1))
+  query = apply(query, input_positions)
+  key = apply(key, input_positions)
+  return dot_product_attention(query, key, value, **kwargs)
+
+
 class MultiHeadAttention(Module):
   """Multi-head attention.
 
@@ -601,6 +739,7 @@ class MultiHeadAttention(Module):
     is_causal=False,
     out_sharding = None,
     qkv_sharding = None,
+    input_positions: Array | None = None
   ):
     """Applies multi-head dot product attention on the input data.
 
@@ -637,6 +776,9 @@ class MultiHeadAttention(Module):
         the output linear layer for the output arrays.
       qkv_sharding: Optional sharding specification to pass to
         the QKV linear layers for the output arrays.
+      input_positions: Optional position indices of shape
+        ``[batch_sizes..., length]`` forwarded to the ``attention_fn``.
+        Used by :func:`dot_product_attention_with_rope` for RoPE.
 
     Returns:
       output of shape `[batch_sizes..., length, features]`.
@@ -749,6 +891,9 @@ class MultiHeadAttention(Module):
       dropout_rng = None
 
     # apply attention
+    attn_kwargs = {}
+    if input_positions is not None:
+       attn_kwargs["input_positions"] = input_positions
     x = self.attention_fn(
       query,
       key,
@@ -761,7 +906,8 @@ class MultiHeadAttention(Module):
       dtype=self.dtype,
       precision=self.precision,
       module=self if sow_weights else None,
-      is_causal=is_causal
+      is_causal=is_causal,
+      **attn_kwargs
     )
     # back to the original inputs dimensions
     out = self.out(x, out_sharding=out_sharding)

--- a/tests/nnx/nn/attention_test.py
+++ b/tests/nnx/nn/attention_test.py
@@ -12,8 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import functools
+
+import jax
 import jax, jax.numpy as jnp
 from jax.lax import Precision
+
+import torch
+import torch.onnx.ops
 
 from flax import linen
 from flax import nnx
@@ -398,9 +404,149 @@ class TestDotProductAttentionValidation(parameterized.TestCase):
     with self.assertRaisesRegex(ValueError, match):
       nnx.dot_product_attention(q, k, v, dropout_rate=0.1,
                                 dropout_rng=jax.random.key(0))
+class TestRoPE(absltest.TestCase):
+
+  def _torch_rope(self, x_np, theta, seq_len, head_dim):
+    """Apply RoPE using torch.onnx.ops.rotary_embedding as reference."""
+    freqs = 1.0 / (theta ** (torch.arange(0, head_dim, 2, dtype=torch.float32) / head_dim))
+    angles = torch.outer(torch.arange(seq_len, dtype=torch.float32), freqs)
+    cos_cache = torch.cos(angles)
+    sin_cache = torch.sin(angles)
+    # torch expects (batch, heads, seq, dim)
+    x_torch = torch.from_numpy(np.array(x_np))
+    batch_size = x_torch.shape[0]
+    position_ids = torch.arange(seq_len).unsqueeze(0).expand(batch_size, -1)
+    out = torch.onnx.ops.rotary_embedding(
+      x_torch, cos_cache, sin_cache, position_ids, interleaved=False
+    )
+    return out.numpy()
+
+  def test_matches_torch_single_head(self):
+    """RoPE.__call__ matches torch.onnx.ops.rotary_embedding on a single (seq, dim) input."""
+
+    seq_len, head_dim = 32, 64
+    x = jax.random.normal(jax.random.key(0), (seq_len, head_dim))
+
+    flax_rope = nnx.RoPE(theta=10000.0)
+    out_flax = flax_rope(x)
+
+    # torch 4D: (batch=1, heads=1, seq, dim)
+    out_torch = self._torch_rope(
+      x[None, None], theta=10000.0, seq_len=seq_len, head_dim=head_dim
+    )[0, 0]
+
+    np.testing.assert_allclose(out_flax, out_torch, atol=1e-5)
+
+  def test_matches_torch_multi_head(self):
+    """RoPE applied per-head via vmap matches torch.onnx.ops.rotary_embedding with heads."""
+    seq_len, num_heads, head_dim = 16, 4, 32
+    x = jax.random.normal(jax.random.key(1), (seq_len, num_heads, head_dim))
+
+    flax_rope = nnx.RoPE(theta=10000.0)
+    out_flax = jax.vmap(flax_rope, in_axes=1, out_axes=1)(x)
+
+    # torch 4D: (batch=1, heads, seq, dim) — need to transpose from (seq, heads, dim)
+    x_torch_4d = np.array(x).transpose(1, 0, 2)[None]  # (1, heads, seq, dim)
+    out_torch = self._torch_rope(
+      x_torch_4d, theta=10000.0, seq_len=seq_len, head_dim=head_dim
+    )[0].transpose(1, 0, 2)  # back to (seq, heads, dim)
+
+    np.testing.assert_allclose(out_flax, out_torch, atol=1e-5)
+
+  def test_dot_product_attention_with_rope_matches_torch(self):
+    """Full attention with RoPE matches manual torch-RoPE + standard attention."""
+    batch, seq_len, num_heads, head_dim = 2, 16, 4, 32
+
+    key = jax.random.key(42)
+    k1, k2, k3 = jax.random.split(key, 3)
+    query = jax.random.normal(k1, (batch, seq_len, num_heads, head_dim))
+    kv = jax.random.normal(k2, (batch, seq_len, num_heads, head_dim))
+    value = jax.random.normal(k3, (batch, seq_len, num_heads, head_dim))
+
+    # torch expects (batch, heads, seq, dim)
+    def apply_torch_rope(x):
+      x_np = np.array(x).transpose(0, 2, 1, 3)  # (batch, heads, seq, dim)
+      out = self._torch_rope(x_np, theta=10000.0, seq_len=seq_len, head_dim=head_dim)
+      return jnp.array(out.transpose(0, 2, 1, 3))  # back to (batch, seq, heads, dim)
+
+    q_torch = apply_torch_rope(query)
+    k_torch = apply_torch_rope(kv)
+    out_torch = nnx.dot_product_attention(q_torch, k_torch, value)
+
+    flax_rope = nnx.RoPE(theta=10000.0)
+    out_flax = nnx.dot_product_attention_with_rope(
+      query, kv, value, rope=flax_rope
+    )
+
+    np.testing.assert_allclose(out_flax, out_torch, atol=1e-5)
+
+  def test_with_mha(self):
+    """RoPE integrates correctly as attention_fn in MultiHeadAttention."""
+    with jax.numpy_rank_promotion("raise"):
+      batch, seq_len, in_features = 2, 8, 64
+      num_heads = 4
+
+      rope = nnx.RoPE()
+      layer = nnx.MultiHeadAttention(
+        num_heads=num_heads,
+        in_features=in_features,
+        qkv_features=in_features,
+        attention_fn=functools.partial(
+          nnx.dot_product_attention_with_rope, rope=rope
+        ),
+        decode=False,
+        rngs=nnx.Rngs(0),
+      )
+
+      x = jax.random.normal(jax.random.key(1), (batch, seq_len, in_features))
+      out = layer(x)
+      self.assertEqual(out.shape, (batch, seq_len, in_features))
+
+  def test_different_theta(self):
+    """Different theta values produce different outputs."""
+    seq_len, head_dim = 16, 32
+    x = jax.random.normal(jax.random.key(0), (seq_len, head_dim))
+
+    rope_a = nnx.RoPE(theta=10000.0)
+    rope_b = nnx.RoPE(theta=500.0)
+
+    out_a = rope_a(x)
+    out_b = rope_b(x)
+    self.assertFalse(jnp.allclose(out_a, out_b, atol=1e-3))
+
+  def test_relative_position_invariance(self):
+    """Dot product of RoPE-rotated vectors depends only on relative position.
+
+    For any offset d, <RoPE(q, pos=i), RoPE(k, pos=j)> should equal
+    <RoPE(q, pos=i+d), RoPE(k, pos=j+d)>.
+    """
+    head_dim = 64
+    max_len = 128
+    rope = nnx.RoPE()
+
+    k1, k2 = jax.random.split(jax.random.key(7))
+    q_vec = jax.random.normal(k1, (head_dim,))
+    k_vec = jax.random.normal(k2, (head_dim,))
+
+    # Place q at position i and k at position j, then shift both by d.
+    i, j = 5, 12
+    d = 37
+
+    def rope_at(vec, pos):
+      # Build a dummy sequence long enough, apply RoPE, extract one position.
+      seq = jnp.zeros((pos + 1, head_dim)).at[pos].set(vec)
+      return rope(seq)[pos]
+
+    q_rot = rope_at(q_vec, i)
+    k_rot = rope_at(k_vec, j)
+    dot_original = jnp.dot(q_rot, k_rot)
+
+    q_rot_shifted = rope_at(q_vec, i + d)
+    k_rot_shifted = rope_at(k_vec, j + d)
+    dot_shifted = jnp.dot(q_rot_shifted, k_rot_shifted)
+
+    np.testing.assert_allclose(dot_original, dot_shifted, atol=1e-5)
 
 
 if __name__ == '__main__':
   absltest.main()
-
-


### PR DESCRIPTION
This PR adds support for RoPE. Specifically, a new function `dot_product_attention_with_rope` can be used as the `attention_fn` argument for `nnx.MultiHeadAttention`. 