### PR TITLE
Fix load_dataset arguments to load mnist data set

### DIFF
--- a/docs/guides/data_preprocessing/loading_datasets.ipynb
+++ b/docs/guides/data_preprocessing/loading_datasets.ipynb
@@ -224,7 +224,7 @@
    "outputs": [],
    "source": [
     "def get_dataset_hf():\n",
-    "    mnist = load_dataset(\"mnist\")\n",
+    "    mnist = load_dataset(\"ylecun/mnist\")\n",
     "\n",
     "    ds = {}\n",
     "\n",


### PR DESCRIPTION
HF Repository id must be 'namespace/name'

# What does this PR do? Fix the input for load_dataset function.


Fixes # (issue) calling the loading function.

