### PR TITLE
fix(nnx): store WeightNorm scales as Param so they train

### DIFF
--- a/flax/nnx/nn/normalization.py
+++ b/flax/nnx/nn/normalization.py
@@ -1016,9 +1016,12 @@ class WeightNorm(nnx.Module):
         feature_axes = _canonicalize_axes(param.ndim, self.feature_axes)
         scale_shape = tuple(param.shape[ax] for ax in feature_axes)
         return scale_init(rngs['params'], scale_shape)
+      # Store as Param so scales are trainable (Weight Normalization paper).
       self.scales = nnx.data({
-        path: init_scales(param) for path, param in nnx.to_flat_state(state)
-        if self.variable_filter(path, param)})
+        path: nnx.Param(init_scales(param))
+        for path, param in nnx.to_flat_state(state)
+        if self.variable_filter(path, param)
+      })
 
   def _weightnorm_inplace(self, path, param):
     if not self.variable_filter(path, param):
@@ -1041,7 +1044,7 @@ class WeightNorm(nnx.Module):
           f'Could not find the scale corresponding to the param {path} '
           'in scales dict. Parameters of the layer_instance should not change!'
         )
-      scale_value = self.scales[path]
+      scale_value = self.scales[path][...]
 
       if len(feature_axes) < param.ndim:
         broadcast_shape = [1] * param.ndim

--- a/tests/nnx/nn/normalization_test.py
+++ b/tests/nnx/nn/normalization_test.py
@@ -413,8 +413,12 @@ class TestLinenConsistency(parameterized.TestCase):
 
     np.testing.assert_array_equal(
       variables['params']['weight_norm']['dense/kernel/scale'],
-      nnx_model.normed.scales[('kernel',)])
+      nnx_model.normed.scales[('kernel',)][...])
     np.testing.assert_array_equal(linen_out, nnx_out)
+
+    # scales must be Params so they train (issue #5577)
+    assert isinstance(nnx_model.normed.scales[('kernel',)], nnx.Param)
+    assert 'scales' in nnx.state(nnx_model.normed, nnx.Param)
 
   @parameterized.product(
     dtype=[jnp.float32, jnp.float16],


### PR DESCRIPTION
## Summary
`nnx.WeightNorm.scales` was a dict of raw arrays, so it did not appear in `nnx.state(module, nnx.Param)` and was not trainable — unlike the Weight Normalization paper and Linen's `WeightNorm`.

Each scale is now an `nnx.Param`. Equivalence tests compare `.value` via `[...]`.

Fixes #5577

## Test plan
- [x] `tests/nnx/nn/normalization_test.py::test_nnx_linen_weightnorm_equivalence` now asserts scales are `Param` and present in Param state
- [ ] Hosted NNX normalization tests


Made with [Cursor](https://cursor.com)