### PR TITLE
Add pickle/cloudpickle round-trip tests for Linen modules (#1481)

### DIFF
--- a/tests/pickle_test.py
+++ b/tests/pickle_test.py
@@ -12,11 +12,31 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Tests for flax.errors."""
+"""Tests for pickling flax objects."""
 
-from absl.testing import absltest
-from flax.errors import FlaxError, ScopeVariableNotFoundError
 import pickle
+
+from absl.testing import absltest, parameterized
+import cloudpickle
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from flax import linen as nn
+from flax.errors import FlaxError, ScopeVariableNotFoundError
+
+
+class MLP(nn.Module):
+  # Defined at module level so stdlib pickle can serialize it by reference.
+  hidden: int
+  out: int
+
+  @nn.compact
+  def __call__(self, x):
+    x = nn.Dense(self.hidden)(x)
+    x = nn.relu(x)
+    return nn.Dense(self.out)(x)
+
 
 class ErrorrsTest(absltest.TestCase):
   def test_exception_can_be_pickled(self):
@@ -28,6 +48,75 @@ class ErrorrsTest(absltest.TestCase):
     self.assertIn('varname', str(unpicked_ex))
     self.assertIn('#flax.errors.ScopeVariableNotFoundError', str(unpicked_ex))
     self.assertNotIn('#flax.errors.FlaxError', str(unpicked_ex))
+
+
+class ModulePickleTest(parameterized.TestCase):
+  def assert_roundtrip_identical(self, module, pickler):
+    """Round-trips ``module`` through ``pickler`` and checks behavior matches."""
+    x = jnp.ones((2, 4))
+    # Initialize before dumping so the module has been bound at least once:
+    # internal state from init/apply must not leak into the payload (#1481).
+    params = module.init(jax.random.PRNGKey(0), x)
+    restored = pickler.loads(pickler.dumps(module))
+    # The restored module must come back unbound.
+    self.assertIsNone(restored.scope)
+    y_original = module.apply(params, x)
+    y_restored = restored.apply(params, x)
+    np.testing.assert_array_equal(
+      np.asarray(y_original), np.asarray(y_restored)
+    )
+    restored_params = restored.init(jax.random.PRNGKey(0), x)
+    jax.tree_util.tree_map(
+      np.testing.assert_array_equal, params, restored_params
+    )
+    return restored
+
+  def test_dense_roundtrip_pickle(self):
+    # Stdlib pickle serializes functions by reference, so field values must
+    # be importable top-level functions (zeros/ones are, lecun_normal is not).
+    module = nn.Dense(
+      features=3,
+      kernel_init=nn.initializers.ones_init(),
+      bias_init=nn.initializers.zeros_init(),
+    )
+    restored = self.assert_roundtrip_identical(module, pickle)
+    self.assertEqual(module, restored)
+
+  def test_dense_roundtrip_cloudpickle(self):
+    # cloudpickle serializes the default initializer closures by value, so
+    # the default Dense round-trips. No object-equality check: the restored
+    # initializers are equivalent copies, not identical function objects.
+    self.assert_roundtrip_identical(nn.Dense(features=3), cloudpickle)
+
+  def test_pickle_default_initializer_limitation(self):
+    # Known limitation: the default kernel initializer (lecun_normal) is a
+    # closure created inside jax.nn.initializers.variance_scaling, which
+    # stdlib pickle cannot serialize by reference. This is the main reason
+    # cloudpickle support (#1475) matters. If this test starts failing, the
+    # limitation was lifted and the docs/tests should be updated.
+    with self.assertRaises((AttributeError, pickle.PicklingError)):
+      pickle.dumps(nn.Dense(features=3))
+
+  @parameterized.named_parameters(
+    ('pickle', pickle), ('cloudpickle', cloudpickle)
+  )
+  def test_nested_module_roundtrip(self, pickler):
+    module = MLP(hidden=8, out=2)
+    restored = self.assert_roundtrip_identical(module, pickler)
+    self.assertEqual(module, restored)
+
+  def test_cloudpickle_locally_defined_module(self):
+    # Modules defined in a local scope (e.g. a notebook cell) can only be
+    # serialized by value, which cloudpickle supports and stdlib pickle
+    # does not. This is the use case fixed by PR #1475.
+    class LocalDense(nn.Module):
+      features: int
+
+      @nn.compact
+      def __call__(self, x):
+        return nn.Dense(self.features)(x)
+
+    self.assert_roundtrip_identical(LocalDense(features=3), cloudpickle)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fixes #1481

### Description
This PR introduces unit tests ensuring that Flax Linen Modules can be safely
serialized and deserialized via `pickle` and `cloudpickle` without leaking
internal binding state. All new assertions are isolated within
`tests/pickle_test.py`; no library code is modified.

### Changes Introduced
* Created `ModulePickleTest` with a shared helper `assert_roundtrip_identical`
  that initializes the module *before* dumping (so it has been bound at least
  once), verifies the restored module comes back unbound (`scope is None`),
  and asserts `apply` outputs and freshly-`init`-ed parameters are
  bit-identical before and after round-tripping.
* Added 6 test cases covering:
  * `nn.Dense` with explicitly picklable initializers via stdlib `pickle`
    (with full object equality), and *default* `nn.Dense` via `cloudpickle`.
  * A compact MLP with nested submodules and random default initializers,
    via both picklers.
  * A module class defined in a local scope (the notebook use case fixed in
    #1475), via `cloudpickle`.

### Technical Findings
* **JAX initializer closure limitation:** default `nn.Dense` fails stdlib
  pickling because the default kernel initializer (`lecun_normal`) is a
  closure created inside `jax.nn.initializers.variance_scaling`, which pickle
  cannot serialize by reference. Rather than modifying core code, this is
  documented via an expected-failure canary test
  (`test_pickle_default_initializer_limitation`) — if it ever starts failing,
  the limitation was lifted and the tests should be updated.
* **Cloudpickle function identity:** cloudpickle restores initializer closures
  by value, so restored function fields are equivalent copies rather than
  identical objects. The default-Dense cloudpickle test therefore validates
  behavioral equality (outputs and re-initialized parameters) instead of
  dataclass equality.
* **dill interplay (raised in the issue):** nothing in this test file's import
  chain pulls in dill, so the dill/cloudpickle test-setup conflict described
  in #1481 does not affect these tests. `cloudpickle>=3.0.0` is already in the
  `testing` extras, so CI needs no dependency changes.

### Checklist
- [ ] This PR fixes a minor issue (e.g.: typo or small bug) or improves the docs.
- [x] This change is discussed in a Github issue/discussion: #1481
- [ ] The documentation and docstrings adhere to the documentation guidelines.
- [x] This change includes necessary high-coverage tests. (No quality testing = no merge!)