### PR TITLE
docs: clarify shape dynamics and add example for make_causal_mask

### DIFF
--- a/flax/linen/attention.py
+++ b/flax/linen/attention.py
@@ -864,15 +864,34 @@ def make_causal_mask(
 ) -> Array:
   """Make a causal mask for self-attention.
 
-  In case of 1d inputs (i.e., ``[batch..., len]``, the self-attention weights
+  This utility creates a boolean mask used to prevent attention mechanisms from
+  looking at future tokens (e.g., in autoregressive language modeling).
+
+  ``x`` is used only for its shape; its values are never read. The trailing
+  dimension is treated as the sequence length, and any leading dimensions
+  are treated as batch dimensions.
+
+  In case of inputs with shape ``[batch..., len]``, the self-attention weights
   will be ``[batch..., heads, len, len]`` and this function will produce a
-  causal mask of shape ``[batch..., 1, len, len]``.
+  causal mask of shape ``[batch..., 1, len, len]``, which cleanly broadcasts
+  across the head dimension inside MultiHeadAttention.
+
+  Example::
+
+    >>> import jax.numpy as jnp
+    >>> from flax.linen.attention import make_causal_mask
+    >>> # Simulating a batch of 2 sequences, each of length 3
+    >>> x = jnp.ones((2, 3))
+    >>> mask = make_causal_mask(x)
+    >>> mask.shape
+    (2, 1, 3, 3)
 
   Args:
-    x: input array of shape ``[batch..., len]``
-    extra_batch_dims: number of batch dims to add singleton axes for, none by
-      default
-    dtype: mask return dtype
+    x: A reference array whose shape ``[batch..., len]`` determines the
+      shape of the returned mask. Its values are not used.
+    extra_batch_dims: Number of batch dims to add singleton axes for, none by
+      default.
+    dtype: The data type of the returned mask array (defaults to ``jnp.float32``).
 
   Returns:
     A ``[batch..., 1, len, len]`` shaped causal mask for 1d attention.


### PR DESCRIPTION
Closes #1520

### What does this PR do?
This PR enhances the documentation for the `make_causal_mask` utility function by clarifying its tensor shape dynamics and explaining how its output shape `[batch..., 1, len, len]` seamlessly broadcasts across head dimensions within `MultiHeadAttention`.

### Changes Made:
* Updated the core docstring in `flax/linen/attention.py`.
* Added a clear, functional description relating the function to autoregressive language modeling.
* Provided a concrete, reproducible code example showing input and output shapes using standard doctest syntax.

## Checklist
- [x] This PR fixes a minor issue (e.g.: typo or small bug) or improves the docs (you can dismiss the other checks if that's the case).
- [x] This change is discussed in a Github issue/[discussion](https://github.com/google/flax/issues/1520).
- [x] The documentation and docstrings adhere to the [documentation guidelines](https://github.com/google/flax/blob/main/docs/README.md#how-to-write-code-documentation).
- [ ] This change includes necessary high-coverage tests. (No quality testing = no merge!) *[Note: Dismissed as this is a pure docstring documentation enhancement]*