### PR TITLE
Fix tracing cache misses in nnx.cond and nnx.switch (#5512)

### DIFF
--- a/flax/nnx/transforms/general.py
+++ b/flax/nnx/transforms/general.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import functools
+import types
 import typing as tp
 
 from flax.nnx import (
@@ -22,6 +23,32 @@ from flax.typing import MISSING, Missing
 
 A = tp.TypeVar('A')
 F = tp.TypeVar('F', bound=tp.Callable[..., tp.Any])
+
+_FN_WRAPPERS_ATTR = '_nnx_fn_wrappers'
+
+
+def get_fn_wrapper(cls: type, f: tp.Callable[..., tp.Any], *keys):
+  """Creates a ``cls(f, *keys)`` wrapper, reusing instances across calls.
+
+  JAX's control-flow tracing caches hold a weakref to the traced callable
+  and evict the entry when it is garbage collected, so creating a transient
+  wrapper on every call guarantees a tracing cache miss (see issue #5512).
+  For plain functions the wrapper is stored in the function's ``__dict__``,
+  giving it the same lifetime as the function itself. Other callables (bound
+  methods, partials, callable objects) get a fresh wrapper per call.
+  """
+  if type(f) is types.FunctionType:
+    cache = f.__dict__.setdefault(_FN_WRAPPERS_ATTR, {})
+    key = (cls, *keys)
+    entry = cache.get(key)
+    # functools.wraps can copy this cache dict onto other functions, so
+    # validate that the entry was created for this exact function.
+    if entry is not None and entry[0] is f:
+      return entry[1]
+    wrapper = cls(f, *keys)
+    cache[key] = (f, wrapper)
+    return wrapper
+  return cls(f, *keys)
 
 
 # -------------------------------
@@ -158,6 +185,35 @@ def split_inputs(
 
   return split_inputs_wrapper  # type: ignore
 
+class MergeInputsFn:
+  # __slots__ keeps the instance __dict__-free: outer decorators that apply
+  # ``functools.wraps`` to this wrapper (e.g. jax.checkpoint) copy the wrapped
+  # callable's __dict__, and leaked ``f``/``ctxtag`` entries would corrupt
+  # other wrapper dataclasses further up the chain (e.g. CustomVjpFnWrapper).
+  # __weakref__ is required by jax's weakref-based tracing caches.
+  __slots__ = ('f', 'ctxtag', '__weakref__')
+
+  def __init__(self, f: tp.Callable[..., tp.Any], ctxtag: str):
+    self.f = f
+    self.ctxtag = ctxtag
+
+  @property
+  def __wrapped__(self):
+    return self.f
+
+  @property
+  def __name__(self):
+    return getattr(self.f, '__name__', repr(self.f))
+
+  def __call__(self, *pure_args):
+    args = extract.from_tree(pure_args, ctxtag=self.ctxtag, is_inner=True)
+    out = self.f(*args)
+    args_out = extract.clear_non_graph_nodes(args)
+    pure_args_out, pure_out = extract.to_tree(
+      (args_out, out), ctxtag=self.ctxtag
+    )
+    return pure_args_out, pure_out
+
 @tp.overload
 def merge_inputs(
   *,
@@ -192,12 +248,4 @@ def merge_inputs(
   if isinstance(f, Missing):
     return functools.partial(merge_inputs, ctxtag=ctxtag)  # type: ignore[return-value]
 
-  @functools.wraps(f)
-  def merge_inputs_wrapper(*pure_args):
-    args = extract.from_tree(pure_args, ctxtag=ctxtag, is_inner=True)
-    out = f(*args)
-    args_out = extract.clear_non_graph_nodes(args)
-    pure_args_out, pure_out = extract.to_tree((args_out, out), ctxtag=ctxtag)
-    return pure_args_out, pure_out
-
-  return merge_inputs_wrapper  # type: ignore
+  return get_fn_wrapper(MergeInputsFn, f, ctxtag)  # type: ignore

--- a/flax/nnx/transforms/transforms.py
+++ b/flax/nnx/transforms/transforms.py
@@ -622,8 +622,8 @@ def cond(
     variables = extract.check_no_aliases('cond', operands=operands)
     out, updates = jax.lax.cond(
       pred,
-      SimpleCondFn(true_fun, graph=graph),
-      SimpleCondFn(false_fun, graph=graph),
+      general.get_fn_wrapper(SimpleCondFn, true_fun, graph),
+      general.get_fn_wrapper(SimpleCondFn, false_fun, graph),
       *operands,
     )
     if graph:
@@ -677,7 +677,7 @@ def switch(
     variables = extract.check_no_aliases('switch', operands=operands)
     out, updates = jax.lax.switch(
       index,
-      [SimpleCondFn(f, graph=graph) for f in branches],
+      [general.get_fn_wrapper(SimpleCondFn, f, graph) for f in branches],
       *operands,
     )
     if graph:

--- a/tests/nnx/transforms_test.py
+++ b/tests/nnx/transforms_test.py
@@ -7121,6 +7121,31 @@ class TestCond(parameterized.TestCase):
     with self.assertRaises(ValueError):
       nnx.cond(True, true_fn, false_fn, m, graph=False)
 
+  @parameterized.parameters(
+    (True, True), (True, False), (False, False),
+  )
+  def test_cond_no_retrace(self, graph, graph_updates):
+    # regression test for #5512: repeated cond calls with the same branch
+    # functions must hit JAX's tracing cache instead of retracing
+    n_traces = {'true_fn': 0, 'false_fn': 0}
+
+    def true_fn(x):
+      n_traces['true_fn'] += 1
+      return x + 1
+
+    def false_fn(x):
+      n_traces['false_fn'] += 1
+      return x - 1
+
+    x = jnp.zeros(())
+    for i in range(3):
+      nnx.cond(
+        jnp.bool_(i % 2 == 0), true_fn, false_fn, x,
+        graph=graph, graph_updates=graph_updates,
+      )
+
+    self.assertEqual(n_traces, {'true_fn': 1, 'false_fn': 1})
+
 class TestSwitch(parameterized.TestCase):
   @parameterized.parameters(
     (True, False),
@@ -7217,6 +7242,30 @@ class TestSwitch(parameterized.TestCase):
 
     with self.assertRaises(ValueError):
       nnx.switch(0, (add_a, add_b), m, graph=False)
+
+  @parameterized.parameters(
+    (True, True), (True, False), (False, False),
+  )
+  def test_switch_no_retrace(self, graph, graph_updates):
+    # regression test for #5512, see TestCond.test_cond_no_retrace
+    n_traces = {'branch_0': 0, 'branch_1': 0}
+
+    def branch_0(x):
+      n_traces['branch_0'] += 1
+      return x + 1
+
+    def branch_1(x):
+      n_traces['branch_1'] += 1
+      return x - 1
+
+    x = jnp.zeros(())
+    for i in range(3):
+      nnx.switch(
+        jnp.int32(i % 2), (branch_0, branch_1), x,
+        graph=graph, graph_updates=graph_updates,
+      )
+
+    self.assertEqual(n_traces, {'branch_0': 1, 'branch_1': 1})
 
 class TestWhileLoop(parameterized.TestCase):
   @parameterized.parameters(


### PR DESCRIPTION
## What does this PR do?

Fixes #5512

`nnx.cond` and `nnx.switch` created fresh branch-function wrappers on every
call — `merge_inputs` closures on the default (`graph_updates=True`) path and
`SimpleCondFn` instances on the fast path. JAX's control-flow tracing caches
hold a weakref to the branch callable and evict the entry when it is garbage
collected, so every call was a guaranteed tracing cache miss, and prevented
persistent compilation cache loads for large modules.

**Fix:** wrapper instances are now reused across calls via `get_fn_wrapper`,
which interns them on the wrapped function object itself — giving them exactly
the function's lifetime, with no global registry and no leaks. Non-plain-function
callables (bound methods, partials, callable Modules) keep the previous
per-call behavior. `nnx.remat` benefits as well since it goes through
`merge_inputs`.

**Design note:** `MergeInputsFn` deliberately uses `__slots__` rather than a
dataclass. Outer decorators that apply `functools.wraps` to the wrapper (e.g.
`jax.checkpoint` inside `nnx.remat`) copy the wrapped callable's `__dict__`;
with a dataclass, the leaked `f`/`ctxtag` instance attributes propagated up the
wraps chain and silently overwrote `CustomVjpFnWrapper.ctxtag` in the
`custom_vjp` + `remat` composition. `__slots__` leaves nothing to leak
(`__weakref__` is kept for JAX's weakref-based caches).

**Testing:**
- Retraces drop from N (one per call) to 1 on both code paths, for both
  `nnx.cond` and `nnx.switch`.
- Added regression tests (`TestCond::test_cond_no_retrace`,
  `TestSwitch::test_switch_no_retrace`), parameterized over
  `(graph, graph_updates)` combinations — all six fail without the fix and
  pass with it.
- Full `tests/nnx/` suite passes: 1657 passed, 9 skipped (pre-existing
  environment skips), including the `custom_vjp`/`remat` interaction tests.