### PR TITLE
docs(nnx): fill missing docstrings in variables/rnglib, fix helpers g…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Changelog
 vNext
 ------
 (Add your change to a random empty line to avoid merge conflicts)
--
+- Added missing docstrings for `nnx.with_metadata` and `nnx.RngStream`; fixed `List`/`Dict` docstring typo.
 -
 -
 -

--- a/flax/nnx/helpers.py
+++ b/flax/nnx/helpers.py
@@ -37,7 +37,7 @@ class Dict(reprlib.MappingReprMixin, Module, tp.MutableMapping[str, A]):
   """A Module that implements a mutable mapping.
 
   This class provides a way to store and manipulate a mapping of keys to values
-  contained a mixed set of data (e.g. Array, Variables, Modules) and static
+  containing a mixed set of data (e.g. Array, Variables, Modules) and static
   (e.g. functions, strings) types.
 
   Example:
@@ -100,7 +100,7 @@ class List(reprlib.SequenceReprMixin, Module, tp.MutableSequence[A]):
   """A Module that implements a mutable sequence.
 
   This class provides a way to store and manipulate a sequence of values
-  contained a mixed set of data (e.g. Array, Variables, Modules) and static
+  containing a mixed set of data (e.g. Array, Variables, Modules) and static
   (e.g. functions, strings) types.
 
   Example:

--- a/flax/nnx/rnglib.py
+++ b/flax/nnx/rnglib.py
@@ -96,6 +96,32 @@ NotKey = filterlib.All(RngState, filterlib.Not(RngKey))
 
 
 class RngStream(Pytree):
+  """A named stream of PRNG keys.
+
+  An ``RngStream`` holds a base ``key`` and a ``count``. Each call to the
+  stream derives a fresh, unique key by folding the current count into the
+  base key and then incrementing the count, so repeated calls never return
+  the same key.
+
+  Streams are usually created and accessed through :class:`Rngs` (e.g.
+  ``rngs.params`` or ``rngs.dropout``) rather than constructed directly.
+
+  Example::
+
+    >>> from flax import nnx
+    ...
+    >>> stream = nnx.RngStream(0, tag='dropout')
+    >>> key1 = stream()
+    >>> key2 = stream()
+    >>> bool((key1 != key2).any())
+    True
+
+  Attributes:
+    tag: the name of the stream (e.g. ``'params'`` or ``'dropout'``).
+    key: the base PRNG key wrapped in an ``RngKey`` Variable.
+    count: the number of keys generated so far, wrapped in an ``RngCount``
+      Variable.
+  """
 
   def __init__(
     self,

--- a/flax/nnx/variablelib.py
+++ b/flax/nnx/variablelib.py
@@ -2133,6 +2133,44 @@ def with_metadata(
   ] = (),
   **metadata: tp.Any,
 ) -> F:
+  """Wraps a `Variable` initializer to attach metadata to the initialized value.
+
+  The returned function calls ``initializer`` and boxes its output in a
+  :class:`VariableMetadata` object carrying the given ``**metadata``. When the
+  result is used to create a :class:`Variable` (e.g. inside a Module), the
+  metadata is stored on the Variable and can be retrieved with
+  ``Variable.get_metadata()``.
+
+  This is the mechanism used by :func:`flax.nnx.with_partitioning` to attach
+  sharding annotations to parameters.
+
+  Example::
+
+    >>> from flax import nnx
+    >>> import jax, jax.numpy as jnp
+    ...
+    >>> init_fn = nnx.with_metadata(
+    ...   nnx.initializers.lecun_normal(), custom_tag='dense'
+    ... )
+    >>> layer = nnx.Linear(2, 3, kernel_init=init_fn, rngs=nnx.Rngs(0))
+    >>> layer.kernel.get_metadata()['custom_tag']
+    'dense'
+
+  Args:
+    initializer: an initializer function to wrap.
+    on_set_value: deprecated Variable hook(s); prefer subclassing
+      :class:`Variable` and overriding ``set_value`` instead.
+    on_get_value: deprecated Variable hook(s); prefer subclassing
+      :class:`Variable` and overriding ``get_value`` instead.
+    on_create_value: deprecated Variable hook(s).
+    on_add_axis: deprecated Variable hook(s).
+    on_remove_axis: deprecated Variable hook(s).
+    **metadata: arbitrary keyword metadata to attach to the created Variable.
+
+  Returns:
+    A wrapped initializer with the same signature as ``initializer`` whose
+    output carries the given metadata.
+  """
   if on_set_value or on_get_value or on_create_value or on_add_axis or on_remove_axis:
     warnings.warn(
       'Variable hooks are deprecated in favor of users creating their own '


### PR DESCRIPTION
# What does this PR do?

More docstring fixes for the NNX API reference (part of #5161):

- `with_metadata` had no docstring, so it rendered as a bare signature in the reference — added one with a working example.
- `RngStream` inherited the generic Pytree docstring ("Base class for all NNX objects.") in the reference — added a proper one.
- Fixed a "contained" → "containing" typo in the `List` and `Dict` docstrings.

Scope: docs + docstrings only, no behavioral changes. Doctests for the touched modules pass locally.

Relates to #5161.

## Checklist
- [x] This PR fixes a minor issue (e.g.: typo or small bug) or improves the docs (you can dismiss the other checks if that's the case).
- [x] This change is discussed in a Github issue: #5161
- [x] The documentation and docstrings adhere to the documentation guidelines.
- [ ] This change includes necessary high-coverage tests. (No quality testing = no merge!)