### PR TITLE
Fixed CI issues: doctest, test examples

### DIFF
--- a/docs/guides/converting_and_upgrading/orbax_upgrade_guide.rst
+++ b/docs/guides/converting_and_upgrading/orbax_upgrade_guide.rst
@@ -26,10 +26,6 @@ Throughout the guide, you will be able to compare code examples with and without
   import jax.numpy as jnp
   import numpy as np
 
-  # Orbax needs to have asyncio enabled in the Colab environment.
-  import nest_asyncio
-  nest_asyncio.apply()
-
   # Set up the directory.
   import os
   import shutil

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,10 +46,7 @@ testing = [
     "ml-collections",
     "mypy",
     "opencv-python",
-    # Set protobuf version to prevent error in
-    # examples/mnist/train_test.py::TrainTest::test_train_and_evaluate
-    # Failed to construct dataset "mnist", builder_kwargs "{}": Value out of range: 11594722
-    "protobuf<6",
+    "protobuf",
     "pytest",
     "pytest-cov",
     "pytest-custom_exit_code",
@@ -61,13 +58,17 @@ testing = [
     "tensorflow_datasets",
     "tensorflow_cpu>=2.12.0; python_version<'3.13'", # to fix Numpy np.bool8 deprecation error
     "tensorflow_cpu>=2.20.0; python_version>='3.13' and python_version<'3.14'",
+    "tensorboard",
     # Temporary fix for https://github.com/google/flax/issues/5143
     "keras<3.13",
     "torch",
     "treescope>=0.1.1; python_version>='3.10'",
     "cloudpickle>=3.0.0",
     "ale-py>=0.10.2; python_version<'3.14'",
-    "grain>=0.2",
+    # Pinned grain version to 0.2.16 to prevent the error:
+    # absl.flags._exceptions.UnparsedFlagAccessError: Trying to access flag --grain_enable_multiprocess_worker_profiling before flags were parsed.
+    # in the test: examples/gemma/input_pipeline_test.py::InputPipelineTest::test_eval_ds0
+    "grain==0.2.16",
 ]
 docs = [
     "sphinx==6.2.1",

--- a/tests/download_dataset_metadata.sh
+++ b/tests/download_dataset_metadata.sh
@@ -16,7 +16,7 @@ if [ -d "../.tfds/metadata" ]; then
   echo 'TFDS metadata already exists.';
 else
   echo 'TFDS metadata does not exist. Downloading...';
-  git clone --branch v4.9.9 --depth 3 --filter=blob:none --sparse https://github.com/tensorflow/datasets/
+  git clone --branch v4.9.10 --depth 3 --filter=blob:none --sparse https://github.com/tensorflow/datasets/
   cd datasets
   git sparse-checkout set tensorflow_datasets/testing/metadata
   mkdir ../../.tfds


### PR DESCRIPTION
- Fixed failing doctest by removing nest_async usage from linen orbax guide (should be an old hack)
- Fixed failing pytest on examples:
  - tdfs issue: updated protobuf version and tfds metadata for mock datasets
  - pinned grain version as 0.2.17 has an problem to identify and report on their repo
  - added tensorboard to pyproject.toml testing (somehow it is not installed anymore)