### PR TITLE
fix(traverse_util): validate keys in flatten_dict when separator is specified (#5554)

### DIFF
--- a/flax/traverse_util.py
+++ b/flax/traverse_util.py
@@ -91,6 +91,12 @@ def _flatten(xs, prefix, keep_empty_nodes, is_leaf, sep):
   result = {}
   is_empty = True
   for key, value in xs.items():
+    if sep is not None:
+      if not isinstance(key, str) or sep in key:
+        raise ValueError(
+          f"flatten_dict with sep='{sep}' requires string keys that do not "
+          f"contain the separator; got key {key!r} at path {prefix + (key,)}"
+        )
     is_empty = False
     path = prefix + (key,)
     result.update(_flatten(value, path, keep_empty_nodes, is_leaf, sep))
@@ -130,9 +136,13 @@ def flatten_dict(xs, keep_empty_nodes=False, is_leaf=None, sep=None):
       leaf (i.e., should not be flattened further).
     sep: if specified, then the keys of the returned
       dictionary will be ``sep``-joined strings (if
-      ``None``, then keys will be tuples).
+      ``None``, then keys will be tuples). When specified,
+      all keys must be strings that do not contain ``sep``.
   Returns:
     The flattened dictionary.
+  Raises:
+    ValueError: if ``sep`` is specified and any dictionary key is not a string
+      or contains the separator ``sep``.
   """
   assert isinstance(
     xs, (flax.core.FrozenDict, dict)

--- a/tests/traverse_util_test.py
+++ b/tests/traverse_util_test.py
@@ -175,6 +175,43 @@ class TraversalTest(absltest.TestCase):
       },
     )
 
+  def test_flatten_dict_sep_key_containing_sep(self):
+    xs = {'a/b': 1, 'c': {'d': 2}}
+    with self.assertRaisesRegex(
+      ValueError,
+      r"flatten_dict with sep='/' requires string keys that do not contain the separator; got key 'a/b' at path \('a/b',\)",
+    ):
+      traverse_util.flatten_dict(xs, sep='/')
+
+    xs_nested = {'a': {'b/c': 2}}
+    with self.assertRaisesRegex(
+      ValueError,
+      r"flatten_dict with sep='/' requires string keys that do not contain the separator; got key 'b/c' at path \('a', 'b/c'\)",
+    ):
+      traverse_util.flatten_dict(xs_nested, sep='/')
+
+  def test_flatten_dict_sep_non_string_key(self):
+    xs = {1: {2: 3}}
+    with self.assertRaisesRegex(
+      ValueError,
+      r"flatten_dict with sep='/' requires string keys that do not contain the separator; got key 1 at path \(1,\)",
+    ):
+      traverse_util.flatten_dict(xs, sep='/')
+
+    xs_nested = {'a': {42: 'foo'}}
+    with self.assertRaisesRegex(
+      ValueError,
+      r"flatten_dict with sep='/' requires string keys that do not contain the separator; got key 42 at path \('a', 42\)",
+    ):
+      traverse_util.flatten_dict(xs_nested, sep='/')
+
+  def test_flatten_dict_none_sep_preserves_non_string_and_sep_keys(self):
+    xs = {'a/b': 1, 1: {2: 3}}
+    flat = traverse_util.flatten_dict(xs)
+    self.assertEqual(flat, {('a/b',): 1, (1, 2): 3})
+    back = traverse_util.unflatten_dict(flat)
+    self.assertEqual(back, xs)
+
   def test_unflatten_dict(self):
     expected_xs = {'foo': 1, 'bar': {'a': 2}}
     xs = traverse_util.unflatten_dict(


### PR DESCRIPTION
### Summary

Fixes #5554

When `flax.traverse_util.flatten_dict` is called with a separator (`sep is not None`):
1. **Case 1 (Structural corruption)**: A string key containing the separator (e.g. `{"a/b": 1, "c": {"d": 2}}` with `sep="/"`) flattens to `{"a/b": 1, "c/d": 2}`. When `unflatten_dict(..., sep="/")` is called, `"a/b"` is split into a nested path `{"a": {"b": 1}}`, silently corrupting the round-trip structure without error.
2. **Case 2 (Opaque TypeError)**: A non-string key (e.g. `{1: {2: 3}}` with `sep="/"`) surfaces an internal `TypeError: sequence item 0: expected str instance, int found` from deep inside string joining.

### Solution

- Validates each key in `_flatten` when `sep is not None` to ensure it is a string and does not contain `sep`.
- Raises a descriptive `ValueError`:
  ```
  ValueError: flatten_dict with sep='/' requires string keys that do not contain the separator; got key 'a/b' at path ('a/b',)
  ```
- Updates `flatten_dict` docstrings to document the string/separator requirement and `ValueError`.
- Added unit tests in `traverse_util_test.py` covering non-string keys, separator-containing keys, nested dictionary paths, and verifying `sep=None` behavior remains unaffected.

cc @IvyZX @cgarciae @jheek @Amey-Thakur
