### PR TITLE
fix(attention): validate dropout_rate range and require dropout_rng w…

### DIFF
--- a/flax/nnx/nn/attention.py
+++ b/flax/nnx/nn/attention.py
@@ -104,6 +104,16 @@ def dot_product_attention_weights(
   Returns:
     Output of shape `[batch..., num_heads, q_length, kv_length]`.
   """
+  if not (0.0 <= dropout_rate < 1.0):
+    raise ValueError(
+      f'dropout_rate must be in the range [0, 1), got {dropout_rate!r}. '
+      'A negative or NaN value silently disables dropout without regularizing.'
+    )
+  if not deterministic and dropout_rate > 0.0 and dropout_rng is None:
+    raise ValueError(
+      'dropout_rng must be provided when dropout_rate > 0.0 and '
+      'deterministic=False. Pass a JAX PRNGKey as dropout_rng.'
+    )
   query, key = promote_dtype((query, key), dtype=dtype)  # type: ignore[bad-unpacking]
   dtype = query.dtype
 


### PR DESCRIPTION
In `dot_product_attention_weights`, a negative or NaN `dropout_rate` silently passes the `dropout_rate > 0.0` guard, causing dropout to be skipped without any warning or error — the user believes regularization is applied but it isn't.

Additionally, when `dropout_rate > 0.0` and `deterministic=False` but `dropout_rng=None`, the error surfaces deep inside `jax.random.bernoulli` as `TypeError: unexpected PRNG key type NoneType` instead of a helpful message pointing to the missing argument.

**Fix:** add two early validation checks at the top of `dot_product_attention_weights`:
1. `ValueError` if `dropout_rate` is not in `[0, 1)`
2. `ValueError` if dropout will be applied but `dropout_rng is None`

Fixes #5497.

## Checklist

- [x] This PR fixes a minor issue (e.g.: typo or small bug) or improves the docs (you can dismiss the other checks if that's the case).
- [x] This change is discussed in a GitHub issue([#5497](https://github.com/google/flax/issues/5497)).
- [x] The documentation and docstrings adhere to the [documentation guidelines](https://github.com/google/flax/blob/main/docs/README.md#how-to-write-code-documentation).