### PR TITLE
Fix LinearGeneral batch axis mapping order

### DIFF
--- a/flax/nnx/nn/linear.py
+++ b/flax/nnx/nn/linear.py
@@ -177,7 +177,7 @@ class LinearGeneral(Module):
     self.in_features = _canonicalize_tuple(in_features)
     self.out_features = _canonicalize_tuple(out_features)
     self.axis = _canonicalize_tuple(axis)
-    self.batch_axis = FrozenDict[Axis, Size](batch_axis)
+    self.batch_axis = FrozenDict[Axis, Size](dict(sorted(batch_axis.items())))
     self.use_bias = use_bias
     self.dtype = dtype
     self.param_dtype = param_dtype

--- a/tests/nnx/nn/linear_test.py
+++ b/tests/nnx/nn/linear_test.py
@@ -69,6 +69,21 @@ class TestLinearGeneral(parameterized.TestCase):
     assert module.bias is not None
     assert module.bias.shape == (3, 4)
 
+  def test_batch_axis_mapping_order(self):
+    inputs = jnp.arange(60, dtype=jnp.float32).reshape(3, 4, 5)
+    module = nnx.LinearGeneral(
+      5,
+      2,
+      batch_axis={1: 4, 0: 3},
+      use_bias=False,
+      kernel_init=nnx.initializers.ones,
+      rngs=nnx.Rngs(0),
+    )
+
+    assert module.kernel.shape == (3, 4, 5, 2)
+    expected = jnp.repeat(inputs.sum(axis=-1, keepdims=True), 2, axis=-1)
+    np.testing.assert_array_equal(module(inputs), expected)
+
 
 class TestLinenConsistency(parameterized.TestCase):
   @parameterized.product(


### PR DESCRIPTION
## Summary

- canonicalize `LinearGeneral.batch_axis` by axis index before constructing parameter shapes
- add a regression test for an out-of-order mapping with two differently sized batch axes

## Root cause and impact

`batch_axis` is documented and typed as a mapping, but parameter shapes were built from its insertion-ordered values while `dot_general` canonicalized the input batch axes numerically. Supplying an equivalent mapping in a different insertion order, such as `{1: 4, 0: 3}`, therefore created a `(4, 3, ...)` kernel for `(3, 4, ...)` inputs and failed with mismatched batch dimensions.

Sorting the mapping once at construction keeps the stored axis keys, kernel/bias shapes, and `dot_general` batch dimensions aligned. This makes behavior independent of mapping insertion order without changing already sorted inputs.

## Validation

- Regression test applied to pristine `01854da1`: fails because the kernel shape is `(4, 3, 5, 2)` instead of `(3, 4, 5, 2)`
- `pytest tests/nnx/nn/linear_test.py::TestLinearGeneral::test_batch_axis_mapping_order -q` (`1 passed`)
- `pytest tests/nnx/nn/linear_test.py -q` (`209 passed`)
- `pytest tests/nnx/nn -q` (`604 passed`)
- `pre-commit run --files flax/nnx/nn/linear.py tests/nnx/nn/linear_test.py` (all hooks passed)

## Checklist

- [x] This PR fixes a minor issue (the remaining checklist items that require prior discussion are not applicable).
- [ ] This change is discussed in a GitHub issue/discussion.
- [x] Documentation and docstrings remain compliant; no public API text changes are needed.
- [x] This change includes a focused regression test.

## AI assistance disclosure

OpenAI Codex assisted with repository inspection, reproduction, implementation, test execution, duplicate/history checks, and drafting this pull request. I reviewed the focused diff and verified the reported behavior and validation results locally.