### PR TITLE
docs(nnx): fix training API reference inconsistencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+
 Changelog
 ----------
 
@@ -5,9 +6,8 @@ vNext
 ------
 (Add your change to a random empty line to avoid merge conflicts)
 -
--
--
--
+
+- Fixed several `flax.nnx.training` API reference inconsistencies (`EMA.apply_to`, `Accuracy` members, `Statistics` docstring).
 - removed GeGLU simplistic activation, it should be implemented manually.
 -
 -
@@ -26,6 +26,7 @@ vNext
 
 0.8.2
 -----
+
 - fixed rng guide outputs by @chiamp in https://github.com/google/flax/pull/3685
 - enforce mask kwarg in norm layers by @chiamp in https://github.com/google/flax/pull/3663
 - added kwargs to self.param and self.variable by @chiamp in https://github.com/google/flax/pull/3675

--- a/docs_nnx/api_reference/flax.nnx/training/ema.rst
+++ b/docs_nnx/api_reference/flax.nnx/training/ema.rst
@@ -5,4 +5,4 @@ EMA
 .. currentmodule:: flax.nnx
 
 .. autoclass:: EMA
-   :members: __init__, update
+   :members: __init__, update, apply_to

--- a/docs_nnx/api_reference/flax.nnx/training/metrics.rst
+++ b/docs_nnx/api_reference/flax.nnx/training/metrics.rst
@@ -12,7 +12,7 @@ Metrics
    :members: __init__, reset, update, compute
 
 .. autoclass:: Accuracy
-   :members: update
+   :members: __init__, reset, update, compute
 
 .. autoclass:: Welford
    :members: __init__, reset, update, compute

--- a/flax/nnx/training/metrics.py
+++ b/flax/nnx/training/metrics.py
@@ -130,9 +130,18 @@ class Average(Metric):
     """Compute and return the average."""
     return self.total / self.count
 
-
 @struct.dataclass
 class Statistics:
+  """Summary statistics returned by :meth:`Welford.compute`.
+
+  Attributes:
+    mean: The running mean of the values seen so far.
+    standard_error_of_mean: The standard error of the mean, i.e. the standard
+      deviation divided by the square root of the number of values seen.
+    standard_deviation: The (population) standard deviation of the values seen
+      so far.
+  """
+
   mean: jnp.float32
   standard_error_of_mean: jnp.float32
   standard_deviation: jnp.float32


### PR DESCRIPTION
# What does this PR do?

Fixes a few inconsistencies in the `flax.nnx.training` API reference (part of #5161):

- `EMA.apply_to()` is public and used in EMA's own docstring examples, but wasn't rendered in the reference — added it to `:members:`.
- `Accuracy` listed only `update` while the sibling metrics list `__init__, reset, update, compute` — aligned it (this also surfaces the `threshold` constructor doc).
- `Statistics` (returned by `Welford.compute()`) had no docstring — added one.

Scope: docs + docstrings only, no behavioral changes. All `training` module doctests pass locally.

Relates to #5161.

## Checklist
- [x] This PR fixes a minor issue (e.g.: typo or small bug) or improves the docs (you can dismiss the other checks if that's the case).
- [x] This change is discussed in a Github issue: #5161
- [x] The documentation and docstrings adhere to the documentation guidelines.
- [ ] This change includes necessary high-coverage tests. (No quality testing = no merge!)
