### PR TITLE
Fix nnx.Dropout crash when broadcast_dims includes a sharded axis

### DIFF
--- a/flax/nnx/nn/stochastic.py
+++ b/flax/nnx/nn/stochastic.py
@@ -159,10 +159,23 @@ class Dropout(Module):
     broadcast_shape = list(inputs.shape)
     for dim in self.broadcast_dims:
       broadcast_shape[dim] = 1
+    inputs_sharding = jax.typeof(inputs).sharding
+    # The mask has size 1 along the broadcast dims, so it cannot be
+    # partitioned there; drop those axes from the mask's sharding.
+    mask_spec = list(inputs_sharding.spec) + [None] * (
+      inputs.ndim - len(inputs_sharding.spec)
+    )
+    for dim in self.broadcast_dims:
+      mask_spec[dim] = None
+    mask_sharding = inputs_sharding.update(
+      spec=jax.sharding.PartitionSpec(*mask_spec)
+    )
     mask = random.bernoulli(
-      key, p=keep_prob, shape=broadcast_shape, out_sharding=jax.typeof(inputs).sharding
+      key, p=keep_prob, shape=broadcast_shape, out_sharding=mask_sharding
     )
     mask = jnp.broadcast_to(mask, inputs.shape)
+    if mask_sharding != inputs_sharding:
+      mask = jax.sharding.reshard(mask, inputs_sharding)
     return lax.select(mask, inputs / keep_prob, jnp.zeros_like(inputs))
 
   def set_view(

--- a/tests/nnx/spmd_test.py
+++ b/tests/nnx/spmd_test.py
@@ -353,6 +353,27 @@ class TestSPMD(parameterized.TestCase):
 
         assert 'float32[2@X,4]' in str(jax.typeof(func(sharded_array, nnx.Rngs(0))))
 
+  def test_out_sharding_dropout_broadcast_sharded_axis(self):
+    mesh = jax.make_mesh((2, 2), ("X", "Y"), axis_types=(AxisType.Explicit, AxisType.Explicit))
+    with jax.set_mesh(mesh):
+      replicated_array = (jnp.arange(8) + 1).reshape(2, 4).astype(jnp.float32)
+      sharded_array = reshard(replicated_array, P("X", None))
+      # broadcast_dims includes the sharded axis 0
+      layer = nnx.Dropout(
+        rate=0.5, deterministic=False, broadcast_dims=(0,), rngs=nnx.Rngs(0)
+      )
+      out = layer(sharded_array)
+      assert 'float32[2@X,4]' in str(jax.typeof(out))
+      # the dropout mask must be shared along the broadcast axis
+      out_host = jax.device_get(out)
+      assert ((out_host[0] == 0.0) == (out_host[1] == 0.0)).all()
+
+      @jax.jit
+      def func(x, rngs):
+        return layer(x, rngs=rngs)
+
+      assert 'float32[2@X,4]' in str(jax.typeof(func(sharded_array, nnx.Rngs(0))))
+
   def test_out_sharding_mha(self):
     mesh = jax.make_mesh((2, 2), ("fsdp", "tp"), axis_types=(AxisType.Explicit, AxisType.Explicit))
     with jax.set_mesh(mesh):


### PR DESCRIPTION
# What does this PR do?

`nnx.Dropout` crashes when `broadcast_dims` includes an axis that is sharded under JAX explicit sharding (`AxisType.Explicit`).

**Repro** (2 host devices):

```python
import os
os.environ["XLA_FLAGS"] = "--xla_force_host_platform_device_count=2"
import jax, jax.numpy as jnp
from jax.sharding import NamedSharding, PartitionSpec as P, AxisType
from flax import nnx

mesh = jax.make_mesh((2,), ("data",), axis_types=(AxisType.Explicit,))
with jax.set_mesh(mesh):
  x = jax.device_put(jnp.ones((4, 3, 5)), NamedSharding(mesh, P("data", None, None)))
  nnx.Dropout(0.5, broadcast_dims=(0,), deterministic=False, rngs=nnx.Rngs(0))(x)
```

fails with:

```
ValueError: Sharding spec ('data',) implies that array axis 0 is partitioned 2 times,
but does not evenly divide the dimension size 1. Got shape: (1, 3, 5) and sharding
NamedSharding(..., spec=P('data', None, None))
```

## Root cause

Since #5212, `Dropout.__call__` passes the input's full sharding as `out_sharding` to `random.bernoulli`. But the mask shape has the `broadcast_dims` collapsed to size 1, and a size-1 axis cannot be partitioned across >1 devices, so `bernoulli`'s internal reshard raises. `broadcast_dims=()` and broadcasting over an unsharded axis both work; only the sharded-broadcast-axis combination is broken (the existing `test_out_sharding_dropout` only broadcasts the unsharded axis).

## Fix

Derive the mask's `out_sharding` from the input sharding with the broadcast dims left unpartitioned, then (only when they differ) `reshard` the broadcasted mask back to the input sharding before `lax.select`. This is a no-op when `broadcast_dims` is empty or the broadcast axes are unsharded, and preserves the mask-shared-along-broadcast-axis semantics.

## How tested

Added `test_out_sharding_dropout_broadcast_sharded_axis` to `tests/nnx/spmd_test.py` (fails on `main` with the error above, passes with this change; also checks the mask is shared along the broadcast axis and that it works under `jax.jit`).

```
pytest tests/nnx/nn tests/nnx/spmd_test.py -q
621 passed in 49.76s
```

## Checklist
- [x] This PR fixes a minor issue (e.g.: typo or small bug) or improves the docs (you can dismiss the other checks if that's the case).
- [ ] This change is discussed in a Github issue/[discussion](https://github.com/google/flax/discussions) (please add a link).
- [x] The documentation and docstrings adhere to the [documentation guidelines](https://github.com/google/flax/blob/main/docs/README.md#how-to-write-code-documentation).
- [x] This change includes necessary high-coverage tests. (No quality testing = no merge!)
