### PR TITLE
implement axes_scan's broadcast semantics via dce

### DIFF
--- a/flax/core/axes_scan.py
+++ b/flax/core/axes_scan.py
@@ -178,20 +178,21 @@ def scan(
     assert all(isinstance(a, core.AbstractValue) for a in in_avals), in_avals
 
     debug_info = jax.api_util.debug_info("flax scan", broadcast_body,
-                                         (in_tree,), {})
+                                         (init, xs), {})
     f_flat, out_tree = jax.api_util.flatten_fun_nokwargs(
         lu.wrap_init(broadcast_body, debug_info=debug_info), in_tree
     )
-    in_pvals = list(map(pe.PartialVal.unknown, in_avals))
-    _, out_pvals, _ = pe.trace_to_jaxpr_nounits(f_flat, in_pvals)
-
-    out_flat = []
-    for pv, const in out_pvals:
-      if pv is not None:
-        raise ValueError(
-            'broadcasted variable has a data dependency on the scan body.'
-        )
-      out_flat.append(const)
+    jaxpr, _, consts = pe.trace_to_jaxpr_dynamic(f_flat, in_avals)
+    jaxpr, used_inputs = pe.dce_jaxpr(jaxpr, [True] * len(jaxpr.outvars))
+    num_const_invars = len(used_inputs) - len(in_avals)
+    used_consts, used_args = (used_inputs[:num_const_invars],
+                              used_inputs[num_const_invars:])
+    if any(used_args):
+      raise ValueError(
+          'broadcasted variable has a data dependency on the scan body.')
+    if num_const_invars:
+      consts = [c for c, u in zip(consts, used_consts) if u]
+    out_flat = core.eval_jaxpr(jaxpr, consts)
     broadcast_in, constants_out = jax.tree_util.tree_unflatten(
         out_tree(), out_flat
     )


### PR DESCRIPTION
By using DCE instead of partial evaluation, we unblock JAX_REMAT3=1 and the deletion of general partial eval in JAX.

Drive-by fix of a separate issue in how debug_info was being created (don't pass in_tree, pass args). That should improve some error messages.