### PR TITLE
replace bare asserts with ValueError in NNX attention validation

### DIFF
--- a/flax/nnx/nn/attention.py
+++ b/flax/nnx/nn/attention.py
@@ -49,6 +49,17 @@ from flax.typing import (
 Array = jax.Array
 
 
+def _validate_qkv_shapes(query, key, value=None):
+  arrays = (query, key, value) if value is not None else (query, key)
+  names = 'q, k, v' if value is not None else 'q, k'
+  if not all(a.ndim == arrays[0].ndim for a in arrays[1:]):
+    ndims = ', '.join(str(a.ndim) for a in arrays)
+    raise ValueError(f'{names} must have same rank, but got {ndims}.')
+  if not all(a.shape[:-3] == arrays[0].shape[:-3] for a in arrays[1:]):
+    shapes = ', '.join(str(a.shape) for a in arrays)
+    raise ValueError(f'{names} batch dims must match, but got shapes {shapes}.')
+
+
 def dot_product_attention_weights(
   query: Array,
   key: Array,
@@ -107,9 +118,11 @@ def dot_product_attention_weights(
   query, key = promote_dtype((query, key), dtype=dtype)  # type: ignore[bad-unpacking]
   dtype = query.dtype
 
-  assert query.ndim == key.ndim, 'q, k must have same rank.'
-  assert query.shape[:-3] == key.shape[:-3], 'q, k batch dims must match.'
-  assert query.shape[-1] == key.shape[-1], 'q, k depths must match.'
+  _validate_qkv_shapes(query, key)
+  if query.shape[-1] != key.shape[-1]:
+    raise ValueError(
+      f'q, k depths must match, but got {query.shape[-1]} and {key.shape[-1]}.'
+    )
 
   # check if we need to broadcast Key heads to match Query heads
   is_gqa = False
@@ -135,7 +148,6 @@ def dot_product_attention_weights(
   else:
     q_heads = query.shape[-2]
     einsum_str = '...qhd,...khd->...hqk'
-    assert query.shape[-2] == key.shape[-2], 'q, k num_heads must match.'
 
   # calculate attention matrix
   depth = query.shape[-1]
@@ -255,11 +267,12 @@ def dot_product_attention(
   query, key, value = promote_dtype((query, key, value), dtype=dtype)  # type: ignore[bad-unpacking]
   dtype = query.dtype
 
-  assert key.ndim == query.ndim == value.ndim, 'q, k, v must have same rank.'
-  assert (
-    query.shape[:-3] == key.shape[:-3] == value.shape[:-3]
-  ), 'q, k, v batch dims must match.'
-  assert key.shape[-3] == value.shape[-3], 'k, v lengths must match.'
+  _validate_qkv_shapes(query, key, value)
+  if key.shape[-3] != value.shape[-3]:
+    raise ValueError(
+      f'k, v lengths must match, but got {key.shape[-3]} and '
+      f'{value.shape[-3]}.'
+    )
 
   # Criteria that invoke the more optimized dot product attention
   if dropout_rate == 0.0 and module is None:
@@ -910,9 +923,11 @@ def combine_masks(
   masks_list = [m for m in masks if m is not None]
   if not masks_list:
     return None
-  assert all(
-    map(lambda x: x.ndim == masks_list[0].ndim, masks_list)
-  ), f'masks must have same rank: {tuple(map(lambda x: x.ndim, masks_list))}'
+  if not all(m.ndim == masks_list[0].ndim for m in masks_list):
+    raise ValueError(
+      f'masks must have same rank, but got '
+      f'{tuple(m.ndim for m in masks_list)}.'
+    )
   mask, *other_masks = masks_list
   for other_mask in other_masks:
     mask = jnp.logical_and(mask, other_mask)

--- a/tests/nnx/nn/attention_test.py
+++ b/tests/nnx/nn/attention_test.py
@@ -383,6 +383,23 @@ class TestGQADotProductAttention(parameterized.TestCase):
     np.testing.assert_allclose(nnx_out, jax_out, atol=1e-3, rtol=1e-3)
 
 
+class TestDotProductAttentionValidation(parameterized.TestCase):
+
+  @parameterized.parameters(
+    ((2, 16, 4, 8), (16, 4, 8), (16, 4, 8), 'same rank'),
+    ((2, 16, 4, 8), (3, 16, 4, 8), (3, 16, 4, 8), 'batch dims'),
+    ((2, 16, 4, 8), (2, 16, 4, 8), (2, 15, 4, 8), 'lengths must match'),
+    ((2, 16, 4, 8), (2, 16, 4, 7), (2, 16, 4, 8), 'depths must match'),
+  )
+  def test_invalid_shapes(self, q_shape, k_shape, v_shape, match):
+    q = jnp.ones(q_shape)
+    k = jnp.ones(k_shape)
+    v = jnp.ones(v_shape)
+    with self.assertRaisesRegex(ValueError, match):
+      nnx.dot_product_attention(q, k, v, dropout_rate=0.1,
+                                dropout_rng=jax.random.key(0))
+
+
 if __name__ == '__main__':
   absltest.main()
 


### PR DESCRIPTION
Fixes #5496

`dot_product_attention`, `dot_product_attention_weights`, and `combine_masks` used bare `assert` for input shape validation. Under `python -O`, these are stripped and invalid inputs silently produce wrong-shaped output on the dropout/module path.

Replaced with `if/raise ValueError`. Also removed one dead-code assert in the non-GQA else branch where the condition was already guaranteed by the enclosing if/else.