### PR TITLE
Fix vmap axes for input_positions in dot_product_attention_with_rope

### DIFF
--- a/flax/nnx/nn/attention.py
+++ b/flax/nnx/nn/attention.py
@@ -469,11 +469,9 @@ def dot_product_attention_with_rope(
     Output of shape ``[batch..., q_length, num_heads, v_dim]``.
   """
   # query/key: [batch..., seq_length, num_heads, head_dim]
-  # RoPE.__call__ expects (..., seq_length, head_dim), so vmap over heads.
-  if input_positions is None:
-    apply = jax.vmap(rope, in_axes=-2, out_axes=-2)
-  else:
-    apply = jax.vmap(rope, in_axes=(-2, -1), out_axes=(-2, -1))
+  # RoPE.__call__ expects (..., seq_length, head_dim), so vmap over the heads
+  # axis and broadcast the positions, which are shared by every head.
+  apply = jax.vmap(rope, in_axes=(-2, None), out_axes=-2)
   query = apply(query, input_positions)
   key = apply(key, input_positions)
   return dot_product_attention(query, key, value, **kwargs)

--- a/tests/nnx/nn/attention_test.py
+++ b/tests/nnx/nn/attention_test.py
@@ -500,6 +500,41 @@ class TestRoPE(absltest.TestCase):
 
     np.testing.assert_allclose(out_flax, out_torch, atol=1e-5)
 
+  def test_dot_product_attention_with_rope_input_positions(self):
+    """Explicit input_positions work and default positions match arange."""
+    batch, seq_len, num_heads, head_dim = 2, 6, 4, 8
+
+    key = jax.random.key(0)
+    k1, k2, k3 = jax.random.split(key, 3)
+    query = jax.random.normal(k1, (batch, seq_len, num_heads, head_dim))
+    kv = jax.random.normal(k2, (batch, seq_len, num_heads, head_dim))
+    value = jax.random.normal(k3, (batch, seq_len, num_heads, head_dim))
+
+    rope = nnx.RoPE(theta=10000.0)
+    out_default = nnx.dot_product_attention_with_rope(
+      query, kv, value, rope=rope
+    )
+    # Positions are shared by every head, so arange must match the default.
+    out_arange = nnx.dot_product_attention_with_rope(
+      query, kv, value, rope=rope, input_positions=jnp.arange(seq_len)
+    )
+    np.testing.assert_allclose(out_arange, out_default, atol=1e-6)
+
+    # RoPE encodes relative position: a uniform shift preserves every pairwise
+    # difference, so the attention output must not change.
+    out_shifted = nnx.dot_product_attention_with_rope(
+      query, kv, value, rope=rope, input_positions=jnp.arange(seq_len) + 3
+    )
+    np.testing.assert_allclose(out_shifted, out_default, atol=1e-5)
+
+    # Non-uniform positions change the relative differences, so they must
+    # produce a different result — proving the positions take effect.
+    out_scaled = nnx.dot_product_attention_with_rope(
+      query, kv, value, rope=rope, input_positions=jnp.arange(seq_len) * 2
+    )
+    self.assertEqual(out_scaled.shape, out_default.shape)
+    self.assertFalse(jnp.allclose(out_scaled, out_default, atol=1e-3))
+
   def test_with_mha(self):
     """RoPE integrates correctly as attention_fn in MultiHeadAttention."""
     with jax.numpy_rank_promotion("raise"):


### PR DESCRIPTION
## What does this PR do?

Fixes the `input_positions` argument of `dot_product_attention_with_rope` (added in #5481), which crashes on every call that passes it:

```
ValueError: vmap got inconsistent sizes for array axes to be mapped:
  * one axis had size 2: axis -2 of argument x of type float32[1,6,2,8];
  * one axis had size 6: axis -1 of argument input_positions of type float32[6]
```

The heads-axis vmap used `in_axes=(-2, -1)`, mapping the positions' **last axis — which is `seq_len`, not a heads axis** — so any call with `num_heads != seq_len` raises, and `out_axes=(-2, -1)` was a 2-tuple for a function returning a single array. Both docstrings (`dot_product_attention_with_rope` and `MultiHeadAttention.__call__`) document `input_positions` of shape `(..., seq_len,)`, and there was no test coverage for it.

Positions are shared by every head, so the fix broadcasts them: `jax.vmap(rope, in_axes=(-2, None), out_axes=-2)`. Since `in_axes=None` also handles `input_positions=None`, the single vmap replaces the previous branch.

## Tests

`test_dot_product_attention_with_rope_input_positions` pins three properties:

- explicit `arange(seq_len)` positions produce the same output as the default (they are the default),
- a **uniform shift preserves the output** — RoPE encodes relative position, so `arange + 3` leaves every pairwise difference unchanged, which distinguishes real broadcasting from positions being ignored per-head,
- **non-uniform positions** (`arange * 2`) change the output, proving positions take effect.

The test fails on `main` (with the vmap error above) and passes with the fix. Full `tests/nnx/nn/attention_test.py`: 127 passed. `ruff check` clean.

## Checklist

- [x] This change is discussed in a Github issue/discussion — the bug is in a feature merged three days ago (#5481); filed directly as a fix given the crash is unconditional.
- [x] The documentation and docstrings adhere to the documentation guidelines.
- [x] This change includes necessary high-coverage tests.
