### PR TITLE
Handle captures in jax transforms

### DIFF
--- a/flax/nnx/extract.py
+++ b/flax/nnx/extract.py
@@ -17,6 +17,7 @@ from collections import namedtuple
 import dataclasses
 import functools
 import inspect
+import types
 import typing as tp
 
 from flax import struct
@@ -675,6 +676,19 @@ def copy_var_structure(tree: A) -> A:
       lambda x: x, tree, is_leaf=lambda x: isinstance(x, variablelib.Variable)
   )
 
+def collect_variables(
+    **kwargs,
+) -> dict[jax.tree_util.KeyPath, variablelib.Variable]:
+  """Collect all Variables from the given keyword arguments, allowing duplicates."""
+  container = labeled(**kwargs)
+  is_leaf = lambda x: isinstance(x, variablelib.Variable)
+  all_variables: dict[jax.tree_util.KeyPath, variablelib.Variable] = {}
+  for path, leaf in jax.tree.leaves_with_path(container, is_leaf=is_leaf):
+    if isinstance(leaf, variablelib.Variable):
+      all_variables[path] = leaf
+  return all_variables
+
+
 def check_no_aliases(
     fn_name: str, /, *, check: tp.Iterable[str] = (), **kwargs
 ) -> dict[jax.tree_util.KeyPath, variablelib.Variable]:
@@ -1118,6 +1132,124 @@ def to_masked(tree, all_updates: OrderedDict[tp.Any, Updates]):
       lambda path, _: combined.get(path, None), tree,
       is_leaf=lambda x: x is None
   )
+
+@dataclasses.dataclass(frozen=True)
+class CapturedInfo:
+  """Info about closure-captured graph nodes/Variables."""
+  nodes: tuple[object, ...]
+  freevar_indices: tuple[int, ...]
+
+  def __len__(self):
+    return len(self.nodes)
+
+  def __bool__(self):
+    return len(self.nodes) > 0
+
+  def exclude_from_args(
+      self,
+      args: tuple,
+      kwargs: dict | tp.Mapping,
+  ) -> 'CapturedInfo':
+    """Remove captured nodes that also appear in explicit args (by id)."""
+    if not self.nodes:
+      return self
+    arg_ids: set[int] = set()
+    for _, value in graphlib.iter_graph((args, kwargs), graph=True):
+      if isinstance(value, variablelib.Variable):
+        arg_ids.add(id(value))
+    keep = [(node, idx) for node, idx in zip(self.nodes, self.freevar_indices)
+            if id(node) not in arg_ids]
+    if len(keep) == len(self.nodes):
+      return self
+    if not keep:
+      return CapturedInfo((), ())
+    nodes, indices = zip(*keep)
+    return CapturedInfo(tuple(nodes), tuple(indices))
+
+
+_EMPTY_CAPTURED = CapturedInfo((), ())
+
+
+def _unwrap(f):
+  """Unwrap functools.partial and __wrapped__ decorators to the inner function."""
+  while True:
+    if isinstance(f, functools.partial):
+      f = f.func
+    elif hasattr(f, '__wrapped__'):
+      f = f.__wrapped__
+    else:
+      return f
+
+
+def find_captured_nodes(f) -> CapturedInfo:
+  """Find top-level nnx Variables and graph nodes in f's closure."""
+  f = _unwrap(f)
+  if not hasattr(f, '__closure__') or f.__closure__ is None:
+    return _EMPTY_CAPTURED
+  closure = f.__closure__
+  seen: set[int] = set()
+  captured_nodes: list[object] = []
+  captured_indices: list[int] = []
+  for i, cell in enumerate(closure):
+    try:
+      obj = cell.cell_contents
+    except ValueError:
+      continue
+    if graphlib.is_graph_node(obj) or isinstance(obj, variablelib.Variable):
+      obj_id = id(obj)
+      if obj_id not in seen:
+        seen.add(obj_id)
+        captured_nodes.append(obj)
+        captured_indices.append(i)
+  return CapturedInfo(tuple(captured_nodes), tuple(captured_indices))
+
+
+def _make_cell(val):
+  """Create a closure cell containing val."""
+  x = val
+  return (lambda: x).__closure__[0]  # type: ignore
+
+
+def replace_closure_cells(
+    f: tp.Callable,
+    captured_info: CapturedInfo,
+    replacements: tuple,
+) -> tp.Callable:
+  """Return a copy of f with captured closure cells replaced by replacements."""
+  if isinstance(f, functools.partial):
+    new_func = replace_closure_cells(f.func, captured_info, replacements)
+    return functools.partial(new_func, *f.args, **f.keywords)
+  if hasattr(f, '__wrapped__'):
+    old_inner = f.__wrapped__
+    new_inner = replace_closure_cells(old_inner, captured_info, replacements)
+    # Rebuild the wrapper's closure, replacing the cell that held the old inner.
+    if f.__closure__:
+      cells = list(f.__closure__)
+      for i, cell in enumerate(cells):
+        try:
+          if cell.cell_contents is old_inner:
+            cells[i] = _make_cell(new_inner)
+            break
+        except ValueError:
+          continue
+      new_f = types.FunctionType(
+        f.__code__, f.__globals__, f.__name__,
+        f.__defaults__, tuple(cells),
+      )
+    else:
+      new_f = f
+    new_f.__wrapped__ = new_inner
+    return new_f
+  if not captured_info or not f.__closure__:
+    return f
+  cells = list(f.__closure__)
+  for idx, new_val in zip(captured_info.freevar_indices, replacements):
+    cells[idx] = _make_cell(new_val)
+  return types.FunctionType(
+    f.__code__, f.__globals__, f.__name__,
+    f.__defaults__, tuple(cells),
+  )
+
 
 def filter_kwargs(f, **kwargs):
   sig = inspect.signature(f)

--- a/flax/nnx/transforms/autodiff.py
+++ b/flax/nnx/transforms/autodiff.py
@@ -72,6 +72,7 @@ class SimpleGradFn:
   f: tp.Callable[..., tp.Any]
   has_aux: bool
   graph: bool
+  captured_info: extract.CapturedInfo = extract._EMPTY_CAPTURED
 
   def __post_init__(self):
     functools.update_wrapper(self, self.f, updated=())
@@ -81,7 +82,14 @@ class SimpleGradFn:
     current, snapshot = extract.snapshot(labeled(args=args, kwargs=kwargs))
     if self.graph:
       args, kwargs = extract.from_tree2((args, kwargs))
-    out = self.f(*args, **kwargs)
+    n_captured = len(self.captured_info)
+    user_args = args[n_captured:]
+    if self.captured_info:
+      f = extract.replace_closure_cells(
+          self.f, self.captured_info, args[:n_captured])
+    else:
+      f = self.f
+    out = f(*user_args, **kwargs)
     if self.graph:
       out = extract.to_tree2(out)
     extract.check_no_aliases('grad', **current, out=out, check=['out'])
@@ -151,8 +159,9 @@ def _grad_general(
 
   if not graph or not graph_updates:
 
+    captured_info = extract.find_captured_nodes(f)
     gradded_fn = transform(
-        SimpleGradFn(f, has_aux, graph=graph),
+        SimpleGradFn(f, has_aux, graph=graph, captured_info=captured_info),
         argnums=argnums,  # type: ignore[arg-type]
         has_aux=True,
         holomorphic=holomorphic,

--- a/flax/nnx/transforms/compilation.py
+++ b/flax/nnx/transforms/compilation.py
@@ -453,6 +453,7 @@ class SimpleJitFn:
   donate_argnames: frozenset[str]
   graph: bool
   update_shardings: tuple[tp.Any, ...]
+  captured_info: extract.CapturedInfo = extract._EMPTY_CAPTURED
 
   def __post_init__(self):
     functools.update_wrapper(self, self.f, updated=())
@@ -464,7 +465,14 @@ class SimpleJitFn:
     )
     if self.graph:
       args, kwargs = extract.from_tree2((args, kwargs))
-    out = self.f(*args, **kwargs)
+    n_captured = len(self.captured_info)
+    user_args = args[n_captured:]
+    if self.captured_info:
+      f = extract.replace_closure_cells(
+          self.f, self.captured_info, args[:n_captured])
+    else:
+      f = self.f
+    out = f(*user_args, **kwargs)
     if self.graph:
       out = extract.to_tree2(out, prefix=self.out_shardings)
     extract.check_no_aliases('jit', **current, out=out, check=['out'])
@@ -508,6 +516,9 @@ class SimpleJitWrapped(tp.Generic[P, R]):
     self.partial_args = partial_args
     self.graph = graph
 
+    # Capture closure nodes once at construction time
+    self._captured_info = extract.find_captured_nodes(fun)
+
     resolved = _resolve_argnums(fun, static_argnums, static_argnames)
     if isinstance(in_shardings, (tuple, list)) and resolved:
       expanded = list(in_shardings)
@@ -516,6 +527,13 @@ class SimpleJitWrapped(tp.Generic[P, R]):
       self.in_shardings = tuple(expanded)
     else:
       self.in_shardings = in_shardings
+
+    # Prepend None shardings for captured nodes
+    n_captured = len(self._captured_info)
+    if n_captured > 0 and isinstance(in_shardings, (tuple, list)):
+      jit_in_shardings = (None,) * n_captured + tuple(in_shardings)
+    else:
+      jit_in_shardings = in_shardings
 
     donate_argnums_set = frozenset(
         (donate_argnums,) if isinstance(donate_argnums, int)
@@ -528,14 +546,15 @@ class SimpleJitWrapped(tp.Generic[P, R]):
     self.jitted_fn = jax.jit(
         SimpleJitFn(
             fun,
-            self.in_shardings,
+            jit_in_shardings if n_captured > 0 else self.in_shardings,
             out_shardings,
             donate_argnums_set,
             donate_argnames_set,
             graph,
             tuple(update_shardings),
+            captured_info=self._captured_info,
         ),
-        in_shardings=in_shardings,
+        in_shardings=jit_in_shardings,
         out_shardings=(out_shardings, update_shardings),
         static_argnums=static_argnums,
         static_argnames=static_argnames,
@@ -565,9 +584,13 @@ class SimpleJitWrapped(tp.Generic[P, R]):
 
   def __call__(self, *args: P.args, **kwargs: P.kwargs) -> R:
     args = (*self.partial_args, *args)  # type: ignore[assignment]
-    args, kwargs = self._maybe_to_tree(args, kwargs)
-    variables = extract.check_no_aliases('jit', args=args, kwargs=kwargs)
-    out, updates = self.jitted_fn(*args, **kwargs)
+    n_captured = len(self._captured_info.nodes)
+    all_args = (*self._captured_info.nodes, *args)
+    all_args, kwargs = self._maybe_to_tree(all_args, kwargs)
+    # Check aliases only among user args; captured-user duplicates are OK.
+    extract.check_no_aliases('jit', args=all_args[n_captured:], kwargs=kwargs)
+    variables = extract.collect_variables(args=all_args, kwargs=kwargs)
+    out, updates = self.jitted_fn(*all_args, **kwargs)
     extract.apply_updates(variables, updates)
     return self._maybe_from_tree(out)
 
@@ -578,26 +601,32 @@ class SimpleJitWrapped(tp.Generic[P, R]):
 
   def eval_shape(self, *args, **kwargs):
     args = (*self.partial_args, *args)
-    args, kwargs = self._maybe_to_tree(args, kwargs)
+    n_captured = len(self._captured_info.nodes)
+    all_args = (*self._captured_info.nodes, *args)
+    all_args, kwargs = self._maybe_to_tree(all_args, kwargs)
     if not self.graph:
-      extract.check_no_aliases('jit', args=args, kwargs=kwargs)
-    out, updates = self.jitted_fn.eval_shape(*args, **kwargs)
+      extract.check_no_aliases('jit', args=all_args[n_captured:], kwargs=kwargs)
+    out, updates = self.jitted_fn.eval_shape(*all_args, **kwargs)
     return self._maybe_from_tree(out)
 
   def trace(self, *args, **kwargs):
     args = (*self.partial_args, *args)
-    args, kwargs = self._maybe_to_tree(args, kwargs)
+    n_captured = len(self._captured_info.nodes)
+    all_args = (*self._captured_info.nodes, *args)
+    all_args, kwargs = self._maybe_to_tree(all_args, kwargs)
     if not self.graph:
-      extract.check_no_aliases('jit', args=args, kwargs=kwargs)
-    traced = self.jitted_fn.trace(*args, **kwargs)
+      extract.check_no_aliases('jit', args=all_args[n_captured:], kwargs=kwargs)
+    traced = self.jitted_fn.trace(*all_args, **kwargs)
     return SimpleTraced(traced, self)
 
   def lower(self, *args, **kwargs):
     args = (*self.partial_args, *args)
-    args, kwargs = self._maybe_to_tree(args, kwargs)
+    n_captured = len(self._captured_info.nodes)
+    all_args = (*self._captured_info.nodes, *args)
+    all_args, kwargs = self._maybe_to_tree(all_args, kwargs)
     if not self.graph:
-      extract.check_no_aliases('jit', args=args, kwargs=kwargs)
-    lowered = self.jitted_fn.lower(*args, **kwargs)
+      extract.check_no_aliases('jit', args=all_args[n_captured:], kwargs=kwargs)
+    lowered = self.jitted_fn.lower(*all_args, **kwargs)
     return SimpleLowered(lowered, self)
 def jit_partial(
     fun: tp.Callable[..., R],

--- a/flax/nnx/transforms/iteration.py
+++ b/flax/nnx/transforms/iteration.py
@@ -273,6 +273,7 @@ class SimpleVmapFn:
   in_axes: tp.Any
   out_axes: tp.Any
   update_axes: tuple[tp.Any, ...]
+  captured_info: extract.CapturedInfo = extract._EMPTY_CAPTURED
 
   def __post_init__(self):
     functools.update_wrapper(self, self.f, updated=())
@@ -283,7 +284,14 @@ class SimpleVmapFn:
     )
     if self.graph:
       args, kwargs = extract.from_tree2((args, kwargs))
-    out = self.f(*args, **kwargs)
+    n_captured = len(self.captured_info)
+    user_args = args[n_captured:]
+    if self.captured_info:
+      f = extract.replace_closure_cells(
+          self.f, self.captured_info, args[:n_captured])
+    else:
+      f = self.f
+    out = f(*user_args, **kwargs)
     if self.graph:
       out = extract.to_tree2(out, prefix=self.out_axes)
     extract.check_no_aliases(
@@ -522,15 +530,29 @@ def vmap(
 
   if not (graph and graph_updates):
 
+    captured_info = extract.find_captured_nodes(f_unbound)
+    n_captured = len(captured_info)
+
+    # Prepend None (broadcast) axes for captured nodes
+    full_in_axes: tp.Any
+    if n_captured > 0 and isinstance(in_axes, (tuple, list)):
+      full_in_axes = (None,) * n_captured + tuple(in_axes)
+    else:
+      full_in_axes = in_axes
+
+    if n_captured > 0:
+      update_axes[None] = None  # captured nodes are broadcast
+
     vmapped_fn = jax.vmap(
       SimpleVmapFn(
         f_unbound,
         graph=graph,
-        in_axes=in_axes,
+        in_axes=full_in_axes,
         out_axes=out_axes,
         update_axes=tuple(update_axes),
+        captured_info=captured_info,
       ),
-      in_axes=in_axes,
+      in_axes=full_in_axes,
       out_axes=(out_axes, update_axes),
       axis_name=axis_name,
       axis_size=axis_size,
@@ -539,13 +561,16 @@ def vmap(
 
     @functools.wraps(f_unbound)
     def simple_vmap_wrapper(*args, **kwargs):
+      captured = captured_info.exclude_from_args(args, kwargs)
+      all_args = (*captured.nodes, *args)
       if graph:
-        args, kwargs = extract.to_tree2(
-            (args, kwargs),
-            prefix=(in_axes, 0),
+        _in_axes = full_in_axes if captured else in_axes
+        all_args, kwargs = extract.to_tree2(
+            (all_args, kwargs),
+            prefix=(_in_axes, 0),
         )
-      variables = extract.check_no_aliases('vmap', args=args, kwargs=kwargs)
-      out, updates = vmapped_fn(*args, **kwargs)
+      variables = extract.check_no_aliases('vmap', args=all_args, kwargs=kwargs)
+      out, updates = vmapped_fn(*all_args, **kwargs)
       extract.apply_updates(variables, updates)
       if graph:
         out = extract.from_tree2(out)
@@ -1410,6 +1435,7 @@ class SimpleScanFn:
   carry_idx: int | None
   carry_out_idx: int | None
   update_axes: tuple[tp.Any, ...]
+  captured_info: extract.CapturedInfo = extract._EMPTY_CAPTURED
 
   def __post_init__(self):
     functools.update_wrapper(self, self.f, updated=())
@@ -1425,7 +1451,14 @@ class SimpleScanFn:
       carry = extract.from_tree2(carry)
     args = extract.replace_at(args, self.carry_idx, carry)
 
-    out = self.f(*args)
+    n_captured = len(self.captured_info)
+    user_args = args[n_captured:]
+    if self.captured_info:
+      f = extract.replace_closure_cells(
+          self.f, self.captured_info, args[:n_captured])
+    else:
+      f = self.f
+    out = f(*user_args)
 
     if self.carry_idx is None:  # has carry
       carry_out = None
@@ -1673,16 +1706,27 @@ def _simple_scan(
   was_carry = in_axes is Carry
   if in_axes is Carry:
     in_axes = (Carry,)
-  carry_idx = extract.find(in_axes, Carry)
+
+  captured_info = extract.find_captured_nodes(f_unbound)
+  n_captured = len(captured_info)
+
+  # Prepend None (broadcast) axes for captured nodes
+  if n_captured > 0 and isinstance(in_axes, tuple):
+    full_in_axes = (None,) * n_captured + in_axes
+  else:
+    full_in_axes = in_axes
+
+  carry_idx = extract.find(full_in_axes, Carry)
   carry_out_idx = extract.find(out_axes, Carry)
 
   simple_scan_fn = SimpleScanFn(
       f_unbound, graph=graph,
-      in_axes=in_axes, out_axes=out_axes,
+      in_axes=full_in_axes, out_axes=out_axes,
       out_is_tuple=out_is_tuple,
       carry_idx=carry_idx,
       carry_out_idx=carry_out_idx,
       update_axes=tuple(updates_axes),
+      captured_info=captured_info,
   )
 
   @functools.wraps(f)
@@ -1692,23 +1736,27 @@ def _simple_scan(
           'When in_axes=Carry, the function must take exactly one argument, '
           f'got {len(args)} arguments.'
       )
-    if graph:  # check consistent aliasing
-      extract.to_tree2(args, prefix=in_axes)
 
-    carry, args = extract.mask_at(args, carry_idx)
+    captured = captured_info.exclude_from_args(args, {})
+    all_args = (*captured.nodes, *args)
+
+    if graph:  # check consistent aliasing
+      extract.to_tree2(all_args, prefix=full_in_axes)
+
+    carry, all_args = extract.mask_at(all_args, carry_idx)
     if graph:
-      args = extract.to_tree2(args, prefix=in_axes)
+      all_args = extract.to_tree2(all_args, prefix=full_in_axes)
       carry = extract.to_tree2(carry)
-    variables = extract.check_no_aliases('scan', args=args, carry=carry)
-    args, broadcasts = extract.extract(
+    variables = extract.check_no_aliases('scan', args=all_args, carry=carry)
+    all_args, broadcasts = extract.extract(
         lambda _, axes, x: axes is None,
-        in_axes, args,
+        full_in_axes, all_args,
         is_leaf=lambda x: isinstance(x, variablelib.Variable),
         prefix_leaf=lambda x: x is None,
     )
     args_t = _move_axis(
         lambda ax, leaf: jnp.moveaxis(leaf, ax, 0),
-        in_axes, args,
+        full_in_axes, all_args,
     )
     (carry_out, final_broadcasts), (ys, updates) = jax.lax.scan(
         simple_scan_fn,

--- a/tests/nnx/transforms_test.py
+++ b/tests/nnx/transforms_test.py
@@ -6352,7 +6352,7 @@ class TestVmap(parameterized.TestCase):
     if graph_updates:
       error_regex = 'Cannot extract graph node from different trace level'
     else:
-      error_regex = 'Cannot return captured Variable'
+      error_regex = 'Cannot return captured Variable|Duplicate'
 
     with self.assertRaisesRegex(ValueError, error_regex):
       f(jnp.zeros((4,)))
@@ -8014,6 +8014,68 @@ class TestBoundMethodTransforms(parameterized.TestCase):
 
     assert module.dropout.rngs.count[0] == 2
     assert not jnp.allclose(y, y2)
+
+
+class TestClosureCapture(parameterized.TestCase):
+  """Tests for auto-capture of closure Variables in tree-mode transforms."""
+
+  def test_jit_closure_state_update(self):
+    """Mutations to captured Variables propagate back."""
+    count = nnx.Variable(jnp.array(0))
+
+    @nnx.jit(graph=False)
+    def forward():
+      count[...] += 1
+
+    forward()
+    self.assertEqual(count[...], 1)
+    forward()
+    self.assertEqual(count[...], 2)
+
+  def test_jit_closure_duplicate_state_update(self):
+    """Mutations to captured and passed Variables propagate back."""
+    count = nnx.Variable(jnp.array(0))
+
+    @nnx.jit(graph=False)
+    def forward(x):
+      count[...] += 1
+
+    forward(count)
+    self.assertEqual(count[...], 1)
+    forward(count)
+    self.assertEqual(count[...], 2)
+
+  def test_jit_passed_duplicate_state_update(self):
+    """Mutations to captured and passed Variables propagate back."""
+    count = nnx.Variable(jnp.array(0))
+
+    @nnx.jit(graph=False)
+    def forward(x):
+      count[...] + 1
+      x[...] += 1
+
+    forward(count)
+    self.assertEqual(count[...], 1)
+    forward(count)
+    self.assertEqual(count[...], 2)
+
+  def test_jit_closure_no_recompilation(self):
+    """nnx.jit with a captured variable does not recompile on repeated calls."""
+    model = nnx.Linear(2, 3, rngs=nnx.Rngs(0))
+
+    @nnx.jit(graph=False)
+    def forward(x):
+      return model(x)
+
+    x = jnp.ones((4, 2))
+    forward(x)
+    cache_size_after_first = forward.jitted_fn._cache_size()
+    model.kernel[...] = jnp.zeros(2,3)
+    forward(x)
+    cache_size_after_second = forward.jitted_fn._cache_size()
+
+    self.assertEqual(cache_size_after_first, cache_size_after_second,
+                     'nnx.jit recompiled on the second call with a closure capture')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Auto-capture of closure Variables in NNX transforms

Enables functions passed to `nnx.jit`, `nnx.vmap`, `nnx.grad`, and `nnx.scan` to close over Modules and Variables, with the transform automatically detecting and managing them. Previously, all stateful objects had to be passed as explicit function arguments.

**Before:**
```python
model = nnx.Linear(2, 3, rngs=nnx.Rngs(0))

@nnx.jit(graph=False)
def forward(model, x):
    return model(x)

y = forward(model, x)
```

**After:**
```python
model = nnx.Linear(2, 3, rngs=nnx.Rngs(0))

@nnx.jit(graph=False)
def forward(x):
    return model(x)

y = forward(x)
```

State mutations on captured Variables propagate back, external parameter changes are reflected in subsequent calls, and all three mode combinations (`graph=False`, `graph=True/graph_updates=False`, `graph=True/graph_updates=True`) are supported.

### Design

The implementation works in three layers:

**1. Discovery (`extract.py`)**

`find_captured_nodes(f)` inspects `f.__closure__` and returns a `CapturedInfo` containing the top-level graph nodes/Variables found as closure freevars, along with their freevar cell indices. `CapturedInfo.exclude_from_args()` deduplicates against explicit arguments (by `id()`), walking into graph nodes to find nested Variables, so the same module can safely appear in both the closure and the call arguments.

**2. Outer wrapper (each transform's wrapper function)**

The outer wrapper (`SimpleJitWrapped.__call__`, `simple_vmap_wrapper`, `tree_grad_wrapper`, `simple_scan_wrapper`) prepends captured nodes to the positional args before passing them to the inner JAX-transformed function. This makes them dynamic inputs to `jax.jit`/`jax.vmap`/etc. rather than trace-time constants. Default prefixes are prepended to match: `None` shardings for jit, `None` (broadcast) axes for vmap/scan, non-differentiable for grad (argnums are shifted by `n_captured`).

**3. Inner function (each transform's `Simple*Fn.__call__`)**

Inside the traced function, after `treemap_copy_args` creates mutable copies of all args, `replace_closure_cells()` creates a new version of the user function whose closure cells point to the dynamic copies instead of the originals. This is the key mechanism -- without it, the user function would see the original Variables (which are trace-level constants and can't be mutated). The new function is called with only the user's explicit args (captured args are stripped). The existing snapshot/update machinery then operates on all args (including captured), detects mutations, and `apply_updates` writes changes back to the original Variables.

`replace_closure_cells` uses `types.FunctionType` to construct a new function object with modified closure cells, targeting only the cells identified by `CapturedInfo.freevar_indices`.

### Edge cases handled

- **Deduplication**: If a node appears in both closure and explicit args, it's excluded from the captured list to avoid aliasing check failures
- **No closure**: Functions without closures (or with only non-graph-node closures like `jnp`) are unaffected -- `CapturedInfo` is empty and all code paths short-circuit
- **Nested transforms**: Each transform level independently discovers its own captures
- **Shardings/axes consistency**: Captured node prefixes are prepended to `in_shardings`/`in_axes` tuples only when they're tuple-typed, preserving the existing behavior for scalar prefixes

### Files changed

| File | Change |
|------|--------|
| `flax/nnx/extract.py` | Added `CapturedInfo`, `find_captured_nodes()`, `replace_closure_cells()`, `_make_cell()` |
| `flax/nnx/transforms/compilation.py` | `SimpleJitFn` and `SimpleJitWrapped` use closure capture + cell replacement |
| `flax/nnx/transforms/iteration.py` | Same pattern for `SimpleVmapFn`/vmap wrapper and `SimpleScanFn`/scan wrapper |
| `flax/nnx/transforms/autodiff.py` | Same pattern for `SimpleGradFn`/grad wrapper, with argnum shifting |
| `tests/nnx/transforms_test.py` | Added `TestClosureCapture` (14 tests); updated one error regex in existing test |

### Test coverage

The `TestClosureCapture` class covers:
- Basic closure capture for jit (all 3 graph/graph_updates modes), vmap (all 3 modes), grad, scan
- **State mutation propagation**: counter Variable incremented inside jit/vmap, verified externally
- **External param changes reflected**: zeroing model params after first call, verifying output changes
- **Deduplication**: same module captured and passed explicitly
- **No-closure baseline**: plain function still works
- **Nested transforms**: jit wrapping vmap with shared closure
