### PR TITLE
Fix root leaf handling in traverse_util

### DIFF
--- a/flax/traverse_util.py
+++ b/flax/traverse_util.py
@@ -82,6 +82,10 @@ def _flatten(xs, prefix, keep_empty_nodes, is_leaf, sep):
   def _key(path):
     if sep is None:
       return path
+    if not path:
+      raise ValueError(
+        'Cannot flatten the root as a leaf when a separator is specified.'
+      )
     return sep.join(path)
 
   if not isinstance(xs, (flax.core.FrozenDict, dict)) or (
@@ -130,7 +134,9 @@ def flatten_dict(xs, keep_empty_nodes=False, is_leaf=None, sep=None):
       leaf (i.e., should not be flattened further).
     sep: if specified, then the keys of the returned
       dictionary will be ``sep``-joined strings (if
-      ``None``, then keys will be tuples).
+      ``None``, then keys will be tuples). The root cannot be selected by
+      ``is_leaf`` when ``sep`` is specified because an empty path has no
+      unambiguous string encoding.
   Returns:
     The flattened dictionary.
   """
@@ -163,6 +169,14 @@ def unflatten_dict(xs, sep=None):
     The nested dictionary.
   """
   assert isinstance(xs, dict), f'input is not a dict; it is a {type(xs)}'
+  if sep is None and () in xs:
+    if len(xs) != 1:
+      raise ValueError(
+        'Cannot unflatten a root path alongside other paths.'
+      )
+    value = xs[()]
+    return {} if value is empty_node else value
+
   result = {}
   for path, value in xs.items():
     if sep is not None:

--- a/tests/traverse_util_test.py
+++ b/tests/traverse_util_test.py
@@ -222,6 +222,32 @@ class TraversalTest(absltest.TestCase):
     xs_restore = traverse_util.unflatten_dict(flat_xs)
     self.assertEqual(xs, xs_restore)
 
+  def test_flatten_dict_is_leaf_at_root(self):
+    xs = {'foo': {'bar': 1}}
+    is_root = lambda path, _: path == ()
+
+    flat_xs = traverse_util.flatten_dict(xs, is_leaf=is_root)
+    xs_restore = traverse_util.unflatten_dict(flat_xs)
+    self.assertEqual(xs, xs_restore)
+
+    with self.assertRaisesRegex(
+      ValueError,
+      'Cannot flatten the root as a leaf when a separator is specified.',
+    ):
+      traverse_util.flatten_dict(xs, is_leaf=is_root, sep='/')
+
+  def test_flatten_dict_empty_string_key_with_separator(self):
+    xs = {'': 1}
+    flat_xs = traverse_util.flatten_dict(xs, sep='/')
+    xs_restore = traverse_util.unflatten_dict(flat_xs, sep='/')
+    self.assertEqual(xs, xs_restore)
+
+  def test_unflatten_dict_rejects_root_with_other_paths(self):
+    with self.assertRaisesRegex(
+      ValueError, 'Cannot unflatten a root path alongside other paths.'
+    ):
+      traverse_util.unflatten_dict({(): {'foo': 1}, ('bar',): 2})
+
 
 class ModelParamTraversalTest(absltest.TestCase):
   def test_only_works_on_model_params(self):


### PR DESCRIPTION
# What does this PR do?

`flatten_dict()` allows `is_leaf` to select the root dictionary. Without a separator this produces the valid flat representation `{(): value}`, but `unflatten_dict()` previously indexed the empty path and raised `IndexError` instead of restoring the original dictionary.

This change recognizes a sole empty tuple path as the root value. It also rejects a root path combined with other paths, since such an input cannot represent one tree unambiguously.

When a string separator is requested, the empty root path and a real empty-string key both encode as `""`. Root-leaf selection in that mode now raises a descriptive `ValueError` rather than silently restoring a different structure. Existing empty-string keys continue to round-trip unchanged.

## Validation

- `uv run pytest -q tests/traverse_util_test.py tests/serialization_test.py tests/struct_test.py` — 127 passed, 4 skipped
- `uv run pre-commit run --files flax/traverse_util.py tests/traverse_util_test.py` — all hooks passed
- Full core suite — 3196 passed, 14 skipped; one unrelated local-environment failure in `SummaryTest.test_tabulate_enum` because Rich emitted plain text while the test expects ANSI color escapes

## Checklist

- [x] This PR fixes a minor issue (e.g.: typo or small bug) or improves the docs (you can dismiss the other checks if that's the case).
- [ ] This change is discussed in a Github issue/discussion (not required for this minor bug).
- [x] The documentation and docstrings adhere to the documentation guidelines.
- [x] This change includes necessary high-coverage tests. (No quality testing = no merge!)
