### PR TITLE
Add Dependabot configuration for dependency updates

### DIFF
--- a/.github/.github/dependabot.yml
+++ b/.github/.github/dependabot.yml
@@ -1,0 +1,19 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 7
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
Configure Dependabot for pip and GitHub Actions updates. Taken from JAX: https://github.com/jax-ml/jax/blob/main/.github/dependabot.yml