### PR TITLE
Fix mypy hijax error

### DIFF
--- a/flax/nnx/variablelib.py
+++ b/flax/nnx/variablelib.py
@@ -272,17 +272,6 @@ Leaf = tp.Any
 # ---------------------------------
 
 
-def _bind_new_variable(*leaves, treedef, var_type, ref) -> HijaxVariable:
-  """Binds new_variable_p after instantiating any Zero tangents."""
-  leaves = tuple(hjx.instantiate_zeros(leaf) for leaf in leaves)
-  return new_variable_p.bind(
-    *leaves,
-    treedef=treedef,
-    var_type=var_type,
-    ref=ref,
-  )
-
-
 def _new_hijax_from_variable(variable: Variable) -> HijaxVariable:
   leaves, treedef = jax.tree.flatten(variable)
   var_type = type(variable)
@@ -294,8 +283,15 @@ def _new_hijax_from_variable(variable: Variable) -> HijaxVariable:
   )
   return hijax_var
 
-HiPrim = (hjx.VJPHiPrimitive if jax.__version_info__ <= (0, 11, 1) else
-          hjx.HiPrim)
+if tp.TYPE_CHECKING:
+  # mypy needs a single, unconditional assignment to treat this as a type alias
+  # usable as a base class, and cannot evaluate jax.__version_info__. Pin the
+  # branch matching the locked jax; drop this whole conditional once jax
+  # > 0.11.1 is the floor.
+  HiPrim = hjx.VJPHiPrimitive
+else:
+  HiPrim = (hjx.VJPHiPrimitive if jax.__version_info__ <= (0, 11, 1) else
+            hjx.HiPrim)
 
 class NewVariable(HiPrim):
   def __init__(self, *leaf_avals, treedef, var_type, ref=False):


### PR DESCRIPTION
Currently, `HiPrim` is a type alias for different hijax types depending on the jax version. Unfortunately, this breaks mypy: it can't handle the ternary conditional used in this assignment. This PR uses an if statement instead of a ternary operator to make mypy happy. It also removes the dead `_bind_new_variable` function, which mypy flagged as a redefinition. 