### PR TITLE
fix(nnx): raise ValueError instead of assert for q/k/v shape checks in attention

### DIFF
--- a/flax/nnx/nn/attention.py
+++ b/flax/nnx/nn/attention.py
@@ -107,9 +107,15 @@ def dot_product_attention_weights(
   query, key = promote_dtype((query, key), dtype=dtype)  # type: ignore[bad-unpacking]
   dtype = query.dtype
 
-  assert query.ndim == key.ndim, 'q, k must have same rank.'
-  assert query.shape[:-3] == key.shape[:-3], 'q, k batch dims must match.'
-  assert query.shape[-1] == key.shape[-1], 'q, k depths must match.'
+  # Plain `assert` is dropped under `python -O`, which would let a rank or
+  # shape mismatch silently fall through to the einsum below and return a
+  # wrong-shaped result instead of raising.
+  if query.ndim != key.ndim:
+    raise ValueError('q, k must have same rank.')
+  if query.shape[:-3] != key.shape[:-3]:
+    raise ValueError('q, k batch dims must match.')
+  if query.shape[-1] != key.shape[-1]:
+    raise ValueError('q, k depths must match.')
 
   # check if we need to broadcast Key heads to match Query heads
   is_gqa = False
@@ -255,11 +261,18 @@ def dot_product_attention(
   query, key, value = promote_dtype((query, key, value), dtype=dtype)  # type: ignore[bad-unpacking]
   dtype = query.dtype
 
-  assert key.ndim == query.ndim == value.ndim, 'q, k, v must have same rank.'
-  assert (
-    query.shape[:-3] == key.shape[:-3] == value.shape[:-3]
-  ), 'q, k, v batch dims must match.'
-  assert key.shape[-3] == value.shape[-3], 'k, v lengths must match.'
+  # Plain `assert` is dropped under `python -O`, which would let a rank or
+  # shape mismatch silently fall through to the einsums below and return a
+  # wrong-shaped result instead of raising (the fast path a few lines down
+  # is backstopped by jax.nn.dot_product_attention's own checks, but this
+  # slow path -- used whenever dropout_rate > 0 or module is not None -- is
+  # not).
+  if not (key.ndim == query.ndim == value.ndim):
+    raise ValueError('q, k, v must have same rank.')
+  if not (query.shape[:-3] == key.shape[:-3] == value.shape[:-3]):
+    raise ValueError('q, k, v batch dims must match.')
+  if key.shape[-3] != value.shape[-3]:
+    raise ValueError('k, v lengths must match.')
 
   # Criteria that invoke the more optimized dot product attention
   if dropout_rate == 0.0 and module is None:

--- a/tests/nnx/nn/attention_test.py
+++ b/tests/nnx/nn/attention_test.py
@@ -325,6 +325,23 @@ class TestGQADotProductAttention(parameterized.TestCase):
     with self.assertRaisesRegex(ValueError, "must be a multiple"):
         nnx.dot_product_attention(query, key, value)
 
+  def test_rank_mismatch_raises_under_dropout_path(self):
+    # Regression test for https://github.com/google/flax/issues/5496
+    # The dropout_rate > 0 path used `assert` for q/k/v rank and shape
+    # invariants. `assert` is compiled out under `python -O`, which let a
+    # rank mismatch fall through to the einsum and silently return a
+    # wrong-shaped output instead of raising. The fast path (dropout_rate==0,
+    # module=None) isn't affected since jax.nn.dot_product_attention does
+    # its own validation, so this exercises the slow path specifically.
+    query = jax.random.normal(jax.random.key(0), (2, 16, 4, 8))  # rank 4
+    key = jax.random.normal(jax.random.key(1), (16, 4, 8))  # rank 3
+    value = jax.random.normal(jax.random.key(2), (16, 4, 8))  # rank 3
+
+    with self.assertRaisesRegex(ValueError, "must have same rank"):
+      nnx.dot_product_attention(
+        query, key, value, dropout_rate=0.1, dropout_rng=jax.random.key(3)
+      )
+
   def test_gqa_multihead_attention(self):
     in_feat = 128
     n_heads = 32


### PR DESCRIPTION
## What

`flax.nnx.nn.attention.dot_product_attention` (and `dot_product_attention_weights`) validate q/k/v rank and shape invariants with plain `assert` statements. Python strips `assert` under `-O` / `PYTHONOPTIMIZE=1`, which is common in production serving. On the slow path -- taken whenever `dropout_rate > 0` or a `module` is passed for sowing attention weights -- a rank or shape mismatch then silently falls through to the einsum instead of raising, and returns a **wrong-shaped output with no error at all**.

```python
import jax
import flax.nnx as nnx

attn = nnx.nn.attention.dot_product_attention
q = jax.random.normal(jax.random.PRNGKey(0), (2, 16, 4, 8))  # rank 4
k = jax.random.normal(jax.random.PRNGKey(0), (16, 4, 8))     # rank 3 (mismatch)
v = jax.random.normal(jax.random.PRNGKey(0), (16, 4, 8))     # rank 3 (mismatch)
out = attn(q, k, v, dropout_rate=0.1, dropout_rng=jax.random.PRNGKey(1))
print("result shape:", out.shape)
# python    repro.py -> AssertionError: q, k, v must have same rank.
# python -O repro.py -> result shape: (2, 16, 4, 8)   (silently wrong, no error)
```

## Root cause

The fast path (`dropout_rate == 0`, `module is None`) delegates to `jax.nn.dot_product_attention`, which does its own validation regardless of `-O`, so it was never affected. The slow path's own checks (lines ~110-112, ~258-262 before this change) are bare `assert`s, which Python compiles out entirely under `-O` -- there's no runtime check left at all, not even a degraded one.

## Fix

Replaced the asserts in both `dot_product_attention_weights` and `dot_product_attention` with explicit `if ...: raise ValueError(...)`, so the same clear error is raised with or without `-O`. No behavior change in the normal (non-`-O`) case -- same exceptions, same messages, just `ValueError` instead of `AssertionError` (matching the existing `ValueError` used a few lines below for the GQA head-count check, which already used explicit raises rather than assert).

## Checklist

- [x] New `test_rank_mismatch_raises_under_dropout_path` regression test, asserting a `ValueError` on the dropout-path rank mismatch from the issue repro
- [x] Verified independently (plain Python, no JAX) that `assert` is compiled out under `-O` while `if: raise` is not
- [x] Existing `test_gqa_invalid_heads` (and other attention tests) unaffected -- this only swaps the exception type and is unconditional regardless of `-O`

Fixes #5496