### PR TITLE
fix cached_partial for raw array attributes

### DIFF
--- a/flax/nnx/graphlib.py
+++ b/flax/nnx/graphlib.py
@@ -1517,7 +1517,8 @@ class StaticCache(tp.NamedTuple):
   graphdef: GraphDef[tp.Any]
   final_graphdef: GraphDef[tp.Any]
   paths: tuple[PathParts, ...]
-  variables: list[Variable[tp.Any]]
+  # Variables or raw array leaves (e.g. jax.Array attributes)
+  variables: list[Variable[tp.Any] | tp.Any]
   new_ref_index: RefMap
   new_index_ref: IndexMap
 
@@ -1525,7 +1526,7 @@ class StaticCache(tp.NamedTuple):
   def create(
     graphdef: GraphDef[tp.Any],
     paths: tuple[PathParts, ...],
-    variables: list[Variable[tp.Any]],
+    variables: list[Variable[tp.Any] | tp.Any],
     new_ref_index: RefMap,
   ):
     new_index_ref = IndexMap.from_refmap(new_ref_index)
@@ -1629,6 +1630,12 @@ def _cached_partial(
   after each call to the cached function, otherwise an error will be raised. Temporary
   mutations are allowed (e.g. the use of ``Module.sow``) as long as they are cleaned up before
   the function returns (e.g. via ``nnx.pop``).
+
+  Raw array attributes (e.g. ``jax.Array`` or ``numpy.ndarray`` values not wrapped in a
+  ``Variable``) found in the cached graph nodes are treated as read-only: their values are
+  visible inside the function but any updates to them are not propagated back to the
+  original graph nodes. Attributes that must change across cached calls should be
+  wrapped in an ``nnx.Variable``.
 
   Args:
     f: A function to cache.
@@ -1832,8 +1839,12 @@ class SplitContext:
         leaves = node_static_cache.variables
       else:
         paths = None
+        # non-Variable leaves (e.g. raw arrays) are passed through as-is
         leaves = [
-          variable.get_raw_value() for variable in node_static_cache.variables
+          variable.get_raw_value()
+          if isinstance(variable, Variable)
+          else variable
+          for variable in node_static_cache.variables
         ]
     else:
       graphdef, flat_state = flatten(
@@ -1967,6 +1978,10 @@ class MergeContext:
               f'leaves in the state, got {len(leaves)}'
             )
           for variable, leaf in zip(static_cache_node.variables, leaves):
+            if not isinstance(variable, Variable):
+              # raw array attributes are read-only under cached_partial,
+              # updates are not propagated back to the original graph nodes
+              continue
             if isinstance(leaf, Variable):
               variable.update_from_state(leaf)
             else:

--- a/tests/nnx/transforms_test.py
+++ b/tests/nnx/transforms_test.py
@@ -608,6 +608,32 @@ class TestJIT(parameterized.TestCase):
     cached_m2 = cached_f(m)
     self.assertIs(cached_m, cached_m2)
 
+  def test_cache_args_raw_arrays(self):
+    class Foo(nnx.Module):
+      def __init__(self):
+        self.a = jnp.arange(3, dtype=jnp.float32)  # raw jax.Array
+        self.b = np.arange(3, dtype=np.float32)  # raw np.ndarray
+        self.count = nnx.Variable(jnp.array(0))
+
+      def __call__(self, x):
+        self.count[...] += 1
+        return self.a * x + self.b
+
+    m = Foo()
+
+    @nnx.jit(graph=True, graph_updates=True)
+    def f(m: Foo, x):
+      return m(x) + 1
+
+    x = jnp.ones(3)
+    expected = f(m, x)
+
+    cached_f = nnx.compat.cached_partial(f, m)
+    np.testing.assert_allclose(cached_f(x), expected)
+    np.testing.assert_allclose(cached_f(x), expected)
+    # Variable updates are propagated back to the original node
+    self.assertEqual(m.count[...], 3)
+
   @parameterized.parameters(True, False)
   def test_cache_args_functional(self, graph_mode):
     m = nnx.Linear(2, 3, rngs=nnx.Rngs(0))


### PR DESCRIPTION
# What does this PR do?

nnx.cached_partial crashes on raw jax.Array / numpy.ndarray attributes. The mechanism:
StaticCache.variables stores flatten() leaves, which can be raw arrays, but two downstream
sites assume every entry is a Variable — the flatten with_paths=False fast path calls
get_raw_value() on each cached entry (the reported crash), and the unflatten cache-update
loop calls update_from_state/set_raw_value (a latent crash on the output path).

This implements the read-only behavior discussed in the issue: raw array leaves are passed
through as-is when flattening, and the merge update loop skips non-Variable entries, so
Variable propagation is unchanged. The cached_partial docstring now documents the read-only
semantics, and the StaticCache.variables annotation is widened to match.

No warning is emitted when a cached function would have updated a raw array: comparing
returned leaves to cached arrays by identity always differs after jit, and by value would
force device syncs, so the constraint is documented instead.

Adds a regression test with raw jax.Array and np.ndarray attributes alongside an
nnx.Variable counter that must keep receiving updates across cached calls;
tests/nnx/transforms_test.py and tests/nnx/graph_utils_test.py pass on CPU.

Fixes #5109

## Checklist
- [x] This PR fixes a minor issue (e.g.: typo or small bug) or improves the docs (you can dismiss the other checks if that's the case).
- [x] This change is discussed in a Github issue/[discussion](https://github.com/google/flax/discussions) (please add a link). https://github.com/google/flax/issues/5109
- [x] The documentation and docstrings adhere to the [documentation guidelines](https://github.com/google/flax/blob/main/docs/README.md#how-to-write-code-documentation).
- [x] This change includes necessary high-coverage tests. (No quality testing = no merge!)
