### PR TITLE
Use less precise numbers in linen doctest

### DIFF
--- a/flax/linen/module.py
+++ b/flax/linen/module.py
@@ -2695,11 +2695,11 @@ class Module(ModuleBase):
     so you can easily disable the behavior when not needed::
 
       >>> model.apply(variables, x) # works as expected
-      Array([[-0.04579116,  0.50412744],
-             [-0.04579116,  0.50412744]], dtype=float32)
+      Array([[-0.0457912,  0.50412744],
+             [-0.0457912,  0.50412744]], dtype=float32)
       >>> model.apply({'params': variables['params']}, x) # behaves like a no-op
-      Array([[-0.04579116,  0.50412744],
-             [-0.04579116,  0.50412744]], dtype=float32)
+      Array([[-0.0457912,  0.50412744],
+             [-0.0457912,  0.50412744]], dtype=float32)
       >>> intm_grads = jax.grad(loss, argnums=0)({'params': variables['params']}, x, y)
       >>> 'perturbations' not in intm_grads
       True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -205,6 +205,7 @@ filterwarnings = [
     # DeprecationWarning: Setting `jax_pmap_shmap_merge` is deprecated in JAX v0.9.0 and will be removed in JAX v0.10.0
     "ignore:.*Setting `jax_pmap_shmap_merge` is deprecated in JAX.*:DeprecationWarning",
 ]
+doctest_optionflags = ["NUMBER", "ELLIPSIS"]
 
 [tool.coverage.report]
 exclude_lines = [


### PR DESCRIPTION
This PR should fix the doctests on main, which are broken due to a numerical precision issue- what we see (0.04579117) is only very slightly different from what we expect (0.04579116). It seems this could be addressed by expecting a slightly less precise number (0.0457912), along with the "NUMBER" flag when running doctests to enable dynamic precision. 