### PR TITLE
Preserve RngStream counters for passthrough streams in Rngs.split/broadcast

### DIFF
--- a/flax/nnx/rnglib.py
+++ b/flax/nnx/rnglib.py
@@ -410,12 +410,16 @@ class Rngs(Pytree):
         rngs['default'] = default
 
     for tag, key in rngs.items():
+      count = None
       if isinstance(key, RngStream):
+        count = key.count.get_value()
         key = key.key.get_value()
       stream = RngStream(
         key=key,
         tag=tag,
       )
+      if count is not None:
+        stream.count.set_value(count)
       setattr(self, tag, stream)
 
   def _get_stream(self, name: str, error_type: type[Exception]) -> RngStream:

--- a/tests/nnx/rngs_test.py
+++ b/tests/nnx/rngs_test.py
@@ -421,6 +421,30 @@ class TestRngs(parameterized.TestCase):
     self.assertEqual(broadcasted_rngs_mapped.params.key.shape, (5,))
     self.assertEqual(broadcasted_rngs_mapped.dropout.key.shape, ())
 
+  def test_split_none_preserves_count(self):
+    # Streams passed through split (value None / unmatched) must keep their
+    # counter so already-consumed keys are not re-emitted.
+    rngs = nnx.Rngs(params=1, dropout=2)
+    consumed_key1 = rngs.dropout()
+    consumed_key2 = rngs.dropout()
+
+    new_rngs = rngs.split({'params': 5, 'dropout': None})
+
+    self.assertEqual(new_rngs.params.key.shape, (5,))
+    self.assertEqual(new_rngs.dropout.count[...], 2)
+    self.assertFalse(jnp.array_equal(new_rngs.dropout(), consumed_key1))
+    self.assertFalse(jnp.array_equal(new_rngs.dropout(), consumed_key2))
+
+  def test_broadcast_none_preserves_count(self):
+    rngs = nnx.Rngs(params=1, dropout=2)
+    consumed_key = rngs.dropout()
+
+    new_rngs = rngs.broadcast({'params': 5, 'dropout': None})
+
+    self.assertEqual(new_rngs.params.key.shape, (5,))
+    self.assertEqual(new_rngs.dropout.count[...], 1)
+    self.assertFalse(jnp.array_equal(new_rngs.dropout(), consumed_key))
+
   @parameterized.parameters(True, False)
   def test_with_rngs_decorator(self, graph):
     rngs = nnx.Rngs(params=0, dropout=1)


### PR DESCRIPTION
# What does this PR do?

Fixes silent PRNG key reuse when `Rngs.split` / `Rngs.broadcast` pass a stream through unchanged (`None` value or unmatched by any filter).

## The bug

`Rngs.__init__` accepts `RngStream` values but only keeps the base key and rebuilds the stream with a zeroed counter:

```python
if isinstance(key, RngStream):
  key = key.key.get_value()
stream = RngStream(key=key, tag=tag)  # count = zeros
```

`Rngs.split` and `Rngs.broadcast` pass unmatched/`None` ("don't split this stream") streams straight into `Rngs(**keys)`, so the returned `Rngs` silently rewinds those streams' counters to 0. The new `Rngs` then regenerates the exact `fold_in(key, 0)`, `fold_in(key, 1)`, ... keys that were already consumed from the original stream — e.g. identical dropout masks — with no error. This is the documented API surface: the `Rngs.split` docstring itself shows `{'dropout': None, ...}` meaning "don't split dropout".

Repro on current `main`:

```python
from flax import nnx
import jax

rngs = nnx.Rngs(params=1, dropout=2)
k1 = rngs.dropout()
k2 = rngs.dropout()

new_rngs = rngs.split({'params': 5, 'dropout': None})
nk1 = new_rngs.dropout()
nk2 = new_rngs.dropout()

print(jax.numpy.array_equal(nk1, k1))  # True  <- already-consumed key re-emitted
print(jax.numpy.array_equal(nk2, k2))  # True
```

Same for `broadcast({'params': 5, 'dropout': None})`.

## The fix

Preserve the incoming stream's counter in `Rngs.__init__`: capture `key.count.get_value()` before extracting the base key, and restore it on the rebuilt stream. This is a no-op for freshly split/forked/broadcast streams (their count is already zeros of the matching shape), so only the buggy passthrough case changes.

This also makes `split`/`broadcast` consistent with `nnx.with_rngs`, which already returns unmatched streams unchanged with their count preserved (see `test_unmatched_streams_returned_unchanged`).

Note this deliberately keeps the "`None` = leave the stream as-is" semantics — unlike #5344, which proposed auto-forking non-split streams and was withdrawn as a semantic change. Here the passthrough stream simply continues from where it left off instead of replaying consumed keys. (As with `with_rngs`, the old and new `Rngs` share the stream position afterwards — inherent to "don't split" — but no previously consumed key is ever re-emitted.)

## How tested

- New regression tests `test_split_none_preserves_count` and `test_broadcast_none_preserves_count` in `tests/nnx/rngs_test.py`; both fail on `main` and pass with the fix.
- `pytest tests/nnx/rngs_test.py` → 47 passed.
- `pytest --doctest-modules flax/nnx/rnglib.py` → 8 passed.
- `pytest tests/nnx/transforms_test.py tests/nnx/module_test.py` → 607 passed, 1 skipped.

## Checklist
- [x] This PR fixes a minor issue (e.g.: typo or small bug) or improves the docs (you can dismiss the other checks if that's the case).
- [ ] This change is discussed in a Github issue/[discussion](https://github.com/google/flax/discussions) (please add a link).
- [x] The documentation and docstrings adhere to the [documentation guidelines](https://github.com/google/flax/blob/main/docs/README.md#how-to-write-code-documentation).
- [x] This change includes necessary high-coverage tests. (No quality testing = no merge!)
