### PR TITLE
Exclude haiku doctests from CI

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -73,6 +73,11 @@ templates_path = ['_templates']
 # This pattern also affects html_static_path and html_extra_path.
 exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 
+# haiku is incompatible with newest jax (jax.core.DropVar removed);
+# skip its doctests only, keep the page in the html build.
+if 'doctest' in sys.argv:
+  exclude_patterns.append('guides/converting_and_upgrading/haiku_migration_guide.rst')
+
 # The suffix(es) of source filenames.
 # Note: important to list ipynb before md here: we have both md and ipynb
 # copies of each notebook, and myst will choose which to convert based on

--- a/docs_nnx/conf.py
+++ b/docs_nnx/conf.py
@@ -75,6 +75,12 @@ templates_path = ['_templates']
 # This pattern also affects html_static_path and html_extra_path.
 exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 
+
+# haiku is incompatible with newest jax (jax.core.DropVar removed);
+# skip its doctests only, keep the page in the html build.
+if 'doctest' in sys.argv:
+  exclude_patterns.append('migrating/haiku_to_flax.rst')
+
 # The suffix(es) of source filenames.
 # Note: important to list ipynb before md here: we have both md and ipynb
 # copies of each notebook, and myst will choose which to convert based on


### PR DESCRIPTION
This PR fixes the CI's recent doctest failures. Currently, we get "AttributeError: jax.core.DropVar was deprecated in JAX v0.10.0 and removed in JAX v0.11.0." when running doctests. This is actually a problem with haiku: (dm-haiku==0.0.16's jaxpr_info.py:45 still references jax.core.DropVar, which the latest jax removed). The simplest fix is to just not run guides/converting_and_upgrading/haiku_migration_guide during doctest CI. 