### PR TITLE
docs(attention): document None default behavior in MultiHeadAttention layers

### DIFF
--- a/flax/linen/attention.py
+++ b/flax/linen/attention.py
@@ -351,14 +351,20 @@ class MultiHeadDotProductAttention(Module):
       should be divisible by the number of heads.
     dtype: The dtype of the computation (default: infer from inputs and params)
     param_dtype: The dtype passed to parameter initializers (default: float32)
-    qkv_features: Dimension of the key, query, and value.
-    out_features: Dimension of the last projection
+    qkv_features: Dimension of the key, query, and value. If None (the default),
+      it defaults to the feature dimension of the query inputs
+      (i.e. ``inputs_q.shape[-1]``).
+    out_features: Dimension of the last projection. If None (the default),
+      it defaults to the feature dimension of the query inputs
+      (i.e. ``inputs_q.shape[-1]``).
     broadcast_dropout: Use a broadcasted dropout along batch dims.
     dropout_rate: Dropout rate.
     deterministic: If False, the attention weight is masked randomly using
-      dropout, whereas if True, the attention weights are deterministic.
-    precision: Numerical precision of the computation see ``jax.lax.Precision``
-      for details.
+      dropout, whereas if True, the attention weights are deterministic. If None
+      (the default), ``deterministic`` must be passed to ``__call__`` when
+      ``dropout_rate > 0.0``; if ``dropout_rate == 0.0``, it defaults to True.
+    precision: Numerical precision of the computation, see ``jax.lax.Precision``
+      for details. If None (the default), default precision of JAX operations is used.
     kernel_init: Initializer for the kernel of the Dense layers.
     out_kernel_init: Optional Initializer for the kernel of the output Dense layer,
       if None, ``kernel_init`` will be used.
@@ -466,8 +472,10 @@ class MultiHeadDotProductAttention(Module):
       mask: attention mask of shape ``[batch_sizes..., num_heads, query_length,
         key/value_length]``. Attention weights are masked out if their
         corresponding mask value is ``False``.
-      deterministic: if false, the attention weight is masked randomly using
-        dropout, whereas if true, the attention weights are deterministic.
+      deterministic: If False, the attention weight is masked randomly using
+        dropout, whereas if True, the attention weights are deterministic.
+        If None (the default), the module-level attribute ``self.deterministic``
+        is used if set, or defaults to True when ``dropout_rate == 0.0``.
       dropout_rng: optional rng key to pass to the attention layer's dropout
         mask. Otherwise, self.make_rng('dropout') is used instead.
       sow_weights: if ``True``, the attention weights are sowed into the
@@ -753,14 +761,20 @@ class MultiHeadAttention(MultiHeadDotProductAttention):
       should be divisible by the number of heads.
     dtype: the dtype of the computation (default: infer from inputs and params)
     param_dtype: the dtype passed to parameter initializers (default: float32)
-    qkv_features: dimension of the key, query, and value.
-    out_features: dimension of the last projection
+    qkv_features: Dimension of the key, query, and value. If None (the default),
+      it defaults to the feature dimension of the query inputs
+      (i.e. ``inputs_q.shape[-1]``).
+    out_features: Dimension of the last projection. If None (the default),
+      it defaults to the feature dimension of the query inputs
+      (i.e. ``inputs_q.shape[-1]``).
     broadcast_dropout: bool: use a broadcasted dropout along batch dims.
     dropout_rate: dropout rate
-    deterministic: if false, the attention weight is masked randomly using
-      dropout, whereas if true, the attention weights are deterministic.
-    precision: numerical precision of the computation see ``jax.lax.Precision``
-      for details.
+    deterministic: If False, the attention weight is masked randomly using
+      dropout, whereas if True, the attention weights are deterministic. If None
+      (the default), ``deterministic`` must be passed to ``__call__`` when
+      ``dropout_rate > 0.0``; if ``dropout_rate == 0.0``, it defaults to True.
+    precision: Numerical precision of the computation, see ``jax.lax.Precision``
+      for details. If None (the default), default precision of JAX operations is used.
     kernel_init: initializer for the kernel of the Dense layers.
     bias_init: initializer for the bias of the Dense layers.
     use_bias: bool: whether pointwise QKVO dense transforms use bias.
@@ -802,8 +816,10 @@ class SelfAttention(MultiHeadDotProductAttention):
       mask: attention mask of shape ``[batch_sizes..., num_heads, query_length,
         key/value_length]``. Attention weights are masked out if their
         corresponding mask value is ``False``.
-      deterministic: if false, the attention weight is masked randomly using
-        dropout, whereas if true, the attention weights are deterministic.
+      deterministic: If False, the attention weight is masked randomly using
+        dropout, whereas if True, the attention weights are deterministic.
+        If None (the default), the module-level attribute ``self.deterministic``
+        is used if set, or defaults to True when ``dropout_rate == 0.0``.
 
     Returns:
       output of shape ``[batch_sizes..., length, features]``.

--- a/flax/nnx/nn/attention.py
+++ b/flax/nnx/nn/attention.py
@@ -509,8 +509,10 @@ class MultiHeadAttention(Module):
     num_heads: number of attention heads. Features (i.e. inputs_q.shape[-1])
       should be divisible by the number of heads.
     in_features: int or tuple with number of input features.
-    qkv_features: dimension of the key, query, and value.
-    out_features: dimension of the last projection.
+    qkv_features: Dimension of the key, query, and value. If None (the default),
+      it defaults to ``in_features``.
+    out_features: Dimension of the last projection. If None (the default),
+      it defaults to ``in_features``.
     in_kv_features: number of input features for computing key and value.
     num_kv_heads: number of key and value heads. If None, it defaults to
       ``num_heads``. If set to a value smaller than ``num_heads``, Grouped Query
@@ -520,10 +522,12 @@ class MultiHeadAttention(Module):
     param_dtype: the dtype passed to parameter initializers (default: float32)
     broadcast_dropout: bool: use a broadcasted dropout along batch dims.
     dropout_rate: dropout rate
-    deterministic: if false, the attention weight is masked randomly using
-      dropout, whereas if true, the attention weights are deterministic.
-    precision: numerical precision of the computation see `jax.lax.Precision`
-      for details.
+    deterministic: If False, the attention weight is masked randomly using
+      dropout, whereas if True, the attention weights are deterministic. If None
+      (the default), ``deterministic`` is required when ``keep_rngs=False`` and
+      ``dropout_rate > 0.0``; otherwise defaults to False when RNG stream is available.
+    precision: Numerical precision of the computation, see `jax.lax.Precision`
+      for details. If None (the default), default precision of JAX operations is used.
     kernel_init: initializer for the kernel of the Dense layers.
     out_kernel_init: optional initializer for the kernel of the output Dense layer,
       if None, the kernel_init is used.


### PR DESCRIPTION
# What does this PR do?

Fixes #4182

In `MultiHeadAttention` and `MultiHeadDotProductAttention` (in `flax.linen.attention`) as well as `MultiHeadAttention` (in `flax.nnx.nn.attention`), several optional arguments default to `None`, but their docstrings did not document the exact fallback evaluation behavior when `None` is provided or left as default.

This PR clarifies the `None` default behavior for:
- `qkv_features`: defaults to `inputs_q.shape[-1]` (in Linen) or `in_features` (in NNX).
- `out_features`: defaults to `inputs_q.shape[-1]` (in Linen) or `in_features` (in NNX).
- `deterministic`: clarifies behavior when `None` vs `dropout_rate > 0.0`.
- `precision`: clarifies that `None` uses the default JAX numerical precision.

## Checklist
- [x] This PR fixes a minor issue (e.g.: typo or small bug) or improves the docs (you can dismiss the other checks if that's the case).
- [x] This change is discussed in a Github issue/[discussion](https://github.com/google/flax/issues/4182).
- [x] The documentation and docstrings adhere to the [documentation guidelines](https://github.com/google/flax/blob/main/docs/README.md#how-to-write-code-documentation).
- [x] This change includes necessary high-coverage tests. (No quality testing = no merge!)

cc @vfdev-5 @cgarciae for review.
