### PR TITLE
fix(nnx): make ToLinen hashable for JAX JIT (#4156)

### DIFF
--- a/flax/nnx/bridge/wrappers.py
+++ b/flax/nnx/bridge/wrappers.py
@@ -323,6 +323,13 @@ class ToLinen(linen.Module):
   skip_rng: bool = False
   metadata_fn: tp.Callable[[variablelib.Variable], tp.Any] | None = bv.to_linen_var
 
+  def __post_init__(self):
+    if not isinstance(self.args, tuple):
+      object.__setattr__(self, 'args', tuple(self.args))
+    if not isinstance(self.kwargs, FrozenDict):
+      object.__setattr__(self, 'kwargs', FrozenDict(self.kwargs))
+    super().__post_init__()
+
   @linen.compact
   def __call__(
     self, *args, nnx_method: tp.Callable[..., Any] | str | None = None, **kwargs

--- a/tests/nnx/bridge/wrappers_test.py
+++ b/tests/nnx/bridge/wrappers_test.py
@@ -266,6 +266,28 @@ class TestCompatibility(absltest.TestCase):
     assert y.shape == (1, 64)
     np.testing.assert_allclose(y, x @ variables['params']['kernel'])
 
+  def test_tolinen_hashable(self):
+    # Test that ToLinen is hashable with various arguments (issue #4156)
+    model1 = bridge.ToLinen(nnx.Linear, args=(32, 64))
+    model2 = bridge.ToLinen(nnx.Linear, args=[32, 64], kwargs={'use_bias': True})
+    model3 = bridge.to_linen(nnx.Linear, 32, out_features=64)
+
+    self.assertEqual(hash(model1), hash(bridge.ToLinen(nnx.Linear, args=(32, 64))))
+    self.assertEqual(hash(model2), hash(bridge.ToLinen(nnx.Linear, args=(32, 64), kwargs={'use_bias': True})))
+    self.assertEqual(hash(model3), hash(bridge.to_linen(nnx.Linear, 32, out_features=64)))
+
+    # Test can be used in set / dict key
+    module_set = {model1, model2, model3}
+    self.assertIn(model1, module_set)
+    self.assertIn(model2, module_set)
+    self.assertIn(model3, module_set)
+
+    # Test to_linen_class dynamic wrapper is also hashable
+    LinenLinear = bridge.to_linen_class(nnx.Linear, out_features=64)
+    model4 = LinenLinear(32)
+    self.assertEqual(hash(model4), hash(LinenLinear(32)))
+    self.assertIn(model4, {model4})
+
   def test_nnx_to_linen_multiple_rngs(self):
     class NNXInner(nnx.Module):
       def __init__(self, din, dout, rngs):


### PR DESCRIPTION
# What does this PR do?

Fixes #4156

Standard Linen modules are hashable dataclasses, allowing them to be passed as static arguments to `jax.jit` functions or used in caches. However, `flax.nnx.bridge.ToLinen` could fail with `TypeError: unhashable type: 'dict'` or unhashable sequence errors if instantiated with mutable `args` (e.g. `list`) or `kwargs` (e.g. standard `dict`).

This PR:
1. Adds `__post_init__` in `ToLinen` to ensure `self.args` is converted to a `tuple` and `self.kwargs` is converted to a `flax.core.FrozenDict`.
2. Adds a comprehensive regression test `test_tolinen_hashable` in `tests/nnx/bridge/wrappers_test.py` covering direct `ToLinen`, `to_linen`, and dynamic `to_linen_class` modules.

## Checklist
- [x] This PR fixes a minor issue (e.g.: typo or small bug) or improves the docs (you can dismiss the other checks if that's the case).
- [x] This change is discussed in a Github issue/[discussion](https://github.com/google/flax/issues/4156).
- [x] The documentation and docstrings adhere to the [documentation guidelines](https://github.com/google/flax/blob/main/docs/README.md#how-to-write-code-documentation).
- [x] This change includes necessary high-coverage tests. (No quality testing = no merge!)

cc @cgarciae @vfdev-5 for review.
