### PR TITLE
traverse_util: reject unrestorable keys in flatten_dict with a separator

### DIFF
--- a/flax/traverse_util.py
+++ b/flax/traverse_util.py
@@ -93,6 +93,15 @@ def _flatten(xs, prefix, keep_empty_nodes, is_leaf, sep):
   for key, value in xs.items():
     is_empty = False
     path = prefix + (key,)
+    # With a separator, the flattened key is ``sep``-joined, so a key that is
+    # not a string, or that already contains the separator, cannot be restored
+    # unambiguously by ``unflatten_dict``. Reject it here rather than silently
+    # producing a key that round-trips to a different structure.
+    if sep is not None and (not isinstance(key, str) or sep in key):
+      raise ValueError(
+        f'flatten_dict with sep={sep!r} requires string keys that do not '
+        f'contain the separator; got key {key!r} at path {path}'
+      )
     result.update(_flatten(value, path, keep_empty_nodes, is_leaf, sep))
   if keep_empty_nodes and is_empty:
     if prefix == ():  # when the whole input is empty

--- a/tests/traverse_util_test.py
+++ b/tests/traverse_util_test.py
@@ -175,6 +175,27 @@ class TraversalTest(absltest.TestCase):
       },
     )
 
+  def test_flatten_dict_sep_rejects_unrestorable_keys(self):
+    # A key that contains the separator would flatten to the same joined form
+    # as a genuine nested path, so it cannot be restored unambiguously.
+    with self.assertRaisesRegex(ValueError, 'do not contain the separator'):
+      traverse_util.flatten_dict({'a/b': 1}, sep='/')
+
+    # A non-string key cannot be joined with a separator at all.
+    with self.assertRaisesRegex(ValueError, 'requires string keys'):
+      traverse_util.flatten_dict({1: {2: 3}}, sep='/')
+
+    # Without a separator (tuple-key mode) both inputs are still supported,
+    # since the tuple keys restore faithfully.
+    self.assertEqual(
+      traverse_util.flatten_dict({'a/b': 1}),
+      {('a/b',): 1},
+    )
+    self.assertEqual(
+      traverse_util.flatten_dict({1: {2: 3}}),
+      {(1, 2): 3},
+    )
+
   def test_unflatten_dict(self):
     expected_xs = {'foo': 1, 'bar': {'a': 2}}
     xs = traverse_util.unflatten_dict(


### PR DESCRIPTION
Fixes #5554.

### What

`flatten_dict`, when given a separator, joins each nested path into a single
string key. Two kinds of input cannot then be restored by `unflatten_dict`:

- a key that already contains the separator, which flattens to the same joined
  form as a genuine nested path and so silently round-trips to a different
  structure, and
- a non-string key, which cannot be joined at all and previously surfaced an
  opaque `TypeError` from `sep.join`.

This change validates keys during flattening and raises a single, descriptive
`ValueError` for both cases, so an unrestorable input fails fast instead of
corrupting the tree or raising an internal error.

### Why

`flatten_dict` and `unflatten_dict` are commonly used to move parameter and
state trees to and from a flat, string-keyed representation. Silent structural
corruption of such a tree is difficult to detect downstream, and the
non-string-key error gave no indication of its cause.

### Scope

Tuple-key mode (`sep=None`) is unaffected, since it already restores these
inputs faithfully. Every input that currently round-trips correctly is
unchanged; only the two previously broken cases now raise.

### Before

```python
>>> from flax.traverse_util import flatten_dict, unflatten_dict
>>> xs = {"a/b": 1, "c": {"d": 2}}
>>> unflatten_dict(flatten_dict(xs, sep="/"), sep="/") == xs
False
>>> flatten_dict({1: {2: 3}}, sep="/")
TypeError: sequence item 0: expected str instance, int found
```

### After

```python
>>> flatten_dict({"a/b": 1}, sep="/")
ValueError: flatten_dict with sep='/' requires string keys that do not contain
the separator; got key 'a/b' at path ('a/b',)
```

### Tests

`test_flatten_dict_sep_rejects_unrestorable_keys` in
`tests/traverse_util_test.py` covers both rejected cases and confirms that
tuple-key mode still accepts them. It fails without the change and passes with
it. The full `traverse_util` suite is green.
