### PR TITLE
Use jax-transform based sow

### DIFF
--- a/flax/nnx/module.py
+++ b/flax/nnx/module.py
@@ -14,6 +14,7 @@
 
 from __future__ import annotations
 
+import contextvars
 import inspect
 import typing as tp
 
@@ -24,6 +25,7 @@ from flax.nnx import (
   filterlib,
   graphlib,
   pytreelib,
+  sow as sow_lib,
 )
 from flax.nnx import variablelib as variableslib
 from flax.nnx.pytreelib import Pytree, PytreeMeta
@@ -43,6 +45,16 @@ F = tp.TypeVar('F', bound=tp.Callable[..., tp.Any])
 StateMapping = tp.Mapping[Path, tp.Any]
 tuple_reduce = lambda xs, x: xs + (x,)
 tuple_init = lambda: ()
+
+# Set by 'nnx.capture(functional=...)'; read by 'Module.sow'/'Module.perturb'.
+_functional_sow: contextvars.ContextVar[bool] = contextvars.ContextVar(
+  'nnx_functional_sow', default=False
+)
+# Names of the module methods currently on the stack. Maintained by the wrappers
+# '_add_path_tracking' installs during a functional capture.
+_sow_path: contextvars.ContextVar[PathParts] = contextvars.ContextVar(
+  'nnx_sow_path', default=()
+)
 
 
 class ModuleMeta(PytreeMeta):
@@ -149,6 +161,16 @@ class Module(Pytree, metaclass=ModuleMeta):
           variable_type, allow_register=True
       )
 
+    if _functional_sow.get():
+      if reduce_fn is not tuple_reduce or init_fn is not tuple_init:
+        raise ValueError(
+          "'reduce_fn'/'init_fn' are not supported under "
+          "'nnx.capture(functional=True)': values are always collected into "
+          'a tuple in call order.'
+        )
+      sow_lib.sow(value, name=(variable_type, *_sow_path.get(), name))
+      return True
+
     if hasattr(self, '__captures__'):
       for var in self.__captures__:
         if type(var) == variable_type:
@@ -244,6 +266,11 @@ class Module(Pytree, metaclass=ModuleMeta):
     if isinstance(variable_type, str):
       variable_type = variableslib.variable_type_from_name(
           variable_type, allow_register=True
+      )
+
+    if _functional_sow.get():
+      return sow_lib.perturb(
+        value, name=(variable_type, *_sow_path.get(), name)
       )
 
     if hasattr(self, '__captures__'):
@@ -775,7 +802,8 @@ def capture(
   fn: tp.Callable[P, R],
   *var_types: type[variableslib.Variable],
   init: tp.Optional[State] = None,
-  method_outputs: tp.Optional[type[variableslib.Variable]] = None
+  method_outputs: tp.Optional[type[variableslib.Variable]] = None,
+  functional: bool = False,
 ) -> tp.Callable[P, tuple[R, State]]: ...
 
 @tp.overload
@@ -783,12 +811,14 @@ def capture(
   fn: type[variableslib.Variable],
   *var_types: type[variableslib.Variable],
   init: tp.Optional[State] = None,
-  method_outputs: tp.Optional[type[variableslib.Variable]] = None
+  method_outputs: tp.Optional[type[variableslib.Variable]] = None,
+  functional: bool = False,
 ) -> tp.Callable[[tp.Callable[P, R]], tp.Callable[P, tuple[R, State]]]: ...
 
 def capture(fn: tp.Callable[P, R] | type[variableslib.Variable], *var_types: type[variableslib.Variable],
   init : tp.Optional[State] = None,
-  method_outputs : tp.Optional[type[variableslib.Variable]] = None
+  method_outputs : tp.Optional[type[variableslib.Variable]] = None,
+  functional: bool = False,
 ) -> tp.Callable[P, tuple[R, State]] | tp.Callable[[tp.Callable[P, R]], tp.Callable[P, tuple[R, State]]]:
     """Wraps a function to capture intermediate values from a module during execution.
 
@@ -806,6 +836,12 @@ def capture(fn: tp.Callable[P, R] | type[variableslib.Variable], *var_types: typ
       init: MutableMapping used to initialize perturbation values. This is useful for gradient extraction.
       method_outputs: If provided, automatically sows the output of each method
         in the module and its submodules using this variable type.
+      functional: If ``True``, use the functional implementation: ``fn`` is
+        traced and sown values are collected from the trace (see
+        :func:`flax.nnx.sow`) instead of being stored on the modules.
+        Experimental: only tree mode is supported, ``init`` and custom
+        ``reduce_fn``/``init_fn`` are not, and ``perturb`` collects cotangents
+        from a differentiated function rather than needing initialization.
 
     Returns:
       A wrapped function that returns
@@ -860,7 +896,8 @@ def capture(fn: tp.Callable[P, R] | type[variableslib.Variable], *var_types: typ
       # Partial application: return a function that waits for the actual fn
       all_var_types = (fn,) + var_types
       def partial_capture(actual_fn: tp.Callable[P, R] | Module) -> tp.Callable[P, tuple[R, State]]:
-        return capture(actual_fn, *all_var_types, init=init, method_outputs=method_outputs)
+        return capture(actual_fn, *all_var_types, init=init,
+                       method_outputs=method_outputs, functional=functional)
       return partial_capture
 
     # Handle bound methods and callable Modules
@@ -877,53 +914,114 @@ def capture(fn: tp.Callable[P, R] | type[variableslib.Variable], *var_types: typ
       else:
         module = module_instance
 
-      # Extract initial values from state
-      state_by_path = _collect_state_by_path(init) if init else {}
-
-      # Initialize __captures__ as a tuple of Variables (one per type)
-      for path, m in iter_modules(module):
-        # Create initial dicts for each variable type
-        initial_dicts = {}
-        for var_type in var_types:
-          initial_dicts[var_type] = {}
-
-        # Populate from state if available
-        if path in state_by_path:
-          for name, var in state_by_path[path].items():
-            var_type = type(var)
-            if var_type not in initial_dicts:
-              initial_dicts[var_type] = {}
-            initial_dicts[var_type][name] = var.get_value()
-
-        # Create the captures tuple
-        captures_tuple = tuple(k(v) for (k,v) in initial_dicts.items())
-        m.__captures__ = pytreelib.data(captures_tuple)
-
-      # Wrap methods with capturing if required
-      if method_outputs:
-        for _, m in iter_modules(module):
-          _add_capturing(type(m), method_outputs)
-
+      token = _functional_sow.set(functional)
       try:
-        result = fn(*fn_args, **kwargs)
+        if functional:
+          return _functional_capture(
+            fn, module, var_types, init, method_outputs, fn_args, kwargs
+          )
+        return _stateful_capture(
+          fn, module, var_types, init, method_outputs, fn_args, kwargs
+        )
       finally:
-
-        # Undo method sowing modification
-        for _, m in iter_modules(module):
-          _remove_capturing(type(m))
-
-      # Extract intermediates manually from __captures__
-      interms = State({})
-      _extract_captures(module, interms, set(var_types))
-      if len(var_types) == 0:
-          return result
-      split_states = split_state(interms, *var_types)
-      if len(var_types) == 1:
-        return result, split_states
-      else:
-        return (result, *split_states)
+        _functional_sow.reset(token)
 
     return wrapper
+
+def _stateful_capture(fn, module, var_types, init, method_outputs, fn_args, kwargs):
+  # Extract initial values from state
+  state_by_path = _collect_state_by_path(init) if init else {}
+
+  # Initialize __captures__ as a tuple of Variables (one per type)
+  for path, m in iter_modules(module):
+    # Create initial dicts for each variable type
+    initial_dicts = {}
+    for var_type in var_types:
+      initial_dicts[var_type] = {}
+
+    # Populate from state if available
+    if path in state_by_path:
+      for name, var in state_by_path[path].items():
+        var_type = type(var)
+        if var_type not in initial_dicts:
+          initial_dicts[var_type] = {}
+        initial_dicts[var_type][name] = var.get_value()
+
+    # Create the captures tuple
+    captures_tuple = tuple(k(v) for (k,v) in initial_dicts.items())
+    m.__captures__ = pytreelib.data(captures_tuple)
+
+  # Wrap methods with capturing if required
+  if method_outputs:
+    for _, m in iter_modules(module):
+      _add_capturing(type(m), method_outputs)
+
+  try:
+    result = fn(*fn_args, **kwargs)
+  finally:
+
+    # Undo method sowing modification
+    for _, m in iter_modules(module):
+      _remove_capturing(type(m))
+
+  # Extract intermediates manually from __captures__
+  interms = State({})
+  _extract_captures(module, interms, set(var_types))
+  if len(var_types) == 0:
+      return result
+  split_states = split_state(interms, *var_types)
+  if len(var_types) == 1:
+    return result, split_states
+  else:
+    return (result, *split_states)
+
+def _functional_capture(fn, module, var_types, init, method_outputs, fn_args, kwargs):
+  """``capture(functional=True)``: instead of storing sown
+  values on the modules, trace ``fn`` and collect the values sown by the ``sow``
+  jax transform (see ``flax.nnx.sow``).
+
+  Only tree mode is supported: nested NNX transforms must use ``graph=False``, and
+  graph structure updates are not propagated. A module that updates its own state
+  (``BatchNorm`` statistics, ``Rngs`` counts) needs ref-backed Variables, created
+  inside ``nnx.var_defaults(ref=True)``: being jax refs, those writes cross the
+  trace boundary natively, whereas a plain Variable raises ``TraceContextError``.
+  ``perturb`` sows the cotangent of a value, so perturbations come from capturing
+  a differentiated function rather than from an ``init`` state.
+  """
+  if init is not None:
+    raise ValueError(
+      "'init' is not supported under 'nnx.capture(functional=True)': "
+      'capture a differentiated function instead to collect perturbations.'
+    )
+
+  modules = list(iter_modules(module))
+  for _, m in modules:
+    if method_outputs:
+      _add_capturing(type(m), method_outputs)
+    _add_path_tracking(type(m))
+
+  try:
+    result, collected = sow_lib.capture(lambda: fn(*fn_args, **kwargs))()
+  finally:
+    for _, m in modules:
+      _remove_capturing(type(m))
+
+  if len(var_types) == 0:
+    return result
+  states = tuple(_collected_to_state(collected, t) for t in var_types)
+  return (result, *states)
+
+def _collected_to_state(collected: dict, var_type: type) -> State:
+  """Reshape ``sow.capture``'s flat {(var_type, *path, name): values} into a
+  nested State holding only the entries of ``var_type``."""
+  state: State = State({})
+  for key, values in collected.items():
+    # keys sown by anything other than Module.sow/perturb are not ours
+    if not isinstance(key, tuple) or key[0] is not var_type:
+      continue
+    *path, name = key[1:]
+    _navigate_to_path(state, path)[name] = var_type(values, ref=False)
+  return state
 
 def _collect_state_by_path(state):
   """Build a mapping from module path to state Variables."""
@@ -966,26 +1064,55 @@ def _extract_captures(module, state, var_types):
       delattr(mod, '__captures__')
 
 
+def _is_capturable(name, method):
+  return callable(method) and (not name.startswith('_') or name == '__call__')
+
 def _add_capturing(cls, variable_type):
   """Adds capturing to methods of a Module.
   Does not instrument superclass methods."""
   for name, method in cls.__dict__.items():
-    if callable(method) and (not name.startswith('_') or name == '__call__'):
+    if _is_capturable(name, method):
       if not hasattr(method, '_does_capturing'):
         def closure(name, method): # Necessary to make 'name' immutable during iteration
           @ft.wraps(method)
           def wrapper(self, *args, **kwargs):
             result = method(self, *args, **kwargs)
-            self.sow(variable_type, name, result)
+            # under a functional capture '_add_path_tracking' has already put
+            # this method's name in the path, so the leaf is just 'output';
+            # otherwise the name is the key within the module's '__captures__'
+            self.sow(
+              variable_type, 'output' if _functional_sow.get() else name, result
+            )
             return result
           wrapper._does_capturing = True
           setattr(cls, name, wrapper)
         closure(name, method)
   return cls
 
-def _remove_capturing(cls):
-  """Remove capturing methods from a Module."""
+def _add_path_tracking(cls):
+  """Wraps the methods of a Module so that, while one of them runs, the
+  '_sow_path' contextvar holds the names of the methods currently on the stack.
+  A method inherited from a superclass is not instrumented (same as
+  '_add_capturing'), and keeps the path of its caller."""
   for name, method in cls.__dict__.items():
-    if hasattr(method, '_does_capturing'):
-      setattr(cls, name, method.__wrapped__)
+    if _is_capturable(name, method) and not hasattr(method, '_tracks_path'):
+      def closure(name, method):  # bind per iteration
+        @ft.wraps(method)
+        def wrapper(self, *args, **kwargs):
+          token = _sow_path.set((*_sow_path.get(), name))
+          try:
+            return method(self, *args, **kwargs)
+          finally:
+            _sow_path.reset(token)
+        wrapper._tracks_path = True
+        setattr(cls, name, wrapper)
+      closure(name, method)
+  return cls
+
+def _remove_capturing(cls):
+  """Remove the wrappers added by '_add_capturing'/'_add_path_tracking'."""
+  for name, method in cls.__dict__.items():
+    while hasattr(method, '_does_capturing') or hasattr(method, '_tracks_path'):
+      method = method.__wrapped__
+      setattr(cls, name, method)
   return cls

--- a/flax/nnx/sow.py
+++ b/flax/nnx/sow.py
@@ -1,0 +1,258 @@
+"""A `sow` transform, implemented as a jaxpr interpreter.
+
+`sow(value, *, name)` tags a pytree during tracing. `capture(f)` runs `f` and
+returns `(f_output, collected)` where `collected` maps each name to a tuple of
+the pytrees sown under it, in call order.
+
+`sow` carries a JAX effect so it survives DCE even when its result is unused
+(so you can log metrics with a bare `sow(loss, name="loss")` statement), and a
+trivial identity lowering so a sow-containing function still runs under plain
+`jax.jit` (sows are silently discarded when not harvested).
+
+Control flow: sows inside `jit`/`closed_call` are collected inline. A sow inside
+a `scan` fires once per iteration and is collected as a single pytree stacked
+along the scan axis (leading dim = length). A sow inside `cond` yields the taken
+branch's value; every branch must sow the same names/shapes (enforced by jax's
+own branch-matching check). A sow inside a `remat` is collected by inlining the
+body when it is undifferentiated (which is how jax lowers it anyway) and, once
+differentiated, by rebinding `remat_p` with the sown values as extra outputs so
+the optimization barrier survives — note this makes them residuals, i.e. you keep
+in memory exactly what you harvest. `while_loop` is unsupported (a dynamic trip
+count can't produce a fixed-size collection).
+"""
+from contextvars import ContextVar
+from functools import partial
+
+import jax
+from jax import lax
+from jax._src import core, effects, pjit
+from jax._src.ad_checkpoint import remat_p
+from jax._src.custom_derivatives import custom_jvp_call_p, custom_vjp_call_p
+from jax._src.interpreters import partial_eval as pe
+from jax._src.lax.control_flow.conditionals import cond_p
+from jax._src.lax.control_flow.loops import scan_p
+from jax.interpreters import ad, batching, mlir
+from jax.tree_util import tree_flatten, tree_structure, tree_unflatten
+
+
+class SowEffect(effects.Effect):
+  pass
+
+
+sow_effect = SowEffect()
+effects.lowerable_effects.add_type(SowEffect)
+effects.control_flow_allowed_effects.add_type(SowEffect)
+effects.remat_allowed_effects.add_type(SowEffect)
+
+sow_p = core.Primitive("sow")
+sow_p.multiple_results = True
+sow_p.def_impl(lambda *xs, **__: list(xs))
+sow_p.def_effectful_abstract_eval(lambda *avals, **__: (list(avals), {sow_effect}))
+mlir.register_lowering(sow_p, lambda ctx, *args, **__: args)  # identity; sow discarded
+# sow is a linear identity, so all transform rules are pass-throughs.
+ad.deflinear2(sow_p, lambda cts, *_, **__: cts)
+batching.primitive_batchers[sow_p] = lambda args, dims, **params: (
+    sow_p.bind(*args, **params), dims)
+
+_prefix: ContextVar[str] = ContextVar("sow_prefix", default="")
+
+def sow(value, *, name):
+  """Tag `value` (any pytree) with `name`, any hashable. Identity outside
+  `capture`. `capture_prefix` only applies to string names; a non-string name is
+  taken as already-absolute (nnx's `Module.sow` keys on a tuple that carries its
+  own module path)."""
+  leaves, treedef = tree_flatten(value)
+  if isinstance(name, str):
+    name = _prefix.get() + name
+  out = sow_p.bind(*leaves, name=name, tree=treedef)
+  return tree_unflatten(treedef, out)
+
+
+@partial(jax.custom_vjp, nondiff_argnums=(1,))
+def _perturb(value, name):
+  return value
+
+
+_perturb.defvjp(lambda value, name: (value, None),
+                lambda name, _res, g: (sow(g, name=name),))
+
+
+def perturb(value, *, name):
+  """Identity on the forward pass; sows the incoming cotangent under `name` on
+  the backward pass. Drop it into a function to harvest a gradient:
+
+      def loss(x):
+        return jnp.sum(perturb(x, name="grad_x") ** 2)
+
+      grad, collected = capture(jax.grad(loss))(x)
+      # collected["grad_x"][0] holds d(loss)/d(perturbed value)
+
+  Like `sow`, but for cotangents instead of forward values — the custom_vjp's
+  backward rule stages the sow into the gradient jaxpr at trace time, so
+  `capture(jax.grad(...))` picks it up (see test_sow_in_custom_vjp_backward)."""
+  return _perturb(value, name)
+
+# Call primitives whose sub-jaxpr we inline (sows collected directly). For
+# custom_jvp/vjp we inline the primal call_jaxpr; their differentiation rules
+# already staged any backward-pass sow into the enclosing jaxpr at trace time.
+_CALL_PRIMS = {
+    pjit.jit_p: "jaxpr",
+    core.closed_call_p: "call_jaxpr",
+    custom_jvp_call_p: "call_jaxpr",
+    custom_vjp_call_p: "call_jaxpr",
+}
+
+def _contains_sow(jaxpr: core.Jaxpr) -> bool:
+  return any(
+      eqn.primitive is sow_p or any(map(_contains_sow, core.jaxprs_in_params(eqn.params)))
+      for eqn in jaxpr.eqns
+  )
+
+def _merge(dst: dict, src: dict) -> None:
+  for name, vals in src.items():
+    dst.setdefault(name, []).extend(vals)
+
+def _flatten_collected(collected: dict):
+  """collected {name: [pytree,...]} -> (flat leaves, meta) in a stable order."""
+  leaves, meta = [], []
+  for name in sorted(collected, key=str):  # names need not be orderable, just stable
+    for pytree in collected[name]:
+      lvs, treedef = tree_flatten(pytree)
+      meta.append((name, treedef, len(lvs)))
+      leaves.extend(lvs)
+  return leaves, meta
+
+def _unflatten_collected(leaves, meta) -> dict:
+  out: dict = {}
+  i = 0
+  for name, treedef, n in meta:
+    out.setdefault(name, []).append(tree_unflatten(treedef, leaves[i:i + n]))
+    i += n
+  return out
+
+def _run(jaxpr: core.Jaxpr, consts, *args):
+  """Interpret a jaxpr, returning (outputs, {name: [pytree, ...]})."""
+  env: dict = {}
+  collected: dict = {}
+
+  def read(v):
+    return v.val if isinstance(v, core.Literal) else env[v]
+
+  env.update(zip(jaxpr.constvars, consts))
+  env.update(zip(jaxpr.invars, args))
+
+  for eqn in jaxpr.eqns:
+    invals = [read(v) for v in eqn.invars]
+    prim = eqn.primitive
+    if prim is sow_p:
+      pytree = tree_unflatten(eqn.params["tree"], invals)
+      collected.setdefault(eqn.params["name"], []).append(pytree)
+      outs = invals  # pass through
+    elif prim in _CALL_PRIMS:
+      sub = eqn.params[_CALL_PRIMS[prim]]  # ClosedJaxpr or open Jaxpr
+      jx, cs = (sub.jaxpr, sub.consts) if isinstance(sub, core.ClosedJaxpr) else (sub, [])
+      outs, sub_coll = _run(jx, cs, *invals)
+      _merge(collected, sub_coll)
+    elif prim is scan_p and _contains_sow(eqn.params["jaxpr"].jaxpr):
+      outs, sub_coll = _scan_with_sow(eqn.params, invals)
+      _merge(collected, sub_coll)
+    elif prim is cond_p and any(
+        _contains_sow(b.jaxpr) for b in eqn.params["branches"]):
+      outs, sub_coll = _cond_with_sow(eqn.params, invals)
+      _merge(collected, sub_coll)
+    elif prim is remat_p and _contains_sow(eqn.params["jaxpr"]):
+      if eqn.params["differentiated"]:
+        outs, sub_coll = _remat_with_sow(eqn.params, invals)
+      else:
+        outs, sub_coll = _run(eqn.params["jaxpr"], [], *invals)
+      _merge(collected, sub_coll)
+    else:
+      if any(_contains_sow(sj) for sj in core.jaxprs_in_params(eqn.params)):
+        raise NotImplementedError(
+            f"sow inside {prim} is not supported (handled: top level, jit, "
+            f"closed_call, custom_jvp/vjp, scan, cond, remat; not: while_loop)"
+        )
+      ans = prim.bind(*invals, **eqn.params)
+      outs = ans if prim.multiple_results else [ans]
+    env.update(zip(eqn.outvars, outs))
+
+  return [read(v) for v in jaxpr.outvars], collected
+
+
+def _scan_with_sow(params, invals):
+  """Sows inside a scan body become extra `ys`, so scan stacks them along the
+  scan axis. Each per-iteration sow appears as one stacked pytree entry."""
+  body = params["jaxpr"]
+  # ft_in.update(args).unpack() splits operands into (consts, carry, xs) — the
+  # same call scan's own impl uses (loops.py `_scan_impl`).
+  consts, init, xs = map(list, params["ft_in"].update(invals).unpack())
+  ncarry = len(init)
+  meta_box: list = []
+
+  def new_body(carry, x):
+    outs, coll = _run(body.jaxpr, body.consts, *consts, *carry, *x)
+    leaves, meta = _flatten_collected(coll)
+    meta_box.append(meta)
+    return outs[:ncarry], (outs[ncarry:], leaves)
+
+  final_carry, (stacked_ys, stacked_leaves) = lax.scan(
+      new_body, init, xs, length=params["length"],
+      reverse=params["reverse"], unroll=params["unroll"])
+  return [*final_carry, *stacked_ys], _unflatten_collected(stacked_leaves, meta_box[0])
+
+
+def _cond_with_sow(params, invals):
+  """Sows inside cond branches become extra outputs. jax's own "branches must
+  match" check enforces that every branch sows the same names/shapes."""
+  index, operands = invals[0], invals[1:]
+  branches = params["branches"]
+  n_out = len(branches[0].jaxpr.outvars)
+  meta_box: list = []
+
+  def make(branch):
+    def fn(*ops):
+      outs, coll = _run(branch.jaxpr, branch.consts, *ops)
+      leaves, meta = _flatten_collected(coll)
+      meta_box.append(meta)
+      return (*outs, *leaves)
+    return fn
+
+  results = lax.switch(index, [make(b) for b in branches], *operands)
+  return list(results[:n_out]), _unflatten_collected(results[n_out:], meta_box[-1])
+
+
+def _remat_with_sow(params, invals):
+  """Sows inside an already-differentiated remat become extra outputs, so the
+  optimization barrier and the recompute survive rebinding — only the sown values
+  are promoted to residuals (unavoidable: that is what harvesting them means)."""
+  body = params["jaxpr"]  # open Jaxpr, no constvars
+  meta_box: list = []
+
+  def fn(*args):
+    outs, coll = _run(body, [], *args)
+    leaves, meta = _flatten_collected(coll)
+    meta_box.append(meta)
+    return [*outs, *leaves]
+
+  cj = jax.make_jaxpr(fn)(*invals)
+  # remat bodies must be constvar-free, so consts ride along as leading operands.
+  prevent_cse = params["prevent_cse"]
+  if isinstance(prevent_cse, tuple):
+    prevent_cse = (False,) * len(cj.consts) + prevent_cse
+  results = remat_p.bind(*cj.consts, *invals,
+                         **dict(params, jaxpr=pe.convert_constvars_jaxpr(cj.jaxpr),
+                                prevent_cse=prevent_cse))
+  n_out = len(body.outvars)
+  return list(results[:n_out]), _unflatten_collected(results[n_out:], meta_box[-1])
+
+
+def capture(f):
+  """Transform `f` to return `(f_output, {name: (pytree, ...)})`."""
+  def wrapped(*args, **kwargs):
+    cj, out_shape = jax.make_jaxpr(f, return_shape=True)(*args, **kwargs)
+    flat_args = tree_flatten((args, kwargs))[0]
+    out_flat, collected = _run(cj.jaxpr, cj.consts, *flat_args)
+    out = tree_unflatten(tree_structure(out_shape), out_flat)
+    return out, {name: tuple(vals) for name, vals in collected.items()}
+
+  return wrapped

--- a/flax/nnx/variablelib.py
+++ b/flax/nnx/variablelib.py
@@ -1096,7 +1096,6 @@ class Variable(tp.Generic[A], reprlib.Representable, metaclass=VariableMeta):
   required_metadata = frozenset(
     ['hijax', 'ref', 'eager_sharding']
   )
-
   @property
   def var_type(self):
     return type(self)
@@ -1985,8 +1984,6 @@ class Param(Variable[A]):
       )
     })
   """
-
-  pass
 
 
 class BatchStat(Variable[A]):

--- a/tests/nnx/integration_test.py
+++ b/tests/nnx/integration_test.py
@@ -520,6 +520,9 @@ class TestIntegration(parameterized.TestCase):
         return self.linear_out(x)
 
     model = Model(2, 64, 3, rngs=nnx.Rngs(0))  # eager initialization
+    # Params default to ref=False, opt them in: this example updates them
+    # in-place from inside jit.
+    model = nnx.with_vars(model, ref=True, only=nnx.Param)
     optimizer = nnx.Optimizer(model, optax.adam(1e-3), wrt=nnx.Param)
 
     @jax.jit  # automatic state management for JAX transforms

--- a/tests/nnx/module_test.py
+++ b/tests/nnx/module_test.py
@@ -30,6 +30,7 @@ import flax
 
 A = TypeVar('A')
 
+import contextlib
 from contextlib import contextmanager
 
 @contextmanager
@@ -437,6 +438,205 @@ class TestCapture(parameterized.TestCase):
     self.assertIn('intermediate', intms)
     np.testing.assert_allclose(intms['__call__'][0], y)
     np.testing.assert_allclose(jnp.sin(intms['intermediate'][0]), y)
+
+class TestCaptureFunctional(parameterized.TestCase):
+  """The 'functional=True' style: 'nnx.capture' traces the function it wraps
+  and collects sown values from the trace, so it only supports tree mode."""
+
+  def setUp(self):
+    super().setUp()
+    stack = contextlib.ExitStack()
+    stack.enter_context(set_graph_mode(False))
+    self.addCleanup(stack.close)
+
+  @parameterized.parameters(True, False)
+  def test_state_updates(self, ref):
+    # capture traces the function, so a module that mutates its state needs
+    # ref-backed Variables: as jax refs they write through the trace. A plain
+    # Variable cannot be written from a deeper trace level at all.
+    class Foo(nnx.Module):
+      def __init__(self, rngs):
+        self.bn = nnx.BatchNorm(4, use_running_average=False, rngs=rngs)
+        self.dropout = nnx.Dropout(0.5, deterministic=False, rngs=rngs)
+
+      def __call__(self, x):
+        y = self.dropout(self.bn(x))
+        self.sow(nnx.Intermediate, 'ymean', y.mean())
+        return y
+
+    with nnx.var_defaults(ref=ref):
+      model = Foo(nnx.Rngs(0))
+
+    count = model.dropout.rngs.count.get_value()
+    forward = nnx.capture(model, nnx.Intermediate, functional=True)
+
+    if not ref:
+      with self.assertRaisesRegex(
+        errors.TraceContextError, 'Cannot mutate BatchStat'
+      ):
+        forward(jnp.ones((8, 4)))
+      return
+
+    _, intermediates = forward(jnp.ones((8, 4)))
+    self.assertIn('ymean', intermediates['__call__'])
+    self.assertFalse(jnp.allclose(model.bn.mean.get_value(), 0.0))
+    self.assertEqual(model.dropout.rngs.count.get_value(), count + 1)
+
+  def test_refs_only_for_mutable_vars(self):
+    # refs for state that is written inside the trace, plain Variables for
+    # params so they can still be differentiated.
+    class Foo(nnx.Module):
+      def __init__(self, rngs):
+        self.linear = nnx.Linear(4, 4, rngs=rngs)
+        self.bn = nnx.BatchNorm(4, use_running_average=False, rngs=rngs)
+
+      def __call__(self, x):
+        y = self.bn(self.linear(x))
+        self.sow(nnx.Intermediate, 'ymean', y.mean())
+        return y
+
+    with nnx.var_defaults(ref=True):
+      model = Foo(nnx.Rngs(0))
+    self.assertTrue(model.linear.kernel.ref)
+    self.assertTrue(model.bn.mean.ref)
+
+    def loss_grads(model, x, y):
+      # params must be plain Variables to differentiate with respect to them
+      model = nnx.with_vars(model, ref=False, only=nnx.Param)
+      graphdef, params, nondiff = nnx.split(model, nnx.Param, ...)
+      def loss_fn(params):
+        return jnp.mean((nnx.merge(graphdef, params, nondiff)(x) - y) ** 2)
+      return jax.grad(loss_fn)(params)
+
+    grads, intermediates = nnx.capture(
+      loss_grads, nnx.Intermediate, functional=True
+    )(
+      model, jnp.ones((8, 4)), jnp.zeros((8, 4))
+    )
+
+    self.assertIn('ymean', intermediates['__call__'])
+    self.assertEqual(grads['linear']['kernel'].shape, (4, 4))
+    # the ref-backed running stats were still updated through the trace
+    self.assertFalse(jnp.allclose(model.bn.mean.get_value(), 0.0))
+
+  def test_vmap(self):
+
+    class Foo(nnx.Module):
+      def __init__(self, dim):
+        self.w = nnx.Param(jax.random.normal(jax.random.key(0), dim))
+
+      def __call__(self, x):
+        x = self.perturb('grad_of_x', x)
+        y = jnp.dot(x, self.w)
+        self.sow(nnx.Intermediate, 'y', y)
+        return y
+
+    model, x = Foo(4), jnp.ones((3, 4))
+
+    def loss(model, x):
+      return model(x)
+
+    # perturb sows the cotangent, so the differentiated function is captured
+    _, intermediates, perturbations = nnx.capture(
+      nnx.vmap(nnx.grad(loss, argnums=1), in_axes=(None, 0)),
+      nnx.Intermediate, nnx.Perturbation, functional=True,
+    )(model, x)
+
+    # d(dot(x, w))/dx is w, and is batch independent, so jax keeps it unbatched
+    np.testing.assert_allclose(
+      perturbations['__call__']['grad_of_x'][0], model.w.get_value()
+    )
+    # the forward sow does vary per example, so it comes back batched
+    self.assertEqual(intermediates['__call__']['y'][0].shape, (3,))
+
+  def test_fwd_bwd(self):
+        class Foo(nnx.Module):
+          @nnx.jit
+          def __call__(self, x):
+            x = self.perturb('grad_of_x', x)
+            y = 3 * x
+            self.sow(nnx.Intermediate, 'y', y)
+            return y
+
+        model = Foo()
+        x = 1.0
+
+        def loss(model, x):
+          return model(x)
+
+        _, intermediates, perturbations = nnx.capture(
+          nnx.grad(loss, argnums=1), nnx.Intermediate, nnx.Perturbation,
+          functional=True,
+        )(model, x)
+
+        self.assertEqual(perturbations['__call__']['grad_of_x'][0], 3)
+        self.assertEqual(intermediates['__call__']['y'][0], 3)
+
+  def test_nested_modules(self):
+      class Foo(nnx.Module):
+        def __call__(self, x):
+          x = self.perturb('grad_of_x', x)
+          y = 3 * x
+          self.sow(nnx.Intermediate, 'y', y)
+          return y
+      class Bar(nnx.Module):
+        def __init__(self):
+          self.foos = nnx.data([Foo() for _ in range(3)])
+        def __call__(self, x):
+          for block in self.foos:
+            x = block(x)
+          return x
+
+      model = Bar()
+      x = 1.0
+
+      def loss(model, x):
+        return model(x)
+
+      _, intermediates, perturbations = nnx.capture(
+        nnx.grad(loss, argnums=1), nnx.Intermediate, nnx.Perturbation,
+        functional=True,
+      )(model, x)
+
+      # the three blocks run the same method, so they share a path and their
+      # values accumulate under it
+      perts = perturbations['__call__']['__call__']['grad_of_x']
+      interms = intermediates['__call__']['__call__']['y']
+      for i in range(3):
+        self.assertEqual(perts[i], 3**(i+1))
+        self.assertEqual(interms[i], 3**(i+1))
+
+  def test_method_outputs(self):
+    class Foo(nnx.Module):
+      def helper(self, x):
+        return jnp.sin(x)
+      def __call__(self, x):
+        return self.helper(x)
+
+    y, intms = nnx.capture(
+      Foo(), nnx.Intermediate, method_outputs=nnx.Intermediate,
+      functional=True,
+    )(jnp.ones((2,)))
+
+    np.testing.assert_allclose(intms['__call__']['helper']['output'][0], y)
+    np.testing.assert_allclose(intms['__call__']['output'][0], y)
+
+  def test_init_is_rejected(self):
+    with self.assertRaisesRegex(ValueError, "'init' is not supported"):
+      nnx.capture(
+        SowMod(nnx.Rngs(0)), nnx.Intermediate, init=nnx.State({}),
+        functional=True,
+      )(jnp.ones((2, 4)))
+
+  def test_reduce_fn_is_rejected(self):
+    class Foo(nnx.Module):
+      def __call__(self, x):
+        self.sow(nnx.Intermediate, 'sum', x, init_fn=lambda: 0,
+                 reduce_fn=lambda prev, curr: prev + curr)
+        return x
+
+    with self.assertRaisesRegex(ValueError, "'reduce_fn'/'init_fn'"):
+      nnx.capture(Foo(), nnx.Intermediate, functional=True)(jnp.ones((2, 4)))
 
 class SowMod(nnx.Module):
     def __init__(self, rngs: nnx.Rngs):

--- a/tests/nnx/sow_test.py
+++ b/tests/nnx/sow_test.py
@@ -1,0 +1,246 @@
+import jax
+import jax.numpy as jnp
+
+from flax.nnx.sow import sow, perturb, capture
+
+def test_sow_vmap():
+  @jax.vmap
+  def f(x):
+    sow(x, name="a")
+    return x
+
+  _, collected = capture(f)(jnp.arange(5))
+  print(collected)
+
+
+def test_bare_statement_collected():
+  # No use of sow's return value -> effect keeps it alive.
+  def f(x):
+    sow(x * 2, name="doubled")
+    return x + 1
+
+  out, collected = capture(f)(jnp.float32(3.0))
+  assert out == 4.0
+  assert set(collected) == {"doubled"}
+  assert len(collected["doubled"]) == 1
+  assert collected["doubled"][0] == 6.0
+
+
+def test_multiple_sows_same_name_in_order():
+  def f(x):
+    sow(x, name="a")
+    sow(x + 1, name="a")
+    return x
+
+  _, collected = capture(f)(jnp.float32(10.0))
+  assert collected["a"] == (10.0, 11.0)
+
+
+def test_pytree_value():
+  def f(x):
+    sow({"lo": x, "hi": x + 1}, name="pair")
+    return x
+
+  _, collected = capture(f)(jnp.float32(5.0))
+  (d,) = collected["pair"]
+  assert d["lo"] == 5.0 and d["hi"] == 6.0
+
+
+def test_output_unchanged_vs_plain():
+  def f(x):
+    sow(x, name="x")
+    return jnp.sin(x) + 2
+
+  x = jnp.float32(1.5)
+  out, _ = capture(f)(x)
+  assert jnp.allclose(out, jnp.sin(x) + 2)
+
+
+def test_plain_jit_and_grad_still_work():
+  # sow is a no-op identity under normal execution / jit / grad.
+  def f(x):
+    sow(x, name="x")
+    return jnp.sin(x)
+
+  assert jnp.allclose(jax.jit(f)(jnp.float32(1.0)), jnp.sin(1.0))
+  assert jnp.allclose(jax.grad(f)(jnp.float32(1.0)), jnp.cos(1.0))
+  xs = jnp.arange(3, dtype=jnp.float32)
+  assert jnp.allclose(jax.vmap(f)(xs), jnp.sin(xs))
+
+
+def test_sow_inside_jit_is_collected():
+  @jax.jit
+  def inner(x):
+    sow(x * 3, name="inner")
+    return x
+
+  def f(x):
+    return inner(x) + 1
+
+  out, collected = capture(f)(jnp.float32(2.0))
+  out, collected = capture(f)(jnp.float32(2.0))
+  assert out == 3.0
+  assert collected["inner"] == (6.0,)
+
+
+def test_sown_is_jittable():
+  # The whole transform runs under jit; collected values become jit outputs.
+  def f(x):
+    sow(x * 2, name="m")
+    return x + 1
+
+  out, collected = jax.jit(capture(f))(jnp.float32(4.0))
+  assert out == 5.0
+  assert jnp.allclose(collected["m"][0], 8.0)
+
+
+def test_sow_inside_scan_is_stacked():
+  # A per-iteration sow is stacked along the scan axis as one entry.
+  def f(x):
+    def body(c, _):
+      sow(c, name="step")
+      return c + 1, c
+    c, _ = jax.lax.scan(body, x, None, length=4)
+    return c
+
+  out, collected = capture(f)(jnp.float32(0.0))
+  assert out == 4.0
+  (steps,) = collected["step"]
+  assert jnp.array_equal(steps, jnp.arange(4, dtype=jnp.float32))
+
+
+def test_sow_inside_cond():
+  # Both branches sow the same name/shape -> collected is the taken branch's.
+  def f(x, pred):
+    def t(v):
+      sow(v * 10, name="branch")
+      return v
+    def fl(v):
+      sow(v * 100, name="branch")
+      return v
+    return jax.lax.cond(pred, t, fl, x)
+
+  _, collected = capture(f)(jnp.float32(2.0), True)
+  assert collected["branch"] == (20.0,)
+  _, collected = capture(f)(jnp.float32(2.0), False)
+  assert collected["branch"] == (200.0,)
+
+
+def test_sow_inside_scan_under_jit():
+  def f(x):
+    def body(c, _):
+      sow(c, name="step")
+      return c + 1, c
+    c, _ = jax.lax.scan(body, x, None, length=3)
+    return c
+
+  out, collected = jax.jit(capture(f))(jnp.float32(0.0))
+  assert out == 3.0
+  assert jnp.array_equal(collected["step"][0], jnp.arange(3, dtype=jnp.float32))
+
+
+def test_pytree_sow_inside_scan():
+  def f(x):
+    def body(c, _):
+      sow({"v": c, "sq": c * c}, name="d")
+      return c + 1, c
+    c, _ = jax.lax.scan(body, x, None, length=3)
+    return c
+
+  _, collected = capture(f)(jnp.float32(0.0))
+  (d,) = collected["d"]
+  assert jnp.array_equal(d["v"], jnp.arange(3, dtype=jnp.float32))
+  assert jnp.array_equal(d["sq"], jnp.arange(3, dtype=jnp.float32) ** 2)
+
+
+def test_sow_in_custom_vjp_backward():
+  # A custom_vjp whose backward rule sows: sown(grad(...)) harvests it because
+  # the bwd's sow is staged into the gradient jaxpr at trace time.
+  @jax.custom_vjp
+  def h(x):
+    return x ** 2
+
+  def h_fwd(x):
+    return h(x), x
+
+  def h_bwd(x, g):
+    gx = 2 * x * g
+    sow(gx, name="grad_h")
+    return (gx,)
+
+  h.defvjp(h_fwd, h_bwd)
+
+  def loss(x):
+    return jnp.sum(h(x))
+
+  x = jnp.arange(3.0)
+  grad, collected = capture(jax.grad(loss))(x)
+  assert jnp.array_equal(grad, 2 * x)
+  assert jnp.array_equal(collected["grad_h"][0], 2 * x)
+
+
+def test_sow_inside_remat():
+  # differentiated=False: the body is inlined, exactly as jax lowers it.
+  def f(x):
+    y = jnp.sin(x)
+    sow(y, name="y")
+    return y * 2
+
+  out, collected = capture(jax.checkpoint(f))(jnp.float32(1.0))
+  assert jnp.allclose(out, jnp.sin(1.0) * 2)
+  assert jnp.allclose(collected["y"][0], jnp.sin(1.0))
+
+
+def test_sow_inside_remat_under_grad_fires_once():
+  # The known half is inlined by remat's partial eval, so the forward sow lands
+  # at the top level of the gradient jaxpr and is collected exactly once.
+  def f(x):
+    y = jnp.sin(x)
+    sow(y, name="y")
+    return jnp.sum(y * 2)
+
+  x = jnp.float32(1.0)
+  g, collected = capture(jax.grad(jax.checkpoint(f)))(x)
+  assert jnp.allclose(g, jnp.cos(x) * 2)
+  assert len(collected["y"]) == 1
+  assert jnp.allclose(collected["y"][0], jnp.sin(x))
+
+
+def test_perturb_inside_remat_keeps_barrier():
+  # differentiated=True: grad stages the cotangent sow INSIDE the remat body.
+  # We rebind remat_p rather than inline, so the remat2 eqn must survive.
+  def f(x):
+    return jnp.sum(perturb(jnp.sin(x), name="dx") ** 2)
+
+  x = jnp.float32(2.0)
+  g, collected = capture(jax.grad(jax.checkpoint(f)))(x)
+  assert jnp.allclose(g, 2 * jnp.sin(x) * jnp.cos(x))
+  assert jnp.allclose(collected["dx"][0], 2 * jnp.sin(x))
+  assert "remat2" in str(jax.make_jaxpr(capture(jax.grad(jax.checkpoint(f))))(x))
+
+
+def test_pytree_sow_inside_remat_under_grad():
+  def f(x):
+    d = perturb({"a": jnp.sin(x), "b": jnp.cos(x)}, name="dp")
+    return jnp.sum(d["a"] ** 2 + d["b"] * 3)
+
+  x = jnp.float32(0.5)
+  _, collected = capture(jax.grad(jax.checkpoint(f)))(x)
+  (d,) = collected["dp"]
+  assert jnp.allclose(d["a"], 2 * jnp.sin(x))
+  assert jnp.allclose(d["b"], 3.0)
+
+
+def test_sow_inside_while_raises():
+  import pytest
+
+  def f(x):
+    def cond(c):
+      return c < 3
+    def body(c):
+      sow(c, name="w")
+      return c + 1
+    return jax.lax.while_loop(cond, body, x)
+
+  with pytest.raises(NotImplementedError):
+    capture(f)(jnp.float32(0.0))


### PR DESCRIPTION
This PR swaps out the old sow implementation (which required the types/ shapes of variables we sowed to to change) with one written as a pure jax transform. Only variable mutation using `ref` is supported within the transform, as that's all that's needed if we already have sow.  Closes #5538 